### PR TITLE
fix: simulate — return 422 instead of 500 for invalid node_id overrides

### DIFF
--- a/src/ootils_core/api/routers/simulate.py
+++ b/src/ootils_core/api/routers/simulate.py
@@ -71,6 +71,7 @@ async def create_simulation(
 
     # Apply overrides
     applied = 0
+    failed_overrides: list[dict] = []
     for override in body.overrides:
         try:
             manager.apply_override(
@@ -82,13 +83,28 @@ async def create_simulation(
                 db=db,
             )
             applied += 1
-        except ValueError as exc:
+        except Exception as exc:
             logger.warning(
-                "simulate.override_skipped node=%s field=%s: %s",
+                "simulate.override_failed node=%s field=%s: %s",
                 override.node_id,
                 override.field_name,
                 exc,
             )
+            failed_overrides.append({
+                "node_id": str(override.node_id),
+                "field_name": override.field_name,
+                "error": str(exc),
+            })
+
+    # If all overrides failed, return 422 with details instead of 500
+    if body.overrides and applied == 0 and failed_overrides:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "message": "All overrides failed validation — no changes applied.",
+                "failed_overrides": failed_overrides,
+            },
+        )
 
     logger.info(
         "simulate.created scenario=%s base=%s overrides=%d",

--- a/src/ootils_core/engine/scenario/manager.py
+++ b/src/ootils_core/engine/scenario/manager.py
@@ -217,14 +217,20 @@ class ScenarioManager:
         """
         _validate_field_name(field_name)
 
-        # 1. Fetch current node value
+        # 1. Fetch current node value — also validates that the node exists
         row = db.execute(
             f"SELECT {field_name} FROM nodes WHERE node_id = %s AND scenario_id = %s",
             (node_id, scenario_id),
         ).fetchone()
 
+        if row is None:
+            raise ValueError(
+                f"Node {node_id} not found in scenario {scenario_id}. "
+                "Override cannot be applied to a non-existent node."
+            )
+
         old_value: Optional[str] = None
-        if row is not None and row[field_name] is not None:
+        if row[field_name] is not None:
             old_value = str(row[field_name])
 
         now = datetime.now(timezone.utc)

--- a/tests/test_m6_api.py
+++ b/tests/test_m6_api.py
@@ -625,3 +625,56 @@ def test_openapi_schema_accessible(client, auth_headers):
     schema = resp.json()
     assert schema["info"]["title"] == "Ootils Core API"
     assert schema["info"]["version"] == "1.0.0"
+
+
+def test_post_simulate_invalid_node_returns_422(app, auth_headers):
+    """
+    Non-regression #48: POST /v1/simulate with an invalid node_id must return 422,
+    not 500. All overrides fail → 422 with failed_overrides detail.
+    """
+    mock_conn = _mock_db()
+    new_scenario = Scenario(
+        scenario_id=uuid4(),
+        name="bad-node-sim",
+        parent_scenario_id=BASELINE_ID,
+        is_baseline=False,
+        status="active",
+    )
+
+    from ootils_core.engine.scenario.manager import ScenarioManager
+
+    with patch.object(ScenarioManager, "create_scenario", return_value=new_scenario), \
+         patch.object(
+             ScenarioManager,
+             "apply_override",
+             side_effect=ValueError("Node 00000000-0000-0000-0000-000000000000 not found in scenario"),
+         ):
+
+        def override_db():
+            yield mock_conn
+
+        app.dependency_overrides[get_db] = override_db
+
+        with TestClient(app) as c:
+            resp = c.post(
+                "/v1/simulate",
+                json={
+                    "scenario_name": "bad-node-sim",
+                    "overrides": [
+                        {
+                            "node_id": "00000000-0000-0000-0000-000000000000",
+                            "field_name": "shortage_qty",
+                            "new_value": "0",
+                        }
+                    ],
+                },
+                headers=auth_headers,
+            )
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+    data = resp.json()
+    detail = data.get("detail", {})
+    assert "failed_overrides" in detail, f"Expected failed_overrides in detail: {detail}"
+    assert len(detail["failed_overrides"]) == 1
+    assert "not found" in detail["failed_overrides"][0]["error"].lower()


### PR DESCRIPTION
## Problème

`POST /v1/simulate` retournait 500 quand un override référençait un `node_id` inexistant, à cause d'une FK violation Postgres non catchée.

## Fix

**`ScenarioManager.apply_override`** :
- Validation explicite de l'existence du nœud avant INSERT
- `ValueError` avec message clair si nœud non trouvé
- Empêche la propagation de la FK violation en exception non gérée

**Router `POST /v1/simulate`** :
- Catch toutes les exceptions sur les overrides (pas juste `ValueError`)
- Track les overrides en échec avec node_id + message d'erreur
- Retourne **422** avec détail si tous les overrides échouent
- Succès partiel (certains overrides OK) → 201 avec `override_count` correct

## Tests

212 passed, 30 skipped — aucune régression.

Fixes #48