### PR TITLE
feat: seed enrichment — full causal graph MidCo Electronics

### DIFF
--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -356,7 +356,319 @@ def _seed_shortages(conn, pump_id, valve_id, atl_id, lax_id, series_pump, series
               valve_id, lax_id, d, shortage_qty, severity, calc_run_id))
 
 
+# ===========================================================================
+# ENRICHMENT — MidCo Electronics full causal graph
+# ===========================================================================
+# Items mapping (consistent with existing seed):
+#   Item A = PUMP-01  →  pump_id  = _uid("item:PUMP-01")
+#   Item B = VALVE-02 →  valve_id = _uid("item:VALVE-02")
+#   Loc  A = DC-ATL   →  atl_id   = _uid("location:DC-ATL")
+#   Loc  B = DC-LAX   →  lax_id   = _uid("location:DC-LAX")
+# ---------------------------------------------------------------------------
+
+
+def seed_enrichment(conn):
+    """
+    Enriches the MidCo Electronics demo with a full causal supply chain graph:
+      - Suppliers (Taiwan Semi Components, Euro Parts GmbH)
+      - SupplierItems (preferred sources per item)
+      - item_planning_params (lead times, safety stock, MOQ per item×location)
+      - OnHandSupply nodes (current WMS stock)
+      - Additional PurchaseOrderSupply nodes (PO-001, PO-002, PO-003)
+      - ForecastDemand nodes (12 weekly buckets per item)
+      - CustomerOrderDemand nodes (CO-001, CO-002, CO-003)
+      - Edges linking every supply/demand node to the matching ProjectedInventory bucket
+    """
+    print("\n🔧 Running MidCo enrichment (suppliers, POs, forecasts, COs, edges)...")
+
+    pump_id  = _uid("item:PUMP-01")
+    valve_id = _uid("item:VALVE-02")
+    atl_id   = _uid("location:DC-ATL")
+    lax_id   = _uid("location:DC-LAX")
+    series_pump_atl  = _uid("series:PUMP-01:DC-ATL")
+    series_valve_lax = _uid("series:VALVE-02:DC-LAX")
+
+    _seed_suppliers(conn, pump_id, valve_id)
+    _seed_item_planning_params(conn, pump_id, valve_id, atl_id, lax_id)
+    _seed_onhand_nodes(conn, pump_id, valve_id, atl_id, lax_id, series_pump_atl, series_valve_lax)
+    _seed_po_nodes(conn, pump_id, valve_id, atl_id, lax_id, series_pump_atl, series_valve_lax)
+    _seed_forecast_nodes(conn, pump_id, valve_id, atl_id, lax_id, series_pump_atl, series_valve_lax)
+    _seed_co_nodes(conn, pump_id, valve_id, atl_id, lax_id, series_pump_atl, series_valve_lax)
+
+    conn.commit()
+    print("  ✅ Enrichment complete — full causal graph inserted.")
+
+
+def _seed_suppliers(conn, pump_id, valve_id):
+    """Insert suppliers and supplier_items (idempotent via ON CONFLICT DO NOTHING)."""
+
+    sup_tw_id = _uid("supplier:SUP-001")
+    sup_de_id = _uid("supplier:SUP-002")
+
+    conn.execute("""
+        INSERT INTO suppliers (supplier_id, external_id, name, country, lead_time_days, reliability_score, status)
+        VALUES
+            (%s, 'SUP-001', 'Taiwan Semi Components', 'TW', 21, 0.920, 'active'),
+            (%s, 'SUP-002', 'Euro Parts GmbH',        'DE',  7, 0.980, 'active')
+        ON CONFLICT DO NOTHING
+    """, (sup_tw_id, sup_de_id))
+    print("  ✓ Suppliers: Taiwan Semi Components (SUP-001), Euro Parts GmbH (SUP-002)")
+
+    # supplier_items
+    conn.execute("""
+        INSERT INTO supplier_items (supplier_item_id, supplier_id, item_id, lead_time_days, moq, unit_cost, currency, is_preferred)
+        VALUES
+            -- PUMP-01 → SUP-001 preferred
+            (%s, %s, %s, 21, 100, 12.50, 'USD', TRUE),
+            -- PUMP-01 → SUP-002 alternative
+            (%s, %s, %s,  7, 500, 14.00, 'USD', FALSE),
+            -- VALVE-02 → SUP-001 preferred
+            (%s, %s, %s, 21,  50,  8.75, 'USD', TRUE)
+        ON CONFLICT DO NOTHING
+    """, (
+        _uid("supplier_item:SUP-001:PUMP-01"),  sup_tw_id, pump_id,
+        _uid("supplier_item:SUP-002:PUMP-01"),  sup_de_id, pump_id,
+        _uid("supplier_item:SUP-001:VALVE-02"), sup_tw_id, valve_id,
+    ))
+    print("  ✓ SupplierItems: 3 sourcing links created")
+
+
+def _seed_item_planning_params(conn, pump_id, valve_id, atl_id, lax_id):
+    """Insert item_planning_params for PUMP-01@DC-ATL and VALVE-02@DC-LAX."""
+
+    sup_tw_id = _uid("supplier:SUP-001")
+
+    # PUMP-01 @ DC-ATL
+    conn.execute("""
+        INSERT INTO item_planning_params (
+            param_id, item_id, location_id,
+            lead_time_sourcing_days, lead_time_transit_days,
+            safety_stock_qty, safety_stock_days,
+            min_order_qty, order_multiple,
+            lot_size_rule, planning_horizon_days,
+            is_make, preferred_supplier_id,
+            source, effective_from
+        ) VALUES (%s, %s, %s, 21, 2, 50, 7, 100, 50, 'LOTFORLOT', 90, FALSE, %s, 'manual', %s)
+        ON CONFLICT DO NOTHING
+    """, (_uid("ipp:PUMP-01:DC-ATL:v1"), pump_id, atl_id, sup_tw_id, TODAY))
+
+    # VALVE-02 @ DC-LAX
+    conn.execute("""
+        INSERT INTO item_planning_params (
+            param_id, item_id, location_id,
+            lead_time_sourcing_days, lead_time_transit_days,
+            safety_stock_qty, safety_stock_days,
+            min_order_qty, order_multiple,
+            lot_size_rule, planning_horizon_days,
+            is_make, preferred_supplier_id,
+            source, effective_from
+        ) VALUES (%s, %s, %s, 21, 3, 30, 5, 50, 25, 'LOTFORLOT', 90, FALSE, %s, 'manual', %s)
+        ON CONFLICT DO NOTHING
+    """, (_uid("ipp:VALVE-02:DC-LAX:v1"), valve_id, lax_id, sup_tw_id, TODAY))
+
+    print("  ✓ item_planning_params: PUMP-01@DC-ATL, VALVE-02@DC-LAX")
+
+
+def _find_first_pi(conn, series_id):
+    """Return the node_id of bucket_sequence=0 for a given projection series."""
+    row = conn.execute("""
+        SELECT node_id FROM nodes
+        WHERE projection_series_id = %s AND bucket_sequence = 0 AND active = TRUE
+        LIMIT 1
+    """, (series_id,)).fetchone()
+    return row["node_id"] if row else None
+
+
+def _insert_edge(conn, edge_name, edge_type, from_node_id, to_node_id):
+    """Insert an edge idempotently."""
+    conn.execute("""
+        INSERT INTO edges (edge_id, edge_type, from_node_id, to_node_id, scenario_id, priority, active)
+        VALUES (%s, %s, %s, %s, %s, 0, TRUE)
+        ON CONFLICT DO NOTHING
+    """, (_uid(f"edge:{edge_name}"), edge_type, from_node_id, to_node_id, BASELINE_SCENARIO_ID))
+
+
+def _seed_onhand_nodes(conn, pump_id, valve_id, atl_id, lax_id, series_pump, series_valve):
+    """OnHandSupply: current WMS stock for both items."""
+
+    oh_pump_id  = _uid("node:OnHand:PUMP-01:DC-ATL")
+    oh_valve_id = _uid("node:OnHand:VALVE-02:DC-LAX")
+
+    conn.execute("""
+        INSERT INTO nodes (
+            node_id, node_type, scenario_id, item_id, location_id,
+            time_grain, time_ref, quantity, qty_uom, active
+        ) VALUES
+            (%s, 'OnHandSupply', %s, %s, %s, 'exact_date', %s, 30, 'EA', TRUE),
+            (%s, 'OnHandSupply', %s, %s, %s, 'exact_date', %s, 45, 'EA', TRUE)
+        ON CONFLICT DO NOTHING
+    """, (
+        oh_pump_id,  BASELINE_SCENARIO_ID, pump_id,  atl_id, TODAY,
+        oh_valve_id, BASELINE_SCENARIO_ID, valve_id, lax_id, TODAY,
+    ))
+    print("  ✓ OnHandSupply: PUMP-01@DC-ATL=30, VALVE-02@DC-LAX=45")
+
+    # Edges: OnHand → first PI bucket
+    pi_pump  = _find_first_pi(conn, series_pump)
+    pi_valve = _find_first_pi(conn, series_valve)
+    if pi_pump:
+        _insert_edge(conn, "contributes_to:OnHand-PUMP-01:DC-ATL", "contributes_to", oh_pump_id, pi_pump)
+    if pi_valve:
+        _insert_edge(conn, "contributes_to:OnHand-VALVE-02:DC-LAX", "contributes_to", oh_valve_id, pi_valve)
+    print("  ✓ Edges: OnHandSupply → ProjectedInventory[0] (contributes_to)")
+
+
+def _seed_po_nodes(conn, pump_id, valve_id, atl_id, lax_id, series_pump, series_valve):
+    """
+    PurchaseOrderSupply nodes — enrichment POs (on top of existing day-25 PO):
+      PO-001: PUMP-01 @ DC-ATL, qty=500, day+25  (maps to existing scenario)
+      PO-002: PUMP-01 @ DC-ATL, qty=300, day+45
+      PO-003: VALVE-02 @ DC-LAX, qty=200, day+28
+    """
+    po001_id = _uid("node:PO-001:PUMP-01:DC-ATL:day25")
+    po002_id = _uid("node:PO-002:PUMP-01:DC-ATL:day45")
+    po003_id = _uid("node:PO-003:VALVE-02:DC-LAX:day28")
+
+    conn.execute("""
+        INSERT INTO nodes (
+            node_id, node_type, scenario_id, item_id, location_id,
+            time_grain, time_ref, quantity, qty_uom, active
+        ) VALUES
+            (%s, 'PurchaseOrderSupply', %s, %s, %s, 'exact_date', %s, 500, 'EA', TRUE),
+            (%s, 'PurchaseOrderSupply', %s, %s, %s, 'exact_date', %s, 300, 'EA', TRUE),
+            (%s, 'PurchaseOrderSupply', %s, %s, %s, 'exact_date', %s, 200, 'EA', TRUE)
+        ON CONFLICT DO NOTHING
+    """, (
+        po001_id, BASELINE_SCENARIO_ID, pump_id,  atl_id, TODAY + timedelta(days=25),
+        po002_id, BASELINE_SCENARIO_ID, pump_id,  atl_id, TODAY + timedelta(days=45),
+        po003_id, BASELINE_SCENARIO_ID, valve_id, lax_id, TODAY + timedelta(days=28),
+    ))
+    print("  ✓ PurchaseOrderSupply: PO-001 (day+25), PO-002 (day+45), PO-003 (day+28)")
+
+    # Edges: each PO → nearest PI bucket (by arrival day)
+    for po_id, series_id, bucket in [
+        (po001_id, series_pump,  25),
+        (po002_id, series_pump,  45),
+        (po003_id, series_valve, 28),
+    ]:
+        pi_row = conn.execute("""
+            SELECT node_id FROM nodes
+            WHERE projection_series_id = %s AND bucket_sequence = %s AND active = TRUE
+            LIMIT 1
+        """, (series_id, bucket)).fetchone()
+        if pi_row:
+            _insert_edge(conn, f"replenishes:{po_id}:bucket{bucket}", "replenishes", po_id, pi_row["node_id"])
+
+    print("  ✓ Edges: PurchaseOrderSupply → ProjectedInventory (replenishes)")
+
+
+def _seed_forecast_nodes(conn, pump_id, valve_id, atl_id, lax_id, series_pump, series_valve):
+    """
+    ForecastDemand — 12 weekly buckets:
+      PUMP-01 @ DC-ATL  : 105 units/week (15/day × 7)
+      VALVE-02 @ DC-LAX :  56 units/week (8/day × 7)
+    """
+    nodes = []
+    edges_data = []
+
+    for week in range(12):
+        week_start = TODAY + timedelta(weeks=week)
+        week_end   = week_start + timedelta(days=7)
+
+        # PUMP-01
+        fc_pump_id = _uid(f"node:Forecast:PUMP-01:DC-ATL:week{week}")
+        nodes.append((
+            fc_pump_id, "ForecastDemand", BASELINE_SCENARIO_ID, pump_id, atl_id,
+            "week", week_start, week_start, week_end, 105, "EA", True,
+        ))
+
+        # VALVE-02
+        fc_valve_id = _uid(f"node:Forecast:VALVE-02:DC-LAX:week{week}")
+        nodes.append((
+            fc_valve_id, "ForecastDemand", BASELINE_SCENARIO_ID, valve_id, lax_id,
+            "week", week_start, week_start, week_end, 56, "EA", True,
+        ))
+
+        # Map forecast to a PI bucket near the start of the week
+        bucket_day = week * 7
+        edges_data.append((fc_pump_id,  series_pump,  bucket_day, week))
+        edges_data.append((fc_valve_id, series_valve, bucket_day, week))
+
+    with conn.cursor() as cur:
+        cur.executemany("""
+            INSERT INTO nodes (
+                node_id, node_type, scenario_id, item_id, location_id,
+                time_grain, time_ref, time_span_start, time_span_end,
+                quantity, qty_uom, active
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT DO NOTHING
+        """, nodes)
+
+    print(f"  ✓ ForecastDemand: 12 weekly buckets × 2 items = {len(nodes)} nodes")
+
+    # Edges: ForecastDemand → ProjectedInventory (drives)
+    edge_count = 0
+    for fc_node_id, series_id, bucket_day, week in edges_data:
+        # Use the closest available bucket (cap at 89 for 90-day horizon)
+        capped_day = min(bucket_day, 89)
+        pi_row = conn.execute("""
+            SELECT node_id FROM nodes
+            WHERE projection_series_id = %s AND bucket_sequence = %s AND active = TRUE
+            LIMIT 1
+        """, (series_id, capped_day)).fetchone()
+        if pi_row:
+            _insert_edge(conn, f"drives:{fc_node_id}:pi{capped_day}", "drives", fc_node_id, pi_row["node_id"])
+            edge_count += 1
+
+    print(f"  ✓ Edges: ForecastDemand → ProjectedInventory (drives) — {edge_count} edges")
+
+
+def _seed_co_nodes(conn, pump_id, valve_id, atl_id, lax_id, series_pump, series_valve):
+    """
+    CustomerOrderDemand (firm orders):
+      CO-001: PUMP-01  @ DC-ATL, qty=80,  day+10
+      CO-002: PUMP-01  @ DC-ATL, qty=120, day+20
+      CO-003: VALVE-02 @ DC-LAX, qty=60,  day+15
+    """
+    co001_id = _uid("node:CO-001:PUMP-01:DC-ATL:day10")
+    co002_id = _uid("node:CO-002:PUMP-01:DC-ATL:day20")
+    co003_id = _uid("node:CO-003:VALVE-02:DC-LAX:day15")
+
+    conn.execute("""
+        INSERT INTO nodes (
+            node_id, node_type, scenario_id, item_id, location_id,
+            time_grain, time_ref, quantity, qty_uom, active
+        ) VALUES
+            (%s, 'CustomerOrderDemand', %s, %s, %s, 'exact_date', %s, 80,  'EA', TRUE),
+            (%s, 'CustomerOrderDemand', %s, %s, %s, 'exact_date', %s, 120, 'EA', TRUE),
+            (%s, 'CustomerOrderDemand', %s, %s, %s, 'exact_date', %s, 60,  'EA', TRUE)
+        ON CONFLICT DO NOTHING
+    """, (
+        co001_id, BASELINE_SCENARIO_ID, pump_id,  atl_id, TODAY + timedelta(days=10),
+        co002_id, BASELINE_SCENARIO_ID, pump_id,  atl_id, TODAY + timedelta(days=20),
+        co003_id, BASELINE_SCENARIO_ID, valve_id, lax_id, TODAY + timedelta(days=15),
+    ))
+    print("  ✓ CustomerOrderDemand: CO-001 (day+10), CO-002 (day+20), CO-003 (day+15)")
+
+    # Edges: CustomerOrder → PI bucket at due date
+    for co_id, series_id, bucket in [
+        (co001_id, series_pump,  10),
+        (co002_id, series_pump,  20),
+        (co003_id, series_valve, 15),
+    ]:
+        pi_row = conn.execute("""
+            SELECT node_id FROM nodes
+            WHERE projection_series_id = %s AND bucket_sequence = %s AND active = TRUE
+            LIMIT 1
+        """, (series_id, bucket)).fetchone()
+        if pi_row:
+            _insert_edge(conn, f"drives:{co_id}:bucket{bucket}", "drives", co_id, pi_row["node_id"])
+
+    print("  ✓ Edges: CustomerOrderDemand → ProjectedInventory (drives)")
+
+
 if __name__ == "__main__":
     print(f"Connecting to {DATABASE_URL}...")
     with psycopg.connect(DATABASE_URL, row_factory=dict_row) as conn:
         seed(conn)
