### PR TITLE
feat: migration 007 — pipeline import 2 étapes (staging, DQ, données techniques)

### DIFF
--- a/docs/ADR-009-import-pipeline.md
+++ b/docs/ADR-009-import-pipeline.md
@@ -1,0 +1,108 @@
+# ADR-009 : Architecture Pipeline d'Import — Staging + DQ + Core
+
+## Statut
+ACCEPTED — 2026-04-05
+
+## Contexte
+
+Les outils APS de référence (Kinaxis, SAP IBP, Blue Yonder) partagent tous le même problème structurel : ils traitent les données sources immédiatement à la réception, sans zone tampon. Conséquences directes en production :
+
+- **Données perdues** : si un import échoue après transformation, les données originales sont inaccessibles.
+- **Historique absent** : un `lead_time_days` écrasé par upsert ne laisse aucune trace. Impossible d'auditer une décision de planification prise 3 semaines plus tôt.
+- **Dégradation silencieuse** : un item passe de 14 à 0 jours de lead time sans alerte. Le moteur génère des alertes de rupture décalées. Les planificateurs commandent en urgence.
+- **Cross-entité non vérifiée** : un PO arrive en BOX alors que le stock est en EA. Sans table de conversion UOM, le moteur interprète 10 BOX comme 10 EA — erreur de facteur 24.
+
+Le contexte Ootils amplifie ces risques : le moteur de planification SC (graphe, projections, allocations) consomme directement les données master. Une donnée corrompue en entrée génère des projections aberrantes sans signal d'alerte.
+
+La review architecturale (`REVIEW-IMPORT-ARCHITECTURE.md`) et la review SC expert (`REVIEW-IMPORT-SC-EXPERT.md`) convergent sur une architecture 2 étapes obligatoire : **Staging → Core**, avec un pipeline DQ intercalé.
+
+## Décisions
+
+### D1 — Staging zone : tout accepter sauf encoding invalide
+
+Toutes les données brutes ERP/WMS arrivent en staging sans transformation. Même les lignes malformées sont stockées avec flag. Principe : **ne jamais perdre une donnée source**.
+
+La table `ingest_batches` enregistre chaque batch dès sa réception (HTTP 202 immédiat). La table `ingest_rows` stocke le `raw_content` intégral + les colonnes extraites en TEXT sans conversion. Un batch est toujours créé, même si le payload est partiellement illisible — l'erreur de parsing devient une issue DQ de type `parse_error`, pas un rejet HTTP.
+
+Conséquence directe : rejouer un import depuis le staging est toujours possible. Aucun "qu'est-ce qui nous a été envoyé ?" n'est sans réponse.
+
+### D2 — DQ Pipeline en 4 niveaux séquentiels
+
+```
+L1 Structurel → L2 Référentiel → L3 Métier SC → L4 Croisé
+```
+
+- **L1 Structurel** : types de colonnes, valeurs obligatoires, formats (date, numérique, UUID).
+- **L2 Référentiel** : `item_id` existe dans `items`, `location_id` dans `locations`, etc.
+- **L3 Métier SC** : lead time à 0 → WARNING, `max_order_qty < min_order_qty` → ERROR, UOM non convertible → ERROR.
+- **L4 Croisé** : items actifs sans `item_planning_params` pour leur location, `supplier_items` sans fournisseur actif, doublons inter-batch.
+
+Une ligne peut passer L1 et échouer L3 — statut partiel possible (`dq_level_reached` enregistre le niveau atteint). Les issues sont tracées dans `data_quality_issues` avec `severity` (error/warning/info), `rule_code`, `field_name`, `raw_value`.
+
+Un batch avec au moins une issue de sévérité `error` ne peut pas être approuvé sans intervention humaine explicite. Les warnings n'bloquent pas l'approbation mais sont visibles.
+
+### D3 — Données techniques (item_planning_params) versionnées SCD2
+
+La table `item_planning_params` est versionnée temporellement via `effective_from` / `effective_to`. Une ligne active par item × location à tout moment. L'historique complet est conservé.
+
+Règle de lecture : le moteur charge la version dont `effective_from <= planning_date < effective_to` (ou `effective_to IS NULL` pour la version courante). Une contrainte d'exclusion GIST garantit l'absence de chevauchement à la base de données.
+
+Ne jamais écraser les paramètres en place : à l'import, fermer la version active (`effective_to = today`) et créer une nouvelle ligne. L'`import_audit_log` / `master_data_audit_log` trace chaque changement avec source et batch d'origine.
+
+### D4 — Pas de fast-import qui bypasse le staging
+
+Décision ferme : **même en mode urgent, toute donnée passe par staging**. Pas d'exception.
+
+Un "fast-import" qui écrit directement en core tables contourne le DQ pipeline, perd l'historique source, et crée une brèche d'audit. Le délai introduit par le staging (ingest_rows → DQ → approve) est de quelques secondes pour des batches normaux. Ce coût est non-négociable.
+
+Si la vitesse est critique, optimiser le pipeline DQ (parallélisation des règles L1/L2) — pas bypasser le staging.
+
+### D5 — UOM conversions globales et item-specific
+
+Table `uom_conversions` avec résolution hiérarchique : **item-specific > global**.
+
+Le moteur cherche d'abord une conversion `(from_uom, to_uom, item_id=<id>)`. Si absente, il cherche `(from_uom, to_uom, item_id=NULL)`. Si toujours absente : erreur DQ `UOM_CONVERSION_MISSING` sur toute ligne utilisant ces UOM pour cet item.
+
+Le `factor` est toujours le multiplicateur de `from_uom` vers `to_uom` : `1 from_uom = factor × to_uom`. La conversion inverse est `1/factor`. Le stockage du sens canonique est documenté dans chaque insert.
+
+### D6 — Calendriers opérationnels par location
+
+1 row par location × date. **Absence = jour ouvré par défaut** (convention safe-by-default).
+
+Ne pas stocker des "patterns de calendrier" (ex: "fermé tous les dimanches") — les cas limites (ponts, jours fériés décalés) génèrent des bugs non reproductibles. L'import charge une plage de dates explicite. Le moteur fait un lookup direct sur `(location_id, calendar_date)`. Absence → `is_working_day=TRUE, capacity_factor=1.0`.
+
+## Conséquences
+
+### Positives
+- **Auditabilité complète** : chaque donnée en production est traçable jusqu'à son batch d'origine, sa ligne source, et l'utilisateur qui a approuvé l'import.
+- **Rejeu possible** : un import raté peut être re-soumis depuis le staging sans re-télécharger le fichier source.
+- **Dégradation détectable** : les issues DQ L4 (croisé) détectent activement les régressions de qualité entre imports.
+- **Moteur protégé** : le core engine ne consomme que des données ayant passé le DQ pipeline. Garbage-in/garbage-out est éliminé par construction.
+- **Historique master data** : les décisions de planification passées sont reconstituables (lead times, politiques de sécurité stock, paramètres fournisseurs).
+
+### Négatives / Points de vigilance
+- **Latence d'import** : le pipeline 2 étapes introduit une latence entre la réception et la disponibilité en core. Les planificateurs ne voient pas les données "instantanément". Mitigation : afficher le statut du batch en temps réel, notifier à la fin du DQ.
+- **Volume staging** : `ingest_rows` stocker le `raw_content` de chaque ligne grossit rapidement. Prévoir une politique de rétention (ex: purge des batches `imported` datant de > 90 jours).
+- **Complexité DQ** : 4 niveaux de règles à maintenir par entity_type. Risque de règles L3/L4 trop strictes bloquant des imports valides. Mitigation : démarrer conservateur (peu de règles L3, aucune L4), ajouter progressivement basé sur les incidents observés.
+- **Extension btree_gist requise** : la contrainte d'exclusion GIST sur `item_planning_params` requiert `CREATE EXTENSION IF NOT EXISTS btree_gist`. À vérifier sur l'environnement de production.
+- **BOM et routings** : hors scope de ce sprint. Sans BOM, le manufacturing planning reste limité. Prévoir ADR-010.
+
+## Tables créées par cette migration (007)
+
+| Table | Rôle |
+|-------|------|
+| `ingest_batches` | Registre des batches d'import (staging) |
+| `ingest_rows` | Lignes brutes avec statut DQ |
+| `data_quality_issues` | Issues détectées par le pipeline DQ |
+| `external_references` | Mapping ERP codes → UUID internes |
+| `suppliers` | Référentiel fournisseurs |
+| `supplier_items` | Conditions d'approvisionnement par (fournisseur × item) |
+| `item_planning_params` | Paramètres de planification versionnés SCD2 |
+| `uom_conversions` | Conversions d'unités avec priorité item-specific |
+| `operational_calendars` | Calendriers opérationnels par site |
+| `master_data_audit_log` | Log d'audit des modifications master data |
+
+## Références
+- `docs/REVIEW-IMPORT-ARCHITECTURE.md` — Architecture review détaillée
+- `docs/REVIEW-IMPORT-SC-EXPERT.md` — Review expert SC (Kinaxis/o9/IBP)
+- `src/ootils_core/db/migrations/007_import_pipeline.sql` — DDL complet

