### PR TITLE
feat: calendriers opérationnels

### DIFF
--- a/docs/CALENDAR-INTEGRATION-POINTS.md
+++ b/docs/CALENDAR-INTEGRATION-POINTS.md
@@ -1,0 +1,81 @@
+# Calendar Integration Points
+
+> Document tracking locations in the engine where `timedelta`-based date
+> arithmetic should eventually be replaced by `add_working_days()` /
+> `add_working_days_sync()` from `ootils_core.engine.kernel.calc.calendar`.
+
+## Status
+
+- `add_working_days_sync()` and `add_working_days()` are available as of
+  `feat/calendars`.
+- The API endpoints (`POST /v1/ingest/calendars`, `GET /v1/calendars/*`,
+  `POST /v1/calendars/working-days`) are live.
+- Engine integration is **best-effort / future work** — no calendar-aware
+  date arithmetic was found in the active engine compute paths (lead_time_days
+  is used only for statistical safety-stock calculations, not for scheduling).
+
+---
+
+## Audit of `timedelta` usage in engine
+
+### `src/ootils_core/engine/orchestration/propagator.py`
+
+| Line | Expression | Purpose | Calendar-aware? |
+|------|-----------|---------|-----------------|
+| 107 | `max(old_date, new_date) + timedelta(days=365)` | Propagation window upper bound | No — administrative cap, not a delivery date. Not a candidate. |
+| 110 | `old_date + timedelta(days=365)` | Same | No |
+| 113 | `new_date + timedelta(days=365)` | Same | No |
+
+### `src/ootils_core/engine/kernel/temporal/bridge.py`
+
+| Line | Expression | Purpose | Calendar-aware? |
+|------|-----------|---------|-----------------|
+| 77  | `d - timedelta(days=d.weekday())` | Floor to Monday for bucket alignment | No — time-grain arithmetic, not delivery scheduling. |
+| 99  | `bucket_start + timedelta(days=1)` | Next day bucket | No |
+| 101 | `bucket_start + timedelta(weeks=1)` | Next week bucket | No |
+
+### `src/ootils_core/engine/kernel/temporal/zone_transition.py`
+
+| Line | Expression | Purpose | Calendar-aware? |
+|------|-----------|---------|-----------------|
+| 45  | `today + timedelta(weeks=daily_horizon_weeks)` | Horizon cutoff | No |
+| 359 | `current + timedelta(days=1)` | Day iteration | No |
+| 426, 429, 434 | Week arithmetic | Bucket boundaries | No |
+
+### `src/ootils_core/engine/policies.py`
+
+Uses `lead_time_days` as a **scalar float** for statistical formulas
+(safety stock, reorder point). Not a date computation — not a candidate.
+
+### `src/ootils_core/engine/decision_engine.py`
+
+Uses `lead_time_days` for scoring / comparison only — no calendar date arithmetic.
+
+---
+
+## Where to integrate when scheduling is added
+
+When the engine gains an explicit `planned_delivery_date` calculation
+(e.g., `order_date + lead_time_days → delivery_date`), replace with:
+
+```python
+from ootils_core.engine.kernel.calc.calendar import add_working_days_sync
+
+planned_delivery_date = add_working_days_sync(
+    conn=db,
+    location_id=destination_location_id,
+    start_date=order_date,
+    n=lead_time_days,
+)
+```
+
+Candidate locations (not yet implemented as of 2026-04-07):
+- `engine/orchestration/calc_run.py` — if/when replenishment scheduling is added
+- `engine/supplier_selection.py` — if earliest-delivery-date scoring is added
+
+---
+
+## ADR reference
+
+- ADR-009: Import pipeline & operational calendars
+- Convention: **absence = working day** (safe-by-default)

--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -720,9 +720,33 @@ def seed_bom(conn):
     print(f"        net_requirement = 174 units (shortage!)")
 
 
