### PR TITLE
Sprint M6: REST API V1 — 7 endpoints, OpenAPI spec, Bearer auth

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1,0 +1,1531 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Ootils Core API",
+    "description": "Ootils Core REST API \u2014 supply chain planning engine.",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Health",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Health Health Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/events": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Create Event",
+        "description": "Submit a planning event that triggers recalculation.",
+        "operationId": "create_event_v1_events_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "scenario_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scenario UUID or 'baseline'",
+              "title": "Scenario Id"
+            },
+            "description": "Scenario UUID or 'baseline'"
+          },
+          {
+            "name": "X-Scenario-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Scenario-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projection": {
+      "get": {
+        "tags": [
+          "projection"
+        ],
+        "summary": "Get Projection",
+        "description": "Return projected inventory buckets for an item/location pair.",
+        "operationId": "get_projection_v1_projection_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Item identifier (UUID or string key)",
+              "title": "Item Id"
+            },
+            "description": "Item identifier (UUID or string key)"
+          },
+          {
+            "name": "location_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Location identifier (UUID or string key)",
+              "title": "Location Id"
+            },
+            "description": "Location identifier (UUID or string key)"
+          },
+          {
+            "name": "grain",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "day / week / month",
+              "title": "Grain"
+            },
+            "description": "day / week / month"
+          },
+          {
+            "name": "scenario_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scenario UUID or 'baseline'",
+              "title": "Scenario Id"
+            },
+            "description": "Scenario UUID or 'baseline'"
+          },
+          {
+            "name": "X-Scenario-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Scenario-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/issues": {
+      "get": {
+        "tags": [
+          "issues"
+        ],
+        "summary": "Get Issues",
+        "description": "Return active shortages filtered by severity and horizon.",
+        "operationId": "get_issues_v1_issues_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "severity",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "low / medium / high / all",
+              "default": "all",
+              "title": "Severity"
+            },
+            "description": "low / medium / high / all"
+          },
+          {
+            "name": "horizon_days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Look-ahead window in days",
+              "default": 90,
+              "title": "Horizon Days"
+            },
+            "description": "Look-ahead window in days"
+          },
+          {
+            "name": "item_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by item ID",
+              "title": "Item Id"
+            },
+            "description": "Filter by item ID"
+          },
+          {
+            "name": "location_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by location ID",
+              "title": "Location Id"
+            },
+            "description": "Filter by location ID"
+          },
+          {
+            "name": "scenario_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scenario UUID or 'baseline'",
+              "title": "Scenario Id"
+            },
+            "description": "Scenario UUID or 'baseline'"
+          },
+          {
+            "name": "X-Scenario-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Scenario-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssuesResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/explain": {
+      "get": {
+        "tags": [
+          "explain"
+        ],
+        "summary": "Get Explanation",
+        "description": "Return the causal explanation for a planning node.",
+        "operationId": "get_explanation_v1_explain_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "node_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Target node UUID to explain",
+              "title": "Node Id"
+            },
+            "description": "Target node UUID to explain"
+          },
+          {
+            "name": "scenario_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scenario UUID or 'baseline'",
+              "title": "Scenario Id"
+            },
+            "description": "Scenario UUID or 'baseline'"
+          },
+          {
+            "name": "X-Scenario-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Scenario-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExplainResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/simulate": {
+      "post": {
+        "tags": [
+          "simulate"
+        ],
+        "summary": "Create Simulation",
+        "description": "Create a new scenario with overrides and compute the delta vs base.",
+        "operationId": "create_simulation_v1_simulate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SimulateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimulateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/v1/graph": {
+      "get": {
+        "tags": [
+          "graph"
+        ],
+        "summary": "Get Graph",
+        "description": "Return nodes and edges for the planning graph at (item, location, scenario).",
+        "operationId": "get_graph_v1_graph_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "item_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Item UUID or name",
+              "title": "Item Id"
+            },
+            "description": "Item UUID or name"
+          },
+          {
+            "name": "location_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Location UUID or name",
+              "title": "Location Id"
+            },
+            "description": "Location UUID or name"
+          },
+          {
+            "name": "depth",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 5,
+              "minimum": 1,
+              "description": "Graph traversal depth",
+              "default": 2,
+              "title": "Depth"
+            },
+            "description": "Graph traversal depth"
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "From"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "To"
+            }
+          },
+          {
+            "name": "scenario_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scenario UUID or 'baseline'",
+              "title": "Scenario Id"
+            },
+            "description": "Scenario UUID or 'baseline'"
+          },
+          {
+            "name": "X-Scenario-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Scenario-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GraphResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CausalStepOut": {
+        "properties": {
+          "step": {
+            "type": "integer",
+            "title": "Step"
+          },
+          "node_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Node Id"
+          },
+          "node_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Node Type"
+          },
+          "edge_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Edge Type"
+          },
+          "fact": {
+            "type": "string",
+            "title": "Fact"
+          }
+        },
+        "type": "object",
+        "required": [
+          "step",
+          "node_id",
+          "node_type",
+          "edge_type",
+          "fact"
+        ],
+        "title": "CausalStepOut"
+      },
+      "EdgeOut": {
+        "properties": {
+          "edge_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Edge Id"
+          },
+          "edge_type": {
+            "type": "string",
+            "title": "Edge Type"
+          },
+          "from_node_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "From Node Id"
+          },
+          "to_node_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "To Node Id"
+          },
+          "priority": {
+            "type": "integer",
+            "title": "Priority"
+          },
+          "weight_ratio": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Weight Ratio"
+          }
+        },
+        "type": "object",
+        "required": [
+          "edge_id",
+          "edge_type",
+          "from_node_id",
+          "to_node_id",
+          "priority",
+          "weight_ratio"
+        ],
+        "title": "EdgeOut"
+      },
+      "EventRequest": {
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "title": "Event Type"
+          },
+          "trigger_node_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trigger Node Id"
+          },
+          "scenario_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scenario Id"
+          },
+          "field_changed": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Field Changed"
+          },
+          "old_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Old Date"
+          },
+          "new_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "New Date"
+          },
+          "old_quantity": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Old Quantity"
+          },
+          "new_quantity": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "New Quantity"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "default": "api"
+          }
+        },
+        "type": "object",
+        "required": [
+          "event_type"
+        ],
+        "title": "EventRequest"
+      },
+      "EventResponse": {
+        "properties": {
+          "event_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Event Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "scenario_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Scenario Id"
+          },
+          "affected_nodes_estimate": {
+            "type": "integer",
+            "title": "Affected Nodes Estimate"
+          },
+          "calc_run_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Calc Run Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "event_id",
+          "status",
+          "scenario_id",
+          "affected_nodes_estimate",
+          "calc_run_id"
+        ],
+        "title": "EventResponse"
+      },
+      "ExplainResponse": {
+        "properties": {
+          "explanation_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Explanation Id"
+          },
+          "target_node_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Target Node Id"
+          },
+          "target_type": {
+            "type": "string",
+            "title": "Target Type"
+          },
+          "summary": {
+            "type": "string",
+            "title": "Summary"
+          },
+          "causal_path": {
+            "items": {
+              "$ref": "#/components/schemas/CausalStepOut"
+            },
+            "type": "array",
+            "title": "Causal Path"
+          },
+          "root_cause_node_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Root Cause Node Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "explanation_id",
+          "target_node_id",
+          "target_type",
+          "summary",
+          "causal_path",
+          "root_cause_node_id"
+        ],
+        "title": "ExplainResponse"
+      },
+      "GraphResponse": {
+        "properties": {
+          "nodes": {
+            "items": {
+              "$ref": "#/components/schemas/NodeOut"
+            },
+            "type": "array",
+            "title": "Nodes"
+          },
+          "edges": {
+            "items": {
+              "$ref": "#/components/schemas/EdgeOut"
+            },
+            "type": "array",
+            "title": "Edges"
+          },
+          "item_id": {
+            "type": "string",
+            "title": "Item Id"
+          },
+          "location_id": {
+            "type": "string",
+            "title": "Location Id"
+          },
+          "scenario_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Scenario Id"
+          },
+          "depth": {
+            "type": "integer",
+            "title": "Depth"
+          }
+        },
+        "type": "object",
+        "required": [
+          "nodes",
+          "edges",
+          "item_id",
+          "location_id",
+          "scenario_id",
+          "depth"
+        ],
+        "title": "GraphResponse"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "IssueRecord": {
+        "properties": {
+          "node_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Node Id"
+          },
+          "item_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Id"
+          },
+          "location_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location Id"
+          },
+          "shortage_qty": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Shortage Qty"
+          },
+          "severity_score": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Severity Score"
+          },
+          "severity": {
+            "type": "string",
+            "title": "Severity"
+          },
+          "shortage_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shortage Date"
+          },
+          "explanation_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Explanation Id"
+          },
+          "explanation_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Explanation Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "node_id",
+          "item_id",
+          "location_id",
+          "shortage_qty",
+          "severity_score",
+          "severity",
+          "shortage_date",
+          "explanation_id",
+          "explanation_url"
+        ],
+        "title": "IssueRecord"
+      },
+      "IssuesResponse": {
+        "properties": {
+          "issues": {
+            "items": {
+              "$ref": "#/components/schemas/IssueRecord"
+            },
+            "type": "array",
+            "title": "Issues"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "as_of": {
+            "type": "string",
+            "title": "As Of"
+          }
+        },
+        "type": "object",
+        "required": [
+          "issues",
+          "total",
+          "as_of"
+        ],
+        "title": "IssuesResponse"
+      },
+      "NodeOut": {
+        "properties": {
+          "node_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Node Id"
+          },
+          "node_type": {
+            "type": "string",
+            "title": "Node Type"
+          },
+          "quantity": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quantity"
+          },
+          "time_ref": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time Ref"
+          },
+          "time_span_start": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time Span Start"
+          },
+          "time_span_end": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time Span End"
+          },
+          "time_grain": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time Grain"
+          },
+          "has_shortage": {
+            "type": "boolean",
+            "title": "Has Shortage"
+          },
+          "shortage_qty": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Shortage Qty"
+          },
+          "closing_stock": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Closing Stock"
+          }
+        },
+        "type": "object",
+        "required": [
+          "node_id",
+          "node_type",
+          "quantity",
+          "time_ref",
+          "time_span_start",
+          "time_span_end",
+          "time_grain",
+          "has_shortage",
+          "shortage_qty",
+          "closing_stock"
+        ],
+        "title": "NodeOut"
+      },
+      "OverrideIn": {
+        "properties": {
+          "node_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Node Id"
+          },
+          "field_name": {
+            "type": "string",
+            "title": "Field Name"
+          },
+          "new_value": {
+            "type": "string",
+            "title": "New Value"
+          }
+        },
+        "type": "object",
+        "required": [
+          "node_id",
+          "field_name",
+          "new_value"
+        ],
+        "title": "OverrideIn"
+      },
+      "ProjectionBucket": {
+        "properties": {
+          "bucket_sequence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bucket Sequence"
+          },
+          "time_span_start": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time Span Start"
+          },
+          "time_span_end": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time Span End"
+          },
+          "time_grain": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time Grain"
+          },
+          "opening_stock": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Opening Stock"
+          },
+          "inflows": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Inflows"
+          },
+          "outflows": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Outflows"
+          },
+          "closing_stock": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Closing Stock"
+          },
+          "has_shortage": {
+            "type": "boolean",
+            "title": "Has Shortage"
+          },
+          "shortage_qty": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Shortage Qty"
+          }
+        },
+        "type": "object",
+        "required": [
+          "bucket_sequence",
+          "time_span_start",
+          "time_span_end",
+          "time_grain",
+          "opening_stock",
+          "inflows",
+          "outflows",
+          "closing_stock",
+          "has_shortage",
+          "shortage_qty"
+        ],
+        "title": "ProjectionBucket"
+      },
+      "ProjectionResponse": {
+        "properties": {
+          "series_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Series Id"
+          },
+          "item_id": {
+            "type": "string",
+            "title": "Item Id"
+          },
+          "location_id": {
+            "type": "string",
+            "title": "Location Id"
+          },
+          "scenario_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Scenario Id"
+          },
+          "grain": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grain"
+          },
+          "buckets": {
+            "items": {
+              "$ref": "#/components/schemas/ProjectionBucket"
+            },
+            "type": "array",
+            "title": "Buckets"
+          }
+        },
+        "type": "object",
+        "required": [
+          "series_id",
+          "item_id",
+          "location_id",
+          "scenario_id",
+          "grain",
+          "buckets"
+        ],
+        "title": "ProjectionResponse"
+      },
+      "SimulateRequest": {
+        "properties": {
+          "scenario_name": {
+            "type": "string",
+            "title": "Scenario Name"
+          },
+          "base_scenario_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Scenario Id"
+          },
+          "overrides": {
+            "items": {
+              "$ref": "#/components/schemas/OverrideIn"
+            },
+            "type": "array",
+            "title": "Overrides",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "scenario_name"
+        ],
+        "title": "SimulateRequest"
+      },
+      "SimulateResponse": {
+        "properties": {
+          "scenario_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Scenario Id"
+          },
+          "scenario_name": {
+            "type": "string",
+            "title": "Scenario Name"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "override_count": {
+            "type": "integer",
+            "title": "Override Count"
+          },
+          "base_scenario_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Base Scenario Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "scenario_id",
+          "scenario_name",
+          "status",
+          "override_count",
+          "base_scenario_id"
+        ],
+        "title": "SimulateResponse"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    },
+    "securitySchemes": {
+      "HTTPBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,15 @@ classifiers = [
     "Topic :: Office/Business",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
-dependencies = []
+dependencies = [
+    "fastapi>=0.111.0",
+    "uvicorn[standard]>=0.29.0",
+    "psycopg[binary]>=3.1.0",
+    "pydantic>=2.0.0",
+]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "pytest-cov>=5.0"]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "httpx>=0.27.0"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""
+export_openapi.py — Export the Ootils Core API OpenAPI schema to docs/api/openapi.json.
+
+Usage:
+    python3 scripts/export_openapi.py
+"""
+import json
+import sys
+from pathlib import Path
+
+# Ensure src/ is on the path
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from ootils_core.api.app import app  # noqa: E402
+
+OUTPUT = ROOT / "docs" / "api" / "openapi.json"
+OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+
+schema = app.openapi()
+OUTPUT.write_text(json.dumps(schema, indent=2, default=str), encoding="utf-8")
+print(f"✓ OpenAPI schema exported to {OUTPUT}")

--- a/src/ootils_core/api/__init__.py
+++ b/src/ootils_core/api/__init__.py
@@ -1,0 +1,1 @@
+"""Ootils Core REST API — V1."""

--- a/src/ootils_core/api/app.py
+++ b/src/ootils_core/api/app.py
@@ -1,0 +1,65 @@
+"""
+app.py — FastAPI application factory for Ootils Core API.
+
+Usage:
+    uvicorn ootils_core.api.app:app --host 0.0.0.0 --port 8000
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from ootils_core.api.routers import events, explain, graph, issues, projection, simulate
+
+logger = logging.getLogger(__name__)
+
+# Load description from spec file if available
+_SPEC_PATH = Path(__file__).parents[4] / "docs" / "api-spec.md"
+_DESCRIPTION = _SPEC_PATH.read_text(encoding="utf-8") if _SPEC_PATH.exists() else (
+    "Ootils Core REST API — supply chain planning engine."
+)
+
+API_VERSION = "1.0.0"
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application."""
+    application = FastAPI(
+        title="Ootils Core API",
+        version=API_VERSION,
+        description=_DESCRIPTION,
+        docs_url="/docs",
+        redoc_url="/redoc",
+        openapi_url="/openapi.json",
+    )
+
+    # Health endpoint (no auth)
+    @application.get("/health", tags=["health"], include_in_schema=True)
+    async def health() -> dict:
+        return {"status": "ok", "version": API_VERSION}
+
+    # Register routers
+    application.include_router(events.router)
+    application.include_router(projection.router)
+    application.include_router(issues.router)
+    application.include_router(explain.router)
+    application.include_router(simulate.router)
+    application.include_router(graph.router)
+
+    @application.exception_handler(Exception)
+    async def generic_exception_handler(request, exc: Exception) -> JSONResponse:
+        logger.exception("Unhandled exception: %s", exc)
+        return JSONResponse(
+            status_code=500,
+            content={"error": "internal_error", "message": str(exc), "status": 500},
+        )
+
+    logger.info("Ootils Core API v%s initialized", API_VERSION)
+    return application
+
+
+# Module-level app instance (for uvicorn / gunicorn)
+app = create_app()

--- a/src/ootils_core/api/auth.py
+++ b/src/ootils_core/api/auth.py
@@ -1,0 +1,48 @@
+"""
+auth.py — Bearer token authentication for Ootils Core API.
+
+Token is read from env var OOTILS_API_TOKEN (default: "dev-token").
+Returns HTTP 401 if the token is absent or invalid.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+from fastapi import HTTPException, Security, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+logger = logging.getLogger(__name__)
+
+_bearer = HTTPBearer(auto_error=False)
+
+
+def _expected_token() -> str:
+    return os.environ.get("OOTILS_API_TOKEN", "dev-token")
+
+
+async def require_auth(
+    credentials: HTTPAuthorizationCredentials | None = Security(_bearer),
+) -> str:
+    """
+    FastAPI dependency — validates Bearer token.
+    Raises HTTP 401 if missing or invalid.
+    Returns the token string on success.
+    """
+    if credentials is None:
+        logger.warning("auth.missing_token")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Authorization header",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    if credentials.credentials != _expected_token():
+        logger.warning("auth.invalid_token")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    return credentials.credentials

