### PR TITLE
fix: resolve 5 live deployment bugs (#24-#28)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY pyproject.toml .
+RUN pip install --no-cache-dir -e ".[dev]"
+
+COPY src/ /app/src/
+COPY scripts/ /app/scripts/
+
+CMD ["uvicorn", "ootils_core.api.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -127,7 +127,7 @@ def seed(conn):
     event_id = _uid("event:ingestion_complete:seed-v1")
     conn.execute("""
         INSERT INTO events (event_id, event_type, scenario_id, source)
-        VALUES (%s, 'ingestion_complete', %s, 'seed_script')
+        VALUES (%s, 'ingestion_complete', %s, 'test')
         ON CONFLICT DO NOTHING
     """, (event_id, BASELINE_SCENARIO_ID))
     print("  ✓ Trigger event inserted")
@@ -174,16 +174,17 @@ def _seed_pi_nodes_pump_atl(conn, item_id, location_id, series_id):
         ))
         running = closing
 
-    conn.executemany("""
-        INSERT INTO nodes (
-            node_id, node_type, scenario_id, item_id, location_id,
-            time_grain, time_ref, time_span_start, time_span_end,
-            is_dirty, active, projection_series_id, bucket_sequence,
-            opening_stock, inflows, outflows, closing_stock,
-            has_shortage, shortage_qty
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-        ON CONFLICT DO NOTHING
-    """, nodes)
+    with conn.cursor() as cur:
+        cur.executemany("""
+            INSERT INTO nodes (
+                node_id, node_type, scenario_id, item_id, location_id,
+                time_grain, time_ref, time_span_start, time_span_end,
+                is_dirty, active, projection_series_id, bucket_sequence,
+                opening_stock, inflows, outflows, closing_stock,
+                has_shortage, shortage_qty
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT DO NOTHING
+        """, nodes)
 
 
 def _seed_pi_nodes_valve_lax(conn, item_id, location_id, series_id):
@@ -219,16 +220,17 @@ def _seed_pi_nodes_valve_lax(conn, item_id, location_id, series_id):
         ))
         running = closing
 
-    conn.executemany("""
-        INSERT INTO nodes (
-            node_id, node_type, scenario_id, item_id, location_id,
-            time_grain, time_ref, time_span_start, time_span_end,
-            is_dirty, active, projection_series_id, bucket_sequence,
-            opening_stock, inflows, outflows, closing_stock,
-            has_shortage, shortage_qty
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-        ON CONFLICT DO NOTHING
-    """, nodes)
+    with conn.cursor() as cur:
+        cur.executemany("""
+            INSERT INTO nodes (
+                node_id, node_type, scenario_id, item_id, location_id,
+                time_grain, time_ref, time_span_start, time_span_end,
+                is_dirty, active, projection_series_id, bucket_sequence,
+                opening_stock, inflows, outflows, closing_stock,
+                has_shortage, shortage_qty
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT DO NOTHING
+        """, nodes)
 
 
 def _seed_supply_nodes(conn, pump_id, valve_id, atl_id, lax_id, series_pump, series_valve):

--- a/src/ootils_core/db/migrations/001_initial_schema.sql
+++ b/src/ootils_core/db/migrations/001_initial_schema.sql
@@ -1,11 +1,3 @@
--- ============================================================
--- Ootils Core — Migration 001: DEPRECATED (SQLite legacy)
--- ============================================================
--- This file was the original SQLite schema (pre-Sprint 1).
--- The engine migrated to PostgreSQL in Sprint 1 (migration 002).
--- This file is intentionally a no-op — kept for historical reference only.
--- All PostgreSQL schema is in migrations 002 and above.
--- ============================================================
-
--- No-op: migration 002 defines the full PostgreSQL schema.
+-- Migration 001: legacy no-op (replaced by migration 002)
+-- This file is intentionally empty for PostgreSQL compatibility.
 SELECT 1;

--- a/src/ootils_core/db/migrations/002_sprint1_schema.sql
+++ b/src/ootils_core/db/migrations/002_sprint1_schema.sql
@@ -190,7 +190,7 @@ CREATE TABLE IF NOT EXISTS node_type_policies (
     created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
 
-    UNIQUE (node_type, active) DEFERRABLE INITIALLY DEFERRED  -- only one active policy per node_type
+    UNIQUE (node_type, active)  -- only one active policy per node_type
 );
 
 -- Seed: default ProjectedInventory temporal policy


### PR DESCRIPTION
## Summary

Fixes 5 bugs found during live V1 PostgreSQL deployment.

### Bug #24 — Migration 001 still has SQLite DDL
- Replaced partial comment-based no-op with true no-op: only `SELECT 1;`

### Bug #25 — ON CONFLICT on deferrable unique constraint
- Removed `DEFERRABLE INITIALLY DEFERRED` from `node_type_policies` unique constraint
- PostgreSQL cannot use `ON CONFLICT DO NOTHING` with deferrable constraints

### Bug #26 — scripts/ missing from Docker image
- Added `Dockerfile` with `COPY scripts/ /app/scripts/` after src copy

### Bug #27 — seed uses conn.executemany (psycopg3)
- Replaced all `conn.executemany(sql, data)` with cursor-based calls
- psycopg3: `executemany` lives on the cursor, not the connection

### Bug #28 — seed uses invalid events.source value
- Replaced `'seed_script'` with `'test'` to satisfy DB CHECK constraint

## Test Results
```
208 passed, 4 skipped in 1.05s
```

Closes #24, #25, #26, #27, #28