+def seed_calendars(conn):
+    """Seed US holidays for DC-ATL (2026)."""
+    atl_id = _uid("location:DC-ATL")
+    holidays = [
+        ("2026-01-01", "New Year's Day"),
+        ("2026-05-25", "Memorial Day"),
+        ("2026-07-04", "Independence Day"),
+        ("2026-09-07", "Labor Day"),
+        ("2026-11-26", "Thanksgiving"),
+        ("2026-12-25", "Christmas"),
+    ]
+    for date_str, note in holidays:
+        conn.execute("""
+            INSERT INTO operational_calendars
+                (location_id, calendar_date, is_working_day, capacity_factor, notes)
+            VALUES (%s, %s, false, 0.0, %s)
+            ON CONFLICT (location_id, calendar_date) DO UPDATE
+                SET is_working_day = false, notes = EXCLUDED.notes
+        """, (atl_id, date_str, note))
+    conn.commit()
+    print(f"  ✅ Calendars seeded: {len(holidays)} US holidays for DC-ATL")
+
+
 if __name__ == "__main__":
     print(f"Connecting to {DATABASE_URL}...")
     with psycopg.connect(DATABASE_URL, row_factory=dict_row) as conn:
         seed(conn)
         seed_enrichment(conn)
         seed_bom(conn)
+        seed_calendars(conn)

--- a/src/ootils_core/api/app.py
+++ b/src/ootils_core/api/app.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
-from ootils_core.api.routers import bom, events, explain, graph, ingest, issues, projection, simulate
+from ootils_core.api.routers import bom, calendars, events, explain, graph, ingest, issues, projection, simulate
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +50,7 @@ def create_app() -> FastAPI:
     application.include_router(graph.router)
     application.include_router(ingest.router)
     application.include_router(bom.router)
+    application.include_router(calendars.router)
 
     @application.exception_handler(Exception)
     async def generic_exception_handler(request, exc: Exception) -> JSONResponse:

