### PR TITLE
fix: migration auto-apply + seed external_ids

### DIFF
--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -63,10 +63,11 @@ def seed(conn):
     valve_id = _uid("item:VALVE-02")
 
     conn.execute("""
-        INSERT INTO items (item_id, name, item_type, uom, status)
-        VALUES (%s, 'PUMP-01 Industrial Pump', 'finished_good', 'EA', 'active'),
-               (%s, 'VALVE-02 Control Valve', 'component', 'EA', 'active')
-        ON CONFLICT DO NOTHING
+        INSERT INTO items (item_id, name, item_type, uom, status, external_id)
+        VALUES (%s, 'PUMP-01 Industrial Pump', 'finished_good', 'EA', 'active', 'PUMP-01'),
+               (%s, 'VALVE-02 Control Valve', 'component', 'EA', 'active', 'VALVE-02')
+        ON CONFLICT (item_id) DO UPDATE
+            SET external_id = EXCLUDED.external_id
     """, (pump_id, valve_id))
     print(f"  ✓ Items: PUMP-01 ({pump_id[:8]}...), VALVE-02 ({valve_id[:8]}...)")
 
@@ -77,10 +78,11 @@ def seed(conn):
     lax_id = _uid("location:DC-LAX")
 
     conn.execute("""
-        INSERT INTO locations (location_id, name, location_type, country)
-        VALUES (%s, 'DC-ATL Atlanta Distribution Center', 'dc', 'US'),
-               (%s, 'DC-LAX Los Angeles Distribution Center', 'dc', 'US')
-        ON CONFLICT DO NOTHING
+        INSERT INTO locations (location_id, name, location_type, country, external_id)
+        VALUES (%s, 'DC-ATL Atlanta Distribution Center', 'dc', 'US', 'DC-ATL'),
+               (%s, 'DC-LAX Los Angeles Distribution Center', 'dc', 'US', 'DC-LAX')
+        ON CONFLICT (location_id) DO UPDATE
+            SET external_id = EXCLUDED.external_id
     """, (atl_id, lax_id))
     print(f"  ✓ Locations: DC-ATL ({atl_id[:8]}...), DC-LAX ({lax_id[:8]}...)")
 

--- a/src/ootils_core/db/connection.py
+++ b/src/ootils_core/db/connection.py
@@ -66,6 +66,8 @@ class OotilsDB:
 
     def _apply_migrations(self) -> None:
         """Apply all .sql migration files in order. Idempotent (IF NOT EXISTS throughout)."""
+        import sys
+
         migration_files = sorted(MIGRATIONS_DIR.glob("*.sql"))
         if not migration_files:
             return
@@ -73,14 +75,29 @@ class OotilsDB:
         with psycopg.connect(self.database_url, autocommit=True) as conn:
             for migration_path in migration_files:
                 sql = migration_path.read_text(encoding="utf-8")
-                # Execute each statement individually to avoid transaction issues
-                # with DDL statements in PostgreSQL
                 try:
-                    conn.execute(sql)
+                    # Use cursor.execute() to handle multi-statement SQL files,
+                    # including files with DO $$ ... $$ PL/pgSQL blocks.
+                    # autocommit=True ensures each statement commits independently.
+                    with conn.cursor() as cur:
+                        cur.execute(sql)
                 except Exception as e:
-                    # Ignore "already exists" errors — idempotent
-                    if "already exists" not in str(e):
-                        raise
+                    err_msg = str(e).lower()
+                    # Ignore "already exists" errors — idempotent migrations
+                    if any(phrase in err_msg for phrase in [
+                        "already exists",
+                        "duplicate key",
+                        "relation already exists",
+                        "column already exists",
+                        "constraint already exists",
+                    ]):
+                        continue
+                    # Log real errors instead of silently ignoring them
+                    print(
+                        f"[MIGRATION ERROR] {migration_path.name}: {e}",
+                        file=sys.stderr,
+                    )
+                    raise
 
     def health_check(self) -> dict:
         """


### PR DESCRIPTION
Fix Bug 1: _apply_migrations() gère correctement les fichiers SQL multi-statements.
Fix Bug 2: seed_demo_data.py écrit les external_ids codes métier (PUMP-01, VALVE-02, DC-ATL, DC-LAX) au lieu des UUIDs techniques.
Closes INFRA feedback sur issues #68 et #71.