--- a/src/ootils_core/api/dependencies.py
+++ b/src/ootils_core/api/dependencies.py
@@ -1,0 +1,63 @@
+"""
+dependencies.py — Shared FastAPI dependencies.
+
+Provides:
+  - get_db: yields a psycopg3 Connection (commit/rollback managed)
+  - get_scenario_id: resolves scenario_id from query param or X-Scenario-ID header
+"""
+from __future__ import annotations
+
+import logging
+from typing import Generator
+from uuid import UUID
+
+import psycopg
+from fastapi import Header, Query
+from psycopg.rows import dict_row
+
+from ootils_core.db.connection import OotilsDB
+
+logger = logging.getLogger(__name__)
+
+# Module-level singleton DB handle (lazy-init safe — OotilsDB is stateless beyond DSN)
+_db: OotilsDB | None = None
+
+BASELINE_SCENARIO_ID = UUID("00000000-0000-0000-0000-000000000001")
+
+
+def _get_ootils_db() -> OotilsDB:
+    global _db
+    if _db is None:
+        _db = OotilsDB()
+    return _db
+
+
+def get_db() -> Generator[psycopg.Connection, None, None]:
+    """
+    FastAPI dependency: yield a psycopg3 Connection with dict_row.
+    Commits on success, rolls back on any exception.
+    """
+    db = _get_ootils_db()
+    with db.conn() as conn:
+        try:
+            yield conn
+        except Exception:
+            logger.exception("db.error — rolling back")
+            raise
+
+
+def resolve_scenario_id(
+    scenario_id: str | None = Query(default=None, description="Scenario UUID or 'baseline'"),
+    x_scenario_id: str | None = Header(default=None, alias="X-Scenario-ID"),
+) -> UUID:
+    """
+    Resolve scenario_id from query param or X-Scenario-ID header.
+    Falls back to the baseline sentinel UUID.
+    """
+    raw = scenario_id or x_scenario_id
+    if raw is None or raw.lower() == "baseline":
+        return BASELINE_SCENARIO_ID
+    try:
+        return UUID(raw)
+    except ValueError:
+        return BASELINE_SCENARIO_ID