--- a/src/ootils_core/api/routers/calendars.py
+++ b/src/ootils_core/api/routers/calendars.py
@@ -1,0 +1,363 @@
+"""
+Operational calendar router.
+
+Endpoints:
+  POST /v1/ingest/calendars                   — Upsert non-working days for a location
+  GET  /v1/calendars/{location_external_id}   — List calendar entries
+  POST /v1/calendars/working-days             — Compute delivery date in working days
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from typing import Optional
+from uuid import UUID
+
+import psycopg
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field, field_validator
+
+from ootils_core.api.auth import require_auth
+from ootils_core.api.dependencies import get_db
+from ootils_core.engine.kernel.calc.calendar import add_working_days_sync
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["calendars"])
+
+# ─────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────
+
+def _resolve_location(db: psycopg.Connection, external_id: str) -> Optional[UUID]:
+    """Return location_id for external_id, or None if not found."""
+    row = db.execute(
+        "SELECT location_id FROM locations WHERE external_id = %s",
+        (external_id,),
+    ).fetchone()
+    return row["location_id"] if row else None
+
+
+# ─────────────────────────────────────────────────────────────
+# Pydantic models
+# ─────────────────────────────────────────────────────────────
+
+class CalendarEntryInput(BaseModel):
+    calendar_date: date
+    is_working_day: bool = False
+    shift_count: Optional[int] = Field(default=None, ge=0, le=3)
+    capacity_factor: Optional[float] = Field(default=None, ge=0.0, le=2.0)
+    notes: Optional[str] = None
+
+    @field_validator("capacity_factor")
+    @classmethod
+    def validate_capacity_factor(cls, v: Optional[float]) -> Optional[float]:
+        if v is not None and not (0.0 <= v <= 2.0):
+            raise ValueError("capacity_factor must be in [0, 2]")
+        return v
+
+
+class IngestCalendarsRequest(BaseModel):
+    location_external_id: str
+    entries: list[CalendarEntryInput]
+    dry_run: bool = False
+
+    @field_validator("location_external_id")
+    @classmethod
+    def non_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("location_external_id must not be empty")
+        return v
+
+
+class CalendarIngestSummary(BaseModel):
+    total: int
+    inserted: int
+    updated: int
+    errors: int
+
+
+class IngestCalendarsResponse(BaseModel):
+    status: str
+    location_external_id: str
+    location_id: Optional[str]
+    summary: CalendarIngestSummary
+
+
+class CalendarEntryOutput(BaseModel):
+    calendar_date: date
+    is_working_day: bool
+    shift_count: Optional[int]
+    capacity_factor: Optional[float]
+    notes: Optional[str]
+
+
+class GetCalendarsResponse(BaseModel):
+    location_external_id: str
+    location_id: str
+    entries: list[CalendarEntryOutput]
+    total: int
+
+
+class WorkingDaysRequest(BaseModel):
+    location_external_id: str
+    start_date: date
+    add_working_days: int = Field(..., ge=0, le=1000)
+
+
+class WorkingDaysResponse(BaseModel):
+    location_external_id: str
+    start_date: date
+    add_working_days: int
+    result_date: date
+    working_days_found: int
+    non_working_days_skipped: int
+
+
+# ─────────────────────────────────────────────────────────────
+# POST /v1/ingest/calendars
+# ─────────────────────────────────────────────────────────────
+
+@router.post("/v1/ingest/calendars", response_model=IngestCalendarsResponse)
+async def ingest_calendars(
+    body: IngestCalendarsRequest,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> IngestCalendarsResponse:
+    """
+    Upsert non-working days (and other calendar entries) for a location.
+
+    - Resolves location_external_id → location_id (422 if unknown)
+    - Validates capacity_factor ∈ [0, 2]
+    - ON CONFLICT (location_id, calendar_date) DO UPDATE
+    - Supports dry_run mode (validation only, no DB writes)
+    """
+    # Resolve location
+    location_id = _resolve_location(db, body.location_external_id)
+    if location_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=[{
+                "field": "location_external_id",
+                "error": f"Location '{body.location_external_id}' not found in DB",
+            }],
+        )
+
+    if body.dry_run:
+        return IngestCalendarsResponse(
+            status="dry_run",
+            location_external_id=body.location_external_id,
+            location_id=str(location_id),
+            summary=CalendarIngestSummary(
+                total=len(body.entries), inserted=0, updated=0, errors=0
+            ),
+        )
+
+    inserted = 0
+    updated = 0
+
+    for entry in body.entries:
+        # Check if record exists (to track inserted vs updated)
+        existing = db.execute(
+            """
+            SELECT calendar_id FROM operational_calendars
+            WHERE location_id = %s AND calendar_date = %s
+            """,
+            (location_id, entry.calendar_date),
+        ).fetchone()
+
+        # Build effective values
+        capacity_factor = entry.capacity_factor if entry.capacity_factor is not None else 1.0
+        shift_count = entry.shift_count if entry.shift_count is not None else 1
+
+        db.execute(
+            """
+            INSERT INTO operational_calendars
+                (location_id, calendar_date, is_working_day, shift_count, capacity_factor, notes)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            ON CONFLICT (location_id, calendar_date) DO UPDATE
+                SET is_working_day  = EXCLUDED.is_working_day,
+                    shift_count     = EXCLUDED.shift_count,
+                    capacity_factor = EXCLUDED.capacity_factor,
+                    notes           = EXCLUDED.notes
+            """,
+            (
+                location_id,
+                entry.calendar_date,
+                entry.is_working_day,
+                shift_count,
+                capacity_factor,
+                entry.notes,
+            ),
+        )
+
+        if existing:
+            updated += 1
+        else:
+            inserted += 1
+
+    logger.info(
+        "ingest.calendars location=%s total=%d inserted=%d updated=%d",
+        body.location_external_id, len(body.entries), inserted, updated,
+    )
+
+    return IngestCalendarsResponse(
+        status="ok",
+        location_external_id=body.location_external_id,
+        location_id=str(location_id),
+        summary=CalendarIngestSummary(
+            total=len(body.entries),
+            inserted=inserted,
+            updated=updated,
+            errors=0,
+        ),
+    )
+
+
+# ─────────────────────────────────────────────────────────────
+# GET /v1/calendars/{location_external_id}
+# ─────────────────────────────────────────────────────────────
+
+@router.get("/v1/calendars/{location_external_id}", response_model=GetCalendarsResponse)
+async def get_calendars(
+    location_external_id: str,
+    from_date: Optional[date] = Query(default=None),
+    to_date: Optional[date] = Query(default=None),
+    working_only: bool = Query(default=False),
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> GetCalendarsResponse:
+    """
+    Return calendar entries for a location.
+
+    Query params:
+    - from_date  ISO date, inclusive lower bound
+    - to_date    ISO date, inclusive upper bound
+    - working_only  if true, return only is_working_day=true entries
+    """
+    location_id = _resolve_location(db, location_external_id)
+    if location_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Location '{location_external_id}' not found",
+        )
+
+    # Build dynamic query
+    filters = ["location_id = %s"]
+    params: list = [location_id]
+
+    if from_date is not None:
+        filters.append("calendar_date >= %s")
+        params.append(from_date)
+    if to_date is not None:
+        filters.append("calendar_date <= %s")
+        params.append(to_date)
+    if working_only:
+        filters.append("is_working_day = TRUE")
+
+    where_clause = " AND ".join(filters)
+    rows = db.execute(
+        f"""
+        SELECT calendar_date, is_working_day, shift_count, capacity_factor, notes
+        FROM operational_calendars
+        WHERE {where_clause}
+        ORDER BY calendar_date
+        """,
+        params,
+    ).fetchall()
+
+    entries = [
+        CalendarEntryOutput(
+            calendar_date=row["calendar_date"],
+            is_working_day=row["is_working_day"],
+            shift_count=row["shift_count"],
+            capacity_factor=float(row["capacity_factor"]) if row["capacity_factor"] is not None else None,
+            notes=row["notes"],
+        )
+        for row in rows
+    ]
+
+    return GetCalendarsResponse(
+        location_external_id=location_external_id,
+        location_id=str(location_id),
+        entries=entries,
+        total=len(entries),
+    )
+
+
+# ─────────────────────────────────────────────────────────────
+# POST /v1/calendars/working-days
+# ─────────────────────────────────────────────────────────────
+
+@router.post("/v1/calendars/working-days", response_model=WorkingDaysResponse)
+async def compute_working_days(
+    body: WorkingDaysRequest,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> WorkingDaysResponse:
+    """
+    Compute a delivery date by adding N working days to a start date.
+
+    Algorithm:
+    1. Start from start_date (not counted)
+    2. Advance day by day, up to 365 iterations max
+    3. Skip days where is_working_day = FALSE in operational_calendars
+    4. ADR-009: absent date = working day (safe-by-default)
+    5. Count until add_working_days working days have been found
+    """
+    location_id = _resolve_location(db, body.location_external_id)
+    if location_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=[{
+                "field": "location_external_id",
+                "error": f"Location '{body.location_external_id}' not found",
+            }],
+        )
+
+    n = body.add_working_days
+    start = body.start_date
+    max_iter = 365
+
+    # Fetch non-working days in window
+    window_start = start + timedelta(days=1)
+    window_end = start + timedelta(days=max_iter)
+
+    rows = db.execute(
+        """
+        SELECT calendar_date
+        FROM operational_calendars
+        WHERE location_id = %s
+          AND calendar_date BETWEEN %s AND %s
+          AND is_working_day = FALSE
+        """,
+        (location_id, window_start, window_end),
+    ).fetchall()
+    non_working: set[date] = {row["calendar_date"] for row in rows}
+
+    current = start
+    days_counted = 0
+    skipped = 0
+    iterations = 0
+
+    while days_counted < n and iterations < max_iter:
+        current += timedelta(days=1)
+        iterations += 1
+        if current in non_working:
+            skipped += 1
+        else:
+            days_counted += 1
+
+    logger.info(
+        "calendars.working_days location=%s start=%s n=%d result=%s skipped=%d",
+        body.location_external_id, start, n, current, skipped,
+    )
+
+    return WorkingDaysResponse(
+        location_external_id=body.location_external_id,
+        start_date=start,
+        add_working_days=n,
+        result_date=current,
+        working_days_found=days_counted,
+        non_working_days_skipped=skipped,
+    )

--- a/src/ootils_core/engine/kernel/calc/calendar.py
+++ b/src/ootils_core/engine/kernel/calc/calendar.py
@@ -1,0 +1,141 @@
+"""
+calendar.py — Working-days arithmetic using operational_calendars.
+
+ADR-009 convention: **absence = working day** (safe-by-default).
+
+Public API
+----------
+- add_working_days(conn, location_id, start_date, n, max_iter) → date   [async, asyncpg]
+- add_working_days_sync(conn, location_id, start_date, n, max_iter) → date [sync, psycopg3]
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Union
+from uuid import UUID
+
+
+# ─────────────────────────────────────────────────────────────
+# Async version (asyncpg)
+# ─────────────────────────────────────────────────────────────
+
+async def add_working_days(
+    conn,                       # asyncpg connection
+    location_id: Union[str, UUID],
+    start_date: date,
+    n: int,
+    max_iter: int = 365,
+) -> date:
+    """
+    Return start_date + n working days, using operational_calendars.
+
+    Convention (ADR-009): a date absent from operational_calendars is
+    considered a working day (safe-by-default — avoids silent delays).
+
+    Parameters
+    ----------
+    conn         asyncpg connection (async)
+    location_id  UUID of the location
+    start_date   Inclusive start (day 0, not counted)
+    n            Number of working days to advance (must be >= 0)
+    max_iter     Safety cap on calendar iterations (default 365)
+
+    Returns
+    -------
+    date — first date after start_date that is the n-th working day.
+    """
+    if n <= 0:
+        return start_date
+
+    location_id_str = str(location_id)
+
+    # Fetch the non-working days window [start_date+1 … start_date+max_iter]
+    window_start = start_date + timedelta(days=1)
+    window_end = start_date + timedelta(days=max_iter)
+
+    rows = await conn.fetch(
+        """
+        SELECT calendar_date
+        FROM operational_calendars
+        WHERE location_id = $1
+          AND calendar_date BETWEEN $2 AND $3
+          AND is_working_day = FALSE
+        """,
+        location_id_str, window_start, window_end,
+    )
+    non_working: set[date] = {row["calendar_date"] for row in rows}
+
+    current = start_date
+    days_counted = 0
+    iterations = 0
+
+    while days_counted < n and iterations < max_iter:
+        current += timedelta(days=1)
+        iterations += 1
+        if current not in non_working:
+            days_counted += 1
+
+    return current
+
+
+# ─────────────────────────────────────────────────────────────
+# Sync version (psycopg3) — used by the engine (sync DB layer)
+# ─────────────────────────────────────────────────────────────
+
+def add_working_days_sync(
+    conn,                       # psycopg3 connection
+    location_id: Union[str, UUID],
+    start_date: date,
+    n: int,
+    max_iter: int = 365,
+) -> date:
+    """
+    Return start_date + n working days, using operational_calendars.
+
+    Convention (ADR-009): a date absent from operational_calendars is
+    considered a working day (safe-by-default).
+
+    Parameters
+    ----------
+    conn         psycopg3 connection (sync)
+    location_id  UUID of the location
+    start_date   Inclusive start (day 0, not counted)
+    n            Number of working days to advance (must be >= 0)
+    max_iter     Safety cap on calendar iterations (default 365)
+
+    Returns
+    -------
+    date — first date after start_date that is the n-th working day.
+    """
+    if n <= 0:
+        return start_date
+
+    location_id_str = str(location_id)
+
+    window_start = start_date + timedelta(days=1)
+    window_end = start_date + timedelta(days=max_iter)
+
+    rows = conn.execute(
+        """
+        SELECT calendar_date
+        FROM operational_calendars
+        WHERE location_id = %s
+          AND calendar_date BETWEEN %s AND %s
+          AND is_working_day = FALSE
+        """,
+        (location_id_str, window_start, window_end),
+    ).fetchall()
+
+    non_working: set[date] = {row["calendar_date"] for row in rows}
+
+    current = start_date
+    days_counted = 0
+    iterations = 0
+
+    while days_counted < n and iterations < max_iter:
+        current += timedelta(days=1)
+        iterations += 1
+        if current not in non_working:
+            days_counted += 1
+
+    return current

