### PR TITLE
[feat] GET /v1/events — read event log

### DIFF
--- a/src/ootils_core/api/routers/events.py
+++ b/src/ootils_core/api/routers/events.py
@@ -1,16 +1,16 @@
 """
-POST /v1/events — Submit a supply chain planning event.
+Events router — POST /v1/events (submit event) + GET /v1/events (read event log).
 """
 from __future__ import annotations
 
 import logging
 from datetime import date
 from decimal import Decimal
-from typing import Optional
+from typing import List, Optional
 from uuid import UUID
 
 import psycopg
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
 from ootils_core.api.auth import require_auth
@@ -57,6 +57,28 @@ class EventResponse(BaseModel):
     status: str
     scenario_id: UUID
     affected_nodes_estimate: int
+
+
+class EventRecord(BaseModel):
+    event_id: UUID
+    event_type: str
+    scenario_id: Optional[UUID] = None
+    trigger_node_id: Optional[UUID] = None
+    field_changed: Optional[str] = None
+    old_date: Optional[date] = None
+    new_date: Optional[date] = None
+    old_quantity: Optional[Decimal] = None
+    new_quantity: Optional[Decimal] = None
+    processed: bool
+    source: str
+    created_at: str
+
+
+class EventListResponse(BaseModel):
+    events: List[EventRecord]
+    total: int
+    limit: int
+    offset: int
 
 
 @router.post("", response_model=EventResponse, status_code=status.HTTP_202_ACCEPTED)
@@ -122,4 +144,102 @@ async def create_event(
         status="queued",
         scenario_id=effective_scenario_id,
         affected_nodes_estimate=0,
+    )
+
+
+@router.get("", response_model=EventListResponse)
+async def list_events(
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+    limit: int = Query(default=50, ge=1, le=500, description="Max events to return"),
+    offset: int = Query(default=0, ge=0, description="Pagination offset"),
+    event_type: Optional[str] = Query(default=None, description="Filter by event type"),
+    scenario_id: Optional[str] = Query(default=None, description="Filter by scenario UUID"),
+    processed: Optional[bool] = Query(default=None, description="Filter by processed flag"),
+) -> EventListResponse:
+    """Return the event log, ordered by created_at DESC."""
+
+    # Validate event_type filter if provided
+    if event_type is not None and event_type not in VALID_EVENT_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unknown event_type '{event_type}'. Valid: {sorted(VALID_EVENT_TYPES)}",
+        )
+
+    # Validate scenario_id filter if provided
+    effective_scenario_id: Optional[UUID] = None
+    if scenario_id is not None:
+        try:
+            effective_scenario_id = UUID(scenario_id)
+        except ValueError:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Invalid scenario_id UUID: '{scenario_id}'",
+            )
+
+    # Build WHERE clause dynamically
+    conditions = []
+    params: list = []
+
+    if event_type is not None:
+        conditions.append("event_type = %s")
+        params.append(event_type)
+
+    if effective_scenario_id is not None:
+        conditions.append("scenario_id = %s")
+        params.append(effective_scenario_id)
+
+    if processed is not None:
+        conditions.append("processed = %s")
+        params.append(processed)
+
+    where_clause = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+
+    # Count total matching rows
+    count_row = db.execute(
+        f"SELECT COUNT(*) AS total FROM events {where_clause}",
+        params,
+    ).fetchone()
+    total = count_row[0] if count_row else 0
+
+    # Fetch paginated rows
+    rows = db.execute(
+        f"""
+        SELECT
+            event_id, event_type, scenario_id, trigger_node_id,
+            field_changed, old_date, new_date, old_quantity, new_quantity,
+            processed, source, created_at
+        FROM events
+        {where_clause}
+        ORDER BY created_at DESC
+        LIMIT %s OFFSET %s
+        """,
+        params + [limit, offset],
+    ).fetchall()
+
+    events = [
+        EventRecord(
+            event_id=row[0],
+            event_type=row[1],
+            scenario_id=row[2],
+            trigger_node_id=row[3],
+            field_changed=row[4],
+            old_date=row[5],
+            new_date=row[6],
+            old_quantity=row[7],
+            new_quantity=row[8],
+            processed=bool(row[9]),
+            source=row[10] or "api",
+            created_at=row[11].isoformat() if row[11] else "",
+        )
+        for row in rows
+    ]
+
+    logger.debug("events.list total=%d limit=%d offset=%d", total, limit, offset)
+
+    return EventListResponse(
+        events=events,
+        total=total,
+        limit=limit,
+        offset=offset,
     )