--- a/docs/REVIEW-IMPORT-ARCHITECTURE.md
+++ b/docs/REVIEW-IMPORT-ARCHITECTURE.md
@@ -1,0 +1,1151 @@
+# Review Architecturale — Pipeline d'Import Ootils
+
+> **Auteur :** Architecture Review (Senior)  
+> **Date :** 2026-04-05  
+> **Branche :** `review/import-architecture`  
+> **Scope :** Pipeline d'import 2 étapes, données techniques, migration 004-import  
+> **Statut :** RÉFÉRENCE — opinions fermes, DDL complet
+
+---
+
+## Table des matières
+
+1. [Architecture globale du pipeline d'import](#1-architecture-globale)
+2. [Modèle de données techniques](#2-modèle-de-données-techniques)
+3. [Séparation des responsabilités Python](#3-séparation-des-responsabilités)
+4. [API design — pipeline 2 étapes](#4-api-design)
+5. [Migration prioritaire (004-import)](#5-migration-prioritaire)
+6. [Anti-patterns à éviter absolument](#6-anti-patterns)
+7. [Décisions architecturales clés](#7-décisions-architecturales)
+
+---
+
+## 1. Architecture globale
+
+### Schéma d'architecture (ASCII)
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────────────┐
+│                              SYSTÈMES SOURCES                                           │
+│   ERP (SAP/Dynamics)     WMS/EDI     Excel/TSV     API tierces     Saisie manuelle      │
+└───────────────────────────────────────┬─────────────────────────────────────────────────┘
+                                        │  multipart/form-data (TSV) | application/json
+                                        ▼
+┌─────────────────────────────────────────────────────────────────────────────────────────┐
+│                         COUCHE INGESTION  (ootils_core/ingestion/)                      │
+│                                                                                         │
+│   POST /v1/ingest/{type}                                                                │
+│   ┌─────────────────────────────────────────────────────────────────────────────┐       │
+│   │  IngestRouter                                                               │       │
+│   │  - Accepte TOUT (pas de validation métier ici)                              │       │
+│   │  - Parse : TSV → rows[] | JSON → rows[]                                    │       │
+│   │  - Génère batch_id (UUID)                                                   │       │
+│   │  - Écrit atomiquement dans ingest_batches + ingest_rows (staging)           │       │
+│   │  - Répond HTTP 202 immédiatement avec batch_id                              │       │
+│   └─────────────────────────────────────────────────────────────────────────────┘       │
+│                                                                                         │
+│   Tables PostgreSQL : ingest_batches, ingest_rows                                       │
+│   Garantie : tout ce qui arrive est stocké — jamais perdu, jamais ignoré                │
+└───────────────────────────────────────┬─────────────────────────────────────────────────┘
+                                        │  trigger async (background task ou queue)
+                                        ▼
+┌─────────────────────────────────────────────────────────────────────────────────────────┐
+│                      COUCHE DATA QUALITY  (ootils_core/dq/)                             │
+│                                                                                         │
+│   DQPipeline.run(batch_id)                                                              │
+│   ┌─────────────────────────────────────────────────────────────────────────────┐       │
+│   │  EntityRuleRegistry                                                         │       │
+│   │  - Charge les règles par entity_type                                        │       │
+│   │  - Exécute : structural → referential → business → cross-row               │       │
+│   │  - Écrit les issues dans dq_issues                                          │       │
+│   │  - Met à jour ingest_batches.status :                                       │       │
+│   │      pending → processing → validated | rejected                            │       │
+│   └─────────────────────────────────────────────────────────────────────────────┘       │
+│                                                                                         │
+│   Tables PostgreSQL : dq_issues                                                         │
+│   Garantie : chaque issue est localisée (batch_id, row_index, field)                    │
+│   Garantie : batch rejeté = zéro écriture en core                                       │
+└───────────────────────────────────────┬─────────────────────────────────────────────────┘
+                                        │
+                       ┌────────────────┴───────────────────┐
+                       │                                    │
+                  VALIDATED                            REJECTED
+                       │                                    │
+                       ▼                                    ▼
+        POST /v1/ingest/{batch_id}/approve        GET /v1/ingest/{batch_id}/issues
+        POST /v1/ingest/{batch_id}/fix            → client corrige et recrée un batch
+                       │
+                       ▼
+┌─────────────────────────────────────────────────────────────────────────────────────────┐
+│                     COUCHE IMPORT  (ootils_core/import_pipeline/)                       │
+│                                                                                         │
+│   ImportService.approve(batch_id)                                                       │
+│   ┌─────────────────────────────────────────────────────────────────────────────┐       │
+│   │  - Lit ingest_rows WHERE batch_id = ? AND dq_status = 'valid'              │       │
+│   │  - Résout external_id → UUID interne (external_references)                  │       │
+│   │  - Upsert en core tables (transactionnel)                                   │       │
+│   │  - Écrit import_audit_log                                                   │       │
+│   │  - Émet event 'ingestion_complete' dans events                              │       │
+│   │  - Met à jour ingest_batches.status → imported                              │       │
+│   └─────────────────────────────────────────────────────────────────────────────┘       │
+│                                                                                         │
+│   Tables PostgreSQL core : items, locations, suppliers, supplier_items,                 │
+│                            item_planning_params, uom_conversions,                       │
+│                            operational_calendars, external_references                   │
+│   Garantie : transaction unique — tout ou rien                                          │
+└───────────────────────────────────────┬─────────────────────────────────────────────────┘
+                                        │
+                                        ▼
+┌─────────────────────────────────────────────────────────────────────────────────────────┐
+│                            CORE ENGINE  (ootils_core/engine/)                           │
+│                                                                                         │
+│   GraphPropagator  →  ProjectionCalc  →  ShortageDetector  →  AllocationEngine         │
+│                                                                                         │
+│   Tables : scenarios, nodes, edges, projection_series,                                  │
+│            calc_runs, shortages, events                                                 │
+└─────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Flux de données et leurs garanties
+
+| Étape | Entrée | Sortie | Garantie |
+|-------|--------|--------|---------|
+| Ingestion | Payload brut | `ingest_rows` | Rien n'est perdu. Le batch est toujours créé, même si le fichier est illisible (error = issue de type `parse_error`). |
+| DQ | `ingest_rows` | `dq_issues` + statut batch | Aucune donnée invalide n'atteint le core. Le pipeline DQ s'exécute de manière idempotente. |
+| Approbation | `ingest_rows` validées | Core tables | Transaction atomique. L'import est tout-ou-rien. `import_audit_log` trace chaque upsert. |
+| Engine | Core tables | Nodes, projections | Le moteur lit des données qualifiées. Garbage-in/garbage-out est impossible par construction. |
+
+---
+
+## 2. Modèle de données techniques
+
+Les données techniques sont **le cœur manquant** du schéma actuel. Sans elles, le moteur de planification tourne avec des hypothèses par défaut hardcodées — c'est inacceptable en production.
+
+### 2.1 Table `item_planning_params`
+
+```sql
+-- ============================================================
+-- item_planning_params : Paramètres de planification par item × location
+-- Versioning temporel : effective_from / effective_to
+-- Source tracking : qui a fourni ce paramètre
+-- ============================================================
+
+CREATE TYPE lot_size_rule_enum AS ENUM ('LOTFORLOT', 'FIXED_QTY', 'PERIOD_OF_SUPPLY');
+CREATE TYPE planning_param_source_enum AS ENUM ('erp', 'manual', 'ai_suggested');
+
+CREATE TABLE IF NOT EXISTS item_planning_params (
+    param_id                    UUID            NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Dimension : item × location (obligatoire)
+    item_id                     UUID            NOT NULL REFERENCES items(item_id),
+    location_id                 UUID            NOT NULL REFERENCES locations(location_id),
+
+    -- ── Lead times (en jours, NUMERIC pour fractions acceptées) ──
+    lead_time_sourcing_days     NUMERIC         CHECK (lead_time_sourcing_days >= 0),
+    lead_time_manufacturing_days NUMERIC        CHECK (lead_time_manufacturing_days >= 0),
+    lead_time_transit_days      NUMERIC         NOT NULL DEFAULT 0
+                                CHECK (lead_time_transit_days >= 0),
+    -- Lead time total calculé = sourcing + manufacturing + transit
+    -- Ne pas stocker le total calculé : il se calcule à la lecture
+
+    -- ── Stocks de sécurité ──
+    safety_stock_qty            NUMERIC         NOT NULL DEFAULT 0
+                                CHECK (safety_stock_qty >= 0),
+    safety_stock_days_of_coverage NUMERIC       CHECK (safety_stock_days_of_coverage >= 0),
+    -- Règle : si les deux sont fournis, safety_stock_qty est prioritaire.
+    -- safety_stock_days_of_coverage sert au calcul dynamique par le moteur.
+
+    -- ── Point de réapprovisionnement ──
+    reorder_point_qty           NUMERIC         CHECK (reorder_point_qty >= 0),
+    reorder_point_days          NUMERIC         CHECK (reorder_point_days >= 0),
+
+    -- ── Quantités de commande ──
+    min_order_qty               NUMERIC         NOT NULL DEFAULT 1
+                                CHECK (min_order_qty > 0),
+    max_order_qty               NUMERIC         CHECK (max_order_qty IS NULL OR max_order_qty >= min_order_qty),
+    order_multiple              NUMERIC         NOT NULL DEFAULT 1
+                                CHECK (order_multiple > 0),
+
+    -- ── Politique de lotissement ──
+    lot_size_rule               lot_size_rule_enum NOT NULL DEFAULT 'LOTFORLOT',
+    -- Pour FIXED_QTY : le moteur utilise min_order_qty comme taille fixe de lot
+    -- Pour PERIOD_OF_SUPPLY : planning_horizon_days définit la période couverte par lot
+
+    -- ── Horizon de planification ──
+    planning_horizon_days       INTEGER         NOT NULL DEFAULT 90
+                                CHECK (planning_horizon_days > 0),
+
+    -- ── Make vs Buy ──
+    is_make                     BOOLEAN         NOT NULL DEFAULT FALSE,
+    -- is_make = TRUE  → WorkOrderSupply (fabrication interne)
+    -- is_make = FALSE → PurchaseOrderSupply (achat externe)
+
+    -- ── Fournisseur préféré ──
+    preferred_supplier_id       UUID            REFERENCES suppliers(supplier_id),
+    -- NULL si is_make = TRUE ou si non défini
+
+    -- ── Versioning temporel ──
+    effective_from              DATE            NOT NULL DEFAULT CURRENT_DATE,
+    effective_to                DATE,           -- NULL = toujours valide
+    CHECK (effective_to IS NULL OR effective_to > effective_from),
+
+    -- ── Traçabilité source ──
+    source                      planning_param_source_enum NOT NULL DEFAULT 'manual',
+    source_batch_id             UUID,           -- Référence ingest_batches si source = erp
+    created_by                  TEXT,           -- user_ref ou system_ref
+    notes                       TEXT,
+
+    -- ── Audit ──
+    created_at                  TIMESTAMPTZ     NOT NULL DEFAULT now(),
+    updated_at                  TIMESTAMPTZ     NOT NULL DEFAULT now(),
+
+    -- Contrainte : une seule config active par (item, location) à une date donnée.
+    -- Le moteur charge la version dont effective_from <= planning_date < effective_to.
+    -- Pas de UNIQUE simple : le versioning temporel le gère.
+    -- Index composite couvre l'unicité de la version courante.
+    UNIQUE NULLS NOT DISTINCT (item_id, location_id, effective_from)
+);
+
+-- Accès principal : paramètres actifs pour un item × location à une date
+CREATE INDEX IF NOT EXISTS idx_ipp_item_location_active
+    ON item_planning_params (item_id, location_id, effective_from, effective_to);
+
+-- Accès par source (audit des paramètres ERP vs manual vs AI)
+CREATE INDEX IF NOT EXISTS idx_ipp_source
+    ON item_planning_params (source, updated_at DESC);
+
+-- Lookup fournisseur préféré (pour résolution à l'import)
+CREATE INDEX IF NOT EXISTS idx_ipp_preferred_supplier
+    ON item_planning_params (preferred_supplier_id)
+    WHERE preferred_supplier_id IS NOT NULL;
+```
+
+**Décision ferme sur le versioning temporel :**
+L'approche `effective_from` / `effective_to` est **obligatoire** dès le départ. Ne pas la mettre maintenant, c'est garantir une migration douloureuse en production quand un client veut planifier selon les paramètres "d'avant la renégociation tarifaire". La contrainte `UNIQUE NULLS NOT DISTINCT (item_id, location_id, effective_from)` empêche deux versions démarrant le même jour — le cas de bord est géré à l'application (la nouvelle version ferme la précédente).
+
+### 2.2 Table `uom_conversions`
+
+```sql
+-- ============================================================
+-- uom_conversions : Conversions d'unités de mesure
+-- item_id NULL = conversion globale (EA → PAL pour tous les articles)
+-- item_id non-NULL = conversion spécifique à un article
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS uom_conversions (
+    conversion_id   UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    from_uom        TEXT        NOT NULL,   -- ex: EA, KG, L, M
+    to_uom          TEXT        NOT NULL,   -- ex: PAL, BOX, TON
+
+    -- NULL = conversion universelle applicable à tout article dans ces UOM
+    -- Non-NULL = override pour cet article spécifique
+    item_id         UUID        REFERENCES items(item_id),
+
+    -- factor : 1 from_uom = factor to_uom
+    -- ex: 1 PAL = 48 EA → factor = 48 (from=PAL, to=EA)
+    -- La conversion inverse se calcule : 1/factor
+    factor          NUMERIC     NOT NULL CHECK (factor > 0),
+
+    -- Validité temporelle (optionnel, pour coûts/capacités qui changent)
+    effective_from  DATE        NOT NULL DEFAULT CURRENT_DATE,
+    effective_to    DATE,
+    CHECK (effective_to IS NULL OR effective_to > effective_from),
+
+    -- Audit
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- Unicité : une seule conversion (from_uom, to_uom) par article à une date
+    UNIQUE NULLS NOT DISTINCT (from_uom, to_uom, item_id, effective_from)
+);
+
+-- Lookup par UOM (moteur cherche souvent : "comment convertir EA en PAL ?")
+CREATE INDEX IF NOT EXISTS idx_uom_conv_pair
+    ON uom_conversions (from_uom, to_uom, item_id);
+
+-- Lookup article-specific conversions
+CREATE INDEX IF NOT EXISTS idx_uom_conv_item
+    ON uom_conversions (item_id)
+    WHERE item_id IS NOT NULL;
+```
+
+**Décision ferme sur la résolution :**
+À la lecture, le moteur applique la priorité suivante : conversion item-specific > conversion globale. Ne jamais retourner une erreur "UOM inconnu" sans avoir cherché dans les deux niveaux. Le `factor` est toujours stocké dans un sens canonique (le plus grand vers le plus petit en général, ou l'ordre alphabétique) — la direction est documentée dans une table séparée `uom_registry` (hors scope de cette migration, mais prévoir le slot).
+
+### 2.3 Table `operational_calendars`
+
+```sql
+-- ============================================================
+-- operational_calendars : Calendriers opérationnels par site
+-- Grain : un enregistrement par (location, date)
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS operational_calendars (
+    calendar_id     UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    location_id     UUID        NOT NULL REFERENCES locations(location_id),
+    date            DATE        NOT NULL,
+
+    -- Jour ouvrable ?
+    is_working_day  BOOLEAN     NOT NULL DEFAULT TRUE,
+
+    -- Nombre de shifts actifs ce jour (0 si non-working, 1-3 typiquement)
+    shift_count     SMALLINT    NOT NULL DEFAULT 1
+                    CHECK (shift_count BETWEEN 0 AND 3),
+
+    -- Facteur de capacité (1.0 = pleine capacité, 0.5 = demi-journée, 0.0 = fermé)
+    capacity_factor NUMERIC     NOT NULL DEFAULT 1.0
+                    CHECK (capacity_factor BETWEEN 0.0 AND 1.0),
+
+    -- Raison (férié national, maintenance planifiée, etc.)
+    calendar_type   TEXT        CHECK (calendar_type IN (
+                        'standard', 'public_holiday', 'plant_shutdown',
+                        'reduced_capacity', 'extended_capacity'
+                    )),
+    notes           TEXT,
+
+    -- Audit
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- Un seul enregistrement par (location, date)
+    UNIQUE (location_id, date)
+);
+
+-- Accès principal : plage de dates pour un site
+CREATE INDEX IF NOT EXISTS idx_opcal_location_date
+    ON operational_calendars (location_id, date);
+
+-- Accès des jours non ouvrables (fréquent pour calcul lead time)
+CREATE INDEX IF NOT EXISTS idx_opcal_non_working
+    ON operational_calendars (location_id, date)
+    WHERE is_working_day = FALSE;
+```
+
+**Décision ferme sur la granularité :**
+Un enregistrement par (location, date) est la seule approche viable. Ne pas stocker des "patterns de calendrier" (style "toujours fermé le dimanche") — ça paraît élégant mais génère des bugs dans les cas limites (ponts, jours fériés tombant un lundi). L'import charge une plage explicite. Le moteur fait un lookup direct. Si la date n'existe pas dans le calendrier, il suppose `is_working_day=TRUE, capacity_factor=1.0` — comportement safe-by-default documenté.
+
+---
+
+## 3. Séparation des responsabilités
+
+### Structure des modules Python
+
+```
+src/ootils_core/
+│
+├── ingestion/                    # Couche 1 : réception brute
+│   ├── __init__.py
+│   ├── router.py                 # FastAPI router : POST /v1/ingest/{type}
+│   ├── batch_writer.py           # Écrit ingest_batches + ingest_rows
+│   ├── parsers/
+│   │   ├── __init__.py
+│   │   ├── tsv_parser.py         # TSV → list[dict]
+│   │   └── json_parser.py        # JSON payload → list[dict]
+│   └── models.py                 # Pydantic : IngestRequest, BatchResponse
+│
+├── dq/                           # Couche 2 : Data Quality
+│   ├── __init__.py
+│   ├── pipeline.py               # DQPipeline.run(batch_id) — point d'entrée
+│   ├── registry.py               # EntityRuleRegistry — charge les règles par type
+│   ├── issue_writer.py           # Écrit dq_issues
+│   ├── rules/
+│   │   ├── __init__.py
+│   │   ├── base.py               # Classe abstraite DQRule
+│   │   ├── items.py              # Règles DQ pour entity_type='items'
+│   │   ├── locations.py
+│   │   ├── suppliers.py
+│   │   ├── supplier_items.py
+│   │   ├── item_planning_params.py
+│   │   ├── uom_conversions.py
+│   │   └── operational_calendars.py
+│   └── models.py                 # Pydantic : DQIssue, DQResult
+│
+├── import_pipeline/              # Couche 3 : import validé → core
+│   ├── __init__.py
+│   ├── service.py                # ImportService.approve(batch_id)
+│   ├── resolvers.py              # external_id → UUID via external_references
+│   ├── upsert/
+│   │   ├── __init__.py
+│   │   ├── items.py
+│   │   ├── locations.py
+│   │   ├── suppliers.py
+│   │   ├── supplier_items.py
+│   │   ├── item_planning_params.py
+│   │   ├── uom_conversions.py
+│   │   └── operational_calendars.py
+│   └── audit_writer.py           # Écrit import_audit_log
+│
+└── api/
+    └── routers/
+        └── ingest.py             # Regroupe les endpoints /v1/ingest/*
+```
+
+### Interfaces entre couches
+
+**Règle absolue : aucune couche n'importe depuis une couche "plus bas".**
+
+```
+ingestion/ → ne connaît pas dq/ ni import_pipeline/
+dq/        → ne connaît pas import_pipeline/
+import_pipeline/ → ne connaît pas ingestion/ ni dq/
+```
+
+Le couplage se fait uniquement via la **base de données** (tables partagées) et via des **interfaces de service explicites** :
+
+```python
+# ingestion/batch_writer.py
+class BatchWriter:
+    async def write_batch(self, entity_type: str, rows: list[dict]) -> UUID:
+        """Écrit en staging. Retourne batch_id. Ne valide rien."""
+        ...
+
+# dq/pipeline.py
+class DQPipeline:
+    async def run(self, batch_id: UUID) -> DQResult:
+        """Lit staging, écrit issues, met à jour statut batch."""
+        ...
+
+# import_pipeline/service.py
+class ImportService:
+    async def approve(self, batch_id: UUID) -> ImportResult:
+        """Lit staging validé, upsert en core, écrit audit. Transaction unique."""
+        ...
+```
+
+**Déclenchement asynchrone :**
+L'ingestion déclenche la DQ via un `BackgroundTask` FastAPI (suffisant pour MVP). Quand le volume monte, remplacer par une queue légère (PostgreSQL LISTEN/NOTIFY ou Redis Queue) sans changer l'interface DQPipeline.
+
+```python
+# ingestion/router.py
+@router.post("/v1/ingest/{entity_type}")
+async def ingest(entity_type: str, ..., background_tasks: BackgroundTasks):
+    batch_id = await batch_writer.write_batch(entity_type, rows)
+    background_tasks.add_task(dq_pipeline.run, batch_id)  # ← couplage minimal
+    return BatchResponse(batch_id=batch_id, status="pending")
+```
+
+---
+
+## 4. API design — Pipeline 2 étapes
+
+### Endpoints
+
+```
+POST /v1/ingest/{entity_type}
+  → Staging immédiat, réponse HTTP 202 avec batch_id
+  → entity_type : items | locations | suppliers | supplier_items |
+                  item_planning_params | uom_conversions | operational_calendars
+
+GET  /v1/ingest/{batch_id}
+  → Statut complet du batch
+
+GET  /v1/ingest/{batch_id}/issues
+  → Liste paginée des problèmes DQ
+
+POST /v1/ingest/{batch_id}/fix
+  → Correction d'une ligne avant approbation
+
+POST /v1/ingest/{batch_id}/approve
+  → Import vers core (nécessite status=validated)
+```
+
+### Schéma de réponses
+
+#### `POST /v1/ingest/{entity_type}` — Réponse 202
+
+```json
+{
+  "batch_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "entity_type": "items",
+  "status": "pending",
+  "row_count": 142,
+  "received_at": "2026-04-05T10:00:00Z",
+  "_links": {
+    "status": "/v1/ingest/a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "issues": "/v1/ingest/a1b2c3d4-e5f6-7890-abcd-ef1234567890/issues",
+    "approve": "/v1/ingest/a1b2c3d4-e5f6-7890-abcd-ef1234567890/approve"
+  }
+}
+```
+
+#### `GET /v1/ingest/{batch_id}` — Statut complet
+
+```json
+{
+  "batch_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "entity_type": "items",
+  "status": "validated",
+  "row_count": 142,
+  "dq_summary": {
+    "valid_rows": 139,
+    "invalid_rows": 3,
+    "warnings": 7,
+    "error_types": ["missing_required_field", "invalid_enum_value"]
+  },
+  "received_at": "2026-04-05T10:00:00Z",
+  "dq_completed_at": "2026-04-05T10:00:02Z",
+  "imported_at": null
+}
+```
+
+#### `GET /v1/ingest/{batch_id}/issues` — Problèmes DQ
+
+```json
+{
+  "batch_id": "a1b2c3d4-...",
+  "total_issues": 3,
+  "issues": [
+    {
+      "issue_id": "b2c3d4e5-...",
+      "row_index": 7,
+      "external_id": "SKU-BAD-001",
+      "field": "item_type",
+      "severity": "error",
+      "rule": "enum_validation",
+      "message": "Valeur 'spare_part' invalide. Valeurs autorisées : finished_good, component, raw_material, semi_finished",
+      "raw_value": "spare_part",
+      "suggestion": "component"
+    },
+    {
+      "issue_id": "c3d4e5f6-...",
+      "row_index": 23,
+      "external_id": null,
+      "field": "external_id",
+      "severity": "error",
+      "rule": "required_field",
+      "message": "Le champ 'external_id' est obligatoire et ne peut pas être vide",
+      "raw_value": "",
+      "suggestion": null
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "page_size": 50,
+    "total_pages": 1
+  }
+}
+```
+
+#### `POST /v1/ingest/{batch_id}/fix` — Correction
+
+```json
+// Request
+{
+  "fixes": [
+    {
+      "row_index": 7,
+      "field": "item_type",
+      "corrected_value": "component"
+    }
+  ]
+}
+
+// Response
+{
+  "batch_id": "a1b2c3d4-...",
+  "fixes_applied": 1,
+  "status": "pending",
+  "message": "Correction appliquée. La validation DQ est relancée automatiquement."
+}
+```
+
+**Décision ferme sur le `/fix` :**
+Une correction relance automatiquement le pipeline DQ complet sur le batch (pas seulement la ligne corrigée). C'est plus coûteux mais c'est la seule approche correcte — une correction peut résoudre une erreur de référence croisée sur d'autres lignes.
+
+#### `POST /v1/ingest/{batch_id}/approve` — Import
+
+```json
+// Request (vide, le batch_id suffit)
+{}
+
+// Response 200 — succès
+{
+  "batch_id": "a1b2c3d4-...",
+  "entity_type": "items",
+  "status": "imported",
+  "import_summary": {
+    "inserted": 120,
+    "updated": 19,
+    "skipped": 0
+  },
+  "event_id": "d4e5f6g7-...",
+  "imported_at": "2026-04-05T10:05:33Z"
+}
+
+// Response 409 — batch non validé
+{
+  "error": "batch_not_validated",
+  "message": "Ce batch a le statut 'rejected'. Corrigez les issues avant d'approuver.",
+  "batch_id": "a1b2c3d4-...",
+  "status": "rejected",
+  "open_issues": 3
+}
+```
+
+### Machine d'états du batch
+
+```
+         ┌──────────────────────────────────────────────────────┐
+         │                                                      │
+         ▼                                                      │
+     [pending]                                                  │
+         │                                                      │
+         │  DQPipeline.run() déclenché                          │
+         ▼                                                      │
+    [processing]                                                │
+         │                                                      │
+    ┌────┴────┐                                                  │
+    │         │                                                  │
+    ▼         ▼                                                  │
+[validated] [rejected] ←─── POST /fix ──────────────────────────┘
+    │                    (relance DQ → retour pending)
+    │  POST /approve
+    ▼
+ [importing]
+    │
+    ├── succès ──→ [imported]
+    └── erreur ──→ [import_failed]  (rollback garanti)
+```
+
+---
+
+## 5. Migration prioritaire (004-import)
+
+La migration `004_import_pipeline.sql` est la **priorité absolue** avant toute implémentation des endpoints d'import.
+
+```sql
+-- ============================================================
+-- Ootils Core — Migration 004: Import Pipeline & Technical Data
+-- 
+-- Crée :
+--   1. external_references   (mapping codes ERP → UUIDs internes)
+--   2. ingest_batches        (table staging metadata)
+--   3. ingest_rows           (table staging données brutes)
+--   4. dq_issues             (problèmes Data Quality)
+--   5. import_audit_log      (traçabilité des upserts en core)
+--   6. suppliers             (master data fournisseurs)
+--   7. supplier_items        (relation item × fournisseur)
+--   8. item_planning_params  (données techniques planification)
+--   9. uom_conversions       (conversions unités de mesure)
+--  10. operational_calendars (calendriers opérationnels)
+--  11. external_id sur items et locations
+-- ============================================================
+
+-- ─────────────────────────────────────────────────────────────
+-- TYPES ENUM (idempotents)
+-- ─────────────────────────────────────────────────────────────
+
+DO $$ BEGIN
+    CREATE TYPE lot_size_rule_enum AS ENUM ('LOTFORLOT', 'FIXED_QTY', 'PERIOD_OF_SUPPLY');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE TYPE planning_param_source_enum AS ENUM ('erp', 'manual', 'ai_suggested');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- ─────────────────────────────────────────────────────────────
+-- 1. Ajouter external_id sur items et locations
+-- ─────────────────────────────────────────────────────────────
+
+ALTER TABLE items
+    ADD COLUMN IF NOT EXISTS external_id TEXT;
+
+-- Backfill : les items existants reçoivent leur item_id en external_id temporaire
+UPDATE items
+    SET external_id = item_id::TEXT
+    WHERE external_id IS NULL;
+
+ALTER TABLE items
+    ALTER COLUMN external_id SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_items_external_id
+    ON items (external_id);
+
+
+ALTER TABLE locations
+    ADD COLUMN IF NOT EXISTS external_id TEXT;
+
+UPDATE locations
+    SET external_id = location_id::TEXT
+    WHERE external_id IS NULL;
+
+ALTER TABLE locations
+    ALTER COLUMN external_id SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_locations_external_id
+    ON locations (external_id);
+
+-- ─────────────────────────────────────────────────────────────
+-- 2. external_references : mapping codes ERP → UUIDs Ootils
+-- ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS external_references (
+    ref_id          UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_type     TEXT        NOT NULL
+                    CHECK (entity_type IN (
+                        'item', 'location', 'supplier', 'supplier_item',
+                        'item_planning_params'
+                    )),
+    external_id     TEXT        NOT NULL,
+    source_system   TEXT        NOT NULL DEFAULT 'default',  -- 'sap_ecc', 'dynamics', 'manual', etc.
+    internal_id     UUID        NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    UNIQUE (entity_type, external_id, source_system)
+);
+
+CREATE INDEX IF NOT EXISTS idx_extref_lookup
+    ON external_references (entity_type, external_id, source_system);
+
+CREATE INDEX IF NOT EXISTS idx_extref_internal
+    ON external_references (internal_id, entity_type);
+
+-- ─────────────────────────────────────────────────────────────
+-- 3. ingest_batches : metadata des lots d'import en staging
+-- ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS ingest_batches (
+    batch_id            UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_type         TEXT        NOT NULL,               -- 'items', 'suppliers', etc.
+    source_system       TEXT        NOT NULL DEFAULT 'api', -- 'api', 'sftp', 'manual'
+    original_filename   TEXT,                               -- Nom du fichier TSV si upload
+    row_count           INTEGER     NOT NULL DEFAULT 0,
+    status              TEXT        NOT NULL DEFAULT 'pending'
+                        CHECK (status IN (
+                            'pending', 'processing', 'validated',
+                            'rejected', 'importing', 'imported', 'import_failed'
+                        )),
+    -- DQ summary (dénormalisé pour affichage rapide)
+    dq_valid_rows       INTEGER,
+    dq_invalid_rows     INTEGER,
+    dq_warning_count    INTEGER,
+    -- Timestamps du pipeline
+    received_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    dq_started_at       TIMESTAMPTZ,
+    dq_completed_at     TIMESTAMPTZ,
+    importing_started_at TIMESTAMPTZ,
+    imported_at         TIMESTAMPTZ,
+    -- Provenance
+    submitted_by        TEXT,       -- user_ref ou system_ref
+    conflict_strategy   TEXT        NOT NULL DEFAULT 'upsert'
+                        CHECK (conflict_strategy IN ('upsert', 'reject_duplicates', 'ignore_duplicates')),
+    -- Import results (après approve)
+    import_inserted     INTEGER,
+    import_updated      INTEGER,
+    import_skipped      INTEGER,
+    error_message       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_batches_status
+    ON ingest_batches (status, received_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_batches_entity_type
+    ON ingest_batches (entity_type, status);
+
+-- ─────────────────────────────────────────────────────────────
+-- 4. ingest_rows : données brutes en staging
+-- ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS ingest_rows (
+    row_id          UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id        UUID        NOT NULL REFERENCES ingest_batches(batch_id) ON DELETE CASCADE,
+    row_index       INTEGER     NOT NULL,    -- Position 0-indexée dans le fichier original
+    raw_data        JSONB       NOT NULL,    -- Ligne brute parsée (colonnes → valeurs)
+    dq_status       TEXT        NOT NULL DEFAULT 'pending'
+                    CHECK (dq_status IN ('pending', 'valid', 'warning', 'error')),
+    -- Stocke la version transformée/normalisée après DQ réussie
+    normalized_data JSONB,
+
+    UNIQUE (batch_id, row_index)
+);
+
+-- Note : raw_data est JSONB ici UNIQUEMENT pour la couche staging.
+-- Les core tables n'utilisent jamais JSONB (convention du projet : typed columns everywhere).
+
+CREATE INDEX IF NOT EXISTS idx_ingest_rows_batch
+    ON ingest_rows (batch_id, dq_status);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_rows_batch_valid
+    ON ingest_rows (batch_id)
+    WHERE dq_status IN ('valid', 'warning');
+
+-- ─────────────────────────────────────────────────────────────
+-- 5. dq_issues : problèmes Data Quality par ligne
+-- ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS dq_issues (
+    issue_id        UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id        UUID        NOT NULL REFERENCES ingest_batches(batch_id) ON DELETE CASCADE,
+    row_id          UUID        REFERENCES ingest_rows(row_id) ON DELETE CASCADE,
+    row_index       INTEGER,    -- Dénormalisé pour affichage sans JOIN
+    external_id     TEXT,       -- Code métier de la ligne (pour faciliter le debug)
+    field           TEXT,       -- Colonne concernée (NULL si erreur de structure globale)
+    severity        TEXT        NOT NULL
+                    CHECK (severity IN ('error', 'warning', 'info')),
+    rule            TEXT        NOT NULL,   -- ex: 'required_field', 'enum_validation', 'referential_integrity'
+    message         TEXT        NOT NULL,
+    raw_value       TEXT,       -- Valeur brute qui a causé l'erreur
+    suggestion      TEXT,       -- Correction suggérée si possible
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+    -- Issues are immutable — no updated_at
+    -- Une correction via /fix recrée les issues (on efface + revalide)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dq_issues_batch
+    ON dq_issues (batch_id, severity);
+
+CREATE INDEX IF NOT EXISTS idx_dq_issues_batch_row
+    ON dq_issues (batch_id, row_index);
+
+-- ─────────────────────────────────────────────────────────────
+-- 6. import_audit_log : traçabilité des upserts en core
+-- ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS import_audit_log (
+    audit_id        UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id        UUID        NOT NULL REFERENCES ingest_batches(batch_id),
+    entity_type     TEXT        NOT NULL,
+    entity_id       UUID        NOT NULL,   -- PK de l'entité créée/mise à jour
+    external_id     TEXT,
+    action          TEXT        NOT NULL
+                    CHECK (action IN ('inserted', 'updated', 'skipped')),
+    -- Snapshot avant/après (limité aux champs clés pour ne pas exploser le volume)
+    previous_values JSONB,      -- NULL si inserted
+    new_values      JSONB,
+    imported_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+    -- Immutable
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_batch
+    ON import_audit_log (batch_id);
+
+CREATE INDEX IF NOT EXISTS idx_audit_entity
+    ON import_audit_log (entity_type, entity_id, imported_at DESC);
+
+-- ─────────────────────────────────────────────────────────────
+-- 7. suppliers
+-- ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS suppliers (
+    supplier_id         UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    external_id         TEXT        NOT NULL UNIQUE,
+    name                TEXT        NOT NULL,
+    location_id         UUID        REFERENCES locations(location_id),
+    lead_time_days      NUMERIC     NOT NULL DEFAULT 14 CHECK (lead_time_days >= 0),
+    reliability_score   NUMERIC     NOT NULL DEFAULT 1.0 CHECK (reliability_score BETWEEN 0 AND 1),
+    moq                 NUMERIC     CHECK (moq IS NULL OR moq >= 0),
+    unit_cost_override  NUMERIC     CHECK (unit_cost_override IS NULL OR unit_cost_override >= 0),
+    currency            TEXT        NOT NULL DEFAULT 'USD',
+    status              TEXT        NOT NULL DEFAULT 'active'
+                        CHECK (status IN ('active', 'inactive', 'approved', 'blocked')),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_suppliers_external_id ON suppliers (external_id);
+CREATE INDEX IF NOT EXISTS idx_suppliers_status ON suppliers (status) WHERE status = 'active';
+
+-- ─────────────────────────────────────────────────────────────
+-- 8. supplier_items
+-- ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS supplier_items (
+    supplier_item_id    UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    supplier_id         UUID        NOT NULL REFERENCES suppliers(supplier_id),
+    item_id             UUID        NOT NULL REFERENCES items(item_id),
+    supplier_item_code  TEXT,
+    lead_time_days      NUMERIC     NOT NULL DEFAULT 14 CHECK (lead_time_days >= 0),
+    unit_cost           NUMERIC     CHECK (unit_cost IS NULL OR unit_cost >= 0),
+    moq                 NUMERIC     CHECK (moq IS NULL OR moq >= 0),
+    lot_multiple        NUMERIC     CHECK (lot_multiple IS NULL OR lot_multiple >= 1),
+    reliability_score   NUMERIC     CHECK (reliability_score IS NULL OR reliability_score BETWEEN 0 AND 1),
+    preferred           BOOLEAN     NOT NULL DEFAULT FALSE,
+    effective_start     DATE,
+    effective_end       DATE,
+    CHECK (effective_end IS NULL OR effective_end > effective_start),
+    status              TEXT        NOT NULL DEFAULT 'active'
+                        CHECK (status IN ('active', 'inactive', 'approved')),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    UNIQUE (supplier_id, item_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_supplier_items_item ON supplier_items (item_id);
+CREATE INDEX IF NOT EXISTS idx_supplier_items_preferred ON supplier_items (item_id, preferred) WHERE preferred = TRUE;
+
+-- ─────────────────────────────────────────────────────────────
+-- 9. item_planning_params
+-- ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS item_planning_params (
+    param_id                        UUID            NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    item_id                         UUID            NOT NULL REFERENCES items(item_id),
+    location_id                     UUID            NOT NULL REFERENCES locations(location_id),
+    lead_time_sourcing_days         NUMERIC         CHECK (lead_time_sourcing_days >= 0),
+    lead_time_manufacturing_days    NUMERIC         CHECK (lead_time_manufacturing_days >= 0),
+    lead_time_transit_days          NUMERIC         NOT NULL DEFAULT 0 CHECK (lead_time_transit_days >= 0),
+    safety_stock_qty                NUMERIC         NOT NULL DEFAULT 0 CHECK (safety_stock_qty >= 0),
+    safety_stock_days_of_coverage   NUMERIC         CHECK (safety_stock_days_of_coverage >= 0),
+    reorder_point_qty               NUMERIC         CHECK (reorder_point_qty >= 0),
+    reorder_point_days              NUMERIC         CHECK (reorder_point_days >= 0),
+    min_order_qty                   NUMERIC         NOT NULL DEFAULT 1 CHECK (min_order_qty > 0),
+    max_order_qty                   NUMERIC         CHECK (max_order_qty IS NULL OR max_order_qty >= min_order_qty),
+    order_multiple                  NUMERIC         NOT NULL DEFAULT 1 CHECK (order_multiple > 0),
+    lot_size_rule                   lot_size_rule_enum NOT NULL DEFAULT 'LOTFORLOT',
+    planning_horizon_days           INTEGER         NOT NULL DEFAULT 90 CHECK (planning_horizon_days > 0),
+    is_make                         BOOLEAN         NOT NULL DEFAULT FALSE,
+    preferred_supplier_id           UUID            REFERENCES suppliers(supplier_id),
+    effective_from                  DATE            NOT NULL DEFAULT CURRENT_DATE,
+    effective_to                    DATE,
+    CHECK (effective_to IS NULL OR effective_to > effective_from),
+    source                          planning_param_source_enum NOT NULL DEFAULT 'manual',
+    source_batch_id                 UUID            REFERENCES ingest_batches(batch_id),
+    created_by                      TEXT,
+    notes                           TEXT,
+    created_at                      TIMESTAMPTZ     NOT NULL DEFAULT now(),
+    updated_at                      TIMESTAMPTZ     NOT NULL DEFAULT now(),
+
+    UNIQUE NULLS NOT DISTINCT (item_id, location_id, effective_from)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ipp_item_location_active
+    ON item_planning_params (item_id, location_id, effective_from, effective_to);
+
+CREATE INDEX IF NOT EXISTS idx_ipp_source
+    ON item_planning_params (source, updated_at DESC);
+
+-- ─────────────────────────────────────────────────────────────
+-- 10. uom_conversions
+-- ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS uom_conversions (
+    conversion_id   UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    from_uom        TEXT        NOT NULL,
+    to_uom          TEXT        NOT NULL,
+    item_id         UUID        REFERENCES items(item_id),
+    factor          NUMERIC     NOT NULL CHECK (factor > 0),
+    effective_from  DATE        NOT NULL DEFAULT CURRENT_DATE,
+    effective_to    DATE,
+    CHECK (effective_to IS NULL OR effective_to > effective_from),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    UNIQUE NULLS NOT DISTINCT (from_uom, to_uom, item_id, effective_from)
+);
+
+CREATE INDEX IF NOT EXISTS idx_uom_conv_pair
+    ON uom_conversions (from_uom, to_uom, item_id);
+
+-- ─────────────────────────────────────────────────────────────
+-- 11. operational_calendars
+-- ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS operational_calendars (
+    calendar_id     UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    location_id     UUID        NOT NULL REFERENCES locations(location_id),
+    date            DATE        NOT NULL,
+    is_working_day  BOOLEAN     NOT NULL DEFAULT TRUE,
+    shift_count     SMALLINT    NOT NULL DEFAULT 1 CHECK (shift_count BETWEEN 0 AND 3),
+    capacity_factor NUMERIC     NOT NULL DEFAULT 1.0 CHECK (capacity_factor BETWEEN 0.0 AND 1.0),
+    calendar_type   TEXT        CHECK (calendar_type IN (
+                        'standard', 'public_holiday', 'plant_shutdown',
+                        'reduced_capacity', 'extended_capacity'
+                    )),
+    notes           TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    UNIQUE (location_id, date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_opcal_location_date
+    ON operational_calendars (location_id, date);
+
+CREATE INDEX IF NOT EXISTS idx_opcal_non_working
+    ON operational_calendars (location_id, date)
+    WHERE is_working_day = FALSE;
+```
+
+### Ordre de priorité d'implémentation
+
+| Priorité | Table | Pourquoi |
+|----------|-------|---------|
+| **P0** | `ingest_batches` + `ingest_rows` + `dq_issues` | Sans elles, le pipeline 2 étapes est impossible |
+| **P0** | `external_id` sur `items` + `locations` | Sans ça, aucun import ne peut faire la résolution ERP→UUID |
+| **P0** | `external_references` | Seule table de mapping cross-système |
+| **P1** | `suppliers` + `supplier_items` | Master data manquante, bloque les imports relationnels |
+| **P1** | `item_planning_params` | Le cœur des données techniques — sans ça le moteur tourne à l'aveugle |
+| **P2** | `uom_conversions` | Critique pour les calculs de quantités multi-UOM |
+| **P2** | `operational_calendars` | Critique pour les calculs de lead time précis |
+| **P3** | `import_audit_log` | Traçabilité, peut démarrer sans mais ne doit pas rester sans |
+
+---
+
+## 6. Anti-patterns à éviter absolument
+
+### AP-1 : Import direct en core sans staging ❌
+
+**Pattern à bannir :**
+```python
+# INTERDIT : valider ET persister en une seule passe
+@router.post("/v1/import/items")
+async def import_items(data: list[ItemIn]):
+    for item in data:
+        validate(item)      # si ça échoue → rollback partiel ou état incohérent
+        await db.upsert(item)
+```
+
+**Pourquoi c'est fatal :**
+Un import de 10 000 lignes qui plante à la ligne 9 999 laisse 9 998 lignes commitées et 2 en suspens. Le client ne sait pas quoi relancer. L'état de la base est indéterminé.
+
+**Solution :** staging → DQ → approve (pipeline 2 étapes).
+
+---
+
+### AP-2 : Stocker les paramètres de planification dans le code Python ❌
+
+**Pattern à bannir :**
+```python
+# INTERDIT : hardcoder les lead times dans le moteur
+DEFAULT_LEAD_TIME = 14
+SAFETY_STOCK_MULTIPLIER = 1.5
+```
+
+**Pourquoi c'est fatal :**
+Chaque client a ses propres paramètres. Un changement de paramètre nécessite un redéploiement. Les simulations de scénarios ("que se passe-t-il si le lead time passe à 21 jours ?") deviennent impossibles sans modifier le code.
+
+**Solution :** `item_planning_params` en base. Le moteur lit toujours depuis la DB, jamais depuis des constantes.
+
+---
+
+### AP-3 : Utiliser JSONB pour les données techniques ❌
+
+**Pattern à bannir :**
+```sql
+-- INTERDIT : paramètres dans un blob JSONB
+ALTER TABLE items ADD COLUMN planning_params JSONB;
+```
+
+**Pourquoi c'est fatal :**
+- Impossible d'indexer `lead_time_sourcing_days >= 14`
+- Pas de CHECK constraints sur les valeurs
+- Migrations impossibles (comment ajouter un champ obligatoire dans un JSONB ?)
+- Le moteur ne peut pas joindre sur des critères de planification
+
+**Exception acceptable :** JSONB pour les données *brutes en staging* (`ingest_rows.raw_data`) uniquement — là où la structure est intentionnellement inconnue.
+
+---
+
+### AP-4 : Une seule table de politiques pour tout ❌
+
+**Pattern à bannir :**
+```sql
+-- INTERDIT : tout dans une seule table fourrée
+CREATE TABLE config (key TEXT, value TEXT, item_id UUID, location_id UUID);
+```
+
+**Pourquoi c'est fatal :**
+Impossible de valider les types. Impossible d'indexer efficacement. Les jointures deviennent des pivots coûteux. Le schéma ne documente rien.
+
+**Solution :** une table dédiée par sémantique : `item_planning_params`, `uom_conversions`, `operational_calendars`. Chaque table a ses propres contraintes et index.
+
+---
+
+### AP-5 : Pas de versioning temporel sur les paramètres ❌
+
+**Pattern à bannir :**
+```sql
+-- INTERDIT : un seul enregistrement par (item, location)
+UNIQUE (item_id, location_id)  -- écrase l'historique à chaque mise à jour
+```
+
+**Pourquoi c'est fatal :**
+- Impossible de simuler "comment le plan aurait évolué si j'avais eu ces paramètres en janvier ?"
+- Impossible d'auditer "qui a changé le MOQ et quand ?"
+- Impossible de planifier une transition graduelle (nouveau contrat fournisseur à partir du 1er juillet)
+
+**Solution :** `effective_from` / `effective_to` sur toutes les tables de paramètres. La version courante = `effective_from <= today < effective_to`.
+
+---
+
+### AP-6 : Couplage fort entre les couches du pipeline ❌
+
+**Pattern à bannir :**
+```python
+# INTERDIT : l'ingestion appelle directement le service d'import
+from ootils_core.import_pipeline.service import ImportService
+
+@router.post("/v1/ingest/{type}")
+async def ingest(data, import_service: ImportService = Depends()):
+    batch_id = await stage(data)
+    await import_service.approve(batch_id)  # ← court-circuite la DQ
+```
+
+**Pourquoi c'est fatal :**
+Ça rend le pipeline 2 étapes inutile. En cas d'erreur en production, on ne sait plus à quelle étape le système a failli.
+
+**Solution :** les couches communiquent uniquement via la base de données (statut du batch) et des interfaces de service explicites. Jamais d'imports directs cross-couche.
+
+---
+
+### AP-7 : Import sans résolution external_id → UUID ❌
+
+**Pattern à bannir :**
+```python
+# INTERDIT : utiliser le code ERP comme PK en base Ootils
+INSERT INTO nodes (item_id, ...) VALUES ('SKU-PUMP-01', ...)
+```
+
+**Pourquoi c'est fatal :**
+Les codes ERP ne sont pas stables (restructuration SI, migration ERP, fusion-acquisition). Un client qui change son SAP casse tout.
+
+**Solution :** `external_references` est la seule passerelle. Les core tables n'exposent que des UUIDs internes. La résolution `external_id → UUID` est une opération explicite et traçable.
+
+---
+
+### AP-8 : Pas de gestion d'erreur atomique sur les imports relationnels ❌
+
+**Pattern à bannir :**
+```python
+# INTERDIT : import multi-entités sans transaction
+await import_items(rows_items)
+await import_locations(rows_locations)  # si ça plante ici, items sont commitées sans locations
+await import_supplier_items(rows_supplier_items)
+```
+
+**Solution :** les imports relationnels (ex: `supplier_items` qui dépend de `suppliers` et `items`) s'exécutent dans une transaction unique. Soit tout passe, soit rien.
+
+---
+
+## 7. Décisions architecturales clés
+
+### DA-1 : HTTP 202 à l'ingestion, pas 200
+
+L'ingest répond **202 Accepted** (et non 200 OK) parce que la DQ est asynchrone. Retourner 200 impliquerait que la validation est terminée. C'est un contrat API qu'on ne peut pas tenir si le fichier fait 50 000 lignes.
+
+### DA-2 : JSONB autorisé uniquement en staging
+
+La convention du projet ("no JSONB for structured data — typed columns everywhere") s'applique à toutes les core tables. Exception explicite : `ingest_rows.raw_data` et `import_audit_log.previous_values/new_values` où la structure est intentionnellement dynamique.
+
+### DA-3 : Pas de soft-delete sur les données techniques
+
+Les paramètres de planification ne sont pas soft-deletés — ils sont **clôturés** via `effective_to`. La différence sémantique est importante : une version clôturée reste consultable pour l'historique et les simulations. Un soft-delete masque l'information.
+
+### DA-4 : Le moteur ne lit jamais ingest_rows ou dq_issues
+
+Le moteur de planification (`engine/`) ne connaît pas l'existence du pipeline d'import. Il lit uniquement les core tables. Cette séparation garantit que le moteur ne peut pas être pollué par des données non validées en staging.
+
+### DA-5 : Le pipeline 2 étapes est non-négociable même pour les petits imports
+
+On pourrait être tenté d'ajouter un mode "fast import" pour les petits fichiers (< 100 lignes) qui bypasse le staging. **Non.** La cohérence de l'API est plus précieuse que les 200ms gagnées. Les clients intègrent une fois le pattern `POST → poll → approve` et il fonctionne à toutes les échelles.
+
+---
+
+*Document maintenu par : Architecture Ootils*  
+*Révision suivante : avant implémentation de la migration 004*

--- a/docs/REVIEW-IMPORT-DATA-ENGINEERING.md
+++ b/docs/REVIEW-IMPORT-DATA-ENGINEERING.md
@@ -1,0 +1,1605 @@
+# REVIEW — Import Data Engineering & Data Quality
+
+> **Version :** 1.0.0  
+> **Date :** 2026-04-05  
+> **Auteur :** Data Engineering Review  
+> **Périmètre :** SPEC-IMPORT-STATIC.md + SPEC-IMPORT-DYNAMIC.md  
+> **Branche :** `review/import-data-engineering`
+
+---
+
+## Table des matières
+
+1. [Architecture Staging Zone](#1-architecture-staging-zone)
+2. [Pipeline de Data Quality](#2-pipeline-de-data-quality)
+3. [Gestion des anomalies](#3-gestion-des-anomalies)
+4. [Historisation et audit (SCDs)](#4-historisation-et-audit-scds)
+5. [Détection de dérives statistiques](#5-détection-de-dérives-statistiques)
+6. [Recommandations architecturales — Migration 003+](#6-recommandations-architecturales--migration-003)
+
+---
+
+## 1. Architecture Staging Zone
+
+### 1.1 Principe fondateur : Tout accepter en staging
+
+La staging zone est une **zone de quarantaine brute** : on accepte tout, même les données malformées. Rien n'est rejeté avant d'avoir été enregistré. Le traitement commence *après* la réception.
+
+```
+ERP/WMS/EDI
+    │
+    ├── TSV / JSON / CSV
+    │
+    ▼
+┌─────────────────────────────────────┐
+│          STAGING ZONE               │  ← Tout TEXT, aucun type forcé
+│  stg_items, stg_purchase_orders...  │  ← Métadonnées batch complètes
+│  Acceptation : 100% des lignes      │  ← Flagging des anomalies
+└─────────────────────────────────────┘
+    │
+    ▼  (pipeline DQ asynchrone)
+┌─────────────────────────────────────┐
+│       PRODUCTION TABLES             │  ← Types stricts, contraintes FK
+│  items, purchase_orders, nodes...   │  ← Données qualifiées seulement
+└─────────────────────────────────────┘
+```
+
+**Pourquoi tout accepter ?**
+- Traçabilité complète : même une ligne invalide est auditée
+- Pas de perte silencieuse : chaque rejet est explicite et consultable
+- Replay possible : si une règle DQ change, on peut re-processer le staging
+
+### 1.2 Tables de staging — Schéma générique
+
+Chaque flux a sa table `stg_*`. Toutes partagent la même structure de métadonnées :
+
+```sql
+-- Colonnes de métadonnées communes (template pour toutes stg_*)
+-- batch_id       : identifie l'import (un fichier = un batch_id)
+-- row_number     : numéro de ligne dans le fichier source (pour debug)
+-- source_system  : identifiant du système source (ex: 'SAP-ECC-PROD', 'WMS-MANHATTAN')
+-- imported_at    : timestamp de réception
+-- raw_content    : ligne brute complète (JSON ou TSV line as text)
+-- stg_status     : 'pending' | 'valid' | 'invalid' | 'promoted' | 'quarantined'
+-- dq_level_reached : dernier niveau DQ atteint (1-4), NULL si pas encore traité
+-- error_count    : nombre d'erreurs DQ détectées
+```
+
+### 1.3 Schéma SQL complet des tables staging
+
+```sql
+-- ============================================================
+-- STG_ITEMS — Master Data : Articles
+-- ============================================================
+CREATE TABLE IF NOT EXISTS stg_items (
+    stg_id              UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id            UUID        NOT NULL,
+    row_number          INTEGER     NOT NULL,
+    source_system       TEXT        NOT NULL DEFAULT 'unknown',
+    imported_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    raw_content         TEXT,                  -- Ligne TSV brute ou JSON sérialisé
+
+    -- Colonnes brutes : tout en TEXT, aucun cast en staging
+    external_id         TEXT,
+    name                TEXT,
+    item_type           TEXT,
+    uom                 TEXT,
+    status              TEXT,
+
+    -- Statut DQ
+    stg_status          TEXT        NOT NULL DEFAULT 'pending'
+                        CHECK (stg_status IN ('pending', 'valid', 'invalid', 'promoted', 'quarantined')),
+    dq_level_reached    SMALLINT,              -- NULL = pas encore traité
+    error_count         INTEGER     NOT NULL DEFAULT 0,
+    promoted_at         TIMESTAMPTZ,           -- Quand la ligne a été injectée en prod
+    production_id       UUID                   -- FK vers items.item_id après promotion
+);
+
+CREATE INDEX IF NOT EXISTS idx_stg_items_batch ON stg_items (batch_id);
+CREATE INDEX IF NOT EXISTS idx_stg_items_status ON stg_items (stg_status);
+CREATE INDEX IF NOT EXISTS idx_stg_items_external_id ON stg_items (external_id);
+
+
+-- ============================================================
+-- STG_LOCATIONS — Master Data : Sites
+-- ============================================================
+CREATE TABLE IF NOT EXISTS stg_locations (
+    stg_id              UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id            UUID        NOT NULL,
+    row_number          INTEGER     NOT NULL,
+    source_system       TEXT        NOT NULL DEFAULT 'unknown',
+    imported_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    raw_content         TEXT,
+
+    external_id         TEXT,
+    name                TEXT,
+    location_type       TEXT,
+    country             TEXT,
+    timezone            TEXT,
+    parent_external_id  TEXT,
+
+    stg_status          TEXT        NOT NULL DEFAULT 'pending'
+                        CHECK (stg_status IN ('pending', 'valid', 'invalid', 'promoted', 'quarantined')),
+    dq_level_reached    SMALLINT,
+    error_count         INTEGER     NOT NULL DEFAULT 0,
+    promoted_at         TIMESTAMPTZ,
+    production_id       UUID
+);
+
+CREATE INDEX IF NOT EXISTS idx_stg_locations_batch ON stg_locations (batch_id);
+CREATE INDEX IF NOT EXISTS idx_stg_locations_status ON stg_locations (stg_status);
+
+
+-- ============================================================
+-- STG_SUPPLIERS — Master Data : Fournisseurs
+-- ============================================================
+CREATE TABLE IF NOT EXISTS stg_suppliers (
+    stg_id              UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id            UUID        NOT NULL,
+    row_number          INTEGER     NOT NULL,
+    source_system       TEXT        NOT NULL DEFAULT 'unknown',
+    imported_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    raw_content         TEXT,
+
+    external_id         TEXT,
+    name                TEXT,
+    location_external_id TEXT,
+    lead_time_days      TEXT,       -- TEXT en staging : "14", "14.5", "two weeks" → tout passe
+    reliability_score   TEXT,
+    moq                 TEXT,
+    unit_cost_override  TEXT,
+    currency            TEXT,
+    status              TEXT,
+
+    stg_status          TEXT        NOT NULL DEFAULT 'pending'
+                        CHECK (stg_status IN ('pending', 'valid', 'invalid', 'promoted', 'quarantined')),
+    dq_level_reached    SMALLINT,
+    error_count         INTEGER     NOT NULL DEFAULT 0,
+    promoted_at         TIMESTAMPTZ,
+    production_id       UUID
+);
+
+
+-- ============================================================
+-- STG_SUPPLIER_ITEMS — Relation Supplier × Item
+-- ============================================================
+CREATE TABLE IF NOT EXISTS stg_supplier_items (
+    stg_id                  UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id                UUID        NOT NULL,
+    row_number              INTEGER     NOT NULL,
+    source_system           TEXT        NOT NULL DEFAULT 'unknown',
+    imported_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    raw_content             TEXT,
+
+    supplier_external_id    TEXT,
+    item_external_id        TEXT,
+    supplier_item_code      TEXT,
+    lead_time_days          TEXT,
+    unit_cost               TEXT,
+    moq                     TEXT,
+    lot_multiple            TEXT,
+    reliability_score       TEXT,
+    preferred               TEXT,       -- "true", "1", "yes" → normalisé en boolean au processing
+    effective_start         TEXT,
+    effective_end           TEXT,
+    status                  TEXT,
+
+    stg_status              TEXT        NOT NULL DEFAULT 'pending'
+                            CHECK (stg_status IN ('pending', 'valid', 'invalid', 'promoted', 'quarantined')),
+    dq_level_reached        SMALLINT,
+    error_count             INTEGER     NOT NULL DEFAULT 0,
+    promoted_at             TIMESTAMPTZ,
+    production_id           UUID
+);
+
+
+-- ============================================================
+-- STG_PURCHASE_ORDERS — Données dynamiques : PO
+-- ============================================================
+CREATE TABLE IF NOT EXISTS stg_purchase_orders (
+    stg_id                  UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id                UUID        NOT NULL,
+    row_number              INTEGER     NOT NULL,
+    source_system           TEXT        NOT NULL DEFAULT 'unknown',
+    imported_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    raw_content             TEXT,
+
+    po_number               TEXT,
+    line_number             TEXT,
+    item_external_id        TEXT,
+    supplier_external_id    TEXT,
+    location_external_id    TEXT,
+    quantity                TEXT,
+    uom                     TEXT,
+    expected_date           TEXT,
+    status                  TEXT,
+
+    stg_status              TEXT        NOT NULL DEFAULT 'pending'
+                            CHECK (stg_status IN ('pending', 'valid', 'invalid', 'promoted', 'quarantined')),
+    dq_level_reached        SMALLINT,
+    error_count             INTEGER     NOT NULL DEFAULT 0,
+    promoted_at             TIMESTAMPTZ,
+    production_id           UUID
+);
+
+CREATE INDEX IF NOT EXISTS idx_stg_po_batch ON stg_purchase_orders (batch_id);
+CREATE INDEX IF NOT EXISTS idx_stg_po_status ON stg_purchase_orders (stg_status);
+CREATE INDEX IF NOT EXISTS idx_stg_po_keys ON stg_purchase_orders (po_number, line_number);
+
+
+-- ============================================================
+-- STG_CUSTOMER_ORDERS
+-- ============================================================
+CREATE TABLE IF NOT EXISTS stg_customer_orders (
+    stg_id                  UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id                UUID        NOT NULL,
+    row_number              INTEGER     NOT NULL,
+    source_system           TEXT        NOT NULL DEFAULT 'unknown',
+    imported_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    raw_content             TEXT,
+
+    order_number            TEXT,
+    line_number             TEXT,
+    item_external_id        TEXT,
+    location_external_id    TEXT,
+    quantity                TEXT,
+    uom                     TEXT,
+    requested_date          TEXT,
+    confirmed_date          TEXT,
+    status                  TEXT,
+
+    stg_status              TEXT        NOT NULL DEFAULT 'pending'
+                            CHECK (stg_status IN ('pending', 'valid', 'invalid', 'promoted', 'quarantined')),
+    dq_level_reached        SMALLINT,
+    error_count             INTEGER     NOT NULL DEFAULT 0,
+    promoted_at             TIMESTAMPTZ,
+    production_id           UUID
+);
+
+
+-- ============================================================
+-- STG_FORECASTS
+-- ============================================================
+CREATE TABLE IF NOT EXISTS stg_forecasts (
+    stg_id                  UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id                UUID        NOT NULL,
+    row_number              INTEGER     NOT NULL,
+    source_system           TEXT        NOT NULL DEFAULT 'unknown',
+    imported_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    raw_content             TEXT,
+
+    item_external_id        TEXT,
+    location_external_id    TEXT,
+    forecast_date           TEXT,
+    quantity                TEXT,
+    uom                     TEXT,
+    bucket_type             TEXT,
+    source                  TEXT,
+
+    stg_status              TEXT        NOT NULL DEFAULT 'pending'
+                            CHECK (stg_status IN ('pending', 'valid', 'invalid', 'promoted', 'quarantined')),
+    dq_level_reached        SMALLINT,
+    error_count             INTEGER     NOT NULL DEFAULT 0,
+    promoted_at             TIMESTAMPTZ,
+    production_id           UUID
+);
+
+
+-- ============================================================
+-- STG_WORK_ORDERS
+-- ============================================================
+CREATE TABLE IF NOT EXISTS stg_work_orders (
+    stg_id                  UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id                UUID        NOT NULL,
+    row_number              INTEGER     NOT NULL,
+    source_system           TEXT        NOT NULL DEFAULT 'unknown',
+    imported_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    raw_content             TEXT,
+
+    wo_number               TEXT,
+    item_external_id        TEXT,
+    location_external_id    TEXT,
+    quantity                TEXT,
+    uom                     TEXT,
+    start_date              TEXT,
+    end_date                TEXT,
+    status                  TEXT,
+
+    stg_status              TEXT        NOT NULL DEFAULT 'pending'
+                            CHECK (stg_status IN ('pending', 'valid', 'invalid', 'promoted', 'quarantined')),
+    dq_level_reached        SMALLINT,
+    error_count             INTEGER     NOT NULL DEFAULT 0,
+    promoted_at             TIMESTAMPTZ,
+    production_id           UUID
+);
+
+
+-- ============================================================
+-- STG_TRANSFERS
+-- ============================================================
+CREATE TABLE IF NOT EXISTS stg_transfers (
+    stg_id                  UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id                UUID        NOT NULL,
+    row_number              INTEGER     NOT NULL,
+    source_system           TEXT        NOT NULL DEFAULT 'unknown',
+    imported_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    raw_content             TEXT,
+
+    transfer_number         TEXT,
+    item_external_id        TEXT,
+    from_location           TEXT,
+    to_location             TEXT,
+    quantity                TEXT,
+    uom                     TEXT,
+    ship_date               TEXT,
+    expected_receipt_date   TEXT,
+    status                  TEXT,
+
+    stg_status              TEXT        NOT NULL DEFAULT 'pending'
+                            CHECK (stg_status IN ('pending', 'valid', 'invalid', 'promoted', 'quarantined')),
+    dq_level_reached        SMALLINT,
+    error_count             INTEGER     NOT NULL DEFAULT 0,
+    promoted_at             TIMESTAMPTZ,
+    production_id           UUID
+);
+
+
+-- ============================================================
+-- STG_IMPORT_BATCHES — Registre de tous les imports
+-- ============================================================
+CREATE TABLE IF NOT EXISTS stg_import_batches (
+    batch_id            UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_type         TEXT        NOT NULL,   -- 'items', 'purchase_orders', etc.
+    source_system       TEXT        NOT NULL DEFAULT 'unknown',
+    import_mode         TEXT        NOT NULL DEFAULT 'delta'
+                        CHECK (import_mode IN ('full_replace', 'delta', 'upsert')),
+    filename            TEXT,
+    file_size_bytes     BIGINT,
+    total_rows          INTEGER     NOT NULL DEFAULT 0,
+    rows_accepted       INTEGER     NOT NULL DEFAULT 0,
+    rows_valid          INTEGER     NOT NULL DEFAULT 0,
+    rows_promoted       INTEGER     NOT NULL DEFAULT 0,
+    rows_invalid        INTEGER     NOT NULL DEFAULT 0,
+    rows_quarantined    INTEGER     NOT NULL DEFAULT 0,
+    batch_status        TEXT        NOT NULL DEFAULT 'receiving'
+                        CHECK (batch_status IN ('receiving', 'dq_pending', 'dq_running',
+                                                'dq_complete', 'promoting', 'complete',
+                                                'blocked', 'failed')),
+    error_rate          NUMERIC     GENERATED ALWAYS AS (
+                            CASE WHEN total_rows > 0
+                            THEN ROUND(rows_invalid::NUMERIC / total_rows * 100, 2)
+                            ELSE 0 END
+                        ) STORED,
+    blocking_reason     TEXT,       -- Pourquoi le batch est bloqué (si batch_status = 'blocked')
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    dq_started_at       TIMESTAMPTZ,
+    dq_completed_at     TIMESTAMPTZ,
+    promoted_at         TIMESTAMPTZ,
+    initiated_by        TEXT        NOT NULL DEFAULT 'api',   -- 'api', 'scheduler', 'manual'
+    dry_run             BOOLEAN     NOT NULL DEFAULT FALSE
+);
+
+CREATE INDEX IF NOT EXISTS idx_stg_batches_entity ON stg_import_batches (entity_type, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_stg_batches_status ON stg_import_batches (batch_status);
+```
+
+### 1.4 Règles d'acceptation en staging
+
+**Politique : TOUT ACCEPTER avec flagging immédiat**
+
+```
+Réception fichier TSV/JSON
+    │
+    ├── Encodage invalide (non-UTF8) ?
+    │       → Rejeter le fichier entier (avant staging)
+    │       → Enregistrer le reject dans stg_import_batches (batch_status = 'failed')
+    │       → C'est la SEULE raison de rejeter avant staging
+    │
+    ├── Header TSV absent / colonnes requises manquantes ?
+    │       → Rejeter le fichier entier (structurellement impossible à parser)
+    │       → batch_status = 'failed', blocking_reason = 'missing_required_columns'
+    │
+    └── Sinon → Insérer TOUTES les lignes en stg_*
+                Toutes les lignes = stg_status = 'pending'
+                Pipeline DQ lancé en async
+```
+
+**Pourquoi pas de filtrage en amont ?**
+- Une ligne avec `quantity = "N/A"` doit être loggée et tracée, pas silencieusement perdue
+- Permet le retry avec correction sans reprise complète
+- Garantit que 100% du flux source est visible dans l'audit log
+
+### 1.5 Rétention des données staging
+
+```sql
+-- Politique de rétention recommandée
+-- Staging données dynamiques (PO, CO, forecasts, onhand) : 90 jours
+-- Staging master data (items, locations, suppliers) : 365 jours
+-- Staging promu avec erreurs (stg_status = 'quarantined') : 180 jours
+
+-- Job de purge (à exécuter quotidiennement via pg_cron ou scheduler externe)
+DELETE FROM stg_purchase_orders
+WHERE imported_at < now() - INTERVAL '90 days'
+  AND stg_status IN ('promoted', 'invalid');
+
+DELETE FROM stg_items
+WHERE imported_at < now() - INTERVAL '365 days'
+  AND stg_status IN ('promoted', 'invalid');
+
+-- Les lignes 'quarantined' ne sont jamais purgées automatiquement
+-- Elles nécessitent une résolution manuelle ou une décision explicite
+```
+
+---
+
+## 2. Pipeline de Data Quality
+
+### 2.1 Séquencement général
+
+```
+stg_* (status = 'pending')
+    │
+    ▼
+[NIVEAU 1] Validation structurelle
+    │── Erreur → stg_status = 'invalid', dq_level_reached = 1
+    │── OK     → continue
+    ▼
+[NIVEAU 2] Validation référentielle
+    │── Erreur → stg_status = 'invalid', dq_level_reached = 2
+    │── OK     → continue
+    ▼
+[NIVEAU 3] Validation métier supply chain
+    │── Erreur bloquante → stg_status = 'invalid', dq_level_reached = 3
+    │── Warning          → continue avec flag
+    ▼
+[NIVEAU 4] Validation croisée
+    │── Erreur → stg_status = 'quarantined', dq_level_reached = 4
+    │── OK     → stg_status = 'valid'
+    ▼
+[SEUIL BATCH] Vérification taux d'erreurs
+    │── error_rate > seuil → batch_status = 'blocked'
+    │── error_rate ≤ seuil → promotion en tables production
+    ▼
+Promotion → stg_status = 'promoted', production_id = <uuid>
+```
+
+### 2.2 Niveau 1 — Validation structurelle
+
+#### Pour tous les flux
+
+```sql
+-- Exemple de règles N1 sous forme de requêtes d'audit
+-- Ces requêtes alimentent la table data_quality_issues
+
+-- Règle N1-001 : external_id non null et non vide
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT
+    batch_id,
+    stg_id,
+    'stg_items',
+    'N1-001',
+    'blocking',
+    'external_id is required and cannot be null or empty',
+    external_id
+FROM stg_items
+WHERE batch_id = :batch_id
+  AND (external_id IS NULL OR trim(external_id) = '');
+
+-- Règle N1-002 : name non vide
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT batch_id, stg_id, 'stg_items', 'N1-002', 'blocking',
+       'name is required and cannot be null or empty', name
+FROM stg_items
+WHERE batch_id = :batch_id AND (name IS NULL OR trim(name) = '');
+
+-- Règle N1-003 : lead_time_days parseable en NUMERIC (supplier)
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT batch_id, stg_id, 'stg_suppliers', 'N1-003', 'blocking',
+       'lead_time_days must be a valid number', lead_time_days
+FROM stg_suppliers
+WHERE batch_id = :batch_id
+  AND lead_time_days IS NOT NULL
+  AND lead_time_days !~ '^[0-9]+(\.[0-9]+)?$';
+
+-- Règle N1-004 : expected_date parseable en DATE (PO)
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT batch_id, stg_id, 'stg_purchase_orders', 'N1-004', 'blocking',
+       'expected_date must be a valid ISO 8601 date (YYYY-MM-DD)', expected_date
+FROM stg_purchase_orders
+WHERE batch_id = :batch_id
+  AND expected_date IS NOT NULL
+  AND (
+    expected_date !~ '^\d{4}-\d{2}-\d{2}$'
+    OR expected_date::date IS NULL  -- raises exception → use TRY_CAST equivalent
+  );
+
+-- Règle N1-005 : quantity parseable en NUMERIC
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT batch_id, stg_id, 'stg_purchase_orders', 'N1-005', 'blocking',
+       'quantity must be a valid number', quantity
+FROM stg_purchase_orders
+WHERE batch_id = :batch_id
+  AND (quantity IS NULL OR quantity !~ '^-?[0-9]+(\.[0-9]+)?$');
+
+-- Règle N1-006 : external_id unique dans le batch (doublons intra-fichier)
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT s.batch_id, s.stg_id, 'stg_items', 'N1-006', 'blocking',
+       'Duplicate external_id within the same batch', s.external_id
+FROM stg_items s
+JOIN (
+    SELECT batch_id, external_id
+    FROM stg_items
+    WHERE batch_id = :batch_id AND external_id IS NOT NULL
+    GROUP BY batch_id, external_id
+    HAVING COUNT(*) > 1
+) dups USING (batch_id, external_id)
+WHERE s.batch_id = :batch_id;
+```
+
+#### Catalogue règles N1 par flux
+
+| Code     | Flux       | Champ              | Sévérité | Règle                                        |
+|----------|------------|--------------------|----------|----------------------------------------------|
+| N1-001   | items      | external_id        | blocking | Non null, non vide                           |
+| N1-002   | items      | name               | blocking | Non null, non vide                           |
+| N1-003   | suppliers  | lead_time_days     | blocking | Parseable en NUMERIC si fourni               |
+| N1-004   | PO         | expected_date      | blocking | Format YYYY-MM-DD valide                     |
+| N1-005   | PO/CO/WO   | quantity           | blocking | Parseable en NUMERIC, non null               |
+| N1-006   | tous       | external_id        | blocking | Unique dans le batch                         |
+| N1-007   | PO/CO      | (key, line)        | blocking | (po_number, line_number) unique dans batch   |
+| N1-008   | suppliers  | reliability_score  | blocking | Si fourni : parseable entre 0 et 1           |
+| N1-009   | locations  | country            | warning  | 2 caractères alpha si fourni                 |
+| N1-010   | forecasts  | forecast_date      | blocking | Format selon bucket_type (YYYY-MM-DD / YYYY-Www / YYYY-MM) |
+| N1-011   | transfers  | ship_date          | blocking | Format YYYY-MM-DD valide                     |
+| N1-012   | supplier_items | effective_end  | blocking | Format YYYY-MM-DD si fourni                  |
+
+### 2.3 Niveau 2 — Validation référentielle
+
+```sql
+-- Règle N2-001 : item_external_id résolu dans items (PO)
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT s.batch_id, s.stg_id, 'stg_purchase_orders', 'N2-001', 'blocking',
+       'item_external_id not found in items master data', s.item_external_id
+FROM stg_purchase_orders s
+LEFT JOIN items i ON i.external_id = s.item_external_id
+WHERE s.batch_id = :batch_id
+  AND s.item_external_id IS NOT NULL
+  AND i.item_id IS NULL;
+
+-- Règle N2-002 : location_external_id résolu dans locations
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT s.batch_id, s.stg_id, 'stg_purchase_orders', 'N2-002', 'blocking',
+       'location_external_id not found in locations master data', s.location_external_id
+FROM stg_purchase_orders s
+LEFT JOIN locations l ON l.external_id = s.location_external_id
+WHERE s.batch_id = :batch_id
+  AND l.location_id IS NULL;
+
+-- Règle N2-003 : supplier_external_id résolu (PO — warning si absent car optionnel)
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT s.batch_id, s.stg_id, 'stg_purchase_orders', 'N2-003', 'warning',
+       'supplier_external_id not found in suppliers — PO will import without supplier link',
+       s.supplier_external_id
+FROM stg_purchase_orders s
+LEFT JOIN suppliers sup ON sup.external_id = s.supplier_external_id
+WHERE s.batch_id = :batch_id
+  AND s.supplier_external_id IS NOT NULL
+  AND sup.supplier_id IS NULL;
+
+-- Règle N2-004 : détection de cycles dans la hiérarchie locations
+-- (Exécuté via CTE récursive avant insertion en prod)
+WITH RECURSIVE hierarchy_check AS (
+    -- Base : lignes avec un parent
+    SELECT stg_id, external_id, parent_external_id, ARRAY[external_id] AS path, FALSE AS cycle
+    FROM stg_locations
+    WHERE batch_id = :batch_id AND parent_external_id IS NOT NULL
+
+    UNION ALL
+
+    -- Récursion : suivre le parent
+    SELECT child.stg_id, parent.external_id, parent.parent_external_id,
+           h.path || parent.external_id,
+           parent.external_id = ANY(h.path)
+    FROM stg_locations parent
+    JOIN hierarchy_check h ON h.parent_external_id = parent.external_id
+    WHERE NOT h.cycle
+)
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT DISTINCT :batch_id, stg_id, 'stg_locations', 'N2-005', 'blocking',
+       'Circular reference detected in location hierarchy',
+       array_to_string(path, ' → ')
+FROM hierarchy_check
+WHERE cycle;
+
+-- Règle N2-005 : supplier_items — item ET supplier doivent exister
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT s.batch_id, s.stg_id, 'stg_supplier_items', 'N2-006', 'blocking',
+       'Both supplier and item must exist before importing supplier_items',
+       s.supplier_external_id || ' / ' || s.item_external_id
+FROM stg_supplier_items s
+LEFT JOIN suppliers sup ON sup.external_id = s.supplier_external_id
+LEFT JOIN items i ON i.external_id = s.item_external_id
+WHERE s.batch_id = :batch_id
+  AND (sup.supplier_id IS NULL OR i.item_id IS NULL);
+```
+
+### 2.4 Niveau 3 — Validation métier supply chain
+
+```sql
+-- Règle N3-001 : lead_time_days > 0 (fournisseur actif)
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT batch_id, stg_id, 'stg_suppliers', 'N3-001', 'blocking',
+       'lead_time_days must be > 0 for active suppliers',
+       lead_time_days
+FROM stg_suppliers
+WHERE batch_id = :batch_id
+  AND lead_time_days IS NOT NULL
+  AND lead_time_days ~ '^[0-9]+(\.[0-9]+)?$'
+  AND lead_time_days::NUMERIC <= 0
+  AND (status IS NULL OR status = 'active');
+
+-- Règle N3-002 : quantity > 0 pour PO actifs (non annulation)
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT batch_id, stg_id, 'stg_purchase_orders', 'N3-002', 'blocking',
+       'quantity must be > 0 for active PO (use status=cancelled for cancellations)',
+       quantity
+FROM stg_purchase_orders
+WHERE batch_id = :batch_id
+  AND quantity ~ '^-?[0-9]+(\.[0-9]+)?$'
+  AND quantity::NUMERIC <= 0
+  AND status NOT IN ('cancelled');
+
+-- Règle N3-003 : expected_date >= today pour PO confirmed/pending
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT batch_id, stg_id, 'stg_purchase_orders', 'N3-003', 'warning',
+       'expected_date is in the past for an active PO — possible data lag or error',
+       expected_date
+FROM stg_purchase_orders
+WHERE batch_id = :batch_id
+  AND expected_date ~ '^\d{4}-\d{2}-\d{2}$'
+  AND expected_date::date < CURRENT_DATE
+  AND status IN ('confirmed', 'pending');
+
+-- Règle N3-004 : safety_stock < max_stock (item_location_policies)
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT s.batch_id, s.stg_id, 'stg_item_location_policies', 'N3-004', 'blocking',
+       'safety_stock_qty must be < max_stock when replenishment_type = min_max',
+       'safety=' || s.safety_stock_qty || ' max=' || s.max_stock
+FROM stg_item_location_policies s
+WHERE batch_id = :batch_id
+  AND replenishment_type = 'min_max'
+  AND safety_stock_qty ~ '^[0-9]+(\.[0-9]+)?$'
+  AND max_stock ~ '^[0-9]+(\.[0-9]+)?$'
+  AND safety_stock_qty::NUMERIC >= max_stock::NUMERIC;
+
+-- Règle N3-005 : UOM cohérent avec le référentiel article
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT s.batch_id, s.stg_id, 'stg_purchase_orders', 'N3-005', 'warning',
+       'UOM in PO does not match item master UOM — conversion may be needed',
+       s.uom || ' (item master: ' || i.uom || ')'
+FROM stg_purchase_orders s
+JOIN items i ON i.external_id = s.item_external_id
+WHERE s.batch_id = :batch_id
+  AND s.uom IS NOT NULL
+  AND s.uom <> i.uom;
+
+-- Règle N3-006 : effective_end > effective_start (supplier_items)
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT batch_id, stg_id, 'stg_supplier_items', 'N3-006', 'blocking',
+       'effective_end must be strictly after effective_start',
+       effective_start || ' → ' || effective_end
+FROM stg_supplier_items
+WHERE batch_id = :batch_id
+  AND effective_start ~ '^\d{4}-\d{2}-\d{2}$'
+  AND effective_end ~ '^\d{4}-\d{2}-\d{2}$'
+  AND effective_end::date <= effective_start::date;
+
+-- Règle N3-007 : reliability_score ∈ [0, 1]
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT batch_id, stg_id, 'stg_suppliers', 'N3-007', 'blocking',
+       'reliability_score must be between 0.0 and 1.0',
+       reliability_score
+FROM stg_suppliers
+WHERE batch_id = :batch_id
+  AND reliability_score ~ '^[0-9]+(\.[0-9]+)?$'
+  AND (reliability_score::NUMERIC < 0 OR reliability_score::NUMERIC > 1);
+```
+
+### 2.5 Niveau 4 — Validation croisée
+
+```sql
+-- Règle N4-001 : Transfers — from_location ≠ to_location
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT batch_id, stg_id, 'stg_transfers', 'N4-001', 'blocking',
+       'Transfer from_location and to_location cannot be the same',
+       from_location || ' = ' || to_location
+FROM stg_transfers
+WHERE batch_id = :batch_id
+  AND from_location IS NOT NULL
+  AND from_location = to_location;
+
+-- Règle N4-002 : Transfers — chemin valide (les deux locations existent)
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT s.batch_id, s.stg_id, 'stg_transfers', 'N4-002', 'blocking',
+       'Transfer path invalid: from_location or to_location not found',
+       s.from_location || ' → ' || s.to_location
+FROM stg_transfers s
+LEFT JOIN locations lf ON lf.external_id = s.from_location
+LEFT JOIN locations lt ON lt.external_id = s.to_location
+WHERE s.batch_id = :batch_id
+  AND (lf.location_id IS NULL OR lt.location_id IS NULL);
+
+-- Règle N4-003 : expected_receipt_date > ship_date (transfers)
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT batch_id, stg_id, 'stg_transfers', 'N4-003', 'warning',
+       'expected_receipt_date should be after ship_date',
+       ship_date || ' → ' || expected_receipt_date
+FROM stg_transfers
+WHERE batch_id = :batch_id
+  AND ship_date ~ '^\d{4}-\d{2}-\d{2}$'
+  AND expected_receipt_date ~ '^\d{4}-\d{2}-\d{2}$'
+  AND expected_receipt_date::date < ship_date::date;
+
+-- Règle N4-004 : WO end_date > start_date
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT batch_id, stg_id, 'stg_work_orders', 'N4-004', 'blocking',
+       'end_date must be after start_date',
+       start_date || ' → ' || end_date
+FROM stg_work_orders
+WHERE batch_id = :batch_id
+  AND start_date ~ '^\d{4}-\d{2}-\d{2}$'
+  AND end_date ~ '^\d{4}-\d{2}-\d{2}$'
+  AND end_date::date <= start_date::date;
+
+-- Règle N4-005 : PO pour item avec politique push doit avoir un forecast
+-- (Warning seulement : le PO est accepté mais signalé)
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT s.batch_id, s.stg_id, 'stg_purchase_orders', 'N4-005', 'warning',
+       'PO for push-policy item has no active forecast — review replenishment logic',
+       s.item_external_id || ' @ ' || s.location_external_id
+FROM stg_purchase_orders s
+JOIN items i ON i.external_id = s.item_external_id
+JOIN item_location_policies ilp ON ilp.item_id = i.item_id
+    AND EXISTS (SELECT 1 FROM locations l WHERE l.external_id = s.location_external_id AND l.location_id = ilp.location_id)
+WHERE s.batch_id = :batch_id
+  AND ilp.replenishment_type = 'jit'                    -- politique push/JIT
+  AND s.status IN ('confirmed', 'pending')
+  AND NOT EXISTS (
+    SELECT 1 FROM nodes n
+    JOIN items fi ON fi.item_id = (n.payload->>'item_id')::uuid
+    WHERE fi.external_id = s.item_external_id
+      AND n.node_type = 'ForecastDemand'
+      AND n.is_active = TRUE
+  );
+```
+
+---
+
+## 3. Gestion des anomalies
+
+### 3.1 Table `data_quality_issues`
+
+```sql
+CREATE TABLE IF NOT EXISTS data_quality_issues (
+    issue_id            UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id            UUID        NOT NULL REFERENCES stg_import_batches(batch_id),
+    stg_id              UUID        NOT NULL,           -- FK vers la ligne staging concernée
+    stg_table           TEXT        NOT NULL,           -- 'stg_items', 'stg_purchase_orders', etc.
+    rule_code           TEXT        NOT NULL,           -- 'N1-001', 'N3-002', etc.
+    severity            TEXT        NOT NULL
+                        CHECK (severity IN ('blocking', 'warning', 'info')),
+    dq_level            SMALLINT    NOT NULL            -- 1, 2, 3, ou 4
+                        GENERATED ALWAYS AS (
+                            CASE WHEN rule_code LIKE 'N1%' THEN 1
+                                 WHEN rule_code LIKE 'N2%' THEN 2
+                                 WHEN rule_code LIKE 'N3%' THEN 3
+                                 WHEN rule_code LIKE 'N4%' THEN 4
+                                 ELSE 0 END
+                        ) STORED,
+    description         TEXT        NOT NULL,
+    raw_value           TEXT,                           -- Valeur brute en cause
+    field_name          TEXT,                           -- Colonne en cause (si applicable)
+    resolution_status   TEXT        NOT NULL DEFAULT 'open'
+                        CHECK (resolution_status IN ('open', 'acknowledged', 'corrected',
+                                                     'overridden', 'wont_fix')),
+    resolution_note     TEXT,                           -- Commentaire de résolution
+    resolved_by         TEXT,                           -- Identité du résolveur
+    resolved_at         TIMESTAMPTZ,
+    auto_corrected      BOOLEAN     NOT NULL DEFAULT FALSE,  -- Correction automatique appliquée ?
+    auto_correction_detail TEXT,    -- Description de la correction automatique
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_dqi_batch ON data_quality_issues (batch_id);
+CREATE INDEX IF NOT EXISTS idx_dqi_stg ON data_quality_issues (stg_id, stg_table);
+CREATE INDEX IF NOT EXISTS idx_dqi_status ON data_quality_issues (resolution_status) WHERE resolution_status = 'open';
+CREATE INDEX IF NOT EXISTS idx_dqi_severity ON data_quality_issues (severity, batch_id);
+```
+
+### 3.2 Stratégie de gestion par sévérité
+
+| Sévérité | Action immédiate | Impact sur batch | Workflow |
+|----------|-----------------|-----------------|---------|
+| `blocking` | Ligne → `stg_status = 'invalid'` | Compte pour taux d'erreur | Résolution manuelle requise avant re-import |
+| `warning` | Ligne acceptée, issue loggée | Ne compte pas pour le taux d'erreur de blocage | Notification, résolution optionnelle |
+| `info` | Log seulement | Aucun | Audit trail |
+
+### 3.3 Corrections automatiques (smart substitutions)
+
+Certaines anomalies admettent une correction automatique documentée :
+
+```sql
+-- Correction auto N1-009 : country code en majuscules
+-- "fr" → "FR", "us" → "US"
+UPDATE stg_locations
+SET country = UPPER(country),
+    -- Documenter la correction
+    raw_content = raw_content  -- immutable, la correction est dans la colonne typée
+WHERE batch_id = :batch_id
+  AND country IS NOT NULL
+  AND country <> UPPER(country);
+
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity,
+    description, raw_value, auto_corrected, auto_correction_detail)
+SELECT batch_id, stg_id, 'stg_locations', 'N1-009-AUTO', 'info',
+       'country code normalized to uppercase',
+       country,
+       TRUE,
+       'auto-corrected: ' || country || ' → ' || UPPER(country)
+FROM stg_locations_before_correction  -- snapshot avant correction
+WHERE ...;
+```
+
+**Corrections automatiques autorisées :**
+
+| Cas | Correction | Niveau |
+|-----|-----------|--------|
+| `country` en minuscules | UPPER() | Auto |
+| `uom` avec espaces parasites | TRIM() | Auto |
+| `status` avec casse mixte | LOWER() | Auto |
+| `item_type` absent | Default `finished_good` | Auto (avec log) |
+| `currency` absent | Default `USD` | Auto (avec log) |
+| `lead_time_days` absent sur supplier | Default `14` | Auto (avec log) |
+
+**Corrections INTERDITES (rejet strict) :**
+
+| Cas | Raison |
+|-----|--------|
+| `external_id` absent | Impossible de déduire une clé métier |
+| `quantity` non numérique | Risque de perte de données silencieuse |
+| Date invalide | Aucune substitution raisonnable |
+| Référence inconnue (FK) | Données orphelines = garbage |
+
+### 3.4 Seuils d'acceptation du batch
+
+```sql
+-- Logique de vérification des seuils avant promotion
+-- Exécutée après le pipeline DQ complet
+
+WITH batch_stats AS (
+    SELECT
+        b.batch_id,
+        b.entity_type,
+        b.total_rows,
+        b.rows_invalid,
+        b.error_rate,
+        -- Compter les erreurs bloquantes
+        COUNT(CASE WHEN dqi.severity = 'blocking' THEN 1 END) AS blocking_issues,
+        -- Vérifier si des règles critiques ont été déclenchées
+        COUNT(CASE WHEN dqi.rule_code IN ('N2-001', 'N2-002') THEN 1 END) AS referential_failures
+    FROM stg_import_batches b
+    LEFT JOIN data_quality_issues dqi ON dqi.batch_id = b.batch_id
+    WHERE b.batch_id = :batch_id
+    GROUP BY b.batch_id, b.entity_type, b.total_rows, b.rows_invalid, b.error_rate
+)
+UPDATE stg_import_batches
+SET batch_status = CASE
+    -- Blocage si > 20% d'erreurs sur les flux master data
+    WHEN entity_type IN ('items', 'locations', 'suppliers')
+         AND error_rate > 20 THEN 'blocked'
+    -- Blocage si > 10% d'erreurs sur les flux transactionnels
+    WHEN entity_type IN ('purchase_orders', 'customer_orders', 'forecasts')
+         AND error_rate > 10 THEN 'blocked'
+    -- Blocage si > 5% d'erreurs sur on-hand (full replace = très sensible)
+    WHEN entity_type = 'on_hand' AND error_rate > 5 THEN 'blocked'
+    -- Accepté : promotion possible
+    ELSE 'dq_complete'
+END,
+blocking_reason = CASE
+    WHEN error_rate > 20 AND entity_type IN ('items', 'locations', 'suppliers')
+    THEN 'Error rate ' || error_rate || '% exceeds 20% threshold for master data'
+    WHEN error_rate > 10 AND entity_type IN ('purchase_orders', 'customer_orders', 'forecasts')
+    THEN 'Error rate ' || error_rate || '% exceeds 10% threshold for transactional data'
+    WHEN error_rate > 5 AND entity_type = 'on_hand'
+    THEN 'Error rate ' || error_rate || '% exceeds 5% threshold for on-hand full replace'
+    ELSE NULL
+END
+FROM batch_stats
+WHERE stg_import_batches.batch_id = batch_stats.batch_id;
+```
+
+**Tableau des seuils :**
+
+| Flux | Seuil blocage | Justification |
+|------|--------------|---------------|
+| `items`, `locations`, `suppliers` | > 20% | Master data : plus tolérant (imports initiaux souvent imparfaits) |
+| `purchase_orders`, `customer_orders` | > 10% | Transactionnel : moins tolérant |
+| `forecasts` | > 10% | Full replace : les erreurs propagent |
+| `on_hand` | > 5% | Full replace critique : stock = source de vérité |
+| `transfers`, `work_orders` | > 10% | Transactionnel standard |
+
+### 3.5 Workflow de résolution
+
+```
+Batch 'blocked' ou lignes 'invalid'
+        │
+        ▼
+┌───────────────────────────────────┐
+│  Notification automatique         │
+│  → data steward / intégrateur    │
+│  → email/webhook avec détail     │
+│  → lien vers UI de résolution    │
+└───────────────────────────────────┘
+        │
+        ▼
+┌───────────────────────────────────┐
+│  Interface de résolution          │
+│  GET /v1/imports/{batch_id}/issues│
+│  → liste issues par sévérité     │
+│  → détail raw_value + suggestion  │
+└───────────────────────────────────┘
+        │
+        ├── Correction côté source → re-upload du fichier corrigé
+        │   POST /v1/import/{type} (nouveau batch_id)
+        │
+        ├── Override manuel d'une issue
+        │   PATCH /v1/imports/issues/{issue_id}
+        │   { "resolution_status": "overridden", "resolution_note": "ERP bug, valeur correcte" }
+        │
+        └── Forcer la promotion malgré les erreurs (admin only)
+            POST /v1/imports/{batch_id}/force-promote
+            { "justification": "Known data gap, ops team notified" }
+            → Crée un audit log avec l'identité du décideur
+```
+
+---
+
+## 4. Historisation et audit (SCDs)
+
+### 4.1 Stratégie SCD par champ
+
+Les master data Ootils suivent des **SCDs mixtes** : Type 1 pour les champs opérationnels courants, Type 2 pour les champs qui impactent les calculs historiques.
+
+| Entité | Champ | SCD Type | Justification |
+|--------|-------|----------|---------------|
+| `items` | `name` | Type 1 | Libellé : correction fréquente, pas d'impact historique |
+| `items` | `item_type` | **Type 2** | Changement de type = reclassification métier critique |
+| `items` | `uom` | **Type 2** | Changement UOM = recalcul de tous les historiques |
+| `items` | `status` | Type 1 | Statut courant suffit |
+| `locations` | `name` | Type 1 | Cosmétique |
+| `locations` | `location_type` | **Type 2** | Reclassification réseau = impact graphe |
+| `locations` | `timezone` | Type 1 | Rarement impactant |
+| `suppliers` | `lead_time_days` | **Type 2** | Impacte tous les calculs de dates de dispo |
+| `suppliers` | `reliability_score` | **Type 2** | Impacte les simulations de risque |
+| `suppliers` | `status` | Type 1 | Statut courant |
+| `item_location_policies` | `safety_stock_qty` | **Type 2** | Change le niveau de risque historique |
+| `item_location_policies` | `replenishment_type` | **Type 2** | Changement de politique = rupture de logique |
+| `supplier_items` | `unit_cost` | **Type 2** | Traçabilité prix pour costing |
+| `supplier_items` | `lead_time_days` | **Type 2** | Voir suppliers |
+
+### 4.2 Implémentation SCD Type 2
+
+```sql
+-- Extension des tables master data pour SCD Type 2
+-- Pattern : colonnes valid_from / valid_to / is_current sur chaque entité
+
+-- Exemple sur items (les autres tables suivent le même pattern)
+ALTER TABLE items
+    ADD COLUMN IF NOT EXISTS valid_from     DATE        NOT NULL DEFAULT CURRENT_DATE,
+    ADD COLUMN IF NOT EXISTS valid_to       DATE,                   -- NULL = enregistrement courant
+    ADD COLUMN IF NOT EXISTS is_current     BOOLEAN     NOT NULL DEFAULT TRUE,
+    ADD COLUMN IF NOT EXISTS version        INTEGER     NOT NULL DEFAULT 1,
+    ADD COLUMN IF NOT EXISTS superseded_by  UUID        REFERENCES items(item_id);
+
+-- Index pour accéder à la version courante
+CREATE INDEX IF NOT EXISTS idx_items_current ON items (external_id, is_current) WHERE is_current = TRUE;
+
+-- Fonction de mise à jour SCD Type 2 pour items
+CREATE OR REPLACE FUNCTION upsert_item_scd2(
+    p_external_id   TEXT,
+    p_name          TEXT,
+    p_item_type     TEXT,
+    p_uom           TEXT,
+    p_status        TEXT,
+    p_batch_id      UUID
+) RETURNS UUID AS $$
+DECLARE
+    v_existing_id   UUID;
+    v_new_id        UUID := gen_random_uuid();
+    v_needs_scd2    BOOLEAN := FALSE;
+    v_existing_row  items%ROWTYPE;
+BEGIN
+    -- Chercher la version courante
+    SELECT * INTO v_existing_row
+    FROM items
+    WHERE external_id = p_external_id AND is_current = TRUE
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        -- Premier import : INSERT simple
+        INSERT INTO items (item_id, external_id, name, item_type, uom, status, valid_from, is_current, version)
+        VALUES (v_new_id, p_external_id, p_name, p_item_type, p_uom, p_status, CURRENT_DATE, TRUE, 1);
+        RETURN v_new_id;
+    END IF;
+
+    v_existing_id := v_existing_row.item_id;
+
+    -- Vérifier si un champ SCD Type 2 a changé
+    IF (p_item_type IS NOT NULL AND p_item_type <> v_existing_row.item_type)
+    OR (p_uom IS NOT NULL AND p_uom <> v_existing_row.uom) THEN
+        v_needs_scd2 := TRUE;
+    END IF;
+
+    IF v_needs_scd2 THEN
+        -- Fermer la version courante
+        UPDATE items
+        SET valid_to = CURRENT_DATE - 1,
+            is_current = FALSE,
+            superseded_by = v_new_id,
+            updated_at = now()
+        WHERE item_id = v_existing_id;
+
+        -- Créer la nouvelle version
+        INSERT INTO items (item_id, external_id, name, item_type, uom, status,
+                           valid_from, is_current, version)
+        VALUES (v_new_id, p_external_id,
+                COALESCE(p_name, v_existing_row.name),
+                COALESCE(p_item_type, v_existing_row.item_type),
+                COALESCE(p_uom, v_existing_row.uom),
+                COALESCE(p_status, v_existing_row.status),
+                CURRENT_DATE, TRUE,
+                v_existing_row.version + 1);
+
+        -- Audit log
+        INSERT INTO master_data_audit_log (entity_type, entity_id, external_id, change_type,
+            field_changed, old_value, new_value, batch_id)
+        VALUES ('item', v_new_id, p_external_id, 'scd2_version',
+                CASE WHEN p_item_type <> v_existing_row.item_type THEN 'item_type' ELSE 'uom' END,
+                CASE WHEN p_item_type <> v_existing_row.item_type THEN v_existing_row.item_type::TEXT ELSE v_existing_row.uom END,
+                CASE WHEN p_item_type <> v_existing_row.item_type THEN p_item_type ELSE p_uom END,
+                p_batch_id);
+
+        RETURN v_new_id;
+    ELSE
+        -- Mise à jour Type 1 (champs cosmétiques)
+        UPDATE items
+        SET name = COALESCE(p_name, name),
+            status = COALESCE(p_status, status),
+            updated_at = now()
+        WHERE item_id = v_existing_id;
+
+        -- Audit log Type 1
+        IF p_name IS NOT NULL AND p_name <> v_existing_row.name THEN
+            INSERT INTO master_data_audit_log (entity_type, entity_id, external_id, change_type,
+                field_changed, old_value, new_value, batch_id)
+            VALUES ('item', v_existing_id, p_external_id, 'type1_update',
+                    'name', v_existing_row.name, p_name, p_batch_id);
+        END IF;
+
+        RETURN v_existing_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+```
+
+### 4.3 Table d'audit log
+
+```sql
+CREATE TABLE IF NOT EXISTS master_data_audit_log (
+    audit_id        UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_type     TEXT        NOT NULL,           -- 'item', 'location', 'supplier', etc.
+    entity_id       UUID        NOT NULL,           -- UUID de l'enregistrement modifié (nouvelle version)
+    external_id     TEXT        NOT NULL,           -- Code métier ERP
+    change_type     TEXT        NOT NULL
+                    CHECK (change_type IN ('insert', 'type1_update', 'scd2_version',
+                                           'soft_delete', 'reactivation', 'override')),
+    field_changed   TEXT,                           -- Colonne modifiée
+    old_value       TEXT,
+    new_value       TEXT,
+    batch_id        UUID        REFERENCES stg_import_batches(batch_id),
+    changed_by      TEXT        NOT NULL DEFAULT 'import_pipeline',  -- 'import_pipeline', 'api', 'user:xxx'
+    changed_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    reason          TEXT                            -- Optionnel : justification métier
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_entity ON master_data_audit_log (entity_type, external_id, changed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_batch ON master_data_audit_log (batch_id);
+```
+
+### 4.4 Traçabilité source → staging → production
+
+```sql
+-- Vue de traçabilité complète (exemple pour items)
+CREATE OR REPLACE VIEW v_item_import_lineage AS
+SELECT
+    i.external_id,
+    i.item_id,
+    i.version,
+    i.item_type,
+    i.uom,
+    i.valid_from,
+    i.valid_to,
+    i.is_current,
+    si.stg_id,
+    si.batch_id,
+    si.raw_content,
+    si.imported_at,
+    b.source_system,
+    b.filename,
+    b.initiated_by,
+    b.created_at AS batch_created_at,
+    (SELECT COUNT(*) FROM data_quality_issues dqi
+     WHERE dqi.stg_id = si.stg_id) AS dq_issues_count
+FROM items i
+JOIN stg_items si ON si.production_id = i.item_id
+JOIN stg_import_batches b ON b.batch_id = si.batch_id;
+```
+
+---
+
+## 5. Détection de dérives statistiques
+
+### 5.1 Architecture de détection
+
+La détection de dérives s'intercale entre le **Niveau 3 DQ** et la **promotion** en tables production. Elle utilise les statistiques des imports précédents pour détecter des anomalies qui seraient valides individuellement mais aberrantes en contexte.
+
+```
+Données DQ-validées (stg_status = 'valid')
+        │
+        ▼
+[DRIFT DETECTION ENGINE]
+        │
+        ├── Calcul statistiques sur le batch courant
+        ├── Comparaison avec baseline historique
+        ├── Détection dépassement de seuils adaptatifs
+        │
+        ├── Anomalie détectée → stg_status = 'quarantined'
+        │                     → alerte + issue dans data_quality_issues
+        │
+        └── OK → passage en promotion
+```
+
+### 5.2 Table des baselines statistiques
+
+```sql
+CREATE TABLE IF NOT EXISTS import_drift_baselines (
+    baseline_id         UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_type         TEXT        NOT NULL,       -- 'on_hand', 'purchase_orders', etc.
+    metric_name         TEXT        NOT NULL,       -- 'quantity_mean', 'row_count', etc.
+    item_external_id    TEXT,                       -- Scoped par item si applicable
+    location_external_id TEXT,                     -- Scoped par location si applicable
+    -- Statistiques calculées sur les N derniers imports
+    sample_count        INTEGER     NOT NULL,       -- Nombre d'imports dans la baseline
+    metric_mean         NUMERIC     NOT NULL,
+    metric_stddev       NUMERIC     NOT NULL,
+    metric_p5           NUMERIC,                   -- Percentile 5
+    metric_p95          NUMERIC,                   -- Percentile 95
+    metric_min          NUMERIC,
+    metric_max          NUMERIC,
+    -- Seuils adaptatifs (calculés automatiquement)
+    alert_threshold_low  NUMERIC,                  -- mean - N*stddev
+    alert_threshold_high NUMERIC,                  -- mean + N*stddev
+    stddev_multiplier    NUMERIC    NOT NULL DEFAULT 3.0,  -- Sensibilité : 2=sensible, 3=normal, 4=tolérant
+    -- Fenêtre de calcul
+    computed_from       DATE        NOT NULL,       -- Début de la fenêtre
+    computed_to         DATE        NOT NULL,       -- Fin de la fenêtre (généralement today)
+    computed_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    is_current          BOOLEAN     NOT NULL DEFAULT TRUE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_drift_baseline_current
+    ON import_drift_baselines (entity_type, metric_name, item_external_id, location_external_id)
+    WHERE is_current = TRUE;
+```
+
+### 5.3 Règles de détection de dérives
+
+```sql
+-- ============================================================
+-- DRIFT-001 : On-Hand quantity outlier par item × location
+-- ============================================================
+-- Détecte : stock soudainement 10x supérieur à la normale
+
+WITH current_onhand AS (
+    SELECT
+        item_external_id,
+        location_external_id,
+        quantity::NUMERIC AS qty
+    FROM stg_on_hand
+    WHERE batch_id = :batch_id
+      AND stg_status = 'valid'
+      AND quantity ~ '^[0-9]+(\.[0-9]+)?$'
+),
+baselines AS (
+    SELECT
+        item_external_id,
+        location_external_id,
+        metric_mean,
+        metric_stddev,
+        alert_threshold_high,
+        alert_threshold_low,
+        stddev_multiplier
+    FROM import_drift_baselines
+    WHERE entity_type = 'on_hand'
+      AND metric_name = 'quantity'
+      AND is_current = TRUE
+)
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value, auto_corrected)
+SELECT
+    :batch_id,
+    s.stg_id,
+    'stg_on_hand',
+    'DRIFT-001',
+    'warning',
+    format('On-hand quantity anomaly for %s @ %s: value=%s, baseline_mean=%s ± %s (threshold: [%s, %s])',
+           oh.item_external_id, oh.location_external_id,
+           oh.qty, b.metric_mean, b.metric_stddev * b.stddev_multiplier,
+           b.alert_threshold_low, b.alert_threshold_high),
+    oh.qty::TEXT,
+    FALSE
+FROM current_onhand oh
+JOIN baselines b USING (item_external_id, location_external_id)
+JOIN stg_on_hand s ON s.batch_id = :batch_id
+    AND s.item_external_id = oh.item_external_id
+    AND s.location_external_id = oh.location_external_id
+WHERE oh.qty > b.alert_threshold_high
+   OR oh.qty < b.alert_threshold_low;
+
+
+-- ============================================================
+-- DRIFT-002 : Row count anormal dans le batch
+-- ============================================================
+-- Détecte : un batch on-hand avec 50% moins de lignes que d'habitude
+-- (signe d'export partiel ou d'incident ERP)
+
+WITH batch_row_count AS (
+    SELECT COUNT(*) AS current_count
+    FROM stg_on_hand
+    WHERE batch_id = :batch_id
+),
+baseline_rows AS (
+    SELECT metric_mean, metric_stddev, alert_threshold_low
+    FROM import_drift_baselines
+    WHERE entity_type = 'on_hand'
+      AND metric_name = 'row_count'
+      AND is_current = TRUE
+)
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT
+    :batch_id,
+    :batch_id,  -- stg_id = batch_id pour les alertes de niveau batch
+    'stg_import_batches',
+    'DRIFT-002',
+    'blocking',  -- Critique : si on a 50% moins de lignes, bloquer le full replace
+    format('Batch row count anomaly: %s rows received, baseline mean=%s (threshold_low=%s). Possible incomplete ERP export.',
+           brc.current_count, bl.metric_mean, bl.alert_threshold_low),
+    brc.current_count::TEXT
+FROM batch_row_count brc, baseline_rows bl
+WHERE brc.current_count < bl.alert_threshold_low;
+
+
+-- ============================================================
+-- DRIFT-003 : Somme des quantités PO anormale
+-- ============================================================
+-- Détecte : total des PO confirmés × 10 ce mois = explosion de commande suspecte
+
+WITH batch_po_sum AS (
+    SELECT
+        item_external_id,
+        location_external_id,
+        SUM(quantity::NUMERIC) AS total_qty
+    FROM stg_purchase_orders
+    WHERE batch_id = :batch_id
+      AND status IN ('confirmed', 'pending')
+      AND quantity ~ '^[0-9]+(\.[0-9]+)?$'
+    GROUP BY item_external_id, location_external_id
+),
+baselines AS (
+    SELECT item_external_id, location_external_id, alert_threshold_high, metric_mean
+    FROM import_drift_baselines
+    WHERE entity_type = 'purchase_orders'
+      AND metric_name = 'total_qty_per_item_location'
+      AND is_current = TRUE
+)
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT
+    :batch_id,
+    :batch_id,
+    'stg_purchase_orders',
+    'DRIFT-003',
+    'warning',
+    format('PO total quantity spike for %s @ %s: %s vs baseline %s',
+           ps.item_external_id, ps.location_external_id,
+           ps.total_qty, b.metric_mean),
+    ps.total_qty::TEXT
+FROM batch_po_sum ps
+JOIN baselines b USING (item_external_id, location_external_id)
+WHERE ps.total_qty > b.alert_threshold_high * 2;  -- × 2 pour éviter les faux positifs sur achats saisonniers
+
+
+-- ============================================================
+-- DRIFT-004 : Zero-quantity items soudainement nombreux
+-- ============================================================
+-- Détecte : 80% des lignes à quantity = 0 dans un batch on-hand
+-- (export ERP tronqué ou bug transformation)
+
+WITH zero_rate AS (
+    SELECT
+        COUNT(*) FILTER (WHERE quantity ~ '^[0-9]+(\.[0-9]+)?$' AND quantity::NUMERIC = 0) AS zeros,
+        COUNT(*) AS total
+    FROM stg_on_hand
+    WHERE batch_id = :batch_id
+)
+INSERT INTO data_quality_issues (batch_id, stg_id, stg_table, rule_code, severity, description, raw_value)
+SELECT
+    :batch_id, :batch_id, 'stg_on_hand', 'DRIFT-004', 'blocking',
+    format('Abnormal zero-quantity rate: %s%% of lines have qty=0 (threshold: 30%%)',
+           ROUND(zeros::NUMERIC / total * 100, 1)),
+    zeros || '/' || total
+FROM zero_rate
+WHERE total > 0 AND zeros::NUMERIC / total > 0.30;
+```
+
+### 5.4 Mise à jour des baselines (job périodique)
+
+```sql
+-- Recalcul des baselines toutes les nuits (ou après chaque import réussi)
+-- Fenêtre glissante sur les 30 derniers imports valides
+
+CREATE OR REPLACE PROCEDURE refresh_drift_baselines(p_entity_type TEXT)
+LANGUAGE plpgsql AS $$
+BEGIN
+    -- Marquer les baselines actuelles comme obsolètes
+    UPDATE import_drift_baselines
+    SET is_current = FALSE
+    WHERE entity_type = p_entity_type AND is_current = TRUE;
+
+    -- On-Hand : baseline quantité par item × location
+    IF p_entity_type = 'on_hand' THEN
+        INSERT INTO import_drift_baselines (entity_type, metric_name, item_external_id, location_external_id,
+            sample_count, metric_mean, metric_stddev, metric_p5, metric_p95, metric_min, metric_max,
+            alert_threshold_low, alert_threshold_high, stddev_multiplier,
+            computed_from, computed_to, is_current)
+        SELECT
+            'on_hand',
+            'quantity',
+            item_external_id,
+            location_external_id,
+            COUNT(*)::INTEGER,
+            AVG(qty),
+            STDDEV(qty),
+            PERCENTILE_CONT(0.05) WITHIN GROUP (ORDER BY qty),
+            PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY qty),
+            MIN(qty),
+            MAX(qty),
+            -- Seuil bas : mean - 3σ (jamais < 0)
+            GREATEST(0, AVG(qty) - 3 * STDDEV(qty)),
+            -- Seuil haut : mean + 3σ
+            AVG(qty) + 3 * STDDEV(qty),
+            3.0,
+            MIN(batch_date),
+            MAX(batch_date),
+            TRUE
+        FROM (
+            -- 30 derniers imports on-hand valides
+            SELECT
+                s.item_external_id,
+                s.location_external_id,
+                s.quantity::NUMERIC AS qty,
+                b.created_at::DATE AS batch_date
+            FROM stg_on_hand s
+            JOIN stg_import_batches b ON b.batch_id = s.batch_id
+            WHERE b.entity_type = 'on_hand'
+              AND b.batch_status = 'complete'
+              AND s.stg_status = 'promoted'
+              AND b.created_at >= now() - INTERVAL '90 days'
+        ) hist
+        GROUP BY item_external_id, location_external_id
+        HAVING COUNT(*) >= 5;  -- Minimum 5 imports pour calculer une baseline fiable
+    END IF;
+
+    -- Baselines row count
+    INSERT INTO import_drift_baselines (entity_type, metric_name,
+        sample_count, metric_mean, metric_stddev,
+        alert_threshold_low, alert_threshold_high, stddev_multiplier,
+        computed_from, computed_to, is_current)
+    SELECT
+        p_entity_type,
+        'row_count',
+        COUNT(*)::INTEGER,
+        AVG(total_rows),
+        STDDEV(total_rows),
+        GREATEST(1, AVG(total_rows) - 2 * STDDEV(total_rows)),  -- 2σ pour row count (plus sensible)
+        AVG(total_rows) + 2 * STDDEV(total_rows),
+        2.0,
+        MIN(created_at::DATE),
+        MAX(created_at::DATE),
+        TRUE
+    FROM stg_import_batches
+    WHERE entity_type = p_entity_type
+      AND batch_status = 'complete'
+      AND created_at >= now() - INTERVAL '90 days';
+END;
+$$;
+```
+
+---
+
+## 6. Recommandations architecturales — Migration 003+
+
+### 6.1 Ce qui doit être créé dès maintenant
+
+**Migration 003 — Périmètre minimal obligatoire :**
+
+```sql
+-- ====================================================================
+-- MIGRATION 003 — Data Engineering Foundation
+-- ====================================================================
+
+BEGIN;
+
+-- 1. Ajouter external_id sur les tables existantes
+ALTER TABLE items
+    ADD COLUMN IF NOT EXISTS external_id    TEXT UNIQUE,
+    ADD COLUMN IF NOT EXISTS valid_from     DATE NOT NULL DEFAULT CURRENT_DATE,
+    ADD COLUMN IF NOT EXISTS valid_to       DATE,
+    ADD COLUMN IF NOT EXISTS is_current     BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN IF NOT EXISTS version        INTEGER NOT NULL DEFAULT 1,
+    ADD COLUMN IF NOT EXISTS superseded_by  UUID REFERENCES items(item_id);
+
+ALTER TABLE locations
+    ADD COLUMN IF NOT EXISTS external_id    TEXT UNIQUE,
+    ADD COLUMN IF NOT EXISTS valid_from     DATE NOT NULL DEFAULT CURRENT_DATE,
+    ADD COLUMN IF NOT EXISTS valid_to       DATE,
+    ADD COLUMN IF NOT EXISTS is_current     BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN IF NOT EXISTS version        INTEGER NOT NULL DEFAULT 1;
+
+-- Backfill : utiliser item_id comme external_id temporaire pour les données existantes
+UPDATE items SET external_id = item_id::TEXT WHERE external_id IS NULL;
+UPDATE locations SET external_id = location_id::TEXT WHERE external_id IS NULL;
+
+ALTER TABLE items ALTER COLUMN external_id SET NOT NULL;
+ALTER TABLE locations ALTER COLUMN external_id SET NOT NULL;
+
+-- 2. Tables master data (voir schémas sections 6.1, 7.1, 8.1 de SPEC-IMPORT-STATIC)
+CREATE TABLE IF NOT EXISTS suppliers ( ... );  -- Schéma complet dans SPEC-IMPORT-STATIC §6.1
+CREATE TABLE IF NOT EXISTS supplier_items ( ... );   -- §7.1
+CREATE TABLE IF NOT EXISTS item_location_policies ( ... );  -- §8.1
+
+-- 3. Staging zone complète
+-- (tous les CREATE TABLE stg_* de la section 1.3 de ce document)
+
+-- 4. Infrastructure DQ
+CREATE TABLE IF NOT EXISTS data_quality_issues ( ... );   -- Section 3.1
+CREATE TABLE IF NOT EXISTS master_data_audit_log ( ... ); -- Section 4.3
+CREATE TABLE IF NOT EXISTS import_drift_baselines ( ... ); -- Section 5.2
+
+-- 5. Index critiques
+CREATE INDEX IF NOT EXISTS idx_items_current ON items (external_id) WHERE is_current = TRUE;
+CREATE INDEX IF NOT EXISTS idx_items_external ON items (external_id);
+CREATE INDEX IF NOT EXISTS idx_locations_external ON locations (external_id);
+
+COMMIT;
+```
+
+### 6.2 Points ouverts issus des specs à résoudre avant migration 003
+
+| # | Point | Spec source | Recommandation |
+|---|-------|-------------|---------------|
+| P1 | `external_id` sur items/locations | SPEC-STATIC §11 P1 | **Faire maintenant** — backfill avec item_id::TEXT, NOT NULL après |
+| P2 | Import asynchrone au-delà de 10k lignes | SPEC-STATIC §11 P5 | Job table `import_jobs` + polling endpoint. À concevoir avant prod |
+| P3 | Multi-tenant `org_id` scoping | SPEC-STATIC §11 P8 | Ajouter `org_id UUID` sur TOUTES les tables (items, locations, stg_*, etc.) si multi-tenant prévu. Rétrofit coûteux |
+| P4 | Forecasts full replace : scoped par source ou global | SPEC-DYNAMIC §10 #6 | **Scoped par (item × location × source)** — permet coexistence stat + budget |
+| P5 | `on_hand_update` vs `onhand_updated` | SPEC-DYNAMIC §10 #2 | Canonique = `onhand_updated`, déjà dans la contrainte CHECK DB |
+| P6 | PO `partially_received` : champ `received_quantity` | SPEC-DYNAMIC §10 #9 | Ajouter `received_quantity TEXT` dans `stg_purchase_orders` et `NUMERIC` en prod |
+| P7 | Endpoint lookup `GET /v1/items?external_id=...` | SPEC-STATIC §11 P6 | **Obligatoire** pour les intégrations — à créer sprint 2 |
+| P8 | Staging On-Hand | Non couvert dans specs | Ajouter `stg_on_hand` (identique aux autres stg_*) |
+
+### 6.3 Catalogue complet des règles DQ (référence)
+
+| Code | Niveau | Flux | Sévérité | Description |
+|------|--------|------|----------|-------------|
+| N1-001 | 1 | items | blocking | external_id non null/vide |
+| N1-002 | 1 | items | blocking | name non null/vide |
+| N1-003 | 1 | suppliers | blocking | lead_time_days parseable |
+| N1-004 | 1 | PO | blocking | expected_date format valide |
+| N1-005 | 1 | PO/CO/WO/ON | blocking | quantity parseable |
+| N1-006 | 1 | tous | blocking | external_id unique dans batch |
+| N1-007 | 1 | PO/CO | blocking | (po_number, line) unique dans batch |
+| N1-008 | 1 | suppliers | blocking | reliability_score parseable et ∈ [0,1] |
+| N1-009 | 1 | locations | warning | country = 2 chars alpha |
+| N1-010 | 1 | forecasts | blocking | forecast_date format selon bucket_type |
+| N1-011 | 1 | transfers | blocking | ship_date format valide |
+| N1-012 | 1 | supplier_items | blocking | effective_end format si fourni |
+| N2-001 | 2 | PO/CO/WO/TR/FC | blocking | item_external_id résolu en prod |
+| N2-002 | 2 | PO/CO/WO/TR/FC/ON | blocking | location_external_id résolu en prod |
+| N2-003 | 2 | PO | warning | supplier_external_id résolu si fourni |
+| N2-004 | 2 | locations | blocking | Pas de cycle dans hiérarchie parent |
+| N2-005 | 2 | supplier_items | blocking | supplier ET item existent en prod |
+| N3-001 | 3 | suppliers | blocking | lead_time_days > 0 pour actifs |
+| N3-002 | 3 | PO/CO/WO | blocking | quantity > 0 sauf annulations |
+| N3-003 | 3 | PO | warning | expected_date >= today pour actifs |
+| N3-004 | 3 | policies | blocking | safety_stock < max_stock (min_max) |
+| N3-005 | 3 | PO/CO/WO | warning | UOM cohérent avec référentiel item |
+| N3-006 | 3 | supplier_items | blocking | effective_end > effective_start |
+| N3-007 | 3 | suppliers | blocking | reliability_score ∈ [0.0, 1.0] |
+| N4-001 | 4 | transfers | blocking | from_location ≠ to_location |
+| N4-002 | 4 | transfers | blocking | Les deux locations existent |
+| N4-003 | 4 | transfers | warning | expected_receipt_date > ship_date |
+| N4-004 | 4 | WO | blocking | end_date > start_date |
+| N4-005 | 4 | PO | warning | PO pour item push sans forecast |
+| DRIFT-001 | — | on_hand | warning | Quantité hors plage statistique |
+| DRIFT-002 | — | on_hand | blocking | Row count anormal (export partiel) |
+| DRIFT-003 | — | PO | warning | Somme quantités PO × 2 threshold |
+| DRIFT-004 | — | on_hand | blocking | > 30% de lignes à quantité zéro |
+
+### 6.4 Décision : partial_commit vs atomique
+
+La spec actuelle laisse le choix via `partial_commit=true`. **Recommandation :**
+
+- **Défaut : atomique** pour master data (items, locations, suppliers). Un seul enregistrement invalide ne doit pas corrompre le référentiel partiellement.
+- **Défaut : partial_commit** pour données dynamiques (PO, CO, forecasts). En opérations, il vaut mieux importer 490/500 PO que bloquer les 500. Les 10 en erreur sont trackées et résolues.
+
+```python
+# Suggestion : paramètre par défaut dans l'API selon le type
+IMPORT_DEFAULT_ATOMICITY = {
+    'items': 'atomic',
+    'locations': 'atomic',
+    'suppliers': 'atomic',
+    'supplier_items': 'atomic',
+    'item_location_policies': 'atomic',
+    'purchase_orders': 'partial_commit',
+    'customer_orders': 'partial_commit',
+    'forecasts': 'atomic',          # Full replace : atomique ou rien
+    'work_orders': 'partial_commit',
+    'transfers': 'partial_commit',
+    'on_hand': 'atomic',            # Full replace : atomique ou rien
+}
+```
+
+### 6.5 Gap critique identifié : `stg_on_hand` absente des specs
+
+La spec SPEC-IMPORT-DYNAMIC décrit le flux On-Hand mais ne mentionne pas de table de staging dédiée. **À ajouter impérativement :**
+
+```sql
+CREATE TABLE IF NOT EXISTS stg_on_hand (
+    stg_id                  UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id                UUID        NOT NULL,
+    row_number              INTEGER     NOT NULL,
+    source_system           TEXT        NOT NULL DEFAULT 'unknown',
+    imported_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    raw_content             TEXT,
+
+    item_external_id        TEXT,
+    location_external_id    TEXT,
+    quantity                TEXT,
+    uom                     TEXT,
+    as_of_date              TEXT,
+    lot_number              TEXT,
+
+    stg_status              TEXT        NOT NULL DEFAULT 'pending'
+                            CHECK (stg_status IN ('pending', 'valid', 'invalid', 'promoted', 'quarantined')),
+    dq_level_reached        SMALLINT,
+    error_count             INTEGER     NOT NULL DEFAULT 0,
+    promoted_at             TIMESTAMPTZ,
+    production_id           UUID
+);
+
+CREATE INDEX IF NOT EXISTS idx_stg_onhand_batch ON stg_on_hand (batch_id);
+CREATE INDEX IF NOT EXISTS idx_stg_onhand_keys ON stg_on_hand (item_external_id, location_external_id, as_of_date);
+```
+
+---
+
+*Document produit le 2026-04-05 — Review Data Engineering, Ootils Core*  
+*Branche : `review/import-data-engineering`*

--- a/docs/REVIEW-IMPORT-SC-EXPERT.md
+++ b/docs/REVIEW-IMPORT-SC-EXPERT.md
@@ -1,0 +1,768 @@
+# REVIEW-IMPORT-SC-EXPERT — Review Critique Architecture d'Import
+
+> **Auteur :** Expert Intégration Supply Chain Planning (15 ans APS — Kinaxis, o9, Blue Yonder, SAP IBP)  
+> **Date :** 2026-04-05  
+> **Scope :** SPEC-IMPORT-STATIC, SPEC-IMPORT-DYNAMIC, SPEC-INTEGRATION-STRATEGY  
+> **Verdict global :** Architecture solide pour un MVP, avec des lacunes critiques sur la gestion de la qualité de données qui — si non adressées maintenant — reproduiront exactement les erreurs de Kinaxis.
+
+---
+
+## Table des matières
+
+1. [Verdict général](#1-verdict-général)
+2. [Ce qui manque vs les meilleures pratiques APS](#2-ce-qui-manque-vs-les-meilleures-pratiques-aps)
+3. [Risques opérationnels concrets](#3-risques-opérationnels-concrets)
+4. [La couche Staging — ce qu'elle doit faire](#4-la-couche-staging--ce-quelle-doit-faire)
+5. [La couche Processing — ce qu'elle doit faire](#5-la-couche-processing--ce-quelle-doit-faire)
+6. [Données techniques supply chain — champs critiques](#6-données-techniques-supply-chain--champs-critiques)
+7. [Ce que Kinaxis fait mal — et comment Ootils peut faire mieux](#7-ce-que-kinaxis-fait-mal--et-comment-ootils-peut-faire-mieux)
+8. [Recommandations prioritaires P0/P1/P2](#8-recommandations-prioritaires-p0p1p2)
+
+---
+
+## 1. Verdict général
+
+Les trois specs couvrent correctement les cas nominaux : schéma des entités, API endpoints, formats TSV, upsert strategy. C'est le travail d'une équipe qui a réfléchi aux intégrations ERP.
+
+**Ce qui est bien :**
+- La table `external_references` comme interface universelle ERP ↔ Ootils — c'est une bonne décision architecturale (DA-1)
+- Le mapping déclaratif YAML par source — extensible et auditable (DA-2)
+- Le choix TSV avec justification — pragmatique et aligné avec les réalités SAP
+- La philosophie human-in-the-loop sur les outputs — non-négociable en supply chain
+- La validation atomique (tout ou rien par défaut) — bonne base
+
+**Ce qui manque et qui va casser en production :**
+1. **Aucune couche Staging** — les données arrivent directement en traitement sans zone tampon
+2. **Validation des données techniques insuffisante** — lead times à 0 acceptés, UOM non validés entre entités, pas de cohérence croisée
+3. **Pas de détection de dégradation de données** — rien pour détecter qu'un import a silencieusement corrompu le référentiel
+4. **Pas d'historique des master data** — impossible de savoir quand un lead time a changé, par qui, depuis quelle source
+5. **Données manquantes traitées comme erreurs** — au lieu de gérer intelligemment les defaults et substitutions avec alertes
+6. **Pas de BOM** — absent des specs, mais critique pour le manufacturing planning
+7. **Pas de calendriers opérationnels** — les lead times sans calendriers sont inutilisables
+
+---
+
+## 2. Ce qui manque vs les meilleures pratiques APS
+
+### 2.1 La couche Staging est absente
+
+Tous les bons systèmes (SAP IBP, o9, Blue Yonder) séparent **la réception des données brutes** de **leur traitement**. Ootils reçoit les données et les traite immédiatement. Il n'y a aucune zone où stocker les données source telles qu'elles arrivent de l'ERP, avant transformation.
+
+**Conséquence directe :** si un import se passe mal (transformation incorrecte, bug dans le mapping YAML), les données originales sont perdues. Il est impossible de rejouer proprement.
+
+### 2.2 Pas d'historique des master data (SCD — Slowly Changing Dimensions)
+
+SAP IBP gère les master data avec des dates de validité. Blue Yonder maintient un historique complet des changements. Kinaxis ne fait rien — et c'est son problème principal.
+
+Les specs actuelles font des upserts purs : quand un `lead_time_days` passe de 14 à 7 jours sur un `SupplierItem`, l'ancienne valeur est écrasée. Il est impossible de savoir :
+- Quelle était la valeur avant ?
+- Quand a-t-elle changé ?
+- Quel import a causé ce changement ?
+
+Pour un moteur de planification, c'est inacceptable. Les projections utilisent les lead times. Si une rupture survient et qu'on veut comprendre pourquoi, l'absence d'historique rend le debug impossible.
+
+### 2.3 Pas de gestion des calendriers opérationnels
+
+Les lead times en `days` sont inutilisables sans calendriers. 14 jours calendaires ≠ 14 jours ouvrés. Un lead time de 3 jours qui inclut un week-end change la date de réception. 
+
+Aucune des specs ne mentionne :
+- Calendriers de travail par location (jours ouvrés, jours fériés)
+- Calendriers fournisseurs (le fournisseur ne livre pas le vendredi)
+- Calendriers clients (le client ne réceptionne pas certains jours)
+- Shifts de production par usine
+
+SAP IBP a une entité `WorkCalendar` complète. Blue Yonder aussi. C'est un prérequis pour que les dates de planification soient exploitables.
+
+### 2.4 Pas de BOM (Bill of Materials)
+
+La spec mentionne les Work Orders et les "consommations BOM" comme point ouvert (point 10 de SPEC-IMPORT-DYNAMIC), mais il n'y a aucun schéma pour importer une BOM.
+
+Sans BOM, le moteur ne peut pas :
+- Calculer les besoins en composants à partir des work orders
+- Détecter les pénuries de composants qui bloquent la production
+- Faire du MRP (Material Requirements Planning)
+
+C'est une entité fondamentale du manufacturing planning. Si Ootils cible des industriels avec des usines, c'est P0.
+
+### 2.5 Pas de routings de production
+
+Les Work Orders ont `start_date` et `end_date` mais rien sur les ressources (machines, lignes de production). Sans capacité, le moteur peut planifier des work orders sur des équipements qui n'existent pas ou qui sont déjà surchargés. Les meilleurs APS (Kinaxis, o9) modélisent les resources/routings même au niveau basique.
+
+### 2.6 Pas de détection de dégradation de données
+
+Un bon système doit détecter quand un import diminue la qualité des données :
+- Un champ autrefois renseigné devient vide (ex: lead_time_days passa de 14 à null → prend le default 14 silencieusement)
+- Un ensemble d'enregistrements passe de 500 lignes à 50 (perte de 90% sans alerte)
+- Des `supplier_items` actifs disparaissent du fichier sans être explicitement `cancelled`
+
+Kinaxis ne détecte rien. Les données se dégradent silencieusement. Les planificateurs découvrent le problème 3 semaines plus tard en debuggant des projections aberrantes.
+
+### 2.7 Pas de validation cross-entité lors de l'import
+
+Les validations actuelles sont **intra-entité** (les champs d'une ligne sont valides entre eux). Il n'y a pas de validation **cross-entité** comme :
+- Tous les items d'un WO ont-ils une politique de planification `ItemLocationPolicy` dans leur location de production ?
+- Tous les `SupplierItem` actifs pour un item ont-ils un `preferred=true` ?
+- Un item avec `replenishment_type=eoq` a-t-il les données suffisantes (unit_cost, demand historique) pour calculer l'EOQ ?
+
+### 2.8 Multi-UOM absent
+
+La spec définit un champ `uom` sur `items` (EA, KG, etc.) et sur les données transactionnelles. Mais il n'y a pas de table de **coefficients de conversion UOM**.
+
+En réalité, un même item a souvent plusieurs UOM selon le contexte :
+- UOM de stockage : EA (pièce)
+- UOM de commande : BOX (boîte de 12)
+- UOM de production : KG (poids pour les formules)
+
+Si un PO arrive en BOX et que le stock est en EA, le moteur doit convertir. Sans table de conversion, la seule option est de tout rejeter si l'UOM ne correspond pas — ce qui arrive constamment avec des ERP multi-UOM comme SAP.
+
+---
+
+## 3. Risques opérationnels concrets
+
+Ces risques sont tirés de situations réelles vécues en production sur des déploiements Kinaxis, o9, et IBP.
+
+### Risque 1 : Lead times à zéro — le silent killer
+
+**Scenario :** L'ERP SAP exporte les supplier_items via une extraction MARA/EINA. Pour certains articles, le champ `PLIFZ` (planned delivery time) est vide ou à 0 parce que l'article a été créé "temporairement" par un acheteur sans remplir tous les champs.
+
+**Ce que la spec actuelle fait :** `lead_time_days` a un `DEFAULT 14 CHECK (lead_time_days >= 0)`. Un lead time à 0 passe la validation. Le moteur planifie une livraison le jour même. Les projections d'inventaire sont correctes en apparence mais les dates de réapprovisionnement sont toutes décalées.
+
+**Impact :** Les alerts de rupture arrivent trop tard. Le planificateur passe les commandes en urgence. Surcoûts fret express, pénalités clients.
+
+**Fix nécessaire :** Un lead time à 0 doit déclencher une alerte `WARNING` avec flag `requires_review`. Un seuil minimum configurable par `item_type` (ex: `raw_material` ≥ 1 jour). Pas de rejet automatique — mais visibilité obligatoire.
+
+### Risque 2 : UOM incohérents entre PO et stock
+
+**Scenario :** Le stock On-Hand pour SKU-001 est en EA (pièces). Le fournisseur livre en BOX de 24. Le PO arrive avec `uom=BOX`, `quantity=10`. Le moteur interprète 10 EA et non 240 EA.
+
+**Impact :** Le projeté d'inventaire est 23x trop faible. Des alertes de rupture fictives se déclenchent. Des commandes d'urgence sont passées. Overstock massif.
+
+**Ce que la spec actuelle fait :** Le champ UOM est validé comme string non-vide. Aucune cohérence entre l'UOM d'un PO et l'UOM de base de l'item n'est vérifiée.
+
+**Fix nécessaire :** Table `uom_conversions` (voir section 6). Validation obligatoire : si l'UOM du PO ≠ UOM de base de l'item, une conversion doit exister. Sinon, rejet de la ligne avec `UOM_CONVERSION_MISSING`.
+
+### Risque 3 : PO en doublon inter-imports
+
+**Scenario :** L'ERP envoie un batch quotidien de POs en "Delta" (selon la spec). Un PO modifié dans l'ERP apparaît dans deux exports consécutifs avec des quantités différentes (bug d'extraction côté ERP). L'UPSERT sur `(po_number, line_number)` résout le doublon intra-fichier, mais si les deux exports arrivent dans la même fenêtre (retard SFTP + job planifié), deux imports traitent le même PO avec des states différents.
+
+**Impact :** La quantité du PO oscille entre deux valeurs selon l'ordre d'exécution des imports. Le projeté d'inventaire est instable.
+
+**Fix nécessaire :** La staging zone capture chaque import avec un timestamp. Si deux imports pour le même `po_number+line_number` arrivent à moins de N minutes d'intervalle avec des valeurs différentes, une alerte `CONCURRENCY_CONFLICT` est générée. Le dernier l'emporte, mais avec log explicite.
+
+### Risque 4 : Forecasts non normalisés
+
+**Scenario :** La spec accepte des forecasts en `day`, `week`, et `month`. Un client envoie des forecasts mensuels (2026-04) mais les work orders ont des `start_date` journaliers. Pour calculer si un WO du 15 avril peut être lancé, le moteur doit "désagréger" le forecast mensuel.
+
+**Ce que la spec prévoit :** La clé de déduplication inclut `bucket_type`. Mais il n'y a pas de règle de désagrégation (uniform spread ? courbe historique ? peak en fin de mois ?).
+
+**Impact :** Le moteur utilise implicitement une règle de désagrégation non documentée. Les planificateurs voient des projections qui ne correspondent pas à leur intuition. Perte de confiance dans l'outil.
+
+**Fix nécessaire :** Documenter la règle de désagrégation par défaut (uniform spread = 1/N par jour). Permettre une override via `ItemLocationPolicy`. C'est un paramètre de planning fondamental.
+
+### Risque 5 : Master data périmée silencieuse
+
+**Scenario :** Un fournisseur change ses conditions en cours d'année : le `lead_time_days` passe de 14 à 30 jours. L'acheteur met à jour l'ERP. La nuit suivante, le batch import upserte le `SupplierItem` avec le nouveau lead time. Le moteur recalcule. 
+
+Mais 3 mois plus tard, il y a un litige : "pourquoi ce PO a-t-il été passé si tôt ?" Il est impossible de prouver que le lead time était de 14 jours à l'époque où la décision a été prise.
+
+**Fix nécessaire :** SCD Type 2 sur les données master critiques (voir section 4).
+
+### Risque 6 : Items sans politique de planification
+
+**Scenario :** 2000 items sont importés. `ItemLocationPolicy` est optionnelle selon la spec. 800 items n'ont pas de politique définie. Le moteur utilise des defaults (`safety_stock_qty=0`, `replenishment_type=eoq`). Un EOQ calculé sans `unit_cost` ni données de demand retourne une quantité arbitraire ou une division par zéro.
+
+**Impact :** Des commandes de réapprovisionnement absurdes sont générées pour ces 800 items.
+
+**Fix nécessaire :** Après chaque import d'items, vérifier que chaque item actif a une `ItemLocationPolicy` pour chaque location où il a du stock. Générer un rapport des "items sans politique" — pas un blocage, mais une visibilité obligatoire.
+
+---
+
+## 4. La couche Staging — ce qu'elle doit faire
+
+### 4.1 Principe fondamental
+
+La staging zone est un **miroir brut des données sources**. Rien n'est transformé, rien n'est validé métier. C'est un log immuable de ce que l'ERP a envoyé, avec horodatage.
+
+**Règle d'or :** On ne perd jamais les données brutes. Si le processing échoue ou produit une erreur, on peut toujours rejouer depuis le staging.
+
+### 4.2 Schéma de la staging zone
+
+```sql
+-- Table centrale : tout import arrive ici en premier
+CREATE TABLE staging_batches (
+    batch_id            UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    source_system       TEXT        NOT NULL,           -- 'sap_ecc', 'dynamics', 'manual_upload', 'api'
+    entity_type         TEXT        NOT NULL,           -- 'items', 'suppliers', 'purchase_orders', etc.
+    received_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    file_name           TEXT,                           -- Nom du fichier original si applicable
+    file_hash           TEXT,                           -- SHA-256 du fichier reçu (idempotence)
+    row_count           INTEGER,                        -- Nombre de lignes détectées
+    raw_content         TEXT,                           -- Contenu brut UTF-8 (TSV ou JSON stringifié)
+    content_type        TEXT        NOT NULL,           -- 'tsv' | 'json'
+    status              TEXT        NOT NULL DEFAULT 'received'
+                        CHECK (status IN ('received', 'processing', 'processed', 'failed', 'skipped_duplicate')),
+    processing_started_at   TIMESTAMPTZ,
+    processing_completed_at TIMESTAMPTZ,
+    processing_result   JSONB,                          -- Summary du processing (inserted/updated/errors)
+    triggered_by        TEXT,                           -- user_id ou system job name
+    metadata            JSONB                           -- Champs libres : version ERP, org_id, etc.
+);
+
+-- Lignes individuelles du staging (optionnel mais recommandé pour debug)
+CREATE TABLE staging_rows (
+    row_id              UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id            UUID        NOT NULL REFERENCES staging_batches(batch_id),
+    row_number          INTEGER     NOT NULL,
+    raw_data            JSONB       NOT NULL,           -- Ligne parsée en JSON brut (avant transformation)
+    status              TEXT        NOT NULL DEFAULT 'pending'
+                        CHECK (status IN ('pending', 'accepted', 'rejected', 'warned')),
+    validation_messages JSONB,                          -- Liste des erreurs/warnings détectés
+    processed_entity_id UUID,                          -- UUID de l'entité créée/modifiée (après processing)
+    processed_at        TIMESTAMPTZ,
+    UNIQUE (batch_id, row_number)
+);
+
+-- Index pour les opérations courantes
+CREATE INDEX idx_staging_batches_entity_source ON staging_batches (entity_type, source_system, received_at DESC);
+CREATE INDEX idx_staging_batches_file_hash ON staging_batches (file_hash) WHERE file_hash IS NOT NULL;
+CREATE INDEX idx_staging_rows_batch ON staging_rows (batch_id, status);
+CREATE INDEX idx_staging_rows_entity ON staging_rows (processed_entity_id) WHERE processed_entity_id IS NOT NULL;
+```
+
+### 4.3 Règles d'acceptation des données brutes
+
+**La staging accepte tout, avec conditions minimales :**
+
+| Condition | Action si non respectée |
+|-----------|------------------------|
+| Fichier non vide | Reject `staging_batch.status = 'failed'`, pas de staging_rows créées |
+| Encodage UTF-8 détectable | Tentative de re-encoding depuis latin-1/cp1252 → log WARNING, on continue |
+| Header présent en ligne 1 | Reject `status = 'failed'` |
+| Taille ≤ limite configurée (défaut 100MB) | Reject `status = 'failed'` |
+| SHA-256 déjà vu dans les dernières 24h | `status = 'skipped_duplicate'` — idempotence garantie |
+
+**Ce que la staging NE fait PAS :**
+- Ne valide pas les valeurs métier (lead times, dates, quantités)
+- Ne résout pas les external_ids
+- Ne transforme pas les enums
+- Ne rejette pas les lignes avec des champs vides
+
+**Pourquoi ?** Parce que la staging doit capturer ce que l'ERP a vraiment envoyé, même si c'est imparfait. La validation métier est le rôle du processing.
+
+### 4.4 Traçabilité source-à-cible
+
+Chaque enregistrement dans la base Ootils doit porter une référence à son origine staging :
+
+```sql
+-- Sur toutes les tables master data et transactionnelles
+ALTER TABLE items ADD COLUMN IF NOT EXISTS 
+    last_import_batch_id UUID REFERENCES staging_batches(batch_id);
+
+ALTER TABLE supplier_items ADD COLUMN IF NOT EXISTS 
+    last_import_batch_id UUID REFERENCES staging_batches(batch_id);
+
+-- (idem pour locations, suppliers, purchase_orders, etc.)
+```
+
+Cela permet de répondre à : "Quel import a mis ce lead_time_days à 0 ?" en une seule requête :
+
+```sql
+SELECT sb.received_at, sb.source_system, sb.file_name, sb.triggered_by
+FROM supplier_items si
+JOIN staging_batches sb ON si.last_import_batch_id = sb.batch_id
+WHERE si.item_id = :item_id AND si.supplier_id = :supplier_id;
+```
+
+---
+
+## 5. La couche Processing — ce qu'elle doit faire
+
+### 5.1 Pipeline de validation — ordre et logique
+
+Le processing lit les `staging_rows` en état `pending` et les passe à travers le pipeline suivant :
+
+```
+STAGING_ROW (raw_data JSON)
+  │
+  ├─ [ÉTAPE 1] Validation structure
+  │    • Colonnes obligatoires présentes ?
+  │    • Types corrects (nombre, date, string) ?
+  │    • Longueurs max respectées ?
+  │    ↳ Echec → status='rejected', message MISSING_FIELD / TYPE_ERROR
+  │
+  ├─ [ÉTAPE 2] Résolution des external_ids
+  │    • external_id → UUID interne via external_references
+  │    • Pour master data : non trouvé → création automatique (pré-enregistrement)
+  │    • Pour transactionnel : non trouvé → REJECT avec ENTITY_NOT_FOUND
+  │    ↳ Echec → status='rejected'
+  │
+  ├─ [ÉTAPE 3] Application du mapping YAML
+  │    • Transformation des valeurs (enum_map, date format, normalisation string)
+  │    • Valeurs non mappées → valeur 'default' du YAML, ou WARNING si absent
+  │    ↳ Echec mapping → status='warned', valeur default appliquée + log
+  │
+  ├─ [ÉTAPE 4] Validation métier intra-ligne
+  │    • lead_time_days > 0 ? (0 accepté mais WARNING 'LEAD_TIME_ZERO')
+  │    • effective_end > effective_start ?
+  │    • Quantités ≥ 0 ?
+  │    • UOM cohérent avec l'item (lookup dans uom_conversions) ?
+  │    • Dates dans un horizon raisonnable (pas en 1900, pas en 2099) ?
+  │    ↳ Violations ERROR → status='rejected'
+  │    ↳ Violations WARNING → status='warned', processing continue
+  │
+  ├─ [ÉTAPE 5] Validation cross-entité
+  │    • Si ItemLocationPolicy : l'item existe avec status=active ?
+  │    • Si SupplierItem preferred=true : existe-t-il déjà un preferred pour cet item×location ?
+  │    • Si PO : le supplier a-t-il un SupplierItem actif pour cet item ?
+  │    • Si WorkOrder : l'item a-t-il une ItemLocationPolicy dans la location de production ?
+  │    ↳ Violations → WARNING (pas de reject, mais visible dans le rapport)
+  │
+  ├─ [ÉTAPE 6] Détection de dégradation de données
+  │    • Comparaison avec la valeur actuelle en base
+  │    • Champ critique passe de valeur renseignée à NULL/vide → WARNING 'DATA_REGRESSION'
+  │    • Variation > seuil sur champ critique (ex: lead_time change > 50%) → WARNING 'ANOMALY_DETECTED'
+  │    • Nombre de lignes du batch < 80% du dernier import de même type → WARNING 'VOLUME_DROP'
+  │    ↳ Toutes violations → WARNING (jamais reject — mais dashboard de qualité)
+  │
+  └─ [ÉTAPE 7] Upsert en base + événements
+       • INSERT ... ON CONFLICT DO UPDATE (selon conflict_strategy)
+       • Champs modifiés → événements delta détectés
+       • last_import_batch_id = staging_batch_id courant
+       • updated_at = now()
+       ↳ staging_row.status = 'accepted'
+```
+
+### 5.2 Gestion des données techniques manquantes
+
+**Philosophie : defaults intelligents avec visibilité, pas de rejet silencieux.**
+
+| Champ manquant | Comportement | Alerte générée |
+|----------------|-------------|----------------|
+| `lead_time_days` absent | Applique default du `replenishment_type` ou 14j | WARNING `DEFAULT_APPLIED` |
+| `lead_time_days = 0` | Accepté, flag `requires_review = true` | WARNING `LEAD_TIME_ZERO` |
+| `uom` absent | Hérite de l'item parent | INFO `UOM_INHERITED` |
+| `safety_stock_qty` absent | Calculé si données dispo (demand history × coverage_days) | INFO `SAFETY_STOCK_COMPUTED` |
+| `preferred` manquant avec plusieurs suppliers | Premier fournisseur actif = preferred par défaut | WARNING `PREFERRED_AUTO_SET` |
+| `ItemLocationPolicy` absente pour item actif | Politique default créée automatiquement | WARNING `DEFAULT_POLICY_CREATED` |
+| `reliability_score` absent | Default 1.0 appliqué | INFO `DEFAULT_APPLIED` |
+
+**Règle de substitution vs rejet :**
+
+- **Substitution autorisée** : champs de paramétrage où un default raisonnable existe et est documenté
+- **Rejet obligatoire** : champs de référence (external_ids de FK), champs business-critical sans default possible (ex: `quantity` sur un PO)
+- **Jamais de substitution silencieuse** : chaque substitution est loggée dans `staging_rows.validation_messages`
+
+### 5.3 Validation croisée inter-entités — règles concrètes
+
+```python
+# Ces règles s'exécutent APRÈS l'import batch de chaque entité
+# et génèrent des rapports dans une table data_quality_alerts
+
+CROSS_ENTITY_RULES = [
+    {
+        "id": "CER-001",
+        "name": "Item actif sans politique de planification",
+        "query": """
+            SELECT i.external_id, l.external_id as location_external_id
+            FROM items i
+            CROSS JOIN locations l
+            INNER JOIN nodes n ON n.item_id = i.item_id AND n.location_id = l.location_id
+            LEFT JOIN item_location_policies p ON p.item_id = i.item_id AND p.location_id = l.location_id
+            WHERE i.status = 'active' AND p.policy_id IS NULL
+        """,
+        "severity": "WARNING",
+        "message": "Item {item} dans location {location} sans politique de planification"
+    },
+    {
+        "id": "CER-002",
+        "name": "Item sans fournisseur préféré",
+        "query": """
+            SELECT i.external_id
+            FROM items i
+            WHERE i.status = 'active'
+            AND i.item_type IN ('finished_good', 'component', 'raw_material')
+            AND NOT EXISTS (
+                SELECT 1 FROM supplier_items si 
+                WHERE si.item_id = i.item_id AND si.preferred = true AND si.status = 'active'
+            )
+        """,
+        "severity": "WARNING",
+        "message": "Item {item} sans fournisseur préféré actif"
+    },
+    {
+        "id": "CER-003",
+        "name": "PO référençant un supplier inactif ou bloqué",
+        "severity": "ERROR",
+        "check": "purchase_orders.supplier_id → suppliers.status NOT IN ('active', 'approved')"
+    },
+    {
+        "id": "CER-004",
+        "name": "UOM PO ≠ UOM item sans conversion définie",
+        "severity": "ERROR",
+        "check": "purchase_orders.uom ≠ items.uom AND uom_conversions(from, to) IS NULL"
+    },
+    {
+        "id": "CER-005",
+        "name": "Stock On-Hand pour item obsolète",
+        "severity": "WARNING",
+        "check": "on_hand.quantity > 0 AND items.status = 'obsolete'"
+    }
+]
+```
+
+### 5.4 Table de qualité des données (dashboard de santé)
+
+```sql
+CREATE TABLE data_quality_alerts (
+    alert_id            UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id            UUID        REFERENCES staging_batches(batch_id),
+    rule_id             TEXT        NOT NULL,           -- 'CER-001', 'LEAD_TIME_ZERO', etc.
+    severity            TEXT        NOT NULL CHECK (severity IN ('ERROR', 'WARNING', 'INFO')),
+    entity_type         TEXT        NOT NULL,
+    entity_external_id  TEXT,
+    message             TEXT        NOT NULL,
+    context             JSONB,                          -- Données brutes qui ont déclenché l'alerte
+    acknowledged        BOOLEAN     NOT NULL DEFAULT FALSE,
+    acknowledged_by     TEXT,
+    acknowledged_at     TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    resolved_at         TIMESTAMPTZ                     -- NULL = alerte active
+);
+
+CREATE INDEX idx_dqa_severity_resolved ON data_quality_alerts (severity, resolved_at) 
+    WHERE resolved_at IS NULL;
+CREATE INDEX idx_dqa_entity ON data_quality_alerts (entity_type, entity_external_id);
+```
+
+Un endpoint `GET /v1/data-quality/alerts` expose ces alertes à l'UI. C'est le dashboard de santé des données — absent de toutes les APS du marché, et pourtant la fonctionnalité qui génère le plus de valeur en production.
+
+---
+
+## 6. Données techniques supply chain — champs critiques
+
+### 6.1 Lead Times — ce qui doit être validé rigoureusement
+
+Les lead times sont les paramètres les plus critiques du planning. Un lead time faux donne une date de commande fausse, qui donne une rupture ou un overstock.
+
+**Structure recommandée pour les lead times (à ajouter à `SupplierItem` et `ItemLocationPolicy`) :**
+
+```sql
+-- Sur supplier_items : décomposer le lead time
+lead_time_sourcing_days     NUMERIC NOT NULL DEFAULT 0,   -- Temps de traitement fournisseur
+lead_time_manufacturing_days NUMERIC NOT NULL DEFAULT 0,  -- Si le fournisseur fabrique à la commande
+lead_time_transit_days      NUMERIC NOT NULL DEFAULT 0,   -- Transit logistique
+-- lead_time_days = sourcing + manufacturing + transit (calculé)
+
+-- Sur item_location_policies : lead time de fabrication interne
+manufacturing_lead_time_days NUMERIC DEFAULT NULL,        -- Si produit en interne
+inspection_lead_time_days   NUMERIC NOT NULL DEFAULT 0,   -- Contrôle qualité à réception
+```
+
+**Règles de validation :**
+- `lead_time_days = 0` → WARNING obligatoire (flag `requires_review`)
+- `lead_time_days > 365` → WARNING `ANOMALY_LEAD_TIME_HIGH` (probablement une erreur de saisie)
+- `lead_time_days` modifié de plus de 50% en un seul import → WARNING `ANOMALY_LEAD_TIME_CHANGE`
+- Un item `finished_good` avec `lead_time_manufacturing_days = 0` dans une usine → WARNING
+
+### 6.2 Safety Stock / Reorder Points / MOQ
+
+```sql
+-- Dans item_location_policies, renforcer avec :
+safety_stock_method         TEXT CHECK (safety_stock_method IN 
+                            ('fixed_qty', 'fixed_days', 'statistical', 'manual')),
+safety_stock_service_level  NUMERIC CHECK (safety_stock_service_level BETWEEN 0 AND 1),
+                            -- Pour méthode 'statistical' : ex 0.95 = 95% service level
+demand_variability_cv       NUMERIC,  -- Coefficient de variation de la demande
+lead_time_variability_days  NUMERIC,  -- Écart-type du lead time (pour calcul SS statistique)
+```
+
+**Règles :**
+- `safety_stock_qty` ET `safety_stock_days` tous les deux renseignés → ERROR `AMBIGUOUS_SAFETY_STOCK`
+- `reorder_point < safety_stock_qty` → ERROR (on passerait commande après avoir entamé le SS)
+- `max_stock < min_stock` (pour min_max) → ERROR
+- `fixed_order_qty < moq` → WARNING `ORDER_QTY_BELOW_MOQ`
+
+### 6.3 Calendriers opérationnels — entité manquante à créer
+
+```sql
+CREATE TABLE work_calendars (
+    calendar_id         UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    external_id         TEXT        NOT NULL UNIQUE,
+    name                TEXT        NOT NULL,
+    timezone            TEXT        NOT NULL,           -- IANA timezone
+    working_days        TEXT[]      NOT NULL DEFAULT ARRAY['mon','tue','wed','thu','fri'],
+    calendar_type       TEXT        NOT NULL CHECK (calendar_type IN 
+                        ('plant', 'supplier', 'customer', 'logistics')),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE calendar_exceptions (
+    exception_id        UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    calendar_id         UUID        NOT NULL REFERENCES work_calendars(calendar_id),
+    exception_date      DATE        NOT NULL,
+    is_working_day      BOOLEAN     NOT NULL DEFAULT FALSE,  -- FALSE = jour férié, TRUE = jour travaillé exceptionnel
+    description         TEXT,
+    UNIQUE (calendar_id, exception_date)
+);
+
+-- Lier les calendriers aux entités
+ALTER TABLE locations ADD COLUMN work_calendar_id UUID REFERENCES work_calendars(calendar_id);
+ALTER TABLE suppliers ADD COLUMN work_calendar_id UUID REFERENCES work_calendars(calendar_id);
+```
+
+**Import TSV des exceptions :**
+```tsv
+calendar_external_id	exception_date	is_working_day	description
+CAL-FRANCE	2026-05-01	false	Fête du Travail
+CAL-FRANCE	2026-05-08	false	Victoire 1945
+CAL-US	2026-07-04	false	Independence Day
+CAL-USINE-LYON	2026-08-03	false	Fermeture estivale début
+```
+
+**Sans calendriers, chaque lead_time_days calculé par le moteur est faux.**
+
+### 6.4 Coefficients de conversion UOM — table manquante
+
+```sql
+CREATE TABLE uom_conversions (
+    conversion_id       UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    item_id             UUID        REFERENCES items(item_id),  -- NULL = conversion universelle
+    from_uom            TEXT        NOT NULL,
+    to_uom              TEXT        NOT NULL,
+    conversion_factor   NUMERIC     NOT NULL CHECK (conversion_factor > 0),
+                        -- to_qty = from_qty * conversion_factor
+    is_bidirectional    BOOLEAN     NOT NULL DEFAULT TRUE,
+    effective_start     DATE,
+    effective_end       DATE,
+    UNIQUE (item_id, from_uom, to_uom)  -- item_id peut être NULL pour les conversions universelles
+);
+
+-- Exemples :
+-- item_id=NULL, from_uom='BOX', to_uom='EA', factor=12 → 1 BOX = 12 EA (universel)
+-- item_id=SKU-001, from_uom='KG', to_uom='EA', factor=0.5 → 1 EA = 2 KG (item-spécifique)
+```
+
+**Règle d'import transactionnel :** Si `uom` du PO/CO/stock ≠ `uom` de base de l'item :
+1. Cherche une conversion dans `uom_conversions` (d'abord item-spécifique, puis universelle)
+2. Convertit la quantité en UOM de base avant stockage
+3. Log la conversion avec les valeurs d'origine et converties
+4. Si aucune conversion trouvée → REJECT `UOM_CONVERSION_MISSING`
+
+### 6.5 Politiques de planning par Item×Location — champs à renforcer
+
+La spec actuelle `ItemLocationPolicy` est correcte dans sa structure. Voici les champs à ajouter :
+
+```sql
+-- Ajouter à item_location_policies :
+demand_horizon_days         INTEGER NOT NULL DEFAULT 90,  -- Horizon de lecture de la demande
+freeze_horizon_days         INTEGER NOT NULL DEFAULT 14,  -- Horizon gelé (no-auto-reschedule)
+lot_size_rounding           TEXT CHECK (lot_size_rounding IN ('up', 'down', 'nearest')) DEFAULT 'up',
+service_level_target        NUMERIC DEFAULT 0.95,         -- Cible taux de service
+abc_class                   TEXT CHECK (abc_class IN ('A', 'B', 'C', 'X', 'Y', 'Z')),
+                                                          -- Classification ABC pour priorisation
+make_or_buy                 TEXT CHECK (make_or_buy IN ('make', 'buy', 'either')) DEFAULT 'buy',
+work_calendar_id            UUID REFERENCES work_calendars(calendar_id),
+```
+
+---
+
+## 7. Ce que Kinaxis fait mal — et comment Ootils peut faire mieux
+
+### 7.1 Garbage-in sans détection
+
+**Ce que Kinaxis fait :** Les données arrivent via des connecteurs (SAP, Oracle) et entrent directement dans le "cube" de données. Il n'y a pas de staging zone. Les données brutes ne sont pas conservées. Si une extraction produit des valeurs aberrantes (lead times à 0, items sans UOM, POs avec quantités négatives), Kinaxis les ingère sans broncher.
+
+**Symptôme en production :** Les planificateurs voient des Planned Orders absurdes. Le debug prend des jours parce qu'il n'y a aucun moyen de retracer "quelle extraction a causé ça".
+
+**Ce qu'Ootils doit faire :** La staging zone (section 4) + la table `data_quality_alerts` (section 5.4). Chaque anomalie est visible, horodatée, traçable. Le planificateur voit le dashboard de qualité avant même d'ouvrir les projections.
+
+### 7.2 Pas d'historique des master data
+
+**Ce que Kinaxis fait :** Un upsert sur un `SupplierItem` écrase la valeur précédente. Point. Il n'y a aucun journal des changements de paramètres.
+
+**Situation réelle vécue :** Un acheteur change le lead time d'un fournisseur de 21 à 7 jours dans SAP (erreur de saisie — il voulait mettre 17). La nuit suivante, Kinaxis ingère le 7. Les Planned Orders pour ce fournisseur avancent tous de 14 jours. Des commandes sont passées trop tôt. Deux semaines plus tard, le planificateur réalise qu'il y a un overstock. Il ne peut pas prouver que c'était une erreur de lead time car Kinaxis a écrasé la valeur.
+
+**Ce qu'Ootils doit faire :** SCD Type 2 sur les champs critiques. Pas nécessairement sur toutes les tables — mais au minimum :
+
+```sql
+CREATE TABLE master_data_audit (
+    audit_id            UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_type         TEXT        NOT NULL,
+    entity_id           UUID        NOT NULL,
+    entity_external_id  TEXT,
+    field_name          TEXT        NOT NULL,
+    old_value           TEXT,
+    new_value           TEXT,
+    changed_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    changed_by_batch_id UUID        REFERENCES staging_batches(batch_id),
+    changed_by_user     TEXT
+);
+
+-- Trigger sur supplier_items pour les champs critiques
+-- Champs trackés : lead_time_days, reliability_score, moq, preferred, status, effective_end
+```
+
+### 7.3 Pas de détection de chargement partiel
+
+**Ce que Kinaxis fait :** Si une extraction SAP produit 100 lignes au lieu de 1000 (timeout, bug d'extraction, filtre mal configuré), Kinaxis ingère les 100 lignes. Pour les 900 items manquants, rien ne change dans Kinaxis — les anciennes données restent.
+
+**Problème :** Le planificateur ne sait pas que 900 items n'ont pas été mis à jour. Il planifie avec des données potentiellement périmées de 3 jours.
+
+**Ce qu'Ootils doit faire :** Tracking de la volumétrie par type d'entité et source :
+
+```sql
+CREATE TABLE import_volume_baselines (
+    entity_type         TEXT        NOT NULL,
+    source_system       TEXT        NOT NULL,
+    last_known_count    INTEGER     NOT NULL,
+    baseline_updated_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (entity_type, source_system)
+);
+
+-- Au processing : si batch_row_count < last_known_count * 0.80 → WARNING 'VOLUME_DROP_20PCT'
+-- Si batch_row_count < last_known_count * 0.50 → ERROR 'VOLUME_DROP_50PCT' (bloque le processing)
+```
+
+### 7.4 Pas de dry_run sur le master data en production
+
+**Ce que Kinaxis fait :** Il n'y a pas de mode simulation pour un import de master data. Pour tester l'impact d'un changement de paramètre, il faut soit modifier en prod soit monter un environnement sandbox complet.
+
+**Ce qu'Ootils fait déjà :** `dry_run=true` — c'est bien. Il faut en plus un `impact_preview=true` qui montre non seulement les lignes qui seraient modifiées, mais aussi l'impact estimé sur les projections (ex: "ce changement de lead time affectera 47 Planned Orders").
+
+### 7.5 Verrouillage des données en cours d'utilisation
+
+**Ce que Kinaxis fait :** Pendant un recalcul du moteur, il est possible d'importer de nouvelles données. Le moteur peut utiliser un mix de données anciennes et nouvelles. Les résultats sont indéterministes.
+
+**Ce qu'Ootils doit faire :** Soit un lock optimiste (le processing de staging attend que le moteur ait fini son cycle), soit une versioning des données par snapshot. Le staging zone aide ici : les imports s'accumulent en staging pendant le recalcul, et sont processés en batch une fois le cycle terminé.
+
+---
+
+## 8. Recommandations prioritaires P0/P1/P2
+
+### P0 — À faire avant le premier POC client (bloquant)
+
+**P0-1 : Créer la staging zone**
+- Tables `staging_batches` + `staging_rows` (schéma section 4.2)
+- Modifier tous les endpoints `/v1/import/*` pour écrire d'abord en staging avant de processer
+- Ajouter `last_import_batch_id` sur toutes les tables master data
+- Effort estimé : 3-4 jours backend
+
+**P0-2 : Alerte lead_time_days = 0**
+- Validation étape 4 du pipeline : `lead_time_days = 0` → WARNING `LEAD_TIME_ZERO`
+- Champ `requires_review` flag sur `supplier_items` et `item_location_policies`
+- Endpoint `GET /v1/data-quality/alerts?severity=WARNING&rule_id=LEAD_TIME_ZERO`
+- Effort estimé : 1 jour
+
+**P0-3 : Table `master_data_audit` avec triggers sur champs critiques**
+- Tracker lead_time_days, reliability_score, moq, status sur supplier_items et item_location_policies
+- Effort estimé : 1-2 jours
+
+**P0-4 : Détection de volume drop**
+- Comparer le nombre de lignes du batch avec le dernier import de même type
+- WARNING si < 80%, ERROR bloquant si < 50%
+- Effort estimé : 0.5 jour
+
+**P0-5 : Rapport post-import de qualité**
+- Après chaque batch, générer un `data_quality_report` avec les statistiques et alertes
+- Retourner ce rapport dans la réponse de l'API (ou via webhook si async)
+- Effort estimé : 1 jour
+
+### P1 — Avant onboarding premier client récurrent
+
+**P1-1 : Table `uom_conversions`**
+- Schéma section 6.4
+- Validation croisée UOM lors de l'import des données transactionnelles (PO, CO, On-Hand)
+- Templates TSV pour les conversions standard + import via `/v1/import/uom-conversions`
+- Effort estimé : 2-3 jours
+
+**P1-2 : Entité `WorkCalendar` + exceptions**
+- Schéma section 6.3
+- Liaison aux locations et suppliers
+- Utilisation dans le moteur pour le calcul des dates de livraison
+- Effort estimé : 3-5 jours (+ intégration moteur)
+
+**P1-3 : Validation cross-entité post-import**
+- Règles CER-001 à CER-005 (section 5.3)
+- Table `data_quality_alerts`
+- Dashboard UI basic (liste des alertes actives, acknowledge, résolution)
+- Effort estimé : 3-4 jours
+
+**P1-4 : BOM (Bill of Materials)**
+- Entité critique pour les clients manufacturing
+- Schéma minimal : `bom_headers` (parent item) + `bom_lines` (component, quantity, uom, scrap_factor)
+- Import TSV + endpoint API
+- Effort estimé : 2-3 jours schéma + import
+
+**P1-5 : Décomposition du lead time (sourcing + manufacturing + transit)**
+- Modifier `supplier_items` pour porter les 3 composantes séparément
+- Migration des `lead_time_days` existants vers `lead_time_sourcing_days` (valeur par défaut)
+- Effort estimé : 1 jour
+
+**P1-6 : SCD Type 2 complet sur ItemLocationPolicy**
+- Gérer les dates d'effectivité avec SCD Type 2 (nouvelle ligne à chaque changement)
+- La politique active = celle dont `effective_start <= today <= effective_end`
+- Effort estimé : 2-3 jours
+
+### P2 — Différenciateurs compétitifs post-PMF
+
+**P2-1 : Impact preview avant import**
+- Extension du `dry_run=true` pour montrer l'impact sur le moteur
+- "Si vous modifiez ce lead time, X Planned Orders seront affectés"
+- Effort estimé : 3-5 jours (nécessite intégration avec le moteur de simulation)
+
+**P2-2 : Détection d'anomalies ML sur les master data**
+- Détecter automatiquement les valeurs statistiquement aberrantes par rapport à l'historique
+- "Ce lead time de 180 jours est 12x la moyenne de ce fournisseur — vérifiez"
+- Effort estimé : 5-10 jours (modèle + pipeline)
+
+**P2-3 : Import asynchrone avec job tracking**
+- Pour les fichiers > 10 000 lignes : retourner immédiatement un `job_id`
+- Polling `GET /v1/jobs/{job_id}` ou webhook sur completion
+- Effort estimé : 3-4 jours (queue + worker)
+
+**P2-4 : Réconciliation automatique inter-sources**
+- Détecter les conflits quand deux sources (SAP + WMS) décrivent le même item différemment
+- Règles de prédominance configurables par source et champ
+- Effort estimé : 5+ jours
+
+**P2-5 : Gouvernance des masters avec workflow d'approbation**
+- Certains changements de master data (ex: lead time > 50% de variation) nécessitent une approbation avant application
+- File d'attente `pending_master_changes` avec UI de validation
+- Effort estimé : 5-7 jours
+
+---
+
+## Synthèse des gaps par criticité
+
+| Gap | Impact | Effort | Priorité |
+|-----|--------|--------|----------|
+| Absence staging zone | Irréversible si bug processing | 3-4j | **P0** |
+| Lead time = 0 non alerté | Ruptures non détectées | 0.5j | **P0** |
+| Pas d'audit trail master data | Debug impossible | 1-2j | **P0** |
+| Volume drop non détecté | Données périmées silencieuses | 0.5j | **P0** |
+| UOM sans table de conversion | Quantités erronées | 2-3j | **P1** |
+| Pas de calendriers opérationnels | Dates de livraison fausses | 3-5j | **P1** |
+| Pas de BOM | Pas de MRP possible | 2-3j | **P1** |
+| Validation cross-entité absente | Incohérences non détectées | 3-4j | **P1** |
+| Pas de SCD sur policies | Historique planning perdu | 2-3j | **P1** |
+| Impact preview absent | Risque modification aveugle | 3-5j | P2 |
+
+---
+
+## Conclusion
+
+L'architecture actuelle est un bon point de départ — les fondamentaux (external_ids, upsert strategy, audit log d'import, human-in-the-loop) sont solides. Ce sont des décisions que Kinaxis n'a jamais prises correctement.
+
+Mais sans staging zone et sans pipeline de qualité des données, Ootils reproduira les mêmes problèmes que Kinaxis à l'échelle. Pas parce que le moteur est mauvais — parce que les données qui l'alimentent seront mauvaises, et personne ne le verra.
+
+La promesse d'Ootils — données de qualité, planning fiable — se joue ici, dans ces couches invisibles. Le planificateur ne voit pas la staging zone. Il voit les résultats. Si les données sont propres, les résultats sont fiables. C'est aussi simple que ça.
+
+**Prochaines étapes immédiates recommandées :**
+1. Valider ce document avec l'équipe architecture
+2. Créer les tickets P0 cette semaine
+3. Implémenter staging zone avant tout autre feature d'import
+4. Définir le BOM schema (blocker pour les clients manufacturing)
+
+---
+
+*Review produite par expertise terrain — Supply Chain Planning Integration, 2026-04-05*

--- a/src/ootils_core/db/migrations/007_import_pipeline.sql
+++ b/src/ootils_core/db/migrations/007_import_pipeline.sql
@@ -1,0 +1,330 @@
+-- ============================================================
+-- Ootils Core — Migration 007: Import Pipeline 2 étapes
+-- Staging zone, DQ pipeline, données techniques SC, master data audit
+--
+-- Conventions :
+--   - Tous les PKs sont UUID
+--   - Tous les timestamps sont TIMESTAMPTZ UTC
+--   - IF NOT EXISTS partout pour idempotence
+--   - CREATE TYPE via DO $$ pour idempotence (PostgreSQL < 16)
+-- ============================================================
+
+
+-- ============================================================
+-- 0. Extensions requises
+-- ============================================================
+
+-- btree_gist est nécessaire pour la contrainte EXCLUDE USING gist
+-- sur des colonnes non-géométriques (item_id, location_id, daterange).
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+
+-- ============================================================
+-- 1. external_id sur items et locations (backfill safe)
+-- ============================================================
+
+ALTER TABLE items ADD COLUMN IF NOT EXISTS external_id TEXT;
+UPDATE items SET external_id = item_id::TEXT WHERE external_id IS NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'items_external_id_unique'
+          AND conrelid = 'items'::regclass
+    ) THEN
+        ALTER TABLE items ADD CONSTRAINT items_external_id_unique UNIQUE (external_id);
+    END IF;
+END $$;
+
+ALTER TABLE locations ADD COLUMN IF NOT EXISTS external_id TEXT;
+UPDATE locations SET external_id = location_id::TEXT WHERE external_id IS NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'locations_external_id_unique'
+          AND conrelid = 'locations'::regclass
+    ) THEN
+        ALTER TABLE locations ADD CONSTRAINT locations_external_id_unique UNIQUE (external_id);
+    END IF;
+END $$;
+
+
+-- ============================================================
+-- 2. Table external_references — mapping ERP codes → UUID internes
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS external_references (
+    ref_id          UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_type     TEXT        NOT NULL CHECK (entity_type IN (
+                        'item', 'location', 'supplier', 'purchase_order',
+                        'customer_order', 'work_order', 'transfer', 'forecast'
+                    )),
+    external_id     TEXT        NOT NULL,
+    source_system   TEXT        NOT NULL,
+    internal_id     UUID        NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (entity_type, external_id, source_system)
+);
+
+
+-- ============================================================
+-- 3. Tables staging — ingest_batches + ingest_rows
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS ingest_batches (
+    batch_id        UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_type     TEXT        NOT NULL CHECK (entity_type IN (
+                        'items', 'locations', 'suppliers', 'supplier_items',
+                        'purchase_orders', 'customer_orders', 'forecasts',
+                        'work_orders', 'transfers', 'on_hand'
+                    )),
+    source_system   TEXT        NOT NULL,
+    status          TEXT        NOT NULL DEFAULT 'pending' CHECK (status IN (
+                        'pending', 'processing', 'validated', 'rejected',
+                        'importing', 'imported', 'partial'
+                    )),
+    total_rows      INTEGER,
+    valid_rows      INTEGER,
+    error_rows      INTEGER,
+    warning_rows    INTEGER,
+    submitted_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    processed_at    TIMESTAMPTZ,
+    imported_at     TIMESTAMPTZ,
+    submitted_by    TEXT,
+    notes           TEXT
+);
+
+CREATE TABLE IF NOT EXISTS ingest_rows (
+    row_id          UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id        UUID        NOT NULL REFERENCES ingest_batches(batch_id),
+    row_number      INTEGER     NOT NULL,
+    raw_content     TEXT        NOT NULL,
+    -- Colonnes extraites brutes (TEXT partout — pas de conversion à ce stade)
+    col_01 TEXT, col_02 TEXT, col_03 TEXT, col_04 TEXT, col_05 TEXT,
+    col_06 TEXT, col_07 TEXT, col_08 TEXT, col_09 TEXT, col_10 TEXT,
+    col_11 TEXT, col_12 TEXT, col_13 TEXT, col_14 TEXT, col_15 TEXT,
+    -- Statut DQ
+    dq_status       TEXT        NOT NULL DEFAULT 'pending' CHECK (dq_status IN (
+                        'pending', 'l1_pass', 'l2_pass', 'l3_pass', 'l4_pass',
+                        'rejected', 'imported'
+                    )),
+    dq_level_reached INTEGER    DEFAULT 0,
+    -- Metadata
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (batch_id, row_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_rows_batch ON ingest_rows (batch_id, dq_status);
+CREATE INDEX IF NOT EXISTS idx_ingest_batches_status ON ingest_batches (status, entity_type);
+
+
+-- ============================================================
+-- 4. Table data_quality_issues
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS data_quality_issues (
+    issue_id        UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id        UUID        NOT NULL REFERENCES ingest_batches(batch_id),
+    row_id          UUID        REFERENCES ingest_rows(row_id),
+    row_number      INTEGER,
+    dq_level        INTEGER     NOT NULL CHECK (dq_level BETWEEN 1 AND 4),
+    rule_code       TEXT        NOT NULL,
+    severity        TEXT        NOT NULL CHECK (severity IN ('error', 'warning', 'info')),
+    field_name      TEXT,
+    raw_value       TEXT,
+    message         TEXT        NOT NULL,
+    auto_corrected  BOOLEAN     NOT NULL DEFAULT FALSE,
+    correction_detail TEXT,
+    resolved        BOOLEAN     NOT NULL DEFAULT FALSE,
+    resolved_at     TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_dq_issues_batch ON data_quality_issues (batch_id, severity, resolved);
+
+
+-- ============================================================
+-- 5. Tables suppliers et supplier_items
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS suppliers (
+    supplier_id     UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    external_id     TEXT        UNIQUE,
+    name            TEXT        NOT NULL,
+    country         TEXT,
+    lead_time_days  INTEGER     CHECK (lead_time_days > 0),
+    reliability_score NUMERIC(4,3) CHECK (reliability_score BETWEEN 0 AND 1),
+    status          TEXT        NOT NULL DEFAULT 'active' CHECK (status IN (
+                        'active', 'inactive', 'blocked'
+                    )),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS supplier_items (
+    supplier_item_id UUID       NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    supplier_id     UUID        NOT NULL REFERENCES suppliers(supplier_id),
+    item_id         UUID        NOT NULL REFERENCES items(item_id),
+    lead_time_days  INTEGER     NOT NULL CHECK (lead_time_days > 0),
+    moq             NUMERIC     CHECK (moq > 0),
+    unit_cost       NUMERIC,
+    currency        TEXT        DEFAULT 'EUR',
+    is_preferred    BOOLEAN     NOT NULL DEFAULT FALSE,
+    valid_from      DATE,
+    valid_to        DATE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (supplier_id, item_id)
+);
+
+
+-- ============================================================
+-- 6. Types ENUM pour item_planning_params
+-- ============================================================
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'lot_size_rule_type') THEN
+        CREATE TYPE lot_size_rule_type AS ENUM (
+            'LOTFORLOT', 'FIXED_QTY', 'PERIOD_OF_SUPPLY', 'MIN_MAX'
+        );
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'planning_source_type') THEN
+        CREATE TYPE planning_source_type AS ENUM (
+            'erp', 'manual', 'ai_suggested', 'default'
+        );
+    END IF;
+END $$;
+
+
+-- ============================================================
+-- 7. Table item_planning_params — données techniques versionnées SCD2
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS item_planning_params (
+    param_id                    UUID                NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    item_id                     UUID                NOT NULL REFERENCES items(item_id),
+    location_id                 UUID                NOT NULL REFERENCES locations(location_id),
+
+    -- Lead times
+    lead_time_sourcing_days     INTEGER             CHECK (lead_time_sourcing_days >= 0),
+    lead_time_manufacturing_days INTEGER            CHECK (lead_time_manufacturing_days >= 0),
+    lead_time_transit_days      INTEGER             CHECK (lead_time_transit_days >= 0),
+    lead_time_total_days        INTEGER             GENERATED ALWAYS AS (
+                                    COALESCE(lead_time_sourcing_days, 0) +
+                                    COALESCE(lead_time_manufacturing_days, 0) +
+                                    COALESCE(lead_time_transit_days, 0)
+                                ) STORED,
+
+    -- Safety stock
+    safety_stock_qty            NUMERIC             CHECK (safety_stock_qty >= 0),
+    safety_stock_days           NUMERIC             CHECK (safety_stock_days >= 0),
+
+    -- Reorder
+    reorder_point_qty           NUMERIC             CHECK (reorder_point_qty >= 0),
+    min_order_qty               NUMERIC             CHECK (min_order_qty > 0),
+    max_order_qty               NUMERIC             CHECK (max_order_qty > 0),
+    order_multiple              NUMERIC             CHECK (order_multiple > 0),
+
+    -- Policy
+    lot_size_rule               lot_size_rule_type  NOT NULL DEFAULT 'LOTFORLOT',
+    planning_horizon_days       INTEGER             NOT NULL DEFAULT 90 CHECK (planning_horizon_days > 0),
+    is_make                     BOOLEAN             NOT NULL DEFAULT FALSE,
+    preferred_supplier_id       UUID                REFERENCES suppliers(supplier_id),
+
+    -- Versioning temporel SCD2
+    effective_from              DATE                NOT NULL DEFAULT CURRENT_DATE,
+    effective_to                DATE,
+
+    -- Metadata
+    source                      planning_source_type NOT NULL DEFAULT 'manual',
+    created_at                  TIMESTAMPTZ         NOT NULL DEFAULT now(),
+    updated_at                  TIMESTAMPTZ         NOT NULL DEFAULT now(),
+
+    CONSTRAINT ipp_effective_order CHECK (effective_to IS NULL OR effective_to > effective_from),
+
+    -- Contrainte d'exclusion : pas de chevauchement temporel par (item, location)
+    -- Nécessite l'extension btree_gist (activée ci-dessus)
+    CONSTRAINT ipp_item_location_active_unique EXCLUDE USING gist (
+        item_id WITH =,
+        location_id WITH =,
+        daterange(effective_from, COALESCE(effective_to, '9999-12-31'::DATE)) WITH &&
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_ipp_item_location ON item_planning_params (item_id, location_id);
+CREATE INDEX IF NOT EXISTS idx_ipp_active ON item_planning_params (item_id, location_id, effective_from)
+    WHERE effective_to IS NULL;
+
+
+-- ============================================================
+-- 8. Table uom_conversions
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS uom_conversions (
+    conversion_id   UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    from_uom        TEXT        NOT NULL,
+    to_uom          TEXT        NOT NULL,
+    item_id         UUID        REFERENCES items(item_id),
+    -- factor : 1 from_uom = factor × to_uom
+    -- ex: PALLET → EA, factor=48 signifie 1 PALLET = 48 EA
+    factor          NUMERIC     NOT NULL CHECK (factor > 0),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (from_uom, to_uom, item_id)
+);
+
+-- Conversions globales de base (item_id NULL = applicable à tous les items)
+INSERT INTO uom_conversions (from_uom, to_uom, item_id, factor) VALUES
+    ('PALLET', 'EA',  NULL, 48),
+    ('BOX',    'EA',  NULL, 12),
+    ('KG',     'G',   NULL, 1000),
+    ('T',      'KG',  NULL, 1000)
+ON CONFLICT DO NOTHING;
+
+
+-- ============================================================
+-- 9. Table operational_calendars
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS operational_calendars (
+    calendar_id     UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    location_id     UUID        NOT NULL REFERENCES locations(location_id),
+    calendar_date   DATE        NOT NULL,
+    is_working_day  BOOLEAN     NOT NULL DEFAULT TRUE,
+    shift_count     SMALLINT    DEFAULT 1 CHECK (shift_count BETWEEN 0 AND 3),
+    -- capacity_factor : 1.0 = pleine capacité, 0.5 = demi-capacité, 0.0 = fermé
+    capacity_factor NUMERIC(4,3) DEFAULT 1.0 CHECK (capacity_factor BETWEEN 0 AND 2),
+    notes           TEXT,
+    UNIQUE (location_id, calendar_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_calendar_location_date ON operational_calendars (location_id, calendar_date);
+CREATE INDEX IF NOT EXISTS idx_calendar_non_working ON operational_calendars (location_id, calendar_date)
+    WHERE is_working_day = FALSE;
+
+
+-- ============================================================
+-- 10. Table master_data_audit_log
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS master_data_audit_log (
+    audit_id        UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_type     TEXT        NOT NULL,
+    entity_id       UUID        NOT NULL,
+    field_name      TEXT        NOT NULL,
+    old_value       TEXT,
+    new_value       TEXT,
+    changed_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    changed_by      TEXT,
+    source_system   TEXT,
+    batch_id        UUID        REFERENCES ingest_batches(batch_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_entity ON master_data_audit_log (entity_type, entity_id, changed_at);

--- a/tests/test_migration_007.py
+++ b/tests/test_migration_007.py
@@ -1,0 +1,575 @@
+"""
+tests/test_migration_007.py — Tests de la migration 007 (import pipeline 2 étapes).
+
+Vérifie :
+- Toutes les tables créées par 007 existent
+- item_planning_params rejette lead_time_sourcing_days < 0
+- La contrainte GIST d'exclusion sur effective_from/effective_to bloque les overlaps
+- external_id est unique sur items
+- data_quality_issues et ingest_rows ont leurs FK et CHECK constraints
+- suppliers/supplier_items s'insèrent et se lient correctement
+- uom_conversions : les conversions globales de base sont présentes
+
+Skip si DATABASE_URL n'est pas configuré.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Detect test DB availability (même pattern que tests/integration/)
+# ---------------------------------------------------------------------------
+
+TEST_DB_URL = os.environ.get("DATABASE_URL", "")
+
+
+def _db_available() -> bool:
+    if not TEST_DB_URL:
+        return False
+    try:
+        import psycopg
+        with psycopg.connect(TEST_DB_URL, connect_timeout=3) as conn:
+            conn.execute("SELECT 1")
+        return True
+    except Exception:
+        return False
+
+
+DB_AVAILABLE = _db_available()
+
+requires_db = pytest.mark.skipif(
+    not DB_AVAILABLE,
+    reason="No PostgreSQL available — set DATABASE_URL to a test DB",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def migrated_db():
+    """Apply all migrations (including 007) and yield the DSN."""
+    if not DB_AVAILABLE:
+        pytest.skip("No PostgreSQL available")
+
+    import psycopg
+
+    old_url = os.environ.get("DATABASE_URL")
+    os.environ["DATABASE_URL"] = TEST_DB_URL
+
+    try:
+        from ootils_core.db.connection import OotilsDB
+        OotilsDB(TEST_DB_URL)
+    except Exception as exc:
+        pytest.skip(f"Failed to apply migrations: {exc}")
+
+    yield TEST_DB_URL
+
+    # Tear down
+    try:
+        with psycopg.connect(TEST_DB_URL, autocommit=True) as conn:
+            conn.execute("""
+                DO $$
+                DECLARE r RECORD;
+                BEGIN
+                    FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public') LOOP
+                        EXECUTE 'DROP TABLE IF EXISTS ' || quote_ident(r.tablename) || ' CASCADE';
+                    END LOOP;
+                END $$;
+            """)
+            # Drop custom types
+            conn.execute("DROP TYPE IF EXISTS lot_size_rule_type CASCADE")
+            conn.execute("DROP TYPE IF EXISTS planning_source_type CASCADE")
+    except Exception:
+        pass
+
+    if old_url is not None:
+        os.environ["DATABASE_URL"] = old_url
+    elif "DATABASE_URL" in os.environ:
+        del os.environ["DATABASE_URL"]
+
+
+@pytest.fixture
+def conn(migrated_db):
+    """Function-scoped psycopg connection, rolled back after each test."""
+    import psycopg
+    from psycopg.rows import dict_row
+
+    with psycopg.connect(migrated_db, row_factory=dict_row) as c:
+        yield c
+        c.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _tables(c) -> set[str]:
+    rows = c.execute(
+        "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+    ).fetchall()
+    return {r["tablename"] for r in rows}
+
+
+def _insert_item(conn) -> str:
+    """Insert a minimal item and return its item_id (UUID string)."""
+    item_id = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO items (item_id, name) VALUES (%s::UUID, %s)",
+        (item_id, "Test Item"),
+    )
+    return item_id
+
+
+def _insert_location(conn) -> str:
+    """Insert a minimal location and return its location_id (UUID string)."""
+    location_id = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO locations (location_id, name) VALUES (%s::UUID, %s)",
+        (location_id, "Test Location"),
+    )
+    return location_id
+
+
+def _insert_batch(conn, entity_type: str = "items") -> str:
+    """Insert a minimal ingest_batch and return its batch_id."""
+    batch_id = str(uuid.uuid4())
+    conn.execute(
+        """
+        INSERT INTO ingest_batches (batch_id, entity_type, source_system)
+        VALUES (%s::UUID, %s, 'test_system')
+        """,
+        (batch_id, entity_type),
+    )
+    return batch_id
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — Toutes les tables de la migration 007 existent
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_07_all_tables_created(migrated_db):
+    """Toutes les tables introduites par 007_import_pipeline.sql existent."""
+    import psycopg
+    from psycopg.rows import dict_row
+
+    with psycopg.connect(migrated_db, row_factory=dict_row) as c:
+        tables = _tables(c)
+
+    expected_007 = {
+        "external_references",
+        "ingest_batches",
+        "ingest_rows",
+        "data_quality_issues",
+        "suppliers",
+        "supplier_items",
+        "item_planning_params",
+        "uom_conversions",
+        "operational_calendars",
+        "master_data_audit_log",
+    }
+    missing = expected_007 - tables
+    assert not missing, f"Tables manquantes après migration 007 : {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — items.external_id est UNIQUE
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_07_items_external_id_unique(conn):
+    """Deux items ne peuvent pas avoir le même external_id."""
+    item_id_1 = str(uuid.uuid4())
+    item_id_2 = str(uuid.uuid4())
+    ext_id = f"EXT-{uuid.uuid4().hex[:8]}"
+
+    conn.execute(
+        "INSERT INTO items (item_id, name, external_id) VALUES (%s::UUID, %s, %s)",
+        (item_id_1, "Item A", ext_id),
+    )
+
+    with pytest.raises(Exception, match=r"(unique|duplicate)"):
+        conn.execute(
+            "INSERT INTO items (item_id, name, external_id) VALUES (%s::UUID, %s, %s)",
+            (item_id_2, "Item B", ext_id),
+        )
+        conn.commit()
+
+    conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — item_planning_params rejette lead_time_sourcing_days < 0
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_07_ipp_rejects_negative_lead_time(conn):
+    """lead_time_sourcing_days < 0 viole la CHECK constraint."""
+    item_id = _insert_item(conn)
+    location_id = _insert_location(conn)
+
+    with pytest.raises(Exception, match=r"(check|violates|ipp|lead_time)"):
+        conn.execute(
+            """
+            INSERT INTO item_planning_params
+                (item_id, location_id, lead_time_sourcing_days)
+            VALUES (%s::UUID, %s::UUID, -1)
+            """,
+            (item_id, location_id),
+        )
+        conn.commit()
+
+    conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — item_planning_params rejette lead_time_manufacturing_days < 0
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_07_ipp_rejects_negative_manufacturing_lead_time(conn):
+    """lead_time_manufacturing_days < 0 viole la CHECK constraint."""
+    item_id = _insert_item(conn)
+    location_id = _insert_location(conn)
+
+    with pytest.raises(Exception, match=r"(check|violates)"):
+        conn.execute(
+            """
+            INSERT INTO item_planning_params
+                (item_id, location_id, lead_time_manufacturing_days)
+            VALUES (%s::UUID, %s::UUID, -5)
+            """,
+            (item_id, location_id),
+        )
+        conn.commit()
+
+    conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — item_planning_params : lead_time_total_days est calculé
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_07_ipp_lead_time_total_computed(conn):
+    """lead_time_total_days = sum des 3 composants."""
+    item_id = _insert_item(conn)
+    location_id = _insert_location(conn)
+
+    conn.execute(
+        """
+        INSERT INTO item_planning_params
+            (item_id, location_id,
+             lead_time_sourcing_days, lead_time_manufacturing_days, lead_time_transit_days)
+        VALUES (%s::UUID, %s::UUID, 5, 10, 3)
+        """,
+        (item_id, location_id),
+    )
+
+    row = conn.execute(
+        """
+        SELECT lead_time_total_days FROM item_planning_params
+        WHERE item_id = %s::UUID AND location_id = %s::UUID
+        """,
+        (item_id, location_id),
+    ).fetchone()
+
+    assert row is not None
+    assert row["lead_time_total_days"] == 18, (
+        f"Attendu 18, obtenu {row['lead_time_total_days']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — GIST exclusion bloque les overlaps temporels sur item_planning_params
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_07_ipp_gist_blocks_overlap(conn):
+    """Deux versions overlapping sur le même (item, location) sont bloquées."""
+    item_id = _insert_item(conn)
+    location_id = _insert_location(conn)
+
+    # Version 1 : 2026-01-01 → 2026-06-30
+    conn.execute(
+        """
+        INSERT INTO item_planning_params
+            (item_id, location_id, effective_from, effective_to)
+        VALUES (%s::UUID, %s::UUID, '2026-01-01', '2026-06-30')
+        """,
+        (item_id, location_id),
+    )
+
+    # Version 2 qui chevauche : 2026-04-01 → 2026-12-31 (overlap avec V1)
+    with pytest.raises(Exception, match=r"(exclusion|overlap|conflits|constraint)"):
+        conn.execute(
+            """
+            INSERT INTO item_planning_params
+                (item_id, location_id, effective_from, effective_to)
+            VALUES (%s::UUID, %s::UUID, '2026-04-01', '2026-12-31')
+            """,
+            (item_id, location_id),
+        )
+        conn.commit()
+
+    conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — GIST exclusion accepte des périodes non-chevauchantes
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_07_ipp_gist_allows_non_overlapping(conn):
+    """Deux versions consécutives non-chevauchantes sont acceptées."""
+    item_id = _insert_item(conn)
+    location_id = _insert_location(conn)
+
+    conn.execute(
+        """
+        INSERT INTO item_planning_params
+            (item_id, location_id, effective_from, effective_to)
+        VALUES (%s::UUID, %s::UUID, '2026-01-01', '2026-06-30')
+        """,
+        (item_id, location_id),
+    )
+
+    # Version 2 qui commence exactement après V1
+    conn.execute(
+        """
+        INSERT INTO item_planning_params
+            (item_id, location_id, effective_from, effective_to)
+        VALUES (%s::UUID, %s::UUID, '2026-06-30', '2026-12-31')
+        """,
+        (item_id, location_id),
+    )
+
+    count = conn.execute(
+        "SELECT COUNT(*) AS cnt FROM item_planning_params WHERE item_id = %s::UUID",
+        (item_id,),
+    ).fetchone()["cnt"]
+    assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — ingest_batches : entity_type CHECK constraint
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_07_ingest_batches_entity_type_check(conn):
+    """entity_type invalide est rejeté par la CHECK constraint."""
+    with pytest.raises(Exception, match=r"(check|violates)"):
+        conn.execute(
+            """
+            INSERT INTO ingest_batches (entity_type, source_system)
+            VALUES ('invalid_entity', 'test')
+            """,
+        )
+        conn.commit()
+
+    conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — ingest_rows : UNIQUE (batch_id, row_number)
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_07_ingest_rows_unique_batch_row_number(conn):
+    """Deux lignes avec le même (batch_id, row_number) sont rejetées."""
+    batch_id = _insert_batch(conn)
+
+    conn.execute(
+        """
+        INSERT INTO ingest_rows (batch_id, row_number, raw_content)
+        VALUES (%s::UUID, 1, 'ligne 1')
+        """,
+        (batch_id,),
+    )
+
+    with pytest.raises(Exception, match=r"(unique|duplicate)"):
+        conn.execute(
+            """
+            INSERT INTO ingest_rows (batch_id, row_number, raw_content)
+            VALUES (%s::UUID, 1, 'doublon')
+            """,
+            (batch_id,),
+        )
+        conn.commit()
+
+    conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Test 10 — data_quality_issues : dq_level BETWEEN 1 AND 4
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_07_dq_issues_dq_level_check(conn):
+    """dq_level hors de [1, 4] est rejeté."""
+    batch_id = _insert_batch(conn)
+
+    with pytest.raises(Exception, match=r"(check|violates)"):
+        conn.execute(
+            """
+            INSERT INTO data_quality_issues
+                (batch_id, dq_level, rule_code, severity, message)
+            VALUES (%s::UUID, 0, 'TEST_RULE', 'error', 'test')
+            """,
+            (batch_id,),
+        )
+        conn.commit()
+
+    conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Test 11 — uom_conversions : conversions de base présentes
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_07_uom_conversions_base_data(conn):
+    """Les 4 conversions globales de base sont présentes après migration."""
+    rows = conn.execute(
+        """
+        SELECT from_uom, to_uom, factor
+        FROM uom_conversions
+        WHERE item_id IS NULL
+        ORDER BY from_uom
+        """
+    ).fetchall()
+
+    conversions = {(r["from_uom"], r["to_uom"]): r["factor"] for r in rows}
+
+    assert ("PALLET", "EA") in conversions, "Conversion PALLET→EA manquante"
+    assert conversions[("PALLET", "EA")] == 48
+
+    assert ("BOX", "EA") in conversions, "Conversion BOX→EA manquante"
+    assert conversions[("BOX", "EA")] == 12
+
+    assert ("KG", "G") in conversions, "Conversion KG→G manquante"
+    assert conversions[("KG", "G")] == 1000
+
+    assert ("T", "KG") in conversions, "Conversion T→KG manquante"
+    assert conversions[("T", "KG")] == 1000
+
+
+# ---------------------------------------------------------------------------
+# Test 12 — suppliers + supplier_items : FK et UNIQUE
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_07_suppliers_and_supplier_items(conn):
+    """Insertion d'un supplier et d'un supplier_item, puis vérification de l'unicité."""
+    item_id = _insert_item(conn)
+
+    supplier_id = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO suppliers (supplier_id, name) VALUES (%s::UUID, %s)",
+        (supplier_id, "Fournisseur Test SA"),
+    )
+
+    conn.execute(
+        """
+        INSERT INTO supplier_items (supplier_id, item_id, lead_time_days)
+        VALUES (%s::UUID, %s::UUID, 14)
+        """,
+        (supplier_id, item_id),
+    )
+
+    # Doublon (supplier_id, item_id) interdit
+    with pytest.raises(Exception, match=r"(unique|duplicate)"):
+        conn.execute(
+            """
+            INSERT INTO supplier_items (supplier_id, item_id, lead_time_days)
+            VALUES (%s::UUID, %s::UUID, 7)
+            """,
+            (supplier_id, item_id),
+        )
+        conn.commit()
+
+    conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Test 13 — operational_calendars : UNIQUE (location_id, calendar_date)
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_07_operational_calendars_unique_location_date(conn):
+    """Deux entrées pour la même (location, date) sont rejetées."""
+    location_id = _insert_location(conn)
+
+    conn.execute(
+        """
+        INSERT INTO operational_calendars (location_id, calendar_date, is_working_day)
+        VALUES (%s::UUID, '2026-12-25', FALSE)
+        """,
+        (location_id,),
+    )
+
+    with pytest.raises(Exception, match=r"(unique|duplicate)"):
+        conn.execute(
+            """
+            INSERT INTO operational_calendars (location_id, calendar_date, is_working_day)
+            VALUES (%s::UUID, '2026-12-25', TRUE)
+            """,
+            (location_id,),
+        )
+        conn.commit()
+
+    conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Test 14 — locations.external_id est UNIQUE
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_07_locations_external_id_unique(conn):
+    """Deux locations ne peuvent pas partager le même external_id."""
+    ext_id = f"LOC-{uuid.uuid4().hex[:8]}"
+    loc_id_1 = str(uuid.uuid4())
+    loc_id_2 = str(uuid.uuid4())
+
+    conn.execute(
+        "INSERT INTO locations (location_id, name, external_id) VALUES (%s::UUID, %s, %s)",
+        (loc_id_1, "Location A", ext_id),
+    )
+
+    with pytest.raises(Exception, match=r"(unique|duplicate)"):
+        conn.execute(
+            "INSERT INTO locations (location_id, name, external_id) VALUES (%s::UUID, %s, %s)",
+            (loc_id_2, "Location B", ext_id),
+        )
+        conn.commit()
+
+    conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Test 15 — master_data_audit_log : FK sur ingest_batches
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_07_audit_log_fk_to_batch(conn):
+    """master_data_audit_log.batch_id référence ingest_batches (FK active)."""
+    fake_batch_id = str(uuid.uuid4())  # n'existe pas
+
+    with pytest.raises(Exception, match=r"(foreign key|fk|constraint|violates)"):
+        conn.execute(
+            """
+            INSERT INTO master_data_audit_log
+                (entity_type, entity_id, field_name, batch_id)
+            VALUES ('item', %s::UUID, 'name', %s::UUID)
+            """,
+            (str(uuid.uuid4()), fake_batch_id),
+        )
+        conn.commit()
+
+    conn.rollback()


### PR DESCRIPTION
## Contexte

Implémentation de l'infrastructure DB pour l'architecture d'import 2 étapes d'Ootils (ADR-009).
Pas d'endpoints API dans ce sprint — uniquement schéma DB + migration + tests.

## Livrable

### ADR-009
`docs/ADR-009-import-pipeline.md` — Architecture pipeline d'import : Staging + DQ + Core.
Documente les 6 décisions fermes (D1→D6) et leurs conséquences.

### Migration 007 (`src/ootils_core/db/migrations/007_import_pipeline.sql`)

10 nouvelles tables :
- **`ingest_batches` / `ingest_rows`** — staging zone immuable (principe : ne jamais perdre une donnée source)
- **`data_quality_issues`** — issues DQ L1→L4 avec severity, rule_code, auto_corrected
- **`external_references`** — mapping ERP codes → UUID internes (multi-source)
- **`suppliers` / `supplier_items`** — référentiel fournisseurs + conditions d'approvisionnement
- **`item_planning_params`** — paramètres SC versionnés SCD2, contrainte GIST anti-overlap
- **`uom_conversions`** — conversions UOM globales et item-specific + 4 conversions de base
- **`operational_calendars`** — calendriers opérationnels par site (absence = jour ouvré)
- **`master_data_audit_log`** — traçabilité complète des changements master data

Modifications existantes :
- `items.external_id` (TEXT UNIQUE) — backfill safe depuis item_id
- `locations.external_id` (TEXT UNIQUE) — backfill safe depuis location_id
- Extension `btree_gist` activée pour la contrainte EXCLUDE USING gist

### Tests (`tests/test_migration_007.py`)

15 tests couvrant :
- Présence de toutes les tables 007
- `external_id` UNIQUE sur items et locations
- `item_planning_params` rejette lead_time < 0
- Contrainte GIST bloque les overlaps temporels
- GIST accepte les périodes consécutives
- CHECK constraints sur ingest_batches, dq_issues
- UNIQUE sur ingest_rows, operational_calendars, supplier_items
- FK active sur master_data_audit_log → ingest_batches
- Conversions UOM de base présentes

## Points d'attention

- **`CREATE TYPE IF NOT EXISTS`** n'existe pas en PostgreSQL natif — contourné via `DO $$ BEGIN IF NOT EXISTS ... END $$`
- **`btree_gist`** doit être disponible sur l'environnement de production (extension standard, présente par défaut sur la plupart des distros PostgreSQL 14+)
- **Rétention staging** : `ingest_rows` peut grossir rapidement (`raw_content` TEXT). Prévoir une politique de purge (> 90 jours après import) — hors scope ce sprint
- **BOM + routings** : hors scope, à couvrir dans ADR-010

## Tests

```bash
DATABASE_URL=postgresql://ootils:ootils@localhost/ootils_test pytest tests/test_migration_007.py -v
```

Tests skippés si `DATABASE_URL` non configuré.