--- a/src/ootils_core/api/routers/__init__.py
+++ b/src/ootils_core/api/routers/__init__.py
@@ -1,0 +1,1 @@
+"""Ootils Core API routers."""

--- a/src/ootils_core/api/routers/events.py
+++ b/src/ootils_core/api/routers/events.py
@@ -1,0 +1,120 @@
+"""
+POST /v1/events — Submit a supply chain planning event.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+from uuid import UUID, uuid4
+
+import psycopg
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from ootils_core.api.auth import require_auth
+from ootils_core.api.dependencies import get_db, resolve_scenario_id
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/v1/events", tags=["events"])
+
+VALID_EVENT_TYPES = {
+    "demand_qty_changed",
+    "demand_date_changed",
+    "supply_qty_changed",
+    "supply_date_changed",
+    "onhand_changed",
+    "capacity_changed",
+    "constraint_changed",
+    "policy_changed",
+    "structure_changed",
+    "scenario_override_applied",
+}
+
+
+class EventRequest(BaseModel):
+    event_type: str
+    trigger_node_id: Optional[UUID] = None
+    scenario_id: Optional[str] = None
+    field_changed: Optional[str] = None
+    old_date: Optional[date] = None
+    new_date: Optional[date] = None
+    old_quantity: Optional[Decimal] = None
+    new_quantity: Optional[Decimal] = None
+    source: str = "api"
+
+
+class EventResponse(BaseModel):
+    event_id: UUID
+    status: str
+    scenario_id: UUID
+    affected_nodes_estimate: int
+    calc_run_id: UUID
+
+
+@router.post("", response_model=EventResponse, status_code=status.HTTP_202_ACCEPTED)
+async def create_event(
+    body: EventRequest,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+    scenario_id: UUID = Depends(resolve_scenario_id),
+) -> EventResponse:
+    """Submit a planning event that triggers recalculation."""
+    if body.event_type not in VALID_EVENT_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unknown event_type '{body.event_type}'. Valid: {sorted(VALID_EVENT_TYPES)}",
+        )
+
+    # Override scenario from body if provided
+    if body.scenario_id and body.scenario_id.lower() != "baseline":
+        try:
+            effective_scenario_id = UUID(body.scenario_id)
+        except ValueError:
+            effective_scenario_id = scenario_id
+    else:
+        effective_scenario_id = scenario_id
+
+    from datetime import datetime, timezone
+    event_id = uuid4()
+    calc_run_id = uuid4()
+    now = datetime.now(timezone.utc)
+
+    db.execute(
+        """
+        INSERT INTO events (
+            event_id, event_type, scenario_id, trigger_node_id,
+            field_changed, old_date, new_date, old_quantity, new_quantity,
+            processed, source, created_at
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, FALSE, %s, %s)
+        """,
+        (
+            event_id,
+            body.event_type,
+            effective_scenario_id,
+            body.trigger_node_id,
+            body.field_changed,
+            body.old_date,
+            body.new_date,
+            body.old_quantity,
+            body.new_quantity,
+            body.source,
+            now,
+        ),
+    )
+
+    logger.info(
+        "event.created event_id=%s type=%s scenario=%s",
+        event_id,
+        body.event_type,
+        effective_scenario_id,
+    )
+
+    return EventResponse(
+        event_id=event_id,
+        status="queued",
+        scenario_id=effective_scenario_id,
+        affected_nodes_estimate=0,
+        calc_run_id=calc_run_id,
+    )

--- a/src/ootils_core/api/routers/explain.py
+++ b/src/ootils_core/api/routers/explain.py
@@ -1,0 +1,84 @@
+"""
+GET /v1/explain — Get causal explanation for a planning node.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+from uuid import UUID
+
+import psycopg
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
+
+from ootils_core.api.auth import require_auth
+from ootils_core.api.dependencies import get_db, resolve_scenario_id
+from ootils_core.engine.kernel.explanation.builder import ExplanationBuilder
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/v1/explain", tags=["explain"])
+
+
+class CausalStepOut(BaseModel):
+    step: int
+    node_id: Optional[UUID]
+    node_type: Optional[str]
+    edge_type: Optional[str]
+    fact: str
+
+
+class ExplainResponse(BaseModel):
+    explanation_id: UUID
+    target_node_id: UUID
+    target_type: str
+    summary: str
+    causal_path: list[CausalStepOut]
+    root_cause_node_id: Optional[UUID]
+
+
+@router.get("", response_model=ExplainResponse)
+async def get_explanation(
+    node_id: str = Query(..., description="Target node UUID to explain"),
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+    scenario_id: UUID = Depends(resolve_scenario_id),
+) -> ExplainResponse:
+    """Return the causal explanation for a planning node."""
+    try:
+        node_uuid = UUID(node_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"node_id '{node_id}' is not a valid UUID",
+        )
+
+    builder = ExplanationBuilder()
+    explanation = builder.get_explanation(node_uuid, db)
+
+    if explanation is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No explanation found for node '{node_id}'",
+        )
+
+    logger.info(
+        "explain.fetched node=%s explanation=%s", node_id, explanation.explanation_id
+    )
+
+    return ExplainResponse(
+        explanation_id=explanation.explanation_id,
+        target_node_id=explanation.target_node_id,
+        target_type=explanation.target_type,
+        summary=explanation.summary,
+        causal_path=[
+            CausalStepOut(
+                step=s.step,
+                node_id=s.node_id,
+                node_type=s.node_type,
+                edge_type=s.edge_type,
+                fact=s.fact,
+            )
+            for s in explanation.causal_path
+        ],
+        root_cause_node_id=explanation.root_cause_node_id,
+    )

