### PR TITLE
Fix QC Sprint 1 BLOCKERs: GraphStore abstraction + SAVEPOINT scope + advisory lock doc

### DIFF
--- a/docs/QC-SPRINT1-REVIEW.md
+++ b/docs/QC-SPRINT1-REVIEW.md
@@ -1,0 +1,142 @@
+# QC Sprint 1 — Ootils Core
+*Review date: 2026-04-04 — Reviewer: Claw*
+
+---
+
+## A. Cohérence Architecture
+
+**Verdict: PASS avec 2 warnings**
+
+✅ **2-layers respectés.** `ProjectionKernel` est pur (zéro DB), `GraphStore` est la seule couche DB du kernel. L'orchestration (`PropagationEngine`, `CalcRunManager`) n'implémente pas de logique de calcul — séparation nette.
+
+✅ **Pas de SQLite résiduel.** Tout est psycopg3/Postgres. `connection.py` docstring mentionne explicitement la migration depuis SQLite.
+
+✅ **Pas de JSONB pour données structurées.** `triggered_by_event_ids` utilise `UUID[]` (array typé) — bon choix. Tous les deltas d'events sont en colonnes typées.
+
+✅ **Interface kernel propre.** `GraphStore.__init__` prend une `psycopg.Connection` — swap vers Rust possible sans toucher l'orchestration.
+
+⚠️ **WARNING: `db` passé comme paramètre non typé partout.** `DirtyFlagManager`, `PropagationEngine`, `CalcRunManager` acceptent `db` sans annotation de type. En Python, c'est `Any` implicite — casse la lisibilité et rend le swap plus risqué.
+
+⚠️ **WARNING: couplage direct `propagator.py → store.py` via SQL inline.** `_recompute_pi_node` dans `propagator.py` exécute un `UPDATE nodes` direct (`db.execute("""UPDATE nodes...""")`). C'est de la logique de persistance dans la couche orchestration — ça devrait passer par `GraphStore.upsert_node()`.
+
+---
+
+## B. Qualité du Code Python
+
+**Verdict: PASS avec 3 warnings**
+
+✅ **Typing globalement correct.** Dataclasses typées, `Optional`, `UUID`, `Decimal`, `date` — tout est explicite. `from __future__ import annotations` systématique.
+
+✅ **Gestion des erreurs structurée.** `CycleDetectedError`, `EngineStartupError` — custom exceptions propres. `fail_calc_run` release l'advisory lock en `try/except` best-effort — bon pattern.
+
+✅ **Logging utilisé (pas print).** `logger = logging.getLogger(__name__)` dans `propagator.py`. Reste du code n'a pas de logging (pas de `print` non plus — neutre pour l'instant).
+
+✅ **Docstrings utiles.** Toutes les méthodes publiques sont documentées, avec args/returns explicites sur les méthodes critiques.
+
+✅ **Decimal pour les quantités partout.** Pas de float — correct pour du calcul financier/inventaire.
+
+⚠️ **WARNING: `from datetime import date` importé à l'intérieur d'une méthode** dans `propagator.py` (`process_event`). Import late — antipattern Python, à remonter en haut du fichier.
+
+⚠️ **WARNING: `list` non typé dans la signature de `compute_pi_node`.** `supply_events: list` et `demand_events: list` — devrait être `list[tuple[date, Decimal]]`. Les DTOs `SupplyEvent`/`DemandEvent` existent dans `models/__init__.py` mais ne sont pas utilisés par le kernel.
+
+⚠️ **WARNING: `ProjectedInventoryNode`, `PurchaseOrderNode`, `OnHandNode` dans models** sont des aliases simples (`= Node`). C'est un antipattern — pas de vrai typage, trompe le lecteur. Soit supprimer, soit créer de vraies sous-classes ou des `NewType`.
+
+---
+
+## C. Schéma SQL / Migrations
+
+**Verdict: PASS**
+
+✅ **Toutes les PKs sont UUID.** Avec `DEFAULT gen_random_uuid()` — propre.
+
+✅ **Tous les timestamps sont TIMESTAMPTZ.** Pas de `TIMESTAMP` sans timezone.
+
+✅ **Pas de JSONB pour données structurées.** `events` utilise des colonnes typées (`old_date`, `new_date`, `old_quantity`, etc.). `triggered_by_event_ids` est `UUID[]`. ✅
+
+✅ **CHECK constraints exhaustifs.** `node_type`, `edge_type`, `event_type`, `status` sur toutes les tables concernées.
+
+✅ **Index complets et bien pensés.** Partial indexes avec `WHERE active = TRUE`, index composites sur les patterns d'accès réels (traversal, dirty scan, event queue).
+
+✅ **FKs deferrable.** `fk_nodes_projection_series` et `fk_nodes_last_calc_run` en `DEFERRABLE INITIALLY DEFERRED` — nécessaire pour les inserts en batch circulaires.
+
+✅ **Seed data idempotente.** `ON CONFLICT DO NOTHING` partout.
+
+✅ **`zone_transition_runs` avec `idempotency_key` unique.** Conforme à ADR-006.
+
+**1 point d'attention (pas BLOCKER) :**
+- Le `CHECK` sur `scenarios.status` inclut `'running'` — valeur qui n'apparaît nulle part dans le code Python. À aligner ou documenter.
+
+---
+
+## D. Tests
+
+**Verdict: CONDITIONAL — couverture fonctionnelle correcte, quelques edge cases manquants**
+
+✅ **677 lignes de tests.** Substantiel pour un Sprint 1.
+
+✅ **Séparation tests unitaires / intégration via fixtures.** Tests unitaires sur `ProjectionKernel` (pur, pas de DB), tests d'intégration sur `GraphStore`, `DirtyFlagManager`, `PropagationEngine`.
+
+✅ **Cas critiques couverts :** cycle detection, dirty flag flush/recovery, projection de base (opening/inflows/outflows/shortage), advisory lock (coalescing).
+
+**Edge cases manquants identifiés :**
+
+⚠️ **Pas de test de crash recovery.** `load_from_postgres` (fallback dirty) n'est pas testé — c'est la feature la plus critique pour la durabilité.
+
+⚠️ **Pas de test multi-bucket chain.** `feeds_forward` entre PI nodes en séquence non testée — c'est le cœur de la propagation PI.
+
+⚠️ **Pas de test de demande pro-ratée.** La logique de pro-ration temporelle dans `_recompute_pi_node` (overlap `time_span`) n'a pas de test dédié.
+
+⚠️ **Pas de test `startup_cycle_check`.** Le check de démarrage n'est pas couvert.
+
+---
+
+## E. BLOCKERs et Issues
+
+### 🔴 BLOCKER
+
+**B1 — `_recompute_pi_node` bypass `GraphStore.upsert_node()`**
+`propagator.py:_recompute_pi_node` fait un `db.execute("UPDATE nodes ...")` direct. Ça court-circuite l'abstraction du kernel et casse l'interface propre définie pour le swap Rust. Toute écriture sur `nodes` doit passer par `GraphStore`.
+
+**B2 — Advisory lock jamais releasé si crash entre `start_calc_run` et `fail_calc_run`**
+`process_event` fait `SAVEPOINT propagation_start` puis `ROLLBACK TO SAVEPOINT` sur exception. Mais l'advisory lock est acquis dans `start_calc_run` et releasé dans `complete_calc_run` ou `fail_calc_run`. Si une exception se produit entre le `start_calc_run` et le bloc `try`, le lock n'est jamais releasé. → `recover_pending_runs` sur startup gère les `running` mais n'unlock pas les advisory locks orphelins (qui sont session-scoped côté Postgres, donc ils disparaissent si la connexion est fermée — mais c'est à documenter explicitement).
+
+### ⚠️ WARNING
+
+**W1 — `db` non typé** — voir section B. Risque de régression silencieuse.
+
+**W2 — Aliases de types dans models.py** — `ProjectedInventoryNode = Node` trompe les outils d'analyse statique.
+
+**W3 — Import late `from datetime import date`** dans `propagator.py`.
+
+**W4 — Crash recovery non testée** — test manquant sur `load_from_postgres`.
+
+**W5 — Chain PI multi-bucket non testée** — test manquant sur `feeds_forward` end-to-end.
+
+**W6 — `supply_events: list` / `demand_events: list` non typés dans `compute_pi_node`** — les DTOs `SupplyEvent`/`DemandEvent` existent et ne sont pas utilisés.
+
+### 🟡 NITPICK
+
+**N1 — `_apply_migrations` swallow silencieux des erreurs "already exists"** — les autres erreurs DDL non-"already exists" devraient peut-être avoir un log WARNING avant re-raise.
+
+**N2 — `scenarios.status = 'running'` dans le CHECK non utilisé côté code** — dead value à documenter ou supprimer.
+
+**N3 — `validate_no_cycle` charge TOUTES les edges du scenario en mémoire** — acceptable pour PoA, à noter comme future optimisation à 50K+ nœuds.
+
+---
+
+## F. Score Global
+
+| Dimension | Score | Note |
+|---|---|---|
+| Architecture | 8/10 | 2-layers tenus, 1 BLOCKER sur bypass store |
+| Qualité Python | 7/10 | Typing solide, quelques lacunes sur les signatures |
+| Schéma SQL | 9/10 | Excellent — indexes, constraints, pas de JSONB |
+| Tests | 6/10 | Bon volume, edge cases critiques manquants |
+
+**Verdict global : CONDITIONAL**
+
+2 BLOCKERs à corriger avant Sprint 2 :
+1. Faire passer `_recompute_pi_node` par `GraphStore.upsert_node()`
+2. Documenter/tester le comportement de l'advisory lock sur crash
+
+Le reste peut être adressé en début de Sprint 2 sans bloquer.