--- a/tests/integration/test_events_read.py
+++ b/tests/integration/test_events_read.py
@@ -1,0 +1,253 @@
+"""
+tests/integration/test_events_read.py — GET /v1/events integration tests.
+
+Tests 30–36: read event log via real DB + FastAPI TestClient.
+Skip all tests if DATABASE_URL is not configured.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from .conftest import requires_db, DB_AVAILABLE, TEST_DB_URL
+
+SEED_SCRIPT = Path(__file__).parents[2] / "scripts" / "seed_demo_data.py"
+BASELINE_SCENARIO_ID = "00000000-0000-0000-0000-000000000001"
+
+
+def _run_seed():
+    env = {**os.environ, "DATABASE_URL": TEST_DB_URL}
+    return subprocess.run(
+        [sys.executable, str(SEED_SCRIPT)],
+        capture_output=True, text=True, env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures (mirrored from test_api_db.py)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def seeded_db(migrated_db):
+    result = _run_seed()
+    if result.returncode != 0:
+        pytest.skip(f"Seed failed: {result.stderr[:500]}")
+    return migrated_db
+
+
+@pytest.fixture(scope="module")
+def api_client(seeded_db):
+    os.environ["DATABASE_URL"] = seeded_db
+    os.environ["OOTILS_API_TOKEN"] = "integration-test-token"
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+    from fastapi.testclient import TestClient
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(seeded_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="module")
+def auth():
+    return {"Authorization": "Bearer integration-test-token"}
+
+
+# ---------------------------------------------------------------------------
+# Test 30 — GET /v1/events without auth → 401
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_30_get_events_no_auth(api_client):
+    """GET /v1/events without auth returns 401."""
+    resp = api_client.get("/v1/events")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Test 31 — GET /v1/events basic schema validation
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_31_get_events_schema(api_client, auth):
+    """GET /v1/events returns 200 with correct envelope schema."""
+    resp = api_client.get("/v1/events", headers=auth)
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+
+    data = resp.json()
+    assert "events" in data, "Response must have 'events' key"
+    assert "total" in data, "Response must have 'total' key"
+    assert "limit" in data, "Response must have 'limit' key"
+    assert "offset" in data, "Response must have 'offset' key"
+    assert isinstance(data["events"], list)
+    assert data["limit"] == 50  # default
+    assert data["offset"] == 0  # default
+
+
+# ---------------------------------------------------------------------------
+# Test 32 — GET /v1/events individual event record fields
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_32_get_events_record_fields(api_client, auth):
+    """Each event record contains all required fields."""
+    # First create an event so we have at least one record
+    payload = {
+        "event_type": "test_event",
+        "source": "integration-test",
+        "scenario_id": "baseline",
+    }
+    post_resp = api_client.post("/v1/events", json=payload, headers=auth)
+    assert post_resp.status_code == 202
+
+    resp = api_client.get("/v1/events", headers=auth)
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert data["total"] >= 1
+
+    for event in data["events"]:
+        assert "event_id" in event
+        assert "event_type" in event
+        assert "processed" in event
+        assert "source" in event
+        assert "created_at" in event
+        # Optional fields may be None but must be present
+        assert "scenario_id" in event
+        assert "trigger_node_id" in event
+        assert "field_changed" in event
+        assert "old_date" in event
+        assert "new_date" in event
+        assert "old_quantity" in event
+        assert "new_quantity" in event
+
+
+# ---------------------------------------------------------------------------
+# Test 33 — GET /v1/events ordering (most recent first)
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_33_get_events_ordered_desc(api_client, auth):
+    """Events are returned in created_at DESC order."""
+    resp = api_client.get("/v1/events", headers=auth)
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+
+    if len(events) >= 2:
+        timestamps = [e["created_at"] for e in events]
+        # DESC: each timestamp should be >= next
+        for i in range(len(timestamps) - 1):
+            assert timestamps[i] >= timestamps[i + 1], (
+                f"Events not in DESC order at index {i}: "
+                f"{timestamps[i]} < {timestamps[i + 1]}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test 34 — GET /v1/events pagination (limit / offset)
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_34_get_events_pagination(api_client, auth):
+    """Limit and offset parameters correctly paginate results."""
+    # Ensure at least 3 events exist
+    for i in range(3):
+        api_client.post(
+            "/v1/events",
+            json={"event_type": "test_event", "source": f"pagination-test-{i}", "scenario_id": "baseline"},
+            headers=auth,
+        )
+
+    resp_all = api_client.get("/v1/events?limit=500", headers=auth)
+    assert resp_all.status_code == 200
+    total = resp_all.json()["total"]
+
+    if total < 2:
+        pytest.skip("Not enough events to test pagination")
+
+    # Page 1
+    resp_p1 = api_client.get("/v1/events?limit=2&offset=0", headers=auth)
+    assert resp_p1.status_code == 200
+    data_p1 = resp_p1.json()
+    assert len(data_p1["events"]) == 2
+    assert data_p1["limit"] == 2
+    assert data_p1["offset"] == 0
+    assert data_p1["total"] == total
+
+    # Page 2
+    resp_p2 = api_client.get("/v1/events?limit=2&offset=2", headers=auth)
+    assert resp_p2.status_code == 200
+    data_p2 = resp_p2.json()
+    assert data_p2["offset"] == 2
+
+    # Pages should not overlap (different event_ids)
+    ids_p1 = {e["event_id"] for e in data_p1["events"]}
+    ids_p2 = {e["event_id"] for e in data_p2["events"]}
+    assert ids_p1.isdisjoint(ids_p2), "Pages overlap — pagination broken"
+
+
+# ---------------------------------------------------------------------------
+# Test 35 — GET /v1/events filter by event_type
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_35_get_events_filter_event_type(api_client, auth):
+    """Filter by event_type returns only matching events."""
+    # Create a known-type event
+    api_client.post(
+        "/v1/events",
+        json={"event_type": "ingestion_complete", "source": "filter-test", "scenario_id": "baseline"},
+        headers=auth,
+    )
+
+    resp = api_client.get("/v1/events?event_type=ingestion_complete", headers=auth)
+    assert resp.status_code == 200
+    data = resp.json()
+    for event in data["events"]:
+        assert event["event_type"] == "ingestion_complete", (
+            f"Unexpected event_type '{event['event_type']}' in filtered response"
+        )
+
+    # Invalid event_type → 422
+    resp_bad = api_client.get("/v1/events?event_type=not_a_valid_type", headers=auth)
+    assert resp_bad.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Test 36 — GET /v1/events filter by processed flag
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_36_get_events_filter_processed(api_client, auth):
+    """Filter by processed=false returns only unprocessed events."""
+    # Newly posted events start as processed=false
+    resp = api_client.get("/v1/events?processed=false", headers=auth)
+    assert resp.status_code == 200
+    data = resp.json()
+    for event in data["events"]:
+        assert event["processed"] is False, (
+            f"Processed event returned for processed=false filter"
+        )
+
+    # processed=true — should return 200 (list may be empty)
+    resp_true = api_client.get("/v1/events?processed=true", headers=auth)
+    assert resp_true.status_code == 200
+    for event in resp_true.json()["events"]:
+        assert event["processed"] is True


### PR DESCRIPTION
## Summary

Adds `GET /v1/events` endpoint to read the event log with filtering and pagination.

## Changes

### `src/ootils_core/api/routers/events.py`
- Added `EventRecord` and `EventListResponse` Pydantic models
- Added `GET /v1/events` endpoint with:
  - Auth required (`require_auth`)
  - Query params: `limit` (1–500, default 50), `offset` (default 0), `event_type` (optional), `scenario_id` (optional), `processed` (optional bool)
  - Returns `{ events, total, limit, offset }`
  - Ordered by `created_at DESC`
  - Validates `event_type` against `VALID_EVENT_TYPES`
  - Validates `scenario_id` as valid UUID

### `tests/integration/test_events_read.py`
- Tests 30–36 covering: auth guard, schema validation, field presence, DESC ordering, pagination, event_type filter, processed filter

## Test plan
Integration tests require `DATABASE_URL` pointed to a test DB (same pattern as existing tests).