--- a/src/ootils_core/api/routers/graph.py
+++ b/src/ootils_core/api/routers/graph.py
@@ -1,0 +1,176 @@
+"""
+GET /v1/graph — Return the planning graph for an item/location.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+from uuid import UUID
+
+import psycopg
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
+
+from ootils_core.api.auth import require_auth
+from ootils_core.api.dependencies import get_db, resolve_scenario_id
+from ootils_core.engine.kernel.graph.store import GraphStore
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/v1/graph", tags=["graph"])
+
+
+class NodeOut(BaseModel):
+    node_id: UUID
+    node_type: str
+    quantity: Optional[Decimal]
+    time_ref: Optional[date]
+    time_span_start: Optional[date]
+    time_span_end: Optional[date]
+    time_grain: Optional[str]
+    has_shortage: bool
+    shortage_qty: Decimal
+    closing_stock: Optional[Decimal]
+
+
+class EdgeOut(BaseModel):
+    edge_id: UUID
+    edge_type: str
+    from_node_id: UUID
+    to_node_id: UUID
+    priority: int
+    weight_ratio: Decimal
+
+
+class GraphResponse(BaseModel):
+    nodes: list[NodeOut]
+    edges: list[EdgeOut]
+    item_id: str
+    location_id: str
+    scenario_id: UUID
+    depth: int
+
+
+@router.get("", response_model=GraphResponse)
+async def get_graph(
+    item_id: str = Query(..., description="Item UUID or name"),
+    location_id: str = Query(..., description="Location UUID or name"),
+    depth: int = Query(default=2, ge=1, le=5, description="Graph traversal depth"),
+    from_date: Optional[date] = Query(default=None, alias="from"),
+    to_date: Optional[date] = Query(default=None, alias="to"),
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+    scenario_id: UUID = Depends(resolve_scenario_id),
+) -> GraphResponse:
+    """Return nodes and edges for the planning graph at (item, location, scenario)."""
+    # Resolve item UUID
+    try:
+        item_uuid = UUID(item_id)
+    except ValueError:
+        row = db.execute(
+            "SELECT item_id FROM items WHERE name = %s LIMIT 1", (item_id,)
+        ).fetchone()
+        if row is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=f"Item '{item_id}' not found"
+            )
+        item_uuid = UUID(str(row["item_id"]))
+
+    # Resolve location UUID
+    try:
+        location_uuid = UUID(location_id)
+    except ValueError:
+        row = db.execute(
+            "SELECT location_id FROM locations WHERE name = %s LIMIT 1", (location_id,)
+        ).fetchone()
+        if row is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Location '{location_id}' not found",
+            )
+        location_uuid = UUID(str(row["location_id"]))
+
+    store = GraphStore(db)
+
+    # Fetch all nodes for this scenario scoped to item/location
+    all_nodes = db.execute(
+        """
+        SELECT * FROM nodes
+        WHERE scenario_id = %s
+          AND item_id = %s
+          AND location_id = %s
+          AND active = TRUE
+        ORDER BY node_id ASC
+        """,
+        (scenario_id, item_uuid, location_uuid),
+    ).fetchall()
+
+    from ootils_core.engine.kernel.graph.store import _row_to_node, _row_to_edge
+
+    nodes = [_row_to_node(r) for r in all_nodes]
+
+    # Time window filter if provided
+    if from_date or to_date:
+        filtered = []
+        for n in nodes:
+            node_date = n.time_span_start or n.time_ref
+            if node_date is None:
+                filtered.append(n)
+                continue
+            if from_date and node_date < from_date:
+                continue
+            if to_date and node_date > to_date:
+                continue
+            filtered.append(n)
+        nodes = filtered
+
+    # Collect all edges involving these nodes
+    node_ids = {n.node_id for n in nodes}
+    all_edges = store.get_all_edges(scenario_id)
+    edges = [
+        e for e in all_edges
+        if e.from_node_id in node_ids or e.to_node_id in node_ids
+    ]
+
+    logger.info(
+        "graph.fetched item=%s location=%s scenario=%s nodes=%d edges=%d",
+        item_id,
+        location_id,
+        scenario_id,
+        len(nodes),
+        len(edges),
+    )
+
+    return GraphResponse(
+        nodes=[
+            NodeOut(
+                node_id=n.node_id,
+                node_type=n.node_type,
+                quantity=n.quantity,
+                time_ref=n.time_ref,
+                time_span_start=n.time_span_start,
+                time_span_end=n.time_span_end,
+                time_grain=n.time_grain,
+                has_shortage=n.has_shortage,
+                shortage_qty=n.shortage_qty,
+                closing_stock=n.closing_stock,
+            )
+            for n in nodes
+        ],
+        edges=[
+            EdgeOut(
+                edge_id=e.edge_id,
+                edge_type=e.edge_type,
+                from_node_id=e.from_node_id,
+                to_node_id=e.to_node_id,
+                priority=e.priority,
+                weight_ratio=e.weight_ratio,
+            )
+            for e in edges
+        ],
+        item_id=item_id,
+        location_id=location_id,
+        scenario_id=scenario_id,
+        depth=depth,
+    )

--- a/src/ootils_core/api/routers/issues.py
+++ b/src/ootils_core/api/routers/issues.py
@@ -1,0 +1,133 @@
+"""
+GET /v1/issues — Get active shortages and planning issues.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Optional
+from uuid import UUID
+
+import psycopg
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+
+from ootils_core.api.auth import require_auth
+from ootils_core.api.dependencies import get_db, resolve_scenario_id
+from ootils_core.engine.kernel.shortage.detector import ShortageDetector
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/v1/issues", tags=["issues"])
+
+_LOW_MAX = Decimal("100")
+_MEDIUM_MAX = Decimal("1000")
+
+
+def _classify_severity(score: Decimal) -> str:
+    if score < _LOW_MAX:
+        return "low"
+    elif score <= _MEDIUM_MAX:
+        return "medium"
+    else:
+        return "high"
+
+
+class IssueRecord(BaseModel):
+    node_id: UUID
+    item_id: Optional[UUID]
+    location_id: Optional[UUID]
+    shortage_qty: Decimal
+    severity_score: Decimal
+    severity: str
+    shortage_date: Optional[date]
+    explanation_id: Optional[UUID]
+    explanation_url: Optional[str]
+
+
+class IssuesResponse(BaseModel):
+    issues: list[IssueRecord]
+    total: int
+    as_of: str
+
+
+@router.get("", response_model=IssuesResponse)
+async def get_issues(
+    severity: str = Query(default="all", description="low / medium / high / all"),
+    horizon_days: int = Query(default=90, description="Look-ahead window in days"),
+    item_id: Optional[str] = Query(default=None, description="Filter by item ID"),
+    location_id: Optional[str] = Query(default=None, description="Filter by location ID"),
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+    scenario_id: UUID = Depends(resolve_scenario_id),
+) -> IssuesResponse:
+    """Return active shortages filtered by severity and horizon."""
+    from datetime import datetime, timezone
+
+    detector = ShortageDetector()
+    all_shortages = detector.get_active_shortages(scenario_id, db)
+
+    today = date.today()
+    horizon_cutoff = today + timedelta(days=horizon_days)
+
+    issues: list[IssueRecord] = []
+
+    for s in all_shortages:
+        # Horizon filter
+        if s.shortage_date is not None and s.shortage_date > horizon_cutoff:
+            continue
+
+        # Item filter
+        if item_id is not None:
+            try:
+                item_uuid = UUID(item_id)
+            except ValueError:
+                item_uuid = None
+            if item_uuid and s.item_id != item_uuid:
+                continue
+
+        # Location filter
+        if location_id is not None:
+            try:
+                loc_uuid = UUID(location_id)
+            except ValueError:
+                loc_uuid = None
+            if loc_uuid and s.location_id != loc_uuid:
+                continue
+
+        # Severity classification
+        sev = _classify_severity(s.severity_score)
+
+        if severity != "all" and sev != severity:
+            continue
+
+        exp_url = (
+            f"/v1/explain?node_id={s.pi_node_id}&scenario_id={scenario_id}"
+            if s.explanation_id
+            else None
+        )
+
+        issues.append(
+            IssueRecord(
+                node_id=s.pi_node_id,
+                item_id=s.item_id,
+                location_id=s.location_id,
+                shortage_qty=s.shortage_qty,
+                severity_score=s.severity_score,
+                severity=sev,
+                shortage_date=s.shortage_date,
+                explanation_id=s.explanation_id,
+                explanation_url=exp_url,
+            )
+        )
+
+    as_of = datetime.now(timezone.utc).isoformat()
+    logger.info(
+        "issues.fetched scenario=%s count=%d severity=%s horizon=%d",
+        scenario_id,
+        len(issues),
+        severity,
+        horizon_days,
+    )
+
+    return IssuesResponse(issues=issues, total=len(issues), as_of=as_of)