--- a/src/ootils_core/engine/kernel/graph/store.py
+++ b/src/ootils_core/engine/kernel/graph/store.py
@@ -275,6 +275,52 @@ class GraphStore:
                 if neighbour not in visited:
                     stack.append(neighbour)
 
+    def update_pi_result(
+        self,
+        node_id: UUID,
+        scenario_id: UUID,
+        calc_run_id: UUID,
+        opening_stock: Decimal,
+        inflows: Decimal,
+        outflows: Decimal,
+        closing_stock: Decimal,
+        has_shortage: bool,
+        shortage_qty: Decimal,
+    ) -> None:
+        """
+        Persist the result of a PI node computation.
+        Updates only the computation result fields + clears is_dirty.
+        Called exclusively by the propagation engine — keeps all DB writes in the store.
+        """
+        from datetime import datetime, timezone
+        self._conn.execute(
+            """
+            UPDATE nodes
+            SET opening_stock    = %s,
+                inflows          = %s,
+                outflows         = %s,
+                closing_stock    = %s,
+                has_shortage     = %s,
+                shortage_qty     = %s,
+                is_dirty         = FALSE,
+                last_calc_run_id = %s,
+                updated_at       = %s
+            WHERE node_id = %s AND scenario_id = %s
+            """,
+            (
+                opening_stock,
+                inflows,
+                outflows,
+                closing_stock,
+                has_shortage,
+                shortage_qty,
+                calc_run_id,
+                datetime.now(timezone.utc),
+                node_id,
+                scenario_id,
+            ),
+        )
+
     # ------------------------------------------------------------------
     # Projection series
     # ------------------------------------------------------------------

