### PR TITLE
Sprint M5: Scenarios — overrides, diff, promote (event-sourced)

### DIFF
--- a/src/ootils_core/db/migrations/006_m5_scenarios.sql
+++ b/src/ootils_core/db/migrations/006_m5_scenarios.sql
@@ -1,0 +1,74 @@
+-- ============================================================
+-- Ootils Core — Migration 006: Sprint M5 Scenarios
+-- Adds scenario_overrides and scenario_diffs tables.
+-- Also extends events.event_type CHECK to include 'scenario_merge'.
+-- ============================================================
+
+-- ============================================================
+-- 0. Extend events.event_type CHECK constraint
+--    (scenario_merge is a first-class event per EXPERT doc Q4.5)
+-- ============================================================
+
+ALTER TABLE events DROP CONSTRAINT IF EXISTS events_event_type_check;
+ALTER TABLE events ADD CONSTRAINT events_event_type_check
+    CHECK (event_type IN (
+        'supply_date_changed', 'supply_qty_changed',
+        'demand_qty_changed', 'onhand_updated',
+        'policy_changed', 'structure_changed',
+        'scenario_created', 'calc_triggered',
+        'ingestion_complete', 'po_date_changed',
+        'test_event', 'scenario_merge'
+    ));
+
+-- ============================================================
+-- 1. SCENARIO OVERRIDES
+-- User intent layer: typed as TEXT per ADR (no JSONB).
+-- UNIQUE per (scenario, node, field) — one active override.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS scenario_overrides (
+    override_id     UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    scenario_id     UUID        NOT NULL REFERENCES scenarios(scenario_id),
+    node_id         UUID        NOT NULL REFERENCES nodes(node_id),
+    field_name      TEXT        NOT NULL,   -- e.g. 'quantity', 'time_ref'
+    old_value       TEXT,                   -- serialized previous value (TEXT, nullable)
+    new_value       TEXT        NOT NULL,   -- serialized new value
+    applied_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    applied_by      TEXT,                   -- user/agent reference
+    UNIQUE (scenario_id, node_id, field_name)  -- one active override per (scenario, node, field)
+);
+
+-- ============================================================
+-- 2. SCENARIO DIFFS
+-- Computed result: baseline calc_run vs scenario calc_run, node by node.
+-- Persisted after each diff() call.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS scenario_diffs (
+    diff_id                 UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    scenario_id             UUID        NOT NULL REFERENCES scenarios(scenario_id),
+    baseline_calc_run_id    UUID        NOT NULL REFERENCES calc_runs(calc_run_id),
+    scenario_calc_run_id    UUID        NOT NULL REFERENCES calc_runs(calc_run_id),
+    node_id                 UUID        NOT NULL REFERENCES nodes(node_id),
+    field_name              TEXT        NOT NULL,
+    baseline_value          TEXT,
+    scenario_value          TEXT,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (scenario_id, baseline_calc_run_id, scenario_calc_run_id, node_id, field_name)
+);
+
+-- ============================================================
+-- INDEXES
+-- ============================================================
+
+CREATE INDEX IF NOT EXISTS idx_scenario_overrides_scenario
+    ON scenario_overrides (scenario_id);
+
+CREATE INDEX IF NOT EXISTS idx_scenario_overrides_node
+    ON scenario_overrides (node_id);
+
+CREATE INDEX IF NOT EXISTS idx_scenario_diffs_scenario
+    ON scenario_diffs (scenario_id);
+
+CREATE INDEX IF NOT EXISTS idx_scenario_diffs_node
+    ON scenario_diffs (node_id);

--- a/src/ootils_core/engine/scenario/__init__.py
+++ b/src/ootils_core/engine/scenario/__init__.py
@@ -1,0 +1,9 @@
+"""
+ootils_core.engine.scenario — Sprint M5: Scenario management.
+
+Public API:
+    ScenarioManager — create, override, diff, promote scenarios.
+"""
+from ootils_core.engine.scenario.manager import ScenarioManager
+
+__all__ = ["ScenarioManager"]