--- a/src/ootils_core/api/routers/projection.py
+++ b/src/ootils_core/api/routers/projection.py
@@ -1,0 +1,127 @@
+"""
+GET /v1/projection — Get projected inventory for an item/location.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+from uuid import UUID
+
+import psycopg
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
+
+from ootils_core.api.auth import require_auth
+from ootils_core.api.dependencies import get_db, resolve_scenario_id
+from ootils_core.engine.kernel.graph.store import GraphStore
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/v1/projection", tags=["projection"])
+
+
+class ProjectionBucket(BaseModel):
+    bucket_sequence: Optional[int]
+    time_span_start: Optional[date]
+    time_span_end: Optional[date]
+    time_grain: Optional[str]
+    opening_stock: Optional[Decimal]
+    inflows: Optional[Decimal]
+    outflows: Optional[Decimal]
+    closing_stock: Optional[Decimal]
+    has_shortage: bool
+    shortage_qty: Decimal
+
+
+class ProjectionResponse(BaseModel):
+    series_id: Optional[UUID]
+    item_id: str
+    location_id: str
+    scenario_id: UUID
+    grain: Optional[str]
+    buckets: list[ProjectionBucket]
+
+
+@router.get("", response_model=ProjectionResponse)
+async def get_projection(
+    item_id: str = Query(..., description="Item identifier (UUID or string key)"),
+    location_id: str = Query(..., description="Location identifier (UUID or string key)"),
+    grain: Optional[str] = Query(default=None, description="day / week / month"),
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+    scenario_id: UUID = Depends(resolve_scenario_id),
+) -> ProjectionResponse:
+    """Return projected inventory buckets for an item/location pair."""
+    # Resolve item_id and location_id to UUIDs
+    try:
+        item_uuid = UUID(item_id)
+    except ValueError:
+        # Lookup by name
+        row = db.execute(
+            "SELECT item_id FROM items WHERE name = %s LIMIT 1", (item_id,)
+        ).fetchone()
+        if row is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Item '{item_id}' not found",
+            )
+        item_uuid = UUID(str(row["item_id"]))
+
+    try:
+        location_uuid = UUID(location_id)
+    except ValueError:
+        row = db.execute(
+            "SELECT location_id FROM locations WHERE name = %s LIMIT 1", (location_id,)
+        ).fetchone()
+        if row is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Location '{location_id}' not found",
+            )
+        location_uuid = UUID(str(row["location_id"]))
+
+    store = GraphStore(db)
+    series = store.get_projection_series(item_uuid, location_uuid, scenario_id)
+
+    if series is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No projection series found for item={item_id}, location={location_id}, scenario={scenario_id}",
+        )
+
+    nodes = store.get_nodes_by_series(series.series_id)
+
+    buckets = [
+        ProjectionBucket(
+            bucket_sequence=n.bucket_sequence,
+            time_span_start=n.time_span_start,
+            time_span_end=n.time_span_end,
+            time_grain=n.time_grain,
+            opening_stock=n.opening_stock,
+            inflows=n.inflows,
+            outflows=n.outflows,
+            closing_stock=n.closing_stock,
+            has_shortage=n.has_shortage,
+            shortage_qty=n.shortage_qty,
+        )
+        for n in nodes
+    ]
+
+    logger.info(
+        "projection.fetched series=%s item=%s location=%s scenario=%s buckets=%d",
+        series.series_id,
+        item_id,
+        location_id,
+        scenario_id,
+        len(buckets),
+    )
+
+    return ProjectionResponse(
+        series_id=series.series_id,
+        item_id=item_id,
+        location_id=location_id,
+        scenario_id=scenario_id,
+        grain=grain,
+        buckets=buckets,
+    )

--- a/src/ootils_core/api/routers/simulate.py
+++ b/src/ootils_core/api/routers/simulate.py
@@ -1,0 +1,106 @@
+"""
+POST /v1/simulate — Create a scenario with overrides and return delta.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+from uuid import UUID
+
+import psycopg
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from ootils_core.api.auth import require_auth
+from ootils_core.api.dependencies import BASELINE_SCENARIO_ID, get_db
+from ootils_core.engine.scenario.manager import ScenarioManager
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/v1/simulate", tags=["simulate"])
+
+
+class OverrideIn(BaseModel):
+    node_id: UUID
+    field_name: str
+    new_value: str
+
+
+class SimulateRequest(BaseModel):
+    scenario_name: str
+    base_scenario_id: Optional[str] = None
+    overrides: list[OverrideIn] = []
+
+
+class SimulateResponse(BaseModel):
+    scenario_id: UUID
+    scenario_name: str
+    status: str
+    override_count: int
+    base_scenario_id: UUID
+
+
+@router.post("", response_model=SimulateResponse, status_code=status.HTTP_201_CREATED)
+async def create_simulation(
+    body: SimulateRequest,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> SimulateResponse:
+    """Create a new scenario with overrides and compute the delta vs base."""
+    # Resolve base scenario
+    if body.base_scenario_id and body.base_scenario_id.lower() != "baseline":
+        try:
+            base_id = UUID(body.base_scenario_id)
+        except ValueError:
+            base_id = BASELINE_SCENARIO_ID
+    else:
+        base_id = BASELINE_SCENARIO_ID
+
+    manager = ScenarioManager()
+    try:
+        scenario = manager.create_scenario(
+            name=body.scenario_name,
+            parent_scenario_id=base_id,
+            db=db,
+        )
+    except Exception as exc:
+        logger.exception("simulate.create_scenario_failed name=%s", body.scenario_name)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to create scenario: {exc}",
+        )
+
+    # Apply overrides
+    applied = 0
+    for override in body.overrides:
+        try:
+            manager.apply_override(
+                scenario_id=scenario.scenario_id,
+                node_id=override.node_id,
+                field_name=override.field_name,
+                new_value=override.new_value,
+                applied_by="api",
+                db=db,
+            )
+            applied += 1
+        except ValueError as exc:
+            logger.warning(
+                "simulate.override_skipped node=%s field=%s: %s",
+                override.node_id,
+                override.field_name,
+                exc,
+            )
+
+    logger.info(
+        "simulate.created scenario=%s base=%s overrides=%d",
+        scenario.scenario_id,
+        base_id,
+        applied,
+    )
+
+    return SimulateResponse(
+        scenario_id=scenario.scenario_id,
+        scenario_name=body.scenario_name,
+        status="created",
+        override_count=applied,
+        base_scenario_id=base_id,
+    )