--- a/src/ootils_core/engine/orchestration/calc_run.py
+++ b/src/ootils_core/engine/orchestration/calc_run.py
@@ -195,6 +195,16 @@ class CalcRunManager:
         Return all 'pending' runs so the engine can retry them.
 
         Called once on engine startup.
+
+        Advisory lock note:
+        PostgreSQL advisory locks are session-scoped. If the engine process crashes,
+        the DB connection is closed, and Postgres automatically releases all advisory
+        locks held by that session. There is therefore no risk of orphaned advisory
+        locks surviving a crash — they are cleaned up at the transport level.
+
+        What this method handles: the *calc_runs table state*, which does not auto-recover.
+        Running rows must be transitioned to 'failed' so the engine does not think
+        a run is in progress when it restarts.
         """
         now = datetime.now(timezone.utc)
 

--- a/src/ootils_core/engine/orchestration/propagator.py
+++ b/src/ootils_core/engine/orchestration/propagator.py
@@ -8,7 +8,7 @@ Pipeline:
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
+from datetime import date, timedelta
 from decimal import Decimal
 from typing import Optional
 from uuid import UUID
@@ -77,9 +77,8 @@ class PropagationEngine:
             logger.info("Scenario %s is already locked — skipping", scenario_id)
             return None
 
-        db.execute("SAVEPOINT propagation_start")
-
         try:
+            db.execute("SAVEPOINT propagation_start")
             # Determine time window for dirty expansion
             trigger_node_id = (
                 UUID(str(event_row["trigger_node_id"]))
@@ -108,7 +107,6 @@ class PropagationEngine:
                 window_end = new_date + timedelta(days=365)
             else:
                 # No date context — recompute full downstream
-                from datetime import date
                 window_start = date.min
                 window_end = date.max
 
@@ -354,35 +352,18 @@ class PropagationEngine:
         changed = old_values != new_values
 
         # ------------------------------------------------------------------
-        # 6. Persist
+        # 6. Persist via GraphStore (all DB writes go through the store layer)
         # ------------------------------------------------------------------
-        from datetime import datetime, timezone
-        db.execute(
-            """
-            UPDATE nodes
-            SET opening_stock = %s,
-                inflows = %s,
-                outflows = %s,
-                closing_stock = %s,
-                has_shortage = %s,
-                shortage_qty = %s,
-                is_dirty = FALSE,
-                last_calc_run_id = %s,
-                updated_at = %s
-            WHERE node_id = %s AND scenario_id = %s
-            """,
-            (
-                result["opening_stock"],
-                result["inflows"],
-                result["outflows"],
-                result["closing_stock"],
-                result["has_shortage"],
-                result["shortage_qty"],
-                calc_run_id,
-                datetime.now(timezone.utc),
-                node_id,
-                scenario_id,
-            ),
+        self._store.update_pi_result(
+            node_id=node_id,
+            scenario_id=scenario_id,
+            calc_run_id=calc_run_id,
+            opening_stock=result["opening_stock"],
+            inflows=result["inflows"],
+            outflows=result["outflows"],
+            closing_stock=result["closing_stock"],
+            has_shortage=result["has_shortage"],
+            shortage_qty=result["shortage_qty"],
         )
 
         return changed


### PR DESCRIPTION
## Fixes QC Sprint 1 — 2 BLOCKERs

### B1 — PI persist routed through GraphStore
- Adds `GraphStore.update_pi_result()` — single entry point for all PI computation writes
- `PropagationEngine._recompute_pi_node` no longer executes raw SQL inline
- Preserves the clean kernel/orchestration interface required for future Rust swap

### B2 — SAVEPOINT scope + advisory lock documentation
- `SAVEPOINT propagation_start` moved inside `try` block (was before it — advisory lock could be acquired without protection)
- `recover_pending_runs` docstring documents PostgreSQL session-scoped advisory lock behavior: auto-released on connection close, no orphan risk on crash

### Bonus
- Late `from datetime import date` import in `propagator.py` moved to top-level

Reviewed in `docs/QC-SPRINT1-REVIEW.md`.