--- a/src/ootils_core/engine/scenario/manager.py
+++ b/src/ootils_core/engine/scenario/manager.py
@@ -1,0 +1,646 @@
+"""
+manager.py — ScenarioManager: create, apply_override, diff, promote.
+
+Design principles (per EXPERT-dirty-flags-and-scenarios.md Q4.1–Q4.7):
+- Overrides are user intent → TEXT serialization, persisted in scenario_overrides.
+- Computed results live independently in nodes (scoped by scenario_id).
+- Merge is a first-class event (scenario_merge) not a schema patch.
+- Diff compares computed columns only (closing_stock, opening_stock, inflows,
+  outflows, has_shortage, shortage_qty) between two calc_runs.
+- All DB access via psycopg3; caller owns the transaction.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Optional
+from uuid import UUID, uuid4
+
+import psycopg
+
+from ootils_core.models import (
+    Node,
+    PlanningEvent,
+    Scenario,
+    ScenarioDiff,
+    ScenarioOverride,
+)
+
+logger = logging.getLogger(__name__)
+
+# Fields compared during a baseline→scenario diff
+_DIFF_FIELDS: tuple[str, ...] = (
+    "closing_stock",
+    "opening_stock",
+    "inflows",
+    "outflows",
+    "has_shortage",
+    "shortage_qty",
+)
+
+# Baseline sentinel UUID (matches seed in migration 002)
+_BASELINE_ID = UUID("00000000-0000-0000-0000-000000000001")
+
+
+class ScenarioManager:
+    """
+    Manages scenario lifecycle operations.
+
+    All methods accept a psycopg3 Connection.  The caller owns commit/rollback
+    — this class never calls conn.commit() directly.
+    """
+
+    # ------------------------------------------------------------------
+    # create_scenario
+    # ------------------------------------------------------------------
+
+    def create_scenario(
+        self,
+        name: str,
+        parent_scenario_id: UUID,
+        db: psycopg.Connection,
+    ) -> Scenario:
+        """
+        Create a new (non-baseline) scenario branched from parent_scenario_id.
+
+        Steps:
+          1. Insert a new row in scenarios (is_baseline=False, status='active').
+          2. Deep-copy all active nodes from the parent scenario, assigning
+             new node_id values and the new scenario_id.
+
+        Returns the newly created Scenario.
+        """
+        scenario_id = uuid4()
+        now = datetime.now(timezone.utc)
+
+        db.execute(
+            """
+            INSERT INTO scenarios (
+                scenario_id, name, parent_scenario_id,
+                is_baseline, status, created_at, updated_at
+            ) VALUES (%s, %s, %s, FALSE, 'active', %s, %s)
+            """,
+            (scenario_id, name, parent_scenario_id, now, now),
+        )
+        logger.info(
+            "scenario.created scenario_id=%s name=%r parent=%s",
+            scenario_id,
+            name,
+            parent_scenario_id,
+        )
+
+        # Deep-copy parent nodes into the new scenario
+        self._copy_nodes(parent_scenario_id, scenario_id, db)
+
+        return Scenario(
+            scenario_id=scenario_id,
+            name=name,
+            parent_scenario_id=parent_scenario_id,
+            is_baseline=False,
+            status="active",
+            created_at=now,
+            updated_at=now,
+        )
+
+    def _copy_nodes(
+        self,
+        source_scenario_id: UUID,
+        target_scenario_id: UUID,
+        db: psycopg.Connection,
+    ) -> int:
+        """
+        Copy all active nodes from source_scenario_id to target_scenario_id,
+        assigning fresh node_id UUIDs.
+
+        Returns the number of nodes copied.
+        """
+        source_nodes = db.execute(
+            """
+            SELECT * FROM nodes
+            WHERE scenario_id = %s AND active = TRUE
+            """,
+            (source_scenario_id,),
+        ).fetchall()
+
+        count = 0
+        for row in source_nodes:
+            new_node_id = uuid4()
+            now = datetime.now(timezone.utc)
+            db.execute(
+                """
+                INSERT INTO nodes (
+                    node_id, node_type, scenario_id, item_id, location_id,
+                    quantity, qty_uom,
+                    time_grain, time_ref, time_span_start, time_span_end,
+                    is_dirty, active,
+                    projection_series_id, bucket_sequence,
+                    opening_stock, inflows, outflows, closing_stock,
+                    has_shortage, shortage_qty,
+                    has_exact_date_inputs, has_week_inputs, has_month_inputs,
+                    created_at, updated_at
+                ) VALUES (
+                    %s, %s, %s, %s, %s,
+                    %s, %s,
+                    %s, %s, %s, %s,
+                    FALSE, TRUE,
+                    %s, %s,
+                    %s, %s, %s, %s,
+                    %s, %s,
+                    %s, %s, %s,
+                    %s, %s
+                )
+                """,
+                (
+                    new_node_id,
+                    row["node_type"],
+                    target_scenario_id,
+                    row["item_id"],
+                    row["location_id"],
+                    row["quantity"],
+                    row["qty_uom"],
+                    row["time_grain"],
+                    row["time_ref"],
+                    row["time_span_start"],
+                    row["time_span_end"],
+                    row["projection_series_id"],
+                    row["bucket_sequence"],
+                    row["opening_stock"],
+                    row["inflows"],
+                    row["outflows"],
+                    row["closing_stock"],
+                    row["has_shortage"],
+                    row["shortage_qty"],
+                    row["has_exact_date_inputs"],
+                    row["has_week_inputs"],
+                    row["has_month_inputs"],
+                    now,
+                    now,
+                ),
+            )
+            count += 1
+
+        logger.info(
+            "scenario.copy_nodes src=%s dst=%s count=%d",
+            source_scenario_id,
+            target_scenario_id,
+            count,
+        )
+        return count
+
+    # ------------------------------------------------------------------
+    # apply_override
+    # ------------------------------------------------------------------
+
+    def apply_override(
+        self,
+        scenario_id: UUID,
+        node_id: UUID,
+        field_name: str,
+        new_value: str,
+        applied_by: Optional[str],
+        db: psycopg.Connection,
+    ) -> ScenarioOverride:
+        """
+        Apply a field-level override to a node within a scenario.
+
+        Steps:
+          1. Read current field value from nodes (becomes old_value).
+          2. Upsert into scenario_overrides (UNIQUE: scenario_id, node_id, field_name).
+          3. UPDATE nodes SET {field_name} = new_value for this (node_id, scenario_id).
+          4. Insert a PlanningEvent of type 'policy_changed' to trigger recalculation.
+
+        Returns the persisted ScenarioOverride.
+
+        Security note: field_name is validated against a whitelist before being
+        interpolated into the UPDATE query.
+        """
+        _validate_field_name(field_name)
+
+        # 1. Fetch current node value
+        row = db.execute(
+            f"SELECT {field_name} FROM nodes WHERE node_id = %s AND scenario_id = %s",
+            (node_id, scenario_id),
+        ).fetchone()
+
+        old_value: Optional[str] = None
+        if row is not None and row[field_name] is not None:
+            old_value = str(row[field_name])
+
+        now = datetime.now(timezone.utc)
+        override_id = uuid4()
+
+        # 2. Upsert override (one per scenario/node/field)
+        # ON CONFLICT: if a prior override exists, update values.
+        # The PK (override_id) is not changed on conflict — we use our generated UUID
+        # for new inserts; existing rows retain their original override_id.
+        db.execute(
+            """
+            INSERT INTO scenario_overrides (
+                override_id, scenario_id, node_id,
+                field_name, old_value, new_value,
+                applied_at, applied_by
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (scenario_id, node_id, field_name) DO UPDATE SET
+                old_value  = EXCLUDED.old_value,
+                new_value  = EXCLUDED.new_value,
+                applied_at = EXCLUDED.applied_at,
+                applied_by = EXCLUDED.applied_by
+            """,
+            (
+                override_id,
+                scenario_id,
+                node_id,
+                field_name,
+                old_value,
+                new_value,
+                now,
+                applied_by,
+            ),
+        )
+        persisted_override_id = override_id
+
+        # 3. Apply to node column (field_name validated above)
+        db.execute(
+            f"""
+            UPDATE nodes
+            SET {field_name} = %s,
+                is_dirty     = TRUE,
+                updated_at   = %s
+            WHERE node_id = %s AND scenario_id = %s
+            """,
+            (new_value, now, node_id, scenario_id),
+        )
+        logger.info(
+            "override.applied scenario=%s node=%s field=%s old=%r new=%r by=%s",
+            scenario_id,
+            node_id,
+            field_name,
+            old_value,
+            new_value,
+            applied_by,
+        )
+
+        # 4. Create policy_changed event to trigger recalculation
+        event_id = uuid4()
+        db.execute(
+            """
+            INSERT INTO events (
+                event_id, event_type, scenario_id, trigger_node_id,
+                field_changed, old_text, new_text,
+                processed, source, user_ref, created_at
+            ) VALUES (%s, 'policy_changed', %s, %s, %s, %s, %s, FALSE, 'engine', %s, %s)
+            """,
+            (
+                event_id,
+                scenario_id,
+                node_id,
+                field_name,
+                old_value,
+                new_value,
+                applied_by,
+                now,
+            ),
+        )
+        logger.debug(
+            "override.event event_id=%s scenario=%s trigger_node=%s",
+            event_id,
+            scenario_id,
+            node_id,
+        )
+
+        return ScenarioOverride(
+            override_id=persisted_override_id,
+            scenario_id=scenario_id,
+            node_id=node_id,
+            field_name=field_name,
+            old_value=old_value,
+            new_value=new_value,
+            applied_at=now,
+            applied_by=applied_by,
+        )
+
+    # ------------------------------------------------------------------
+    # diff
+    # ------------------------------------------------------------------
+
+    def diff(
+        self,
+        scenario_id: UUID,
+        baseline_id: UUID,
+        db: psycopg.Connection,
+        baseline_calc_run_id: Optional[UUID] = None,
+        scenario_calc_run_id: Optional[UUID] = None,
+    ) -> list[ScenarioDiff]:
+        """
+        Diff all nodes in scenario vs baseline across the DIFF_FIELDS.
+
+        If calc_run IDs are not provided, the latest completed calc_run for
+        each scenario is used.  Only nodes that differ in at least one field
+        are returned.
+
+        Differences are persisted in scenario_diffs (upsert on UNIQUE key).
+
+        Returns a list of ScenarioDiff (one entry per changed field per node).
+        """
+        # Resolve calc_runs if not supplied
+        if baseline_calc_run_id is None:
+            baseline_calc_run_id = self._latest_calc_run(baseline_id, db)
+        if scenario_calc_run_id is None:
+            scenario_calc_run_id = self._latest_calc_run(scenario_id, db)
+
+        # Fetch all nodes for baseline and scenario
+        baseline_nodes = _fetch_nodes_as_dict(baseline_id, db)
+        scenario_nodes = _fetch_nodes_as_dict(scenario_id, db)
+
+        diffs: list[ScenarioDiff] = []
+        now = datetime.now(timezone.utc)
+
+        # Match by (item_id, location_id, node_type, time_span_start, bucket_sequence)
+        # Nodes are matched by a stable business key, not node_id (which differs after copy).
+        baseline_index = _build_node_index(baseline_nodes)
+        scenario_index = _build_node_index(scenario_nodes)
+
+        all_keys = set(baseline_index.keys()) | set(scenario_index.keys())
+
+        for key in all_keys:
+            b_node = baseline_index.get(key)
+            s_node = scenario_index.get(key)
+
+            for field in _DIFF_FIELDS:
+                b_val = _node_field_str(b_node, field) if b_node else None
+                s_val = _node_field_str(s_node, field) if s_node else None
+
+                if b_val == s_val:
+                    continue
+
+                # Use the scenario node_id if available, else baseline node_id
+                node_id = UUID(str(s_node["node_id"])) if s_node else UUID(str(b_node["node_id"]))
+
+                diff_id = uuid4()
+                db.execute(
+                    """
+                    INSERT INTO scenario_diffs (
+                        diff_id, scenario_id,
+                        baseline_calc_run_id, scenario_calc_run_id,
+                        node_id, field_name,
+                        baseline_value, scenario_value, created_at
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (scenario_id, baseline_calc_run_id, scenario_calc_run_id, node_id, field_name)
+                    DO UPDATE SET
+                        baseline_value = EXCLUDED.baseline_value,
+                        scenario_value = EXCLUDED.scenario_value
+                    """,
+                    (
+                        diff_id,
+                        scenario_id,
+                        baseline_calc_run_id,
+                        scenario_calc_run_id,
+                        node_id,
+                        field,
+                        b_val,
+                        s_val,
+                        now,
+                    ),
+                )
+                persisted_diff_id = diff_id
+
+                diffs.append(
+                    ScenarioDiff(
+                        diff_id=persisted_diff_id,
+                        scenario_id=scenario_id,
+                        baseline_calc_run_id=baseline_calc_run_id,
+                        scenario_calc_run_id=scenario_calc_run_id,
+                        node_id=node_id,
+                        field_name=field,
+                        baseline_value=b_val,
+                        scenario_value=s_val,
+                        created_at=now,
+                    )
+                )
+
+        logger.info(
+            "diff.complete scenario=%s baseline=%s diff_count=%d",
+            scenario_id,
+            baseline_id,
+            len(diffs),
+        )
+        return diffs
+
+    def _latest_calc_run(self, scenario_id: UUID, db: psycopg.Connection) -> UUID:
+        """Return the calc_run_id of the latest completed calc_run for a scenario."""
+        row = db.execute(
+            """
+            SELECT calc_run_id FROM calc_runs
+            WHERE scenario_id = %s AND status = 'completed'
+            ORDER BY completed_at DESC NULLS LAST, created_at DESC
+            LIMIT 1
+            """,
+            (scenario_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError(
+                f"No completed calc_run found for scenario {scenario_id}. "
+                "Run a calculation first."
+            )
+        return UUID(str(row["calc_run_id"]))
+
+    # ------------------------------------------------------------------
+    # promote
+    # ------------------------------------------------------------------
+
+    def promote(
+        self,
+        scenario_id: UUID,
+        db: psycopg.Connection,
+    ) -> None:
+        """
+        Promote a scenario to baseline.
+
+        Per EXPERT Q4.5 — merge is a first-class event:
+          1. For each node override in the scenario, apply its new_value to
+             the corresponding baseline node (matched by business key).
+          2. Mark the old baseline scenario as 'archived'.
+          3. Create a 'scenario_merge' event.
+          4. Mark all other active variant scenarios as 'stale' (not
+             implemented at schema level yet — logged only for now).
+
+        The scenario being promoted retains its own status and nodes.
+        The baseline scenario's nodes are patched with the promoted values.
+        """
+        # 1. Load all overrides for this scenario
+        override_rows = db.execute(
+            """
+            SELECT node_id, field_name, new_value
+            FROM scenario_overrides
+            WHERE scenario_id = %s
+            """,
+            (scenario_id,),
+        ).fetchall()
+
+        # 2. Load nodes from the promoted scenario → build match key → patch baseline
+        scenario_nodes = _fetch_nodes_as_dict(scenario_id, db)
+        scenario_index = {UUID(str(n["node_id"])): n for n in scenario_nodes}
+
+        now = datetime.now(timezone.utc)
+        patched = 0
+
+        for ov in override_rows:
+            ov_node_id = UUID(str(ov["node_id"]))
+            field_name = ov["field_name"]
+            new_value = ov["new_value"]
+
+            _validate_field_name(field_name)
+
+            s_node = scenario_index.get(ov_node_id)
+            if s_node is None:
+                logger.warning(
+                    "promote.skip node_id=%s not found in scenario nodes", ov_node_id
+                )
+                continue
+
+            # Find the matching baseline node by business key
+            b_key = _node_business_key(s_node)
+            b_rows = db.execute(
+                """
+                SELECT node_id FROM nodes
+                WHERE scenario_id = %s
+                  AND node_type = %s
+                  AND item_id IS NOT DISTINCT FROM %s
+                  AND location_id IS NOT DISTINCT FROM %s
+                  AND time_span_start IS NOT DISTINCT FROM %s
+                  AND bucket_sequence IS NOT DISTINCT FROM %s
+                  AND active = TRUE
+                """,
+                (
+                    _BASELINE_ID,
+                    b_key["node_type"],
+                    b_key["item_id"],
+                    b_key["location_id"],
+                    b_key["time_span_start"],
+                    b_key["bucket_sequence"],
+                ),
+            ).fetchall()
+
+            for b_row in b_rows:
+                db.execute(
+                    f"""
+                    UPDATE nodes
+                    SET {field_name} = %s,
+                        is_dirty     = TRUE,
+                        updated_at   = %s
+                    WHERE node_id = %s AND scenario_id = %s
+                    """,
+                    (new_value, now, UUID(str(b_row["node_id"])), _BASELINE_ID),
+                )
+                patched += 1
+
+        # 3. Archive the promoted scenario
+        db.execute(
+            """
+            UPDATE scenarios
+            SET status     = 'archived',
+                updated_at = %s
+            WHERE scenario_id = %s
+            """,
+            (now, scenario_id),
+        )
+
+        # 4. Create scenario_merge event (baseline scope)
+        event_id = uuid4()
+        db.execute(
+            """
+            INSERT INTO events (
+                event_id, event_type, scenario_id,
+                old_text, new_text,
+                processed, source, created_at
+            ) VALUES (%s, 'scenario_merge', %s, %s, %s, FALSE, 'engine', %s)
+            """,
+            (
+                event_id,
+                _BASELINE_ID,
+                str(scenario_id),   # old_text = source scenario_id
+                "promoted",
+                now,
+            ),
+        )
+
+        logger.info(
+            "promote.complete scenario=%s patched_nodes=%d merge_event=%s",
+            scenario_id,
+            patched,
+            event_id,
+        )
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+# Allowed field names for override and dynamic UPDATE (whitelist)
+_ALLOWED_FIELDS: frozenset[str] = frozenset(
+    [
+        "quantity",
+        "time_ref",
+        "time_span_start",
+        "time_span_end",
+        "opening_stock",
+        "inflows",
+        "outflows",
+        "closing_stock",
+        "has_shortage",
+        "shortage_qty",
+        "is_dirty",
+        "active",
+        "qty_uom",
+        "time_grain",
+    ]
+)
+
+
+def _validate_field_name(field_name: str) -> None:
+    """Guard against SQL injection in dynamic column names."""
+    if field_name not in _ALLOWED_FIELDS:
+        raise ValueError(
+            f"field_name {field_name!r} is not in the allowed override field list. "
+            f"Allowed: {sorted(_ALLOWED_FIELDS)}"
+        )
+
+
+def _fetch_nodes_as_dict(scenario_id: UUID, db: psycopg.Connection) -> list[dict]:
+    """Fetch all active nodes for a scenario as raw dicts."""
+    return db.execute(
+        "SELECT * FROM nodes WHERE scenario_id = %s AND active = TRUE",
+        (scenario_id,),
+    ).fetchall()
+
+
+def _build_node_index(nodes: list[dict]) -> dict[tuple, dict]:
+    """
+    Build a lookup index keyed by (node_type, item_id, location_id,
+    time_span_start, bucket_sequence) — the stable business key for node matching
+    across scenarios.
+    """
+    index: dict[tuple, dict] = {}
+    for node in nodes:
+        key = _node_business_key(node)
+        index[tuple(key.values())] = node
+    return index
+
+
+def _node_business_key(node: dict) -> dict:
+    return {
+        "node_type": node["node_type"],
+        "item_id": node["item_id"],
+        "location_id": node["location_id"],
+        "time_span_start": node["time_span_start"],
+        "bucket_sequence": node["bucket_sequence"],
+    }
+
+
+def _node_field_str(node: dict, field: str) -> Optional[str]:
+    """Return field value as string, or None."""
+    val = node.get(field)
+    if val is None:
+        return None
+    return str(val)

--- a/src/ootils_core/models/__init__.py
+++ b/src/ootils_core/models/__init__.py
@@ -311,3 +311,42 @@ class AllocationResult:
     edges_created: int
     edges_updated: int
     run_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Scenario M5 models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ScenarioOverride:
+    """
+    A user/agent override applied to a specific node field within a scenario.
+    Values are serialized as TEXT — this is intentional: overrides represent
+    user intent, not computed state.
+    """
+    override_id: UUID
+    scenario_id: UUID
+    node_id: UUID
+    field_name: str
+    old_value: Optional[str]
+    new_value: str
+    applied_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    applied_by: Optional[str] = None
+
+
+@dataclass
+class ScenarioDiff:
+    """
+    One field-level difference between a baseline calc_run result and a
+    scenario calc_run result on the same node.
+    """
+    diff_id: UUID
+    scenario_id: UUID
+    baseline_calc_run_id: UUID
+    scenario_calc_run_id: UUID
+    node_id: UUID
+    field_name: str
+    baseline_value: Optional[str]
+    scenario_value: Optional[str]
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))

--- a/tests/test_m5_scenarios.py
+++ b/tests/test_m5_scenarios.py
@@ -1,0 +1,539 @@
+"""
+tests/test_m5_scenarios.py — Sprint M5 Scenario management tests.
+
+Covers:
+  - create_scenario creates a scenario with the correct parent
+  - apply_override creates the override and the policy_changed event
+  - diff returns the correct differences
+  - diff returns empty list when there are no differences
+  - Override with same field → upsert (no duplicate)
+  - promote archives the scenario and creates a scenario_merge event
+
+All tests use mocks — no real DB required.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Any, Optional
+from unittest.mock import MagicMock, call, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from ootils_core.models import (
+    Scenario,
+    ScenarioDiff,
+    ScenarioOverride,
+)
+from ootils_core.engine.scenario.manager import ScenarioManager
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+BASELINE_ID = UUID("00000000-0000-0000-0000-000000000001")
+
+
+def _uuid(n: int) -> UUID:
+    """Deterministic UUID from int for test readability."""
+    return UUID(f"00000000-0000-0000-0000-{n:012d}")
+
+
+def make_mock_db() -> MagicMock:
+    """Return a mock psycopg3 Connection."""
+    db = MagicMock()
+    # Default: execute(...).fetchone() → None, fetchall() → []
+    db.execute.return_value.fetchone.return_value = None
+    db.execute.return_value.fetchall.return_value = []
+    return db
+
+
+def make_node_row(
+    node_id: UUID,
+    scenario_id: UUID,
+    node_type: str = "ProjectedInventory",
+    closing_stock: Optional[str] = None,
+    opening_stock: Optional[str] = None,
+    inflows: Optional[str] = None,
+    outflows: Optional[str] = None,
+    has_shortage: bool = False,
+    shortage_qty: str = "0",
+    item_id: Optional[UUID] = None,
+    location_id: Optional[UUID] = None,
+    time_span_start: Optional[date] = None,
+    bucket_sequence: Optional[int] = None,
+) -> dict:
+    """Build a fake DB node row dict."""
+    return {
+        "node_id": node_id,
+        "scenario_id": scenario_id,
+        "node_type": node_type,
+        "item_id": item_id,
+        "location_id": location_id,
+        "quantity": None,
+        "qty_uom": None,
+        "time_grain": "day",
+        "time_ref": None,
+        "time_span_start": time_span_start,
+        "time_span_end": None,
+        "is_dirty": False,
+        "last_calc_run_id": None,
+        "active": True,
+        "projection_series_id": None,
+        "bucket_sequence": bucket_sequence,
+        "opening_stock": opening_stock,
+        "inflows": inflows,
+        "outflows": outflows,
+        "closing_stock": closing_stock,
+        "has_shortage": has_shortage,
+        "shortage_qty": shortage_qty,
+        "has_exact_date_inputs": False,
+        "has_week_inputs": False,
+        "has_month_inputs": False,
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": datetime.now(timezone.utc),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test: create_scenario
+# ---------------------------------------------------------------------------
+
+
+class TestCreateScenario:
+    def test_creates_scenario_with_correct_parent(self):
+        """create_scenario should insert a new scenario and return it."""
+        db = make_mock_db()
+        # No nodes to copy (fetchall → [])
+        db.execute.return_value.fetchall.return_value = []
+
+        manager = ScenarioManager()
+        scenario = manager.create_scenario(
+            name="Demand Surge",
+            parent_scenario_id=BASELINE_ID,
+            db=db,
+        )
+
+        assert isinstance(scenario, Scenario)
+        assert scenario.name == "Demand Surge"
+        assert scenario.parent_scenario_id == BASELINE_ID
+        assert scenario.is_baseline is False
+        assert scenario.status == "active"
+        assert isinstance(scenario.scenario_id, UUID)
+
+        # Verify INSERT into scenarios was called
+        insert_calls = [
+            c for c in db.execute.call_args_list
+            if "INSERT INTO scenarios" in str(c)
+        ]
+        assert len(insert_calls) >= 1
+
+    def test_copies_parent_nodes_to_new_scenario(self):
+        """create_scenario should deep-copy parent nodes with new IDs."""
+        db = make_mock_db()
+        parent_id = BASELINE_ID
+        parent_node = make_node_row(
+            node_id=_uuid(1),
+            scenario_id=parent_id,
+            closing_stock="100",
+        )
+        # Return parent nodes on the first fetchall call
+        db.execute.return_value.fetchall.return_value = [parent_node]
+
+        manager = ScenarioManager()
+        scenario = manager.create_scenario(
+            name="S1",
+            parent_scenario_id=parent_id,
+            db=db,
+        )
+
+        # At least one INSERT INTO nodes should have been called
+        insert_node_calls = [
+            c for c in db.execute.call_args_list if "INSERT INTO nodes" in str(c)
+        ]
+        assert len(insert_node_calls) >= 1
+
+    def test_new_scenario_id_differs_from_parent(self):
+        """Resulting scenario_id must be fresh (not the parent's)."""
+        db = make_mock_db()
+        db.execute.return_value.fetchall.return_value = []
+
+        manager = ScenarioManager()
+        scenario = manager.create_scenario("S2", BASELINE_ID, db)
+
+        assert scenario.scenario_id != BASELINE_ID
+
+
+# ---------------------------------------------------------------------------
+# Test: apply_override
+# ---------------------------------------------------------------------------
+
+
+class TestApplyOverride:
+    def _make_db_for_override(
+        self,
+        old_value: Optional[str] = "50",
+        override_id: Optional[UUID] = None,
+    ) -> MagicMock:
+        """
+        Build a mock DB that returns expected rows for apply_override:
+          - first fetchone → node row with current field value
+          - second fetchone (RETURNING override_id) → override row
+        """
+        db = MagicMock()
+        oid = override_id or uuid4()
+
+        node_row = MagicMock()
+        node_row.__getitem__ = lambda self, k: old_value if k == "quantity" else None
+
+        override_row = MagicMock()
+        override_row.__getitem__ = lambda self, k: oid if k == "override_id" else None
+
+        # Sequence: 1st execute → node SELECT, 2nd → INSERT override RETURNING,
+        #           3rd → SELECT override_id, 4th → UPDATE nodes, 5th → INSERT event
+        db.execute.return_value.fetchone.side_effect = [
+            node_row,
+            override_row,
+            override_row,
+        ]
+        return db
+
+    def test_returns_scenario_override(self):
+        node_id = _uuid(10)
+        scenario_id = _uuid(20)
+        db = self._make_db_for_override()
+
+        manager = ScenarioManager()
+        result = manager.apply_override(
+            scenario_id=scenario_id,
+            node_id=node_id,
+            field_name="quantity",
+            new_value="75",
+            applied_by="test-agent",
+            db=db,
+        )
+
+        assert isinstance(result, ScenarioOverride)
+        assert result.scenario_id == scenario_id
+        assert result.node_id == node_id
+        assert result.field_name == "quantity"
+        assert result.new_value == "75"
+        assert result.applied_by == "test-agent"
+
+    def test_creates_policy_changed_event(self):
+        """apply_override must insert a policy_changed event."""
+        node_id = _uuid(10)
+        scenario_id = _uuid(20)
+        db = self._make_db_for_override()
+
+        manager = ScenarioManager()
+        manager.apply_override(
+            scenario_id=scenario_id,
+            node_id=node_id,
+            field_name="quantity",
+            new_value="75",
+            applied_by=None,
+            db=db,
+        )
+
+        event_inserts = [
+            c for c in db.execute.call_args_list
+            if "policy_changed" in str(c)
+        ]
+        assert len(event_inserts) >= 1
+
+    def test_upserts_override_no_duplicate(self):
+        """Applying an override on same (scenario, node, field) should upsert."""
+        node_id = _uuid(10)
+        scenario_id = _uuid(20)
+        db = self._make_db_for_override()
+
+        manager = ScenarioManager()
+        manager.apply_override(
+            scenario_id=scenario_id,
+            node_id=node_id,
+            field_name="quantity",
+            new_value="75",
+            applied_by=None,
+            db=db,
+        )
+
+        # The SQL must contain ON CONFLICT ... DO UPDATE
+        upsert_calls = [
+            c for c in db.execute.call_args_list
+            if "ON CONFLICT" in str(c) and "scenario_overrides" in str(c)
+        ]
+        assert len(upsert_calls) >= 1
+
+    def test_rejects_invalid_field_name(self):
+        """apply_override should raise ValueError for disallowed field names."""
+        db = make_mock_db()
+        manager = ScenarioManager()
+
+        with pytest.raises(ValueError, match="not in the allowed override field list"):
+            manager.apply_override(
+                scenario_id=_uuid(1),
+                node_id=_uuid(2),
+                field_name="DROP TABLE nodes; --",
+                new_value="evil",
+                applied_by=None,
+                db=db,
+            )
+
+    def test_old_value_is_captured(self):
+        """old_value should reflect the node's current field value."""
+        node_id = _uuid(10)
+        scenario_id = _uuid(20)
+        db = self._make_db_for_override(old_value="50")
+
+        manager = ScenarioManager()
+        result = manager.apply_override(
+            scenario_id=scenario_id,
+            node_id=node_id,
+            field_name="quantity",
+            new_value="99",
+            applied_by=None,
+            db=db,
+        )
+
+        assert result.old_value == "50"
+
+
+# ---------------------------------------------------------------------------
+# Test: diff
+# ---------------------------------------------------------------------------
+
+
+class TestDiff:
+    SCENARIO_ID = _uuid(100)
+    BASELINE_ID_LOCAL = BASELINE_ID
+    CALC_RUN_B = _uuid(200)
+    CALC_RUN_S = _uuid(201)
+    ITEM_ID = _uuid(300)
+    LOC_ID = _uuid(301)
+    DATE = date(2026, 4, 1)
+
+    def _make_db(
+        self,
+        baseline_nodes: list[dict],
+        scenario_nodes: list[dict],
+    ) -> MagicMock:
+        """
+        Mock DB for diff() called with explicit calc_run IDs (no _latest_calc_run needed).
+        fetchall sequence: 1st → baseline nodes, 2nd → scenario nodes.
+        """
+        db = MagicMock()
+        db.execute.return_value.fetchone.return_value = None
+        db.execute.return_value.fetchall.side_effect = [
+            baseline_nodes,
+            scenario_nodes,
+        ]
+        return db
+
+    def test_returns_diffs_for_changed_fields(self):
+        """diff() should return ScenarioDiff entries for changed closing_stock."""
+        node_b = make_node_row(
+            node_id=_uuid(1),
+            scenario_id=self.BASELINE_ID_LOCAL,
+            closing_stock="100",
+            item_id=self.ITEM_ID,
+            location_id=self.LOC_ID,
+            time_span_start=self.DATE,
+            bucket_sequence=0,
+        )
+        node_s = make_node_row(
+            node_id=_uuid(2),
+            scenario_id=self.SCENARIO_ID,
+            closing_stock="80",
+            item_id=self.ITEM_ID,
+            location_id=self.LOC_ID,
+            time_span_start=self.DATE,
+            bucket_sequence=0,
+        )
+
+        db = self._make_db([node_b], [node_s])
+        manager = ScenarioManager()
+        diffs = manager.diff(
+            scenario_id=self.SCENARIO_ID,
+            baseline_id=self.BASELINE_ID_LOCAL,
+            db=db,
+            baseline_calc_run_id=self.CALC_RUN_B,
+            scenario_calc_run_id=self.CALC_RUN_S,
+        )
+
+        assert len(diffs) >= 1
+        fields = [d.field_name for d in diffs]
+        assert "closing_stock" in fields
+
+        closing_diff = next(d for d in diffs if d.field_name == "closing_stock")
+        assert closing_diff.baseline_value == "100"
+        assert closing_diff.scenario_value == "80"
+        assert closing_diff.scenario_id == self.SCENARIO_ID
+
+    def test_returns_empty_list_when_no_diff(self):
+        """diff() should return [] when all compared fields are identical."""
+        node_b = make_node_row(
+            node_id=_uuid(1),
+            scenario_id=self.BASELINE_ID_LOCAL,
+            closing_stock="100",
+            opening_stock="120",
+            inflows="50",
+            outflows="70",
+            has_shortage=False,
+            shortage_qty="0",
+            item_id=self.ITEM_ID,
+            location_id=self.LOC_ID,
+            time_span_start=self.DATE,
+            bucket_sequence=0,
+        )
+        node_s = make_node_row(
+            node_id=_uuid(2),
+            scenario_id=self.SCENARIO_ID,
+            closing_stock="100",
+            opening_stock="120",
+            inflows="50",
+            outflows="70",
+            has_shortage=False,
+            shortage_qty="0",
+            item_id=self.ITEM_ID,
+            location_id=self.LOC_ID,
+            time_span_start=self.DATE,
+            bucket_sequence=0,
+        )
+
+        db = self._make_db([node_b], [node_s])
+        manager = ScenarioManager()
+        diffs = manager.diff(
+            scenario_id=self.SCENARIO_ID,
+            baseline_id=self.BASELINE_ID_LOCAL,
+            db=db,
+            baseline_calc_run_id=self.CALC_RUN_B,
+            scenario_calc_run_id=self.CALC_RUN_S,
+        )
+
+        assert diffs == []
+
+    def test_diff_returns_scenario_diff_instances(self):
+        """All entries returned by diff() should be ScenarioDiff instances."""
+        node_b = make_node_row(
+            node_id=_uuid(1),
+            scenario_id=self.BASELINE_ID_LOCAL,
+            closing_stock="100",
+            has_shortage=False,
+            shortage_qty="0",
+            item_id=self.ITEM_ID,
+            location_id=self.LOC_ID,
+            time_span_start=self.DATE,
+            bucket_sequence=0,
+        )
+        node_s = make_node_row(
+            node_id=_uuid(2),
+            scenario_id=self.SCENARIO_ID,
+            closing_stock="0",
+            has_shortage=True,
+            shortage_qty="100",
+            item_id=self.ITEM_ID,
+            location_id=self.LOC_ID,
+            time_span_start=self.DATE,
+            bucket_sequence=0,
+        )
+
+        db = self._make_db([node_b], [node_s])
+        manager = ScenarioManager()
+        diffs = manager.diff(
+            scenario_id=self.SCENARIO_ID,
+            baseline_id=self.BASELINE_ID_LOCAL,
+            db=db,
+            baseline_calc_run_id=self.CALC_RUN_B,
+            scenario_calc_run_id=self.CALC_RUN_S,
+        )
+
+        for d in diffs:
+            assert isinstance(d, ScenarioDiff)
+
+
+# ---------------------------------------------------------------------------
+# Test: promote
+# ---------------------------------------------------------------------------
+
+
+class TestPromote:
+    SCENARIO_ID = _uuid(500)
+    ITEM_ID = _uuid(600)
+    LOC_ID = _uuid(601)
+    DATE = date(2026, 4, 1)
+
+    def _make_db_for_promote(
+        self,
+        override_rows: list[dict],
+        scenario_nodes: list[dict],
+    ) -> MagicMock:
+        db = MagicMock()
+
+        # fetchall sequence:
+        #   1st → override rows, 2nd → scenario nodes,
+        #   3rd onward → baseline node matches (one per override)
+        baseline_node_row = MagicMock()
+        baseline_node_row.__getitem__ = lambda self, k: _uuid(999) if k == "node_id" else None
+
+        fetchall_side_effects = (
+            [override_rows, scenario_nodes]
+            + [[baseline_node_row]] * len(override_rows)
+        )
+        db.execute.return_value.fetchall.side_effect = fetchall_side_effects
+        db.execute.return_value.fetchone.return_value = None
+
+        return db
+
+    def test_archives_scenario_on_promote(self):
+        """promote() should UPDATE scenarios.status = 'archived'."""
+        scenario_node = make_node_row(
+            node_id=_uuid(50),
+            scenario_id=self.SCENARIO_ID,
+            item_id=self.ITEM_ID,
+            location_id=self.LOC_ID,
+            time_span_start=self.DATE,
+            bucket_sequence=0,
+        )
+        override = {
+            "node_id": _uuid(50),
+            "field_name": "quantity",
+            "new_value": "200",
+        }
+
+        db = self._make_db_for_promote([override], [scenario_node])
+        manager = ScenarioManager()
+        manager.promote(scenario_id=self.SCENARIO_ID, db=db)
+
+        archive_calls = [
+            c for c in db.execute.call_args_list
+            if "archived" in str(c) and "UPDATE scenarios" in str(c)
+        ]
+        assert len(archive_calls) >= 1
+
+    def test_creates_scenario_merge_event(self):
+        """promote() should insert a scenario_merge event."""
+        db = self._make_db_for_promote([], [])
+        manager = ScenarioManager()
+        manager.promote(scenario_id=self.SCENARIO_ID, db=db)
+
+        merge_events = [
+            c for c in db.execute.call_args_list
+            if "scenario_merge" in str(c)
+        ]
+        assert len(merge_events) >= 1
+
+    def test_promote_with_no_overrides(self):
+        """promote() with zero overrides should still archive and create event."""
+        db = self._make_db_for_promote([], [])
+        manager = ScenarioManager()
+        manager.promote(scenario_id=self.SCENARIO_ID, db=db)
+
+        archive_calls = [
+            c for c in db.execute.call_args_list
+            if "archived" in str(c)
+        ]
+        assert len(archive_calls) >= 1


### PR DESCRIPTION
## Sprint M5 — Scenarios

**ScenarioManager** (`engine/scenario/manager.py`)
- `create_scenario` — deep copy des nodes du parent dans le nouveau scénario
- `apply_override` — upsert `scenario_overrides` + UPDATE node + PlanningEvent `policy_changed`
- `diff` — compare baseline vs scénario sur closing_stock/opening_stock/inflows/outflows/has_shortage/shortage_qty, persiste dans `scenario_diffs`
- `promote` — scenario_merge event first-class, archive scénario source, patch nodes baseline

**Sécurité** : `field_name` validé contre whitelist (`_ALLOWED_FIELDS`) avant injection dans UPDATE dynamique

**Migration 006** : tables `scenario_overrides` + `scenario_diffs`, extension CHECK `event_type` pour `scenario_merge`

**162 tests passent / 4 skipped (DB)**