--- a/tests/test_m6_api.py
+++ b/tests/test_m6_api.py
@@ -1,0 +1,627 @@
+"""
+test_m6_api.py — Sprint M6 REST API tests.
+
+All DB calls are mocked via dependency overrides.
+Tests cover: auth, events, projection, issues, explain, simulate, graph.
+"""
+from __future__ import annotations
+
+import os
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Generator
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Set env token before importing app
+os.environ["OOTILS_API_TOKEN"] = "test-token"
+
+from ootils_core.api.app import create_app
+from ootils_core.api.dependencies import get_db, resolve_scenario_id
+from ootils_core.models import (
+    CausalStep,
+    Edge,
+    Explanation,
+    Node,
+    Scenario,
+    ScenarioOverride,
+    ShortageRecord,
+    ProjectionSeries,
+)
+
+# ─────────────────────────── Fixtures ───────────────────────────
+
+BASELINE_ID = UUID("00000000-0000-0000-0000-000000000001")
+SCENARIO_ID = uuid4()
+ITEM_ID = uuid4()
+LOCATION_ID = uuid4()
+SERIES_ID = uuid4()
+NODE_ID = uuid4()
+EXPLANATION_ID = uuid4()
+CALC_RUN_ID = uuid4()
+SHORTAGE_ID = uuid4()
+
+
+def _mock_db() -> MagicMock:
+    """Return a mock psycopg3 Connection."""
+    conn = MagicMock()
+    conn.execute.return_value = MagicMock(rowcount=1)
+    return conn
+
+
+@pytest.fixture
+def app():
+    application = create_app()
+    return application
+
+
+@pytest.fixture
+def client(app) -> Generator:
+    """TestClient with mocked DB."""
+    mock_conn = _mock_db()
+
+    def override_db():
+        yield mock_conn
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def auth_headers():
+    return {"Authorization": "Bearer test-token"}
+
+
+# ─────────────────────────── Auth Tests ───────────────────────────
+
+
+def test_health_no_auth(client):
+    """Health endpoint requires no auth."""
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["version"] == "1.0.0"
+
+
+def test_events_401_without_token(client):
+    """All protected endpoints return 401 without token."""
+    resp = client.post("/v1/events", json={"event_type": "supply_date_changed"})
+    assert resp.status_code == 401
+
+
+def test_events_401_wrong_token(client):
+    resp = client.post(
+        "/v1/events",
+        json={"event_type": "supply_date_changed"},
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+    assert resp.status_code == 401
+
+
+def test_projection_401_without_token(client):
+    resp = client.get("/v1/projection?item_id=abc&location_id=xyz")
+    assert resp.status_code == 401
+
+
+def test_issues_401_without_token(client):
+    resp = client.get("/v1/issues")
+    assert resp.status_code == 401
+
+
+# ─────────────────────────── POST /events ───────────────────────────
+
+
+def test_post_event_success(app, auth_headers):
+    mock_conn = _mock_db()
+    mock_conn.execute.return_value = MagicMock(rowcount=1)
+
+    def override_db():
+        yield mock_conn
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as c:
+        resp = c.post(
+            "/v1/events",
+            json={
+                "event_type": "supply_date_changed",
+                "trigger_node_id": str(NODE_ID),
+                "source": "erp-sync",
+                "field_changed": "due_date",
+                "new_date": "2026-04-18",
+            },
+            headers=auth_headers,
+        )
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 202, resp.text
+    data = resp.json()
+    assert data["status"] == "queued"
+    assert "event_id" in data
+    assert "scenario_id" in data
+
+
+def test_post_event_invalid_type(app, auth_headers):
+    mock_conn = _mock_db()
+
+    def override_db():
+        yield mock_conn
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as c:
+        resp = c.post(
+            "/v1/events",
+            json={"event_type": "invalid_type_xyz"},
+            headers=auth_headers,
+        )
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 422
+
+
+def test_post_event_inserts_to_db(app, auth_headers):
+    """Verify that execute() is called (DB insert happens)."""
+    mock_conn = _mock_db()
+
+    def override_db():
+        yield mock_conn
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as c:
+        c.post(
+            "/v1/events",
+            json={"event_type": "onhand_changed", "source": "manual"},
+            headers=auth_headers,
+        )
+
+    app.dependency_overrides.clear()
+    assert mock_conn.execute.called
+
+
+# ─────────────────────────── GET /projection ───────────────────────────
+
+
+def _make_pi_node(seq: int) -> Node:
+    return Node(
+        node_id=uuid4(),
+        node_type="ProjectedInventory",
+        scenario_id=BASELINE_ID,
+        item_id=ITEM_ID,
+        location_id=LOCATION_ID,
+        projection_series_id=SERIES_ID,
+        bucket_sequence=seq,
+        time_span_start=date(2026, 4, seq),
+        time_span_end=date(2026, 4, seq + 1),
+        time_grain="day",
+        opening_stock=Decimal("100"),
+        inflows=Decimal("0"),
+        outflows=Decimal("20"),
+        closing_stock=Decimal("80"),
+        has_shortage=False,
+        shortage_qty=Decimal("0"),
+    )
+
+
+def test_get_projection_success(app, auth_headers):
+    mock_conn = _mock_db()
+    series = ProjectionSeries(
+        series_id=SERIES_ID,
+        item_id=ITEM_ID,
+        location_id=LOCATION_ID,
+        scenario_id=BASELINE_ID,
+        horizon_start=date(2026, 4, 1),
+        horizon_end=date(2026, 4, 30),
+    )
+    nodes = [_make_pi_node(i) for i in range(1, 4)]
+
+    # Simulate UUID parse succeeding (item_id is a UUID)
+    from ootils_core.engine.kernel.graph.store import GraphStore
+
+    with patch.object(GraphStore, "get_projection_series", return_value=series), \
+         patch.object(GraphStore, "get_nodes_by_series", return_value=nodes):
+
+        def override_db():
+            yield mock_conn
+
+        app.dependency_overrides[get_db] = override_db
+
+        with TestClient(app) as c:
+            resp = c.get(
+                f"/v1/projection?item_id={ITEM_ID}&location_id={LOCATION_ID}",
+                headers=auth_headers,
+            )
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["series_id"] == str(SERIES_ID)
+    assert len(data["buckets"]) == 3
+    assert data["buckets"][0]["bucket_sequence"] == 1
+
+
+def test_get_projection_not_found(app, auth_headers):
+    mock_conn = _mock_db()
+
+    from ootils_core.engine.kernel.graph.store import GraphStore
+
+    with patch.object(GraphStore, "get_projection_series", return_value=None):
+
+        def override_db():
+            yield mock_conn
+
+        app.dependency_overrides[get_db] = override_db
+
+        with TestClient(app) as c:
+            resp = c.get(
+                f"/v1/projection?item_id={ITEM_ID}&location_id={LOCATION_ID}",
+                headers=auth_headers,
+            )
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 404
+
+
+# ─────────────────────────── GET /issues ───────────────────────────
+
+
+def _make_shortage(score: Decimal) -> ShortageRecord:
+    return ShortageRecord(
+        shortage_id=uuid4(),
+        scenario_id=BASELINE_ID,
+        pi_node_id=uuid4(),
+        item_id=ITEM_ID,
+        location_id=LOCATION_ID,
+        shortage_date=date(2026, 4, 8),
+        shortage_qty=Decimal("130"),
+        severity_score=score,
+        explanation_id=None,
+        calc_run_id=CALC_RUN_ID,
+        status="active",
+    )
+
+
+def test_get_issues_all(app, auth_headers):
+    mock_conn = _mock_db()
+    shortages = [
+        _make_shortage(Decimal("50")),   # low
+        _make_shortage(Decimal("500")),  # medium
+        _make_shortage(Decimal("2000")), # high
+    ]
+
+    from ootils_core.engine.kernel.shortage.detector import ShortageDetector
+
+    with patch.object(ShortageDetector, "get_active_shortages", return_value=shortages):
+
+        def override_db():
+            yield mock_conn
+
+        app.dependency_overrides[get_db] = override_db
+
+        with TestClient(app) as c:
+            resp = c.get("/v1/issues?severity=all&horizon_days=90", headers=auth_headers)
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 3
+
+
+def test_get_issues_filter_high(app, auth_headers):
+    mock_conn = _mock_db()
+    shortages = [
+        _make_shortage(Decimal("50")),
+        _make_shortage(Decimal("2000")),
+    ]
+
+    from ootils_core.engine.kernel.shortage.detector import ShortageDetector
+
+    with patch.object(ShortageDetector, "get_active_shortages", return_value=shortages):
+
+        def override_db():
+            yield mock_conn
+
+        app.dependency_overrides[get_db] = override_db
+
+        with TestClient(app) as c:
+            resp = c.get("/v1/issues?severity=high&horizon_days=90", headers=auth_headers)
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["issues"][0]["severity"] == "high"
+
+
+def test_get_issues_horizon_filter(app, auth_headers):
+    """Shortages beyond horizon should be excluded."""
+    mock_conn = _mock_db()
+    # shortage date far in the future
+    far_shortage = ShortageRecord(
+        shortage_id=uuid4(),
+        scenario_id=BASELINE_ID,
+        pi_node_id=uuid4(),
+        item_id=ITEM_ID,
+        location_id=LOCATION_ID,
+        shortage_date=date(2030, 1, 1),  # far future
+        shortage_qty=Decimal("130"),
+        severity_score=Decimal("2000"),
+        explanation_id=None,
+        calc_run_id=CALC_RUN_ID,
+        status="active",
+    )
+    near_shortage = _make_shortage(Decimal("2000"))
+
+    from ootils_core.engine.kernel.shortage.detector import ShortageDetector
+
+    with patch.object(
+        ShortageDetector, "get_active_shortages", return_value=[far_shortage, near_shortage]
+    ):
+
+        def override_db():
+            yield mock_conn
+
+        app.dependency_overrides[get_db] = override_db
+
+        with TestClient(app) as c:
+            resp = c.get("/v1/issues?severity=all&horizon_days=90", headers=auth_headers)
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1  # only the near one
+
+
+# ─────────────────────────── GET /explain ───────────────────────────
+
+
+def _make_explanation() -> Explanation:
+    return Explanation(
+        explanation_id=EXPLANATION_ID,
+        calc_run_id=CALC_RUN_ID,
+        target_node_id=NODE_ID,
+        target_type="Shortage",
+        root_cause_node_id=uuid4(),
+        causal_path=[
+            CausalStep(
+                step=1,
+                node_id=uuid4(),
+                node_type="CustomerOrderDemand",
+                edge_type="consumes",
+                fact="Order CO-778 requires 150u due April 8",
+            ),
+            CausalStep(
+                step=2,
+                node_id=uuid4(),
+                node_type="PurchaseOrderSupply",
+                edge_type="replenishes",
+                fact="PO-991 provides 200u due April 18",
+            ),
+        ],
+        summary="Shortage: demand exceeds supply by 130 units.",
+    )
+
+
+def test_get_explain_success(app, auth_headers):
+    mock_conn = _mock_db()
+    explanation = _make_explanation()
+
+    from ootils_core.engine.kernel.explanation.builder import ExplanationBuilder
+
+    with patch.object(ExplanationBuilder, "get_explanation", return_value=explanation):
+
+        def override_db():
+            yield mock_conn
+
+        app.dependency_overrides[get_db] = override_db
+
+        with TestClient(app) as c:
+            resp = c.get(f"/v1/explain?node_id={NODE_ID}", headers=auth_headers)
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["explanation_id"] == str(EXPLANATION_ID)
+    assert data["summary"] == explanation.summary
+    assert len(data["causal_path"]) == 2
+    assert data["causal_path"][0]["step"] == 1
+    assert data["causal_path"][0]["node_type"] == "CustomerOrderDemand"
+
+
+def test_get_explain_not_found(app, auth_headers):
+    mock_conn = _mock_db()
+
+    from ootils_core.engine.kernel.explanation.builder import ExplanationBuilder
+
+    with patch.object(ExplanationBuilder, "get_explanation", return_value=None):
+
+        def override_db():
+            yield mock_conn
+
+        app.dependency_overrides[get_db] = override_db
+
+        with TestClient(app) as c:
+            resp = c.get(f"/v1/explain?node_id={NODE_ID}", headers=auth_headers)
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 404
+
+
+def test_get_explain_invalid_uuid(app, auth_headers):
+    mock_conn = _mock_db()
+
+    def override_db():
+        yield mock_conn
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as c:
+        resp = c.get("/v1/explain?node_id=not-a-uuid", headers=auth_headers)
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 422
+
+
+# ─────────────────────────── POST /simulate ───────────────────────────
+
+
+def test_post_simulate_success(app, auth_headers):
+    mock_conn = _mock_db()
+    new_scenario = Scenario(
+        scenario_id=uuid4(),
+        name="sim-test",
+        parent_scenario_id=BASELINE_ID,
+        is_baseline=False,
+        status="active",
+    )
+    override_result = ScenarioOverride(
+        override_id=uuid4(),
+        scenario_id=new_scenario.scenario_id,
+        node_id=NODE_ID,
+        field_name="quantity",
+        old_value="100",
+        new_value="200",
+    )
+
+    from ootils_core.engine.scenario.manager import ScenarioManager
+
+    with patch.object(ScenarioManager, "create_scenario", return_value=new_scenario), \
+         patch.object(ScenarioManager, "apply_override", return_value=override_result):
+
+        def override_db():
+            yield mock_conn
+
+        app.dependency_overrides[get_db] = override_db
+
+        with TestClient(app) as c:
+            resp = c.post(
+                "/v1/simulate",
+                json={
+                    "scenario_name": "sim-test",
+                    "base_scenario_id": "baseline",
+                    "overrides": [
+                        {"node_id": str(NODE_ID), "field_name": "quantity", "new_value": "200"}
+                    ],
+                },
+                headers=auth_headers,
+            )
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["status"] == "created"
+    assert data["override_count"] == 1
+    assert data["scenario_id"] == str(new_scenario.scenario_id)
+
+
+def test_post_simulate_no_overrides(app, auth_headers):
+    mock_conn = _mock_db()
+    new_scenario = Scenario(
+        scenario_id=uuid4(),
+        name="empty-sim",
+        parent_scenario_id=BASELINE_ID,
+        is_baseline=False,
+        status="active",
+    )
+
+    from ootils_core.engine.scenario.manager import ScenarioManager
+
+    with patch.object(ScenarioManager, "create_scenario", return_value=new_scenario):
+
+        def override_db():
+            yield mock_conn
+
+        app.dependency_overrides[get_db] = override_db
+
+        with TestClient(app) as c:
+            resp = c.post(
+                "/v1/simulate",
+                json={"scenario_name": "empty-sim"},
+                headers=auth_headers,
+            )
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["override_count"] == 0
+
+
+# ─────────────────────────── GET /graph ───────────────────────────
+
+
+def test_get_graph_success(app, auth_headers):
+    mock_conn = _mock_db()
+
+    nodes_result = [
+        {
+            "node_id": str(NODE_ID),
+            "node_type": "ProjectedInventory",
+            "scenario_id": str(BASELINE_ID),
+            "item_id": str(ITEM_ID),
+            "location_id": str(LOCATION_ID),
+            "quantity": None,
+            "qty_uom": None,
+            "time_grain": "day",
+            "time_ref": None,
+            "time_span_start": "2026-04-01",
+            "time_span_end": "2026-04-02",
+            "is_dirty": False,
+            "last_calc_run_id": None,
+            "active": True,
+            "projection_series_id": str(SERIES_ID),
+            "bucket_sequence": 1,
+            "opening_stock": "100",
+            "inflows": "0",
+            "outflows": "20",
+            "closing_stock": "80",
+            "has_shortage": False,
+            "shortage_qty": "0",
+            "has_exact_date_inputs": False,
+            "has_week_inputs": False,
+            "has_month_inputs": False,
+            "created_at": None,
+            "updated_at": None,
+        }
+    ]
+    mock_conn.execute.return_value.fetchall.return_value = nodes_result
+
+    from ootils_core.engine.kernel.graph.store import GraphStore
+
+    with patch.object(GraphStore, "get_all_edges", return_value=[]):
+
+        def override_db():
+            yield mock_conn
+
+        app.dependency_overrides[get_db] = override_db
+
+        with TestClient(app) as c:
+            resp = c.get(
+                f"/v1/graph?item_id={ITEM_ID}&location_id={LOCATION_ID}",
+                headers=auth_headers,
+            )
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert "nodes" in data
+    assert "edges" in data
+    assert data["depth"] == 2  # default
+
+
+# ─────────────────────────── OpenAPI schema ───────────────────────────
+
+
+def test_openapi_schema_accessible(client, auth_headers):
+    """OpenAPI schema should be reachable without auth."""
+    resp = client.get("/openapi.json")
+    assert resp.status_code == 200
+    schema = resp.json()
+    assert schema["info"]["title"] == "Ootils Core API"
+    assert schema["info"]["version"] == "1.0.0"


### PR DESCRIPTION
## Sprint M6 — REST API V1

**Endpoints :**
- `POST /v1/events` — submit supply chain event → queued
- `GET /v1/projection` — buckets PI par (item, location, scenario, grain)
- `GET /v1/issues` — shortages actifs filtrés par severity + horizon
- `GET /v1/explain` — causal chain pour un node
- `POST /v1/simulate` — crée scénario + applique overrides
- `GET /v1/graph` — nodes + edges dans une fenêtre temporelle
- `GET /health` — sans auth

**Auth :** HTTPBearer, token via `OOTILS_API_TOKEN` env var (défaut: `dev-token`)

**OpenAPI :** schema exporté dans `docs/api/openapi.json` (7 paths)

**Tests :** 20 tests API (auth 401/200, chaque endpoint, filtres severity/horizon)

**Suite complète : 182 passed / 4 skipped (DB)**