+        seed_enrichment(conn)


### PR DESCRIPTION
## Contexte

Le seed actuel ne peuplait que des nœuds `ProjectedInventory` — 0 edges, aucune cause visible dans le graph.

## Ce qui a été ajouté

### Master data
- **Suppliers** (2) : Taiwan Semi Components (SUP-001, TW), Euro Parts GmbH (SUP-002, DE)
- **SupplierItems** (3) : sourcing links PUMP-01↔SUP-001/002, VALVE-02↔SUP-001 avec lead times, MOQ, unit_cost
- **item_planning_params** (2) : PUMP-01@DC-ATL + VALVE-02@DC-LAX avec safety stock, MOQ, lot_size_rule, preferred_supplier

### Nœuds transactionnels
- **OnHandSupply** (2) : stock WMS actuel — PUMP-01=30, VALVE-02=45
- **PurchaseOrderSupply** (3) : PO-001 (500 u, day+25), PO-002 (300 u, day+45), PO-003 (200 u, day+28)
- **ForecastDemand** (24) : 12 buckets hebdo × 2 items — PUMP-01=105/week, VALVE-02=56/week
- **CustomerOrderDemand** (3) : CO-001 (80 u, day+10), CO-002 (120 u, day+20), CO-003 (60 u, day+15)

### Edges (graph causal)
| Source | Target | edge_type |
|--------|--------|-----------|
| OnHandSupply | ProjectedInventory[0] | `contributes_to` |
| PurchaseOrderSupply | ProjectedInventory[arrival_day] | `replenishes` |
| ForecastDemand | ProjectedInventory[week_start] | `drives` |
| CustomerOrderDemand | ProjectedInventory[due_day] | `drives` |

## Idempotence
Tous les blocs utilisent `ON CONFLICT DO NOTHING`. Les UUIDs sont déterministes via `uuid5`. Relancer le seed est safe.

## Déploiement sur la VM (192.168.1.176)

```bash
# Pull la branche sur la VM
git pull origin feat/seed-enrichment   # ou après merge: git pull origin main

# Lancer le seed enrichi (requiert migration 007 appliquée)
DATABASE_URL=postgresql://ootils:ootils@localhost:5432/ootils_db   python scripts/seed_demo_data.py
```

Pré-requis : migration 007 doit être appliquée (`suppliers`, `supplier_items`, `item_planning_params` doivent exister).

## Tests
- `python3 -m py_compile scripts/seed_demo_data.py` ✅ — syntax OK
- Seed existant inchangé (rétrocompatibilité totale)
