### PR TITLE
fix: Dockerfile build order — copy src before pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,11 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+# Copy source before install (editable install requires src/ to exist)
 COPY pyproject.toml .
-RUN pip install --no-cache-dir -e ".[dev]"
-
 COPY src/ /app/src/
 COPY scripts/ /app/scripts/
+
+RUN pip install --no-cache-dir -e ".[dev]"
 
 CMD ["uvicorn", "ootils_core.api.app:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Fixes #31\n\nThe editable install () requires  to exist at install time. Moving  and  before  fixes the build failure on fresh deployments.