--- a/tests/integration/test_calendars.py
+++ b/tests/integration/test_calendars.py
@@ -1,0 +1,380 @@
+"""
+tests/integration/test_calendars.py — Integration tests for operational calendar endpoints.
+
+Endpoints covered:
+  POST /v1/ingest/calendars
+  GET  /v1/calendars/{location_external_id}
+  POST /v1/calendars/working-days
+
+Requires a running PostgreSQL instance with migrations applied.
+Set DATABASE_URL before running:
+    DATABASE_URL=postgresql://ootils:ootils@localhost:5432/ootils_test pytest tests/integration/test_calendars.py -v
+"""
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+from uuid import uuid4
+
+import pytest
+
+from .conftest import requires_db, DB_AVAILABLE, TEST_DB_URL
+
+# ─────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def cal_client(migrated_db):
+    """Module-scoped TestClient wired to a migrated test DB."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = "test-token"
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+    from fastapi.testclient import TestClient
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="module")
+def auth():
+    return {"Authorization": "Bearer test-token"}
+
+
+# Unique prefix to avoid cross-test contamination
+PREFIX = str(uuid4())[:8]
+
+
+def uid(base: str) -> str:
+    return f"{PREFIX}-{base}"
+
+
+@pytest.fixture(scope="module")
+def test_location(cal_client, auth):
+    """Create a location to use across calendar tests."""
+    ext_id = uid("LOC-CAL")
+    resp = cal_client.post(
+        "/v1/ingest/locations",
+        json={
+            "locations": [{"external_id": ext_id, "name": "Calendar Test DC", "location_type": "dc"}],
+            "dry_run": False,
+        },
+        headers=auth,
+    )
+    assert resp.status_code == 200, resp.text
+    return ext_id
+
+
+# ─────────────────────────────────────────────────────────────
+# POST /v1/ingest/calendars — basic insert
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_ingest_calendars_basic(cal_client, auth, test_location):
+    """Import 3 non-working days → verify summary and response."""
+    resp = cal_client.post(
+        "/v1/ingest/calendars",
+        json={
+            "location_external_id": test_location,
+            "entries": [
+                {"calendar_date": "2026-12-25", "is_working_day": False, "notes": "Christmas"},
+                {"calendar_date": "2026-01-01", "is_working_day": False, "notes": "New Year"},
+                {"calendar_date": "2026-07-04", "is_working_day": False, "capacity_factor": 0.0, "notes": "Independence Day"},
+            ],
+            "dry_run": False,
+        },
+        headers=auth,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["location_external_id"] == test_location
+    assert body["location_id"] is not None
+    summary = body["summary"]
+    assert summary["total"] == 3
+    assert summary["inserted"] == 3
+    assert summary["updated"] == 0
+    assert summary["errors"] == 0
+
+
+@requires_db
+def test_ingest_calendars_upsert(cal_client, auth, test_location):
+    """Re-inserting same dates → summary shows updated, not inserted again."""
+    resp = cal_client.post(
+        "/v1/ingest/calendars",
+        json={
+            "location_external_id": test_location,
+            "entries": [
+                {"calendar_date": "2026-12-25", "is_working_day": False, "notes": "Christmas (updated)"},
+                {"calendar_date": "2026-11-26", "is_working_day": False, "notes": "Thanksgiving"},
+            ],
+            "dry_run": False,
+        },
+        headers=auth,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "ok"
+    summary = body["summary"]
+    assert summary["total"] == 2
+    # 2026-12-25 exists (updated) + 2026-11-26 is new (inserted)
+    assert summary["updated"] == 1
+    assert summary["inserted"] == 1
+
+
+# ─────────────────────────────────────────────────────────────
+# POST /v1/ingest/calendars — dry_run
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_ingest_calendars_dry_run(cal_client, auth, test_location):
+    """dry_run=True → status=dry_run, nothing written to DB."""
+    new_date = "2027-06-15"
+    resp = cal_client.post(
+        "/v1/ingest/calendars",
+        json={
+            "location_external_id": test_location,
+            "entries": [
+                {"calendar_date": new_date, "is_working_day": False, "notes": "dry run only"},
+            ],
+            "dry_run": True,
+        },
+        headers=auth,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "dry_run"
+    assert body["summary"]["inserted"] == 0
+    assert body["summary"]["updated"] == 0
+
+    # Confirm nothing was written
+    get_resp = cal_client.get(
+        f"/v1/calendars/{test_location}",
+        params={"from_date": new_date, "to_date": new_date},
+        headers=auth,
+    )
+    assert get_resp.status_code == 200
+    assert get_resp.json()["total"] == 0
+
+
+# ─────────────────────────────────────────────────────────────
+# POST /v1/ingest/calendars — unknown location → 422
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_ingest_calendars_unknown_location(cal_client, auth):
+    """Unknown location_external_id → HTTP 422."""
+    resp = cal_client.post(
+        "/v1/ingest/calendars",
+        json={
+            "location_external_id": uid("NO-SUCH-LOC"),
+            "entries": [
+                {"calendar_date": "2026-12-25", "is_working_day": False},
+            ],
+            "dry_run": False,
+        },
+        headers=auth,
+    )
+    assert resp.status_code == 422, resp.text
+
+
+# ─────────────────────────────────────────────────────────────
+# GET /v1/calendars/{location_external_id}
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_get_calendars(cal_client, auth, test_location):
+    """GET returns calendar entries for the location."""
+    resp = cal_client.get(
+        f"/v1/calendars/{test_location}",
+        headers=auth,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["location_external_id"] == test_location
+    assert body["total"] >= 3  # at least the entries from test_ingest_calendars_basic
+    assert isinstance(body["entries"], list)
+    # Entries should be sorted by date
+    dates = [e["calendar_date"] for e in body["entries"]]
+    assert dates == sorted(dates)
+
+
+@requires_db
+def test_get_calendars_date_filter(cal_client, auth, test_location):
+    """from_date/to_date filtering works correctly."""
+    resp = cal_client.get(
+        f"/v1/calendars/{test_location}",
+        params={"from_date": "2026-12-01", "to_date": "2026-12-31"},
+        headers=auth,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    for entry in body["entries"]:
+        assert "2026-12" in entry["calendar_date"]
+
+
+@requires_db
+def test_get_calendars_unknown_location(cal_client, auth):
+    """Unknown location → 404."""
+    resp = cal_client.get(
+        f"/v1/calendars/{uid('NO-SUCH-LOC')}",
+        headers=auth,
+    )
+    assert resp.status_code == 404
+
+
+# ─────────────────────────────────────────────────────────────
+# POST /v1/calendars/working-days
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_working_days_calculation(cal_client, auth):
+    """
+    start=Friday 2026-04-03, add=3 working days.
+    Insert Sat+Sun as non-working → result should be Wed 2026-04-08.
+    (Fri→Sat skip, Sun skip, Mon=1, Tue=2, Wed=3)
+    """
+    loc_ext_id = uid("LOC-WD-TEST")
+    # Create location
+    cal_client.post(
+        "/v1/ingest/locations",
+        json={
+            "locations": [{"external_id": loc_ext_id, "name": "WD Test DC", "location_type": "dc"}],
+            "dry_run": False,
+        },
+        headers=auth,
+    )
+
+    # Mark Saturday 2026-04-04 and Sunday 2026-04-05 as non-working
+    cal_client.post(
+        "/v1/ingest/calendars",
+        json={
+            "location_external_id": loc_ext_id,
+            "entries": [
+                {"calendar_date": "2026-04-04", "is_working_day": False, "notes": "Saturday"},
+                {"calendar_date": "2026-04-05", "is_working_day": False, "notes": "Sunday"},
+            ],
+            "dry_run": False,
+        },
+        headers=auth,
+    )
+
+    resp = cal_client.post(
+        "/v1/calendars/working-days",
+        json={
+            "location_external_id": loc_ext_id,
+            "start_date": "2026-04-03",
+            "add_working_days": 3,
+        },
+        headers=auth,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["result_date"] == "2026-04-08"  # Mon=1, Tue=2, Wed=3
+    assert body["working_days_found"] == 3
+    assert body["non_working_days_skipped"] == 2  # Sat + Sun
+
+
+@requires_db
+def test_working_days_no_calendar(cal_client, auth):
+    """
+    Location with no calendar entries → all days are working days (safe-by-default).
+    start=2026-04-03 (Friday), add=3 → result=2026-04-06 (Monday? No: +3 calendar days)
+    With no non-working days: result = 2026-04-06 (Fri+1=Sat, Sat+1=Sun, Sun+1=Mon → Mon 2026-04-06)
+    Wait: +3 days with zero skips = 2026-04-03 + 3 = 2026-04-06.
+    """
+    loc_ext_id = uid("LOC-WD-EMPTY")
+    cal_client.post(
+        "/v1/ingest/locations",
+        json={
+            "locations": [{"external_id": loc_ext_id, "name": "Empty Calendar DC", "location_type": "dc"}],
+            "dry_run": False,
+        },
+        headers=auth,
+    )
+
+    resp = cal_client.post(
+        "/v1/calendars/working-days",
+        json={
+            "location_external_id": loc_ext_id,
+            "start_date": "2026-04-03",
+            "add_working_days": 3,
+        },
+        headers=auth,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # No non-working days → advance 3 calendar days
+    assert body["result_date"] == "2026-04-06"
+    assert body["working_days_found"] == 3
+    assert body["non_working_days_skipped"] == 0
+
+
+@requires_db
+def test_working_days_zero(cal_client, auth, test_location):
+    """add_working_days=0 → result_date = start_date."""
+    resp = cal_client.post(
+        "/v1/calendars/working-days",
+        json={
+            "location_external_id": test_location,
+            "start_date": "2026-06-01",
+            "add_working_days": 0,
+        },
+        headers=auth,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["result_date"] == "2026-06-01"
+
+
+# ─────────────────────────────────────────────────────────────
+# Auth tests — 401 without token
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_calendars_401_ingest(cal_client, test_location):
+    """POST /v1/ingest/calendars without auth → 401."""
+    resp = cal_client.post(
+        "/v1/ingest/calendars",
+        json={
+            "location_external_id": test_location,
+            "entries": [{"calendar_date": "2026-12-25", "is_working_day": False}],
+            "dry_run": False,
+        },
+    )
+    assert resp.status_code == 401, resp.text
+
+
+@requires_db
+def test_calendars_401_get(cal_client, test_location):
+    """GET /v1/calendars/{loc} without auth → 401."""
+    resp = cal_client.get(f"/v1/calendars/{test_location}")
+    assert resp.status_code == 401, resp.text
+
+
+@requires_db
+def test_calendars_401_working_days(cal_client, test_location):
+    """POST /v1/calendars/working-days without auth → 401."""
+    resp = cal_client.post(
+        "/v1/calendars/working-days",
+        json={
+            "location_external_id": test_location,
+            "start_date": "2026-04-03",
+            "add_working_days": 5,
+        },
+    )
+    assert resp.status_code == 401, resp.text


### PR DESCRIPTION
Ferme blocage Sage #3 (calendriers).

## Ce qui est livré

- **POST /v1/ingest/calendars** — upsert jours non-ouvrés par location (dry_run supporté)
- **GET /v1/calendars/{location_external_id}** — lecture des entrées calendrier (filtres date, working_only)
- **POST /v1/calendars/working-days** — calcul date de livraison en jours ouvrés
- **Fonction `add_working_days_sync()`** et **`add_working_days()`** réutilisables par le moteur
- **Seed US holidays** DC-ATL (6 jours fériés 2026) dans `seed_demo_data.py`
- **Tests intégration** `tests/integration/test_calendars.py` (10 tests, couvrant insert, upsert, dry_run, auth 401, edge cases)
- **CALENDAR-INTEGRATION-POINTS.md** — audit des points d'intégration futurs dans le moteur

## Convention ADR-009
Absence de date dans `operational_calendars` = jour ouvré (safe-by-default).