### PR TITLE
[feat] DQ Engine V1 — L1 structurel + L2 référentiel

### DIFF
--- a/src/ootils_core/api/app.py
+++ b/src/ootils_core/api/app.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
-from ootils_core.api.routers import bom, calendars, events, explain, graph, ingest, issues, projection, simulate
+from ootils_core.api.routers import bom, calendars, dq, events, explain, graph, ingest, issues, projection, rccp, simulate
 
 logger = logging.getLogger(__name__)
 
@@ -49,8 +49,10 @@ def create_app() -> FastAPI:
     application.include_router(simulate.router)
     application.include_router(graph.router)
     application.include_router(ingest.router)
+    application.include_router(dq.router)
     application.include_router(bom.router)
     application.include_router(calendars.router)
+    application.include_router(rccp.router)
 
     @application.exception_handler(Exception)
     async def generic_exception_handler(request, exc: Exception) -> JSONResponse:

--- a/src/ootils_core/api/routers/dq.py
+++ b/src/ootils_core/api/routers/dq.py
@@ -1,0 +1,258 @@
+"""
+DQ Router — Data Quality pipeline endpoints.
+
+POST /v1/dq/run/{batch_id}  — Trigger DQ run on a batch (synchronous, returns result)
+GET  /v1/dq/{batch_id}      — Get DQ results for a batch
+GET  /v1/dq/issues          — List unresolved issues (filterable)
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+from uuid import UUID
+
+import psycopg
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
+
+from ootils_core.api.auth import require_auth
+from ootils_core.api.dependencies import get_db
+from ootils_core.engine.dq.engine import run_dq
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/dq", tags=["dq"])
+
+
+# ─────────────────────────────────────────────────────────────
+# Response models
+# ─────────────────────────────────────────────────────────────
+
+class DQIssueOut(BaseModel):
+    issue_id: UUID
+    batch_id: UUID
+    row_id: Optional[UUID]
+    row_number: Optional[int]
+    dq_level: int
+    rule_code: str
+    severity: str
+    field_name: Optional[str]
+    raw_value: Optional[str]
+    message: str
+    auto_corrected: bool
+    resolved: bool
+    created_at: Any
+
+
+class DQRunResponse(BaseModel):
+    batch_id: UUID
+    status: str
+    total_rows: int
+    passed_rows: int
+    failed_rows: int
+    warning_rows: int
+    issue_count: int
+    batch_dq_status: str
+
+
+class DQBatchResponse(BaseModel):
+    batch_id: UUID
+    entity_type: str
+    dq_status: Optional[str]
+    total_rows: int
+    issues: list[DQIssueOut]
+
+
+class DQIssuesResponse(BaseModel):
+    total: int
+    issues: list[DQIssueOut]
+
+
+# ─────────────────────────────────────────────────────────────
+# POST /v1/dq/run/{batch_id}
+# ─────────────────────────────────────────────────────────────
+
+@router.post(
+    "/run/{batch_id}",
+    response_model=DQRunResponse,
+    summary="Run DQ pipeline on a batch",
+    description="Execute L1 (structural) + L2 (referential) checks on all rows of a batch.",
+)
+async def run_dq_batch(
+    batch_id: UUID,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> DQRunResponse:
+    # Verify batch exists
+    batch = db.execute(
+        "SELECT batch_id FROM ingest_batches WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+    if not batch:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Batch {batch_id} not found",
+        )
+
+    try:
+        result = run_dq(db, batch_id)
+    except Exception as exc:
+        logger.exception("DQ run failed for batch %s: %s", batch_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"DQ run failed: {exc}",
+        )
+
+    return DQRunResponse(
+        batch_id=result.batch_id,
+        status="completed",
+        total_rows=result.total_rows,
+        passed_rows=result.passed_rows,
+        failed_rows=result.failed_rows,
+        warning_rows=result.warning_rows,
+        issue_count=len(result.issues),
+        batch_dq_status=result.batch_dq_status,
+    )
+
+
+# ─────────────────────────────────────────────────────────────
+# GET /v1/dq/issues  (must come BEFORE /{batch_id} to avoid routing conflict)
+# ─────────────────────────────────────────────────────────────
+
+@router.get(
+    "/issues",
+    response_model=DQIssuesResponse,
+    summary="List unresolved DQ issues",
+    description="Returns all unresolved data quality issues. Filterable by severity, dq_level, entity_type.",
+)
+async def list_issues(
+    severity: Optional[str] = Query(default=None, description="Filter by severity: error | warning | info"),
+    dq_level: Optional[int] = Query(default=None, description="Filter by DQ level: 1 | 2 | 3 | 4"),
+    entity_type: Optional[str] = Query(default=None, description="Filter by entity_type (e.g. purchase_orders)"),
+    limit: int = Query(default=200, ge=1, le=1000, description="Max results"),
+    offset: int = Query(default=0, ge=0, description="Pagination offset"),
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> DQIssuesResponse:
+    conditions: list[str] = ["i.resolved = FALSE"]
+    params: list[Any] = []
+
+    if severity:
+        conditions.append("i.severity = %s")
+        params.append(severity)
+    if dq_level is not None:
+        conditions.append("i.dq_level = %s")
+        params.append(dq_level)
+    if entity_type:
+        conditions.append("b.entity_type = %s")
+        params.append(entity_type)
+
+    where_clause = " AND ".join(conditions)
+    count_sql = f"""
+        SELECT COUNT(*) AS cnt
+        FROM data_quality_issues i
+        JOIN ingest_batches b ON b.batch_id = i.batch_id
+        WHERE {where_clause}
+    """
+    total = db.execute(count_sql, params).fetchone()["cnt"]
+
+    query_sql = f"""
+        SELECT
+            i.issue_id, i.batch_id, i.row_id, i.row_number,
+            i.dq_level, i.rule_code, i.severity,
+            i.field_name, i.raw_value, i.message,
+            i.auto_corrected, i.resolved, i.created_at
+        FROM data_quality_issues i
+        JOIN ingest_batches b ON b.batch_id = i.batch_id
+        WHERE {where_clause}
+        ORDER BY i.created_at DESC
+        LIMIT %s OFFSET %s
+    """
+    rows = db.execute(query_sql, params + [limit, offset]).fetchall()
+
+    issues = [
+        DQIssueOut(
+            issue_id=r["issue_id"],
+            batch_id=r["batch_id"],
+            row_id=r["row_id"],
+            row_number=r["row_number"],
+            dq_level=r["dq_level"],
+            rule_code=r["rule_code"],
+            severity=r["severity"],
+            field_name=r["field_name"],
+            raw_value=r["raw_value"],
+            message=r["message"],
+            auto_corrected=r["auto_corrected"],
+            resolved=r["resolved"],
+            created_at=r["created_at"],
+        )
+        for r in rows
+    ]
+
+    return DQIssuesResponse(total=total, issues=issues)
+
+
+# ─────────────────────────────────────────────────────────────
+# GET /v1/dq/{batch_id}
+# ─────────────────────────────────────────────────────────────
+
+@router.get(
+    "/{batch_id}",
+    response_model=DQBatchResponse,
+    summary="Get DQ results for a batch",
+    description="Returns all DQ issues (resolved or not) for a specific batch.",
+)
+async def get_batch_dq(
+    batch_id: UUID,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> DQBatchResponse:
+    batch = db.execute(
+        "SELECT batch_id, entity_type, dq_status, total_rows FROM ingest_batches WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+
+    if not batch:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Batch {batch_id} not found",
+        )
+
+    rows = db.execute(
+        """
+        SELECT issue_id, batch_id, row_id, row_number, dq_level, rule_code,
+               severity, field_name, raw_value, message,
+               auto_corrected, resolved, created_at
+        FROM data_quality_issues
+        WHERE batch_id = %s
+        ORDER BY row_number, dq_level
+        """,
+        (batch_id,),
+    ).fetchall()
+
+    issues = [
+        DQIssueOut(
+            issue_id=r["issue_id"],
+            batch_id=r["batch_id"],
+            row_id=r["row_id"],
+            row_number=r["row_number"],
+            dq_level=r["dq_level"],
+            rule_code=r["rule_code"],
+            severity=r["severity"],
+            field_name=r["field_name"],
+            raw_value=r["raw_value"],
+            message=r["message"],
+            auto_corrected=r["auto_corrected"],
+            resolved=r["resolved"],
+            created_at=r["created_at"],
+        )
+        for r in rows
+    ]
+
+    return DQBatchResponse(
+        batch_id=batch["batch_id"],
+        entity_type=batch["entity_type"],
+        dq_status=batch.get("dq_status"),
+        total_rows=batch["total_rows"] or 0,
+        issues=issues,
+    )

--- a/src/ootils_core/api/routers/ingest.py
+++ b/src/ootils_core/api/routers/ingest.py
@@ -30,6 +30,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db
+from ootils_core.engine.dq.engine import run_dq
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1/ingest", tags=["ingest"])
@@ -76,6 +77,46 @@ def _dry_run_response(items: list[Any], label: str = "external_id") -> IngestRes
 def _raise_422(errors: list[dict]) -> None:
     """Raise HTTP 422 with structured error list. Nothing is persisted."""
     raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=errors)
+
+
+def _create_ingest_batch(
+    db: psycopg.Connection,
+    entity_type: str,
+    rows_data: list[Any],
+    source_system: str = "ingest_api",
+) -> UUID:
+    """
+    Create an ingest_batch record and persist all rows as ingest_rows.
+    Returns the new batch_id.
+    """
+    import json as _json
+    batch_id = uuid4()
+    db.execute(
+        """
+        INSERT INTO ingest_batches
+            (batch_id, entity_type, source_system, status, total_rows, submitted_by)
+        VALUES (%s, %s, %s, 'processing', %s, 'ingest_api')
+        """,
+        (batch_id, entity_type, source_system, len(rows_data)),
+    )
+    for i, row in enumerate(rows_data):
+        raw = _json.dumps(row if isinstance(row, dict) else row.model_dump(), default=str)
+        db.execute(
+            """
+            INSERT INTO ingest_rows (row_id, batch_id, row_number, raw_content)
+            VALUES (%s, %s, %s, %s)
+            """,
+            (uuid4(), batch_id, i + 1, raw),
+        )
+    return batch_id
+
+
+def _trigger_dq(db: psycopg.Connection, batch_id: UUID) -> None:
+    """Run DQ pipeline on a batch, logging errors but never failing the ingest call."""
+    try:
+        run_dq(db, batch_id)
+    except Exception as exc:
+        logger.warning("DQ run failed for batch %s: %s", batch_id, exc)
 
 
 def _batch_existing(
@@ -182,6 +223,8 @@ async def ingest_items(
             inserted += 1
 
     logger.info("ingest.items total=%d inserted=%d updated=%d", len(body.items), inserted, updated)
+    batch_id = _create_ingest_batch(db, "items", [it.model_dump() for it in body.items])
+    _trigger_dq(db, batch_id)
     return _ok(inserted, updated, len(body.items), results)
 
 
@@ -284,6 +327,8 @@ async def ingest_locations(
             inserted += 1
 
     logger.info("ingest.locations total=%d inserted=%d updated=%d", len(body.locations), inserted, updated)
+    batch_id = _create_ingest_batch(db, "locations", [loc.model_dump() for loc in body.locations])
+    _trigger_dq(db, batch_id)
     return _ok(inserted, updated, len(body.locations), results)
 
 
@@ -377,6 +422,8 @@ async def ingest_suppliers(
             inserted += 1
 
     logger.info("ingest.suppliers total=%d inserted=%d updated=%d", len(body.suppliers), inserted, updated)
+    batch_id = _create_ingest_batch(db, "suppliers", [sup.model_dump() for sup in body.suppliers])
+    _trigger_dq(db, batch_id)
     return _ok(inserted, updated, len(body.suppliers), results)
 
 
@@ -501,6 +548,8 @@ async def ingest_supplier_items(
         "ingest.supplier_items total=%d inserted=%d updated=%d",
         len(body.supplier_items), inserted, updated,
     )
+    batch_id = _create_ingest_batch(db, "supplier_items", [si.model_dump() for si in body.supplier_items])
+    _trigger_dq(db, batch_id)
     return _ok(inserted, updated, len(body.supplier_items), results)
 
 
@@ -625,6 +674,8 @@ async def ingest_on_hand(
         "ingest.on_hand total=%d inserted=%d updated=%d",
         len(body.on_hand), inserted, updated,
     )
+    batch_id = _create_ingest_batch(db, "on_hand", [r.model_dump() for r in body.on_hand])
+    _trigger_dq(db, batch_id)
     return _ok(inserted, updated, len(body.on_hand), results)
 
 
@@ -759,6 +810,8 @@ async def ingest_purchase_orders(
         "ingest.purchase_orders total=%d inserted=%d updated=%d",
         len(body.purchase_orders), inserted, updated,
     )
+    batch_id = _create_ingest_batch(db, "purchase_orders", [po.model_dump() for po in body.purchase_orders])
+    _trigger_dq(db, batch_id)
     return _ok(inserted, updated, len(body.purchase_orders), results)
 
 
@@ -907,4 +960,6 @@ async def ingest_forecast_demand(
         "ingest.forecast_demand total=%d inserted=%d updated=%d",
         len(body.forecasts), inserted, updated,
     )
+    batch_id = _create_ingest_batch(db, "forecast_demand", [fc.model_dump() for fc in body.forecasts])
+    _trigger_dq(db, batch_id)
     return _ok(inserted, updated, len(body.forecasts), results)

--- a/src/ootils_core/db/migrations/010_dq_engine.sql
+++ b/src/ootils_core/db/migrations/010_dq_engine.sql
@@ -1,0 +1,15 @@
+-- ============================================================
+-- Migration 010: DQ Engine V1 — add dq_status to ingest_batches
+-- ============================================================
+
+-- Add dq_status column to ingest_batches (tracks pipeline outcome)
+ALTER TABLE ingest_batches ADD COLUMN IF NOT EXISTS dq_status TEXT
+    CHECK (dq_status IN ('pending', 'running', 'validated', 'rejected', 'warning'));
+
+-- Index for DQ status queries
+CREATE INDEX IF NOT EXISTS idx_ingest_batches_dq_status
+    ON ingest_batches (dq_status, entity_type);
+
+-- Index for fast issue lookups by rule_code
+CREATE INDEX IF NOT EXISTS idx_dq_issues_rule_code
+    ON data_quality_issues (rule_code, severity, resolved);

--- a/src/ootils_core/engine/dq/__init__.py
+++ b/src/ootils_core/engine/dq/__init__.py
@@ -1,0 +1,4 @@
+"""DQ Engine — Data Quality pipeline for ingest batches."""
+from .engine import run_dq, DQResult
+
+__all__ = ["run_dq", "DQResult"]

--- a/src/ootils_core/engine/dq/engine.py
+++ b/src/ootils_core/engine/dq/engine.py
@@ -1,0 +1,654 @@
+"""
+DQ Engine — Data Quality pipeline, L1 (structural) + L2 (referential).
+
+Interface:
+    run_dq(db: psycopg.Connection, batch_id: UUID) -> DQResult
+
+L1 rules — structural checks on raw_content (JSON):
+    - L1_MISSING_FIELD : mandatory field absent or None
+    - L1_INVALID_TYPE  : field value has wrong type/format
+    - L1_INVALID_FORMAT: string too long (> 255 chars)
+
+L2 rules — referential integrity against live DB:
+    - L2_UNKNOWN_REF   : referenced entity not found in DB
+
+After execution:
+    - ingest_rows.dq_status updated (pending → passed/failed/warning)
+    - ingest_rows.dq_level_reached updated
+    - ingest_batches.dq_status updated
+    - data_quality_issues populated
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+# ──────────────────────────────────────────────────────────────
+# Result types
+# ──────────────────────────────────────────────────────────────
+
+@dataclass
+class DQIssue:
+    row_id: UUID
+    row_number: int
+    dq_level: int
+    rule_code: str
+    severity: str  # 'error' | 'warning' | 'info'
+    field_name: str | None
+    raw_value: str | None
+    message: str
+
+
+@dataclass
+class DQResult:
+    batch_id: UUID
+    total_rows: int
+    passed_rows: int
+    failed_rows: int
+    warning_rows: int
+    issues: list[DQIssue] = field(default_factory=list)
+    batch_dq_status: str = "pending"
+
+
+# ──────────────────────────────────────────────────────────────
+# Schema definitions per entity_type
+# Each entry: field_name → (mandatory, type_check, max_len)
+# type_check: 'str' | 'date' | 'numeric_positive' | 'uuid' | 'int_positive'
+# ──────────────────────────────────────────────────────────────
+
+_SCHEMAS: dict[str, list[tuple[str, bool, str, int | None]]] = {
+    # (field_name, mandatory, type_check, max_len)
+    "items": [
+        ("external_id", True, "str", 255),
+        ("name", True, "str", 255),
+        ("item_type", True, "str", 64),
+        ("uom", True, "str", 32),
+        ("status", True, "str", 64),
+    ],
+    "locations": [
+        ("external_id", True, "str", 255),
+        ("name", True, "str", 255),
+        ("location_type", True, "str", 64),
+    ],
+    "suppliers": [
+        ("external_id", True, "str", 255),
+        ("name", True, "str", 255),
+        ("status", True, "str", 64),
+    ],
+    "supplier_items": [
+        ("supplier_external_id", True, "str", 255),
+        ("item_external_id", True, "str", 255),
+        ("lead_time_days", True, "int_positive", None),
+    ],
+    "purchase_orders": [
+        ("external_id", True, "str", 255),
+        ("item_external_id", True, "str", 255),
+        ("location_external_id", True, "str", 255),
+        ("supplier_external_id", True, "str", 255),
+        ("quantity", True, "numeric_positive", None),
+        ("uom", True, "str", 32),
+        ("expected_delivery_date", True, "date", None),
+        ("status", True, "str", 64),
+    ],
+    "forecast_demand": [
+        ("item_external_id", True, "str", 255),
+        ("location_external_id", True, "str", 255),
+        ("quantity", True, "numeric_positive", None),
+        ("bucket_date", True, "date", None),
+        ("time_grain", True, "str", 32),
+    ],
+    "on_hand": [
+        ("item_external_id", True, "str", 255),
+        ("location_external_id", True, "str", 255),
+        ("quantity", True, "numeric_positive", None),
+        ("uom", True, "str", 32),
+        ("as_of_date", True, "date", None),
+    ],
+    # Fallback for unknown entity types — minimal structural checks
+    "forecasts": [
+        ("item_external_id", True, "str", 255),
+        ("location_external_id", True, "str", 255),
+        ("quantity", True, "numeric_positive", None),
+        ("bucket_date", True, "date", None),
+    ],
+    "customer_orders": [
+        ("external_id", True, "str", 255),
+        ("item_external_id", True, "str", 255),
+        ("location_external_id", True, "str", 255),
+        ("quantity", True, "numeric_positive", None),
+    ],
+    "work_orders": [
+        ("external_id", True, "str", 255),
+        ("item_external_id", True, "str", 255),
+        ("quantity", True, "numeric_positive", None),
+    ],
+    "transfers": [
+        ("external_id", True, "str", 255),
+        ("item_external_id", True, "str", 255),
+        ("from_location_external_id", True, "str", 255),
+        ("to_location_external_id", True, "str", 255),
+        ("quantity", True, "numeric_positive", None),
+    ],
+}
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+# ──────────────────────────────────────────────────────────────
+# L1 — Structural checks
+# ──────────────────────────────────────────────────────────────
+
+def _check_l1(
+    row_id: UUID,
+    row_number: int,
+    content: dict[str, Any],
+    entity_type: str,
+) -> list[DQIssue]:
+    issues: list[DQIssue] = []
+    schema = _SCHEMAS.get(entity_type, [])
+
+    for field_name, mandatory, type_check, max_len in schema:
+        value = content.get(field_name)
+
+        # Missing / null mandatory field
+        if mandatory and (value is None or value == ""):
+            issues.append(DQIssue(
+                row_id=row_id,
+                row_number=row_number,
+                dq_level=1,
+                rule_code="L1_MISSING_FIELD",
+                severity="error",
+                field_name=field_name,
+                raw_value=None,
+                message=f"Mandatory field '{field_name}' is missing or null",
+            ))
+            continue  # No point type-checking a missing field
+
+        if value is None:
+            continue  # Optional field, skip
+
+        raw_str = str(value)
+
+        # Type checks
+        type_error = False
+        if type_check == "date":
+            v = value if isinstance(value, str) else str(value)
+            if not _DATE_RE.match(v):
+                type_error = True
+                issues.append(DQIssue(
+                    row_id=row_id,
+                    row_number=row_number,
+                    dq_level=1,
+                    rule_code="L1_INVALID_TYPE",
+                    severity="error",
+                    field_name=field_name,
+                    raw_value=raw_str[:255],
+                    message=f"Field '{field_name}' must be a date (YYYY-MM-DD), got: {raw_str[:100]}",
+                ))
+            else:
+                # Also validate it's a real calendar date
+                try:
+                    datetime.strptime(v, "%Y-%m-%d")
+                except ValueError:
+                    type_error = True
+                    issues.append(DQIssue(
+                        row_id=row_id,
+                        row_number=row_number,
+                        dq_level=1,
+                        rule_code="L1_INVALID_TYPE",
+                        severity="error",
+                        field_name=field_name,
+                        raw_value=raw_str[:255],
+                        message=f"Field '{field_name}' is not a valid calendar date: {raw_str[:100]}",
+                    ))
+
+        elif type_check == "numeric_positive":
+            try:
+                num = float(value)
+                if num <= 0:
+                    raise ValueError("not positive")
+            except (TypeError, ValueError):
+                type_error = True
+                issues.append(DQIssue(
+                    row_id=row_id,
+                    row_number=row_number,
+                    dq_level=1,
+                    rule_code="L1_INVALID_TYPE",
+                    severity="error",
+                    field_name=field_name,
+                    raw_value=raw_str[:255],
+                    message=f"Field '{field_name}' must be a positive number, got: {raw_str[:100]}",
+                ))
+
+        elif type_check == "int_positive":
+            try:
+                num = int(value)
+                if num <= 0:
+                    raise ValueError("not positive")
+            except (TypeError, ValueError):
+                type_error = True
+                issues.append(DQIssue(
+                    row_id=row_id,
+                    row_number=row_number,
+                    dq_level=1,
+                    rule_code="L1_INVALID_TYPE",
+                    severity="error",
+                    field_name=field_name,
+                    raw_value=raw_str[:255],
+                    message=f"Field '{field_name}' must be a positive integer, got: {raw_str[:100]}",
+                ))
+
+        elif type_check == "uuid":
+            if not _UUID_RE.match(str(value)):
+                type_error = True
+                issues.append(DQIssue(
+                    row_id=row_id,
+                    row_number=row_number,
+                    dq_level=1,
+                    rule_code="L1_INVALID_TYPE",
+                    severity="error",
+                    field_name=field_name,
+                    raw_value=raw_str[:255],
+                    message=f"Field '{field_name}' must be a valid UUID, got: {raw_str[:100]}",
+                ))
+
+        # String max length check
+        if not type_error and max_len is not None and isinstance(value, str) and len(value) > max_len:
+            issues.append(DQIssue(
+                row_id=row_id,
+                row_number=row_number,
+                dq_level=1,
+                rule_code="L1_INVALID_FORMAT",
+                severity="error",
+                field_name=field_name,
+                raw_value=raw_str[:255],
+                message=f"Field '{field_name}' exceeds max length {max_len} (got {len(value)} chars)",
+            ))
+
+    return issues
+
+
+# ──────────────────────────────────────────────────────────────
+# L2 — Referential checks
+# ──────────────────────────────────────────────────────────────
+
+def _batch_resolve_items(db: psycopg.Connection, external_ids: list[str]) -> set[str]:
+    """Return set of external_ids that exist in items table."""
+    if not external_ids:
+        return set()
+    rows = db.execute(
+        "SELECT external_id FROM items WHERE external_id = ANY(%s)",
+        (external_ids,),
+    ).fetchall()
+    return {r["external_id"] for r in rows}
+
+
+def _batch_resolve_locations(db: psycopg.Connection, external_ids: list[str]) -> set[str]:
+    if not external_ids:
+        return set()
+    rows = db.execute(
+        "SELECT external_id FROM locations WHERE external_id = ANY(%s)",
+        (external_ids,),
+    ).fetchall()
+    return {r["external_id"] for r in rows}
+
+
+def _batch_resolve_suppliers(db: psycopg.Connection, external_ids: list[str]) -> set[str]:
+    if not external_ids:
+        return set()
+    rows = db.execute(
+        "SELECT external_id FROM suppliers WHERE external_id = ANY(%s)",
+        (external_ids,),
+    ).fetchall()
+    return {r["external_id"] for r in rows}
+
+
+def _check_l2(
+    rows_data: list[tuple[UUID, int, dict[str, Any]]],
+    entity_type: str,
+    db: psycopg.Connection,
+) -> list[DQIssue]:
+    """
+    Batch L2 checks for all rows of a given entity_type.
+    Returns a flat list of issues.
+    """
+    issues: list[DQIssue] = []
+
+    if entity_type == "purchase_orders":
+        item_ids = [r[2].get("item_external_id") for r in rows_data if r[2].get("item_external_id")]
+        loc_ids = [r[2].get("location_external_id") for r in rows_data if r[2].get("location_external_id")]
+        sup_ids = [r[2].get("supplier_external_id") for r in rows_data if r[2].get("supplier_external_id")]
+
+        valid_items = _batch_resolve_items(db, list(set(item_ids)))
+        valid_locs = _batch_resolve_locations(db, list(set(loc_ids)))
+        valid_sups = _batch_resolve_suppliers(db, list(set(sup_ids)))
+
+        for row_id, row_number, content in rows_data:
+            for ref_field, valid_set, label in [
+                ("item_external_id", valid_items, "items"),
+                ("location_external_id", valid_locs, "locations"),
+                ("supplier_external_id", valid_sups, "suppliers"),
+            ]:
+                val = content.get(ref_field)
+                if val and val not in valid_set:
+                    issues.append(DQIssue(
+                        row_id=row_id,
+                        row_number=row_number,
+                        dq_level=2,
+                        rule_code="L2_UNKNOWN_REF",
+                        severity="error",
+                        field_name=ref_field,
+                        raw_value=str(val)[:255],
+                        message=f"'{ref_field}' value '{val}' not found in {label}",
+                    ))
+
+    elif entity_type in ("forecast_demand", "forecasts", "on_hand"):
+        item_ids = [r[2].get("item_external_id") for r in rows_data if r[2].get("item_external_id")]
+        loc_ids = [r[2].get("location_external_id") for r in rows_data if r[2].get("location_external_id")]
+
+        valid_items = _batch_resolve_items(db, list(set(item_ids)))
+        valid_locs = _batch_resolve_locations(db, list(set(loc_ids)))
+
+        for row_id, row_number, content in rows_data:
+            for ref_field, valid_set, label in [
+                ("item_external_id", valid_items, "items"),
+                ("location_external_id", valid_locs, "locations"),
+            ]:
+                val = content.get(ref_field)
+                if val and val not in valid_set:
+                    issues.append(DQIssue(
+                        row_id=row_id,
+                        row_number=row_number,
+                        dq_level=2,
+                        rule_code="L2_UNKNOWN_REF",
+                        severity="error",
+                        field_name=ref_field,
+                        raw_value=str(val)[:255],
+                        message=f"'{ref_field}' value '{val}' not found in {label}",
+                    ))
+
+    elif entity_type == "supplier_items":
+        item_ids = [r[2].get("item_external_id") for r in rows_data if r[2].get("item_external_id")]
+        sup_ids = [r[2].get("supplier_external_id") for r in rows_data if r[2].get("supplier_external_id")]
+
+        valid_items = _batch_resolve_items(db, list(set(item_ids)))
+        valid_sups = _batch_resolve_suppliers(db, list(set(sup_ids)))
+
+        for row_id, row_number, content in rows_data:
+            for ref_field, valid_set, label in [
+                ("item_external_id", valid_items, "items"),
+                ("supplier_external_id", valid_sups, "suppliers"),
+            ]:
+                val = content.get(ref_field)
+                if val and val not in valid_set:
+                    issues.append(DQIssue(
+                        row_id=row_id,
+                        row_number=row_number,
+                        dq_level=2,
+                        rule_code="L2_UNKNOWN_REF",
+                        severity="error",
+                        field_name=ref_field,
+                        raw_value=str(val)[:255],
+                        message=f"'{ref_field}' value '{val}' not found in {label}",
+                    ))
+
+    # No L2 rules for items, locations, suppliers (they ARE the reference tables)
+
+    return issues
+
+
+# ──────────────────────────────────────────────────────────────
+# Persist issues + update row/batch statuses
+# ──────────────────────────────────────────────────────────────
+
+def _persist_issues(db: psycopg.Connection, batch_id: UUID, issues: list[DQIssue]) -> None:
+    if not issues:
+        return
+    with db.cursor() as cur:
+        for issue in issues:
+            cur.execute(
+                """
+                INSERT INTO data_quality_issues
+                    (issue_id, batch_id, row_id, row_number, dq_level, rule_code,
+                     severity, field_name, raw_value, message)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    uuid4(),
+                    batch_id,
+                    issue.row_id,
+                    issue.row_number,
+                    issue.dq_level,
+                    issue.rule_code,
+                    issue.severity,
+                    issue.field_name,
+                    issue.raw_value,
+                    issue.message,
+                ),
+            )
+
+
+def _update_row_statuses(
+    db: psycopg.Connection,
+    row_issues: dict[UUID, list[DQIssue]],
+    all_row_ids: list[UUID],
+    max_level_reached: dict[UUID, int],
+) -> None:
+    """Update dq_status and dq_level_reached on each ingest_row."""
+    for row_id in all_row_ids:
+        row_issue_list = row_issues.get(row_id, [])
+        has_error = any(i.severity == "error" for i in row_issue_list)
+        has_warning = any(i.severity == "warning" for i in row_issue_list)
+
+        if has_error:
+            dq_status = "rejected"
+        elif has_warning:
+            dq_status = "l2_pass"  # passed both levels but with warnings
+        else:
+            dq_status = "l2_pass"  # clean pass
+
+        level_reached = max_level_reached.get(row_id, 0)
+
+        db.execute(
+            """
+            UPDATE ingest_rows
+            SET dq_status = %s, dq_level_reached = %s
+            WHERE row_id = %s
+            """,
+            (dq_status, level_reached, row_id),
+        )
+
+
+def _update_batch_status(
+    db: psycopg.Connection,
+    batch_id: UUID,
+    all_issues: list[DQIssue],
+    total_rows: int,
+) -> str:
+    """Compute and update ingest_batches.dq_status. Returns the new status."""
+    has_error = any(i.severity == "error" for i in all_issues)
+    has_warning = any(i.severity == "warning" for i in all_issues)
+
+    if has_error:
+        dq_status = "rejected"
+    elif has_warning:
+        dq_status = "validated"  # passed with warnings
+    else:
+        dq_status = "validated"
+
+    db.execute(
+        """
+        UPDATE ingest_batches
+        SET dq_status = %s, processed_at = now()
+        WHERE batch_id = %s
+        """,
+        (dq_status, batch_id),
+    )
+    return dq_status
+
+
+# ──────────────────────────────────────────────────────────────
+# Main entry point
+# ──────────────────────────────────────────────────────────────
+
+def run_dq(db: psycopg.Connection, batch_id: UUID) -> DQResult:
+    """
+    Execute L1 + L2 DQ checks for all rows in a batch.
+
+    Steps:
+      1. Load batch metadata (entity_type)
+      2. Load all ingest_rows for the batch
+      3. Run L1 structural checks per row
+      4. Run L2 referential checks (batched per entity_type)
+      5. Persist all issues to data_quality_issues
+      6. Update ingest_rows.dq_status / dq_level_reached
+      7. Update ingest_batches.dq_status
+      8. Return DQResult summary
+    """
+    # 1. Load batch
+    batch_row = db.execute(
+        "SELECT batch_id, entity_type, status FROM ingest_batches WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+
+    if not batch_row:
+        raise ValueError(f"Batch {batch_id} not found")
+
+    entity_type = batch_row["entity_type"]
+
+    # 2. Load rows
+    ingest_rows = db.execute(
+        """
+        SELECT row_id, row_number, raw_content
+        FROM ingest_rows
+        WHERE batch_id = %s
+        ORDER BY row_number
+        """,
+        (batch_id,),
+    ).fetchall()
+
+    if not ingest_rows:
+        # Empty batch — mark as validated
+        db.execute(
+            "UPDATE ingest_batches SET dq_status = 'validated', processed_at = now() WHERE batch_id = %s",
+            (batch_id,),
+        )
+        return DQResult(
+            batch_id=batch_id,
+            total_rows=0,
+            passed_rows=0,
+            failed_rows=0,
+            warning_rows=0,
+            issues=[],
+            batch_dq_status="validated",
+        )
+
+    all_issues: list[DQIssue] = []
+    row_issues: dict[UUID, list[DQIssue]] = {}
+    max_level_reached: dict[UUID, int] = {}
+    rows_data: list[tuple[UUID, int, dict[str, Any]]] = []
+
+    # 3. L1 structural checks
+    for row in ingest_rows:
+        row_id = row["row_id"]
+        row_number = row["row_number"]
+
+        # Parse raw_content
+        try:
+            content = json.loads(row["raw_content"])
+            if not isinstance(content, dict):
+                content = {}
+        except (json.JSONDecodeError, TypeError):
+            # Can't parse — generate a parse error issue
+            parse_issue = DQIssue(
+                row_id=row_id,
+                row_number=row_number,
+                dq_level=1,
+                rule_code="L1_INVALID_FORMAT",
+                severity="error",
+                field_name=None,
+                raw_value=str(row["raw_content"])[:255],
+                message="raw_content is not valid JSON",
+            )
+            row_issues[row_id] = [parse_issue]
+            all_issues.append(parse_issue)
+            max_level_reached[row_id] = 0
+            continue
+
+        rows_data.append((row_id, row_number, content))
+        l1_issues = _check_l1(row_id, row_number, content, entity_type)
+        row_issues[row_id] = list(l1_issues)
+        all_issues.extend(l1_issues)
+        max_level_reached[row_id] = 1  # reached L1
+
+    # 4. L2 referential checks — only for rows that passed L1 (no error issues)
+    l2_candidates = [
+        (row_id, row_number, content)
+        for (row_id, row_number, content) in rows_data
+        if not any(i.severity == "error" for i in row_issues.get(row_id, []))
+    ]
+
+    if l2_candidates:
+        l2_issues = _check_l2(l2_candidates, entity_type, db)
+        for issue in l2_issues:
+            row_issues.setdefault(issue.row_id, []).append(issue)
+        all_issues.extend(l2_issues)
+
+    # Mark L2 reached for candidates
+    for row_id, _, _ in l2_candidates:
+        max_level_reached[row_id] = 2
+
+    # 5. Persist issues
+    _persist_issues(db, batch_id, all_issues)
+
+    # 6. Update row statuses
+    all_row_ids = [row["row_id"] for row in ingest_rows]
+    _update_row_statuses(db, row_issues, all_row_ids, max_level_reached)
+
+    # 7. Update batch status
+    batch_dq_status = _update_batch_status(db, batch_id, all_issues, len(ingest_rows))
+
+    # 8. Build result
+    passed_rows = sum(
+        1 for row_id in all_row_ids
+        if not any(i.severity in ("error", "warning") for i in row_issues.get(row_id, []))
+    )
+    failed_rows = sum(
+        1 for row_id in all_row_ids
+        if any(i.severity == "error" for i in row_issues.get(row_id, []))
+    )
+    warning_rows = sum(
+        1 for row_id in all_row_ids
+        if (
+            any(i.severity == "warning" for i in row_issues.get(row_id, []))
+            and not any(i.severity == "error" for i in row_issues.get(row_id, []))
+        )
+    )
+
+    logger.info(
+        "dq.run batch_id=%s entity=%s total=%d passed=%d failed=%d warnings=%d issues=%d",
+        batch_id, entity_type, len(ingest_rows), passed_rows, failed_rows, warning_rows, len(all_issues),
+    )
+
+    return DQResult(
+        batch_id=batch_id,
+        total_rows=len(ingest_rows),
+        passed_rows=passed_rows,
+        failed_rows=failed_rows,
+        warning_rows=warning_rows,
+        issues=all_issues,
+        batch_dq_status=batch_dq_status,
+    )

--- a/tests/integration/test_dq.py
+++ b/tests/integration/test_dq.py
@@ -1,0 +1,606 @@
+"""
+tests/integration/test_dq.py — Integration tests for DQ Engine V1.
+
+Tests:
+  - L1: missing mandatory field → issue generated
+  - L1: invalid type (date, numeric) → issue generated
+  - L1: string too long → issue generated
+  - L2: unknown reference → issue generated
+  - L2: valid reference → no issue
+  - batch dq_status: passed when no errors
+  - batch dq_status: rejected when errors present
+  - GET /v1/dq/{batch_id} returns issues
+  - POST /v1/dq/run/{batch_id} works
+  - GET /v1/dq/issues filters by severity
+  - GET /v1/dq/issues filters by entity_type
+  - run_dq on empty batch → validated, 0 issues
+
+Requires a running PostgreSQL instance with migrations applied.
+Set DATABASE_URL before running.
+"""
+from __future__ import annotations
+
+import json
+import os
+from uuid import uuid4
+
+import pytest
+import psycopg
+from psycopg.rows import dict_row
+
+from .conftest import requires_db, DB_AVAILABLE, TEST_DB_URL
+
+# ─────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def dq_client(migrated_db):
+    """Module-scoped TestClient with migrated DB."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = "test-token"
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+    from fastapi.testclient import TestClient
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="module")
+def auth():
+    return {"Authorization": "Bearer test-token"}
+
+
+@pytest.fixture(scope="module")
+def db_conn(migrated_db):
+    """Direct psycopg connection for DB assertions."""
+    conn = psycopg.connect(migrated_db, row_factory=dict_row)
+    yield conn
+    conn.close()
+
+
+# ─────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────
+
+PREFIX = str(uuid4())[:8]
+
+
+def uid(base: str) -> str:
+    return f"{PREFIX}-{base}"
+
+
+def _create_batch_with_rows(
+    db: psycopg.Connection,
+    entity_type: str,
+    rows: list[dict],
+) -> str:
+    """Insert an ingest_batch + ingest_rows directly and return batch_id."""
+    batch_id = str(uuid4())
+    db.execute(
+        """
+        INSERT INTO ingest_batches
+            (batch_id, entity_type, source_system, status, total_rows, submitted_by)
+        VALUES (%s, %s, 'test', 'processing', %s, 'pytest')
+        """,
+        (batch_id, entity_type, len(rows)),
+    )
+    for i, row in enumerate(rows):
+        db.execute(
+            """
+            INSERT INTO ingest_rows (row_id, batch_id, row_number, raw_content)
+            VALUES (%s, %s, %s, %s)
+            """,
+            (str(uuid4()), batch_id, i + 1, json.dumps(row)),
+        )
+    db.commit()
+    return batch_id
+
+
+def _insert_item(db: psycopg.Connection, external_id: str) -> str:
+    """Insert a test item, return item_id."""
+    item_id = str(uuid4())
+    db.execute(
+        """
+        INSERT INTO items (item_id, external_id, name, item_type, uom, status)
+        VALUES (%s, %s, 'Test Item', 'component', 'EA', 'active')
+        ON CONFLICT (external_id) DO NOTHING
+        """,
+        (item_id, external_id),
+    )
+    db.commit()
+    return item_id
+
+
+def _insert_location(db: psycopg.Connection, external_id: str) -> str:
+    """Insert a test location, return location_id."""
+    loc_id = str(uuid4())
+    db.execute(
+        """
+        INSERT INTO locations (location_id, external_id, name, location_type)
+        VALUES (%s, %s, 'Test Location', 'warehouse')
+        ON CONFLICT (external_id) DO NOTHING
+        """,
+        (loc_id, external_id),
+    )
+    db.commit()
+    return loc_id
+
+
+def _insert_supplier(db: psycopg.Connection, external_id: str) -> str:
+    """Insert a test supplier, return supplier_id."""
+    sup_id = str(uuid4())
+    db.execute(
+        """
+        INSERT INTO suppliers (supplier_id, external_id, name, status)
+        VALUES (%s, %s, 'Test Supplier', 'active')
+        ON CONFLICT (external_id) DO NOTHING
+        """,
+        (sup_id, external_id),
+    )
+    db.commit()
+    return sup_id
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 1: L1 — missing mandatory field generates issue
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_l1_missing_field_generates_issue(db_conn, migrated_db):
+    """Missing 'name' field in items batch → L1_MISSING_FIELD issue."""
+    from ootils_core.engine.dq.engine import run_dq
+    import psycopg as _psycopg
+
+    batch_id = _create_batch_with_rows(
+        db_conn,
+        "items",
+        [{"external_id": uid("item-missing-name"), "item_type": "component", "uom": "EA", "status": "active"}],
+        # 'name' is missing
+    )
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        result = run_dq(conn, batch_id)
+        conn.commit()
+
+    assert result.total_rows == 1
+    assert result.failed_rows == 1
+    assert any(i.rule_code == "L1_MISSING_FIELD" and i.field_name == "name" for i in result.issues)
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 2: L1 — invalid date type generates issue
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_l1_invalid_date_generates_issue(db_conn, migrated_db):
+    """Invalid date format in purchase_orders → L1_INVALID_TYPE issue."""
+    from ootils_core.engine.dq.engine import run_dq
+    import psycopg as _psycopg
+
+    batch_id = _create_batch_with_rows(
+        db_conn,
+        "purchase_orders",
+        [{
+            "external_id": uid("po-bad-date"),
+            "item_external_id": uid("item-x"),
+            "location_external_id": uid("loc-x"),
+            "supplier_external_id": uid("sup-x"),
+            "quantity": 10,
+            "uom": "EA",
+            "expected_delivery_date": "not-a-date",  # bad format
+            "status": "confirmed",
+        }],
+    )
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        result = run_dq(conn, batch_id)
+        conn.commit()
+
+    assert any(i.rule_code == "L1_INVALID_TYPE" and i.field_name == "expected_delivery_date" for i in result.issues)
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 3: L1 — non-positive numeric generates issue
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_l1_invalid_numeric_generates_issue(db_conn, migrated_db):
+    """Negative quantity in on_hand → L1_INVALID_TYPE issue."""
+    from ootils_core.engine.dq.engine import run_dq
+    import psycopg as _psycopg
+
+    batch_id = _create_batch_with_rows(
+        db_conn,
+        "on_hand",
+        [{
+            "item_external_id": uid("item-y"),
+            "location_external_id": uid("loc-y"),
+            "quantity": -5,  # invalid
+            "uom": "EA",
+            "as_of_date": "2026-04-01",
+        }],
+    )
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        result = run_dq(conn, batch_id)
+        conn.commit()
+
+    assert any(i.rule_code == "L1_INVALID_TYPE" and i.field_name == "quantity" for i in result.issues)
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 4: L1 — string too long generates issue
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_l1_string_too_long_generates_issue(db_conn, migrated_db):
+    """external_id > 255 chars in items → L1_INVALID_FORMAT issue."""
+    from ootils_core.engine.dq.engine import run_dq
+    import psycopg as _psycopg
+
+    long_id = "X" * 300
+
+    batch_id = _create_batch_with_rows(
+        db_conn,
+        "items",
+        [{
+            "external_id": long_id,
+            "name": "Test",
+            "item_type": "component",
+            "uom": "EA",
+            "status": "active",
+        }],
+    )
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        result = run_dq(conn, batch_id)
+        conn.commit()
+
+    assert any(i.rule_code == "L1_INVALID_FORMAT" and i.field_name == "external_id" for i in result.issues)
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 5: L2 — unknown reference generates issue
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_l2_unknown_ref_generates_issue(db_conn, migrated_db):
+    """Valid L1 but non-existent item_external_id → L2_UNKNOWN_REF issue."""
+    from ootils_core.engine.dq.engine import run_dq
+    import psycopg as _psycopg
+
+    nonexistent_item = uid("ghost-item")
+
+    batch_id = _create_batch_with_rows(
+        db_conn,
+        "on_hand",
+        [{
+            "item_external_id": nonexistent_item,
+            "location_external_id": uid("loc-also-ghost"),
+            "quantity": 100,
+            "uom": "EA",
+            "as_of_date": "2026-04-01",
+        }],
+    )
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        result = run_dq(conn, batch_id)
+        conn.commit()
+
+    l2_issues = [i for i in result.issues if i.rule_code == "L2_UNKNOWN_REF"]
+    assert len(l2_issues) >= 1
+    assert any(i.field_name == "item_external_id" for i in l2_issues)
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 6: L2 — valid reference → no L2 issue
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_l2_valid_ref_no_issue(db_conn, migrated_db):
+    """Valid item_external_id and location_external_id → no L2 issues."""
+    from ootils_core.engine.dq.engine import run_dq
+    import psycopg as _psycopg
+
+    item_ext = uid("item-valid-ref")
+    loc_ext = uid("loc-valid-ref")
+    _insert_item(db_conn, item_ext)
+    _insert_location(db_conn, loc_ext)
+
+    batch_id = _create_batch_with_rows(
+        db_conn,
+        "on_hand",
+        [{
+            "item_external_id": item_ext,
+            "location_external_id": loc_ext,
+            "quantity": 50,
+            "uom": "EA",
+            "as_of_date": "2026-04-01",
+        }],
+    )
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        result = run_dq(conn, batch_id)
+        conn.commit()
+
+    l2_issues = [i for i in result.issues if i.rule_code == "L2_UNKNOWN_REF"]
+    assert len(l2_issues) == 0
+    assert result.failed_rows == 0
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 7: batch dq_status = validated when no errors
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_batch_status_validated_when_no_errors(db_conn, migrated_db):
+    """Clean batch → dq_status = validated in ingest_batches."""
+    from ootils_core.engine.dq.engine import run_dq
+    import psycopg as _psycopg
+
+    item_ext = uid("item-clean")
+    loc_ext = uid("loc-clean")
+    _insert_item(db_conn, item_ext)
+    _insert_location(db_conn, loc_ext)
+
+    batch_id = _create_batch_with_rows(
+        db_conn,
+        "on_hand",
+        [{
+            "item_external_id": item_ext,
+            "location_external_id": loc_ext,
+            "quantity": 10,
+            "uom": "EA",
+            "as_of_date": "2026-04-08",
+        }],
+    )
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        result = run_dq(conn, batch_id)
+        conn.commit()
+
+    assert result.batch_dq_status == "validated"
+
+    batch = db_conn.execute(
+        "SELECT dq_status FROM ingest_batches WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+    assert batch["dq_status"] == "validated"
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 8: batch dq_status = rejected when errors present
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_batch_status_rejected_when_errors(db_conn, migrated_db):
+    """Batch with L1 errors → dq_status = rejected in ingest_batches."""
+    from ootils_core.engine.dq.engine import run_dq
+    import psycopg as _psycopg
+
+    batch_id = _create_batch_with_rows(
+        db_conn,
+        "items",
+        [{"external_id": uid("err-item"), "item_type": "component", "uom": "EA", "status": "active"}],
+        # missing 'name'
+    )
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        result = run_dq(conn, batch_id)
+        conn.commit()
+
+    assert result.batch_dq_status == "rejected"
+
+    batch = db_conn.execute(
+        "SELECT dq_status FROM ingest_batches WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+    assert batch["dq_status"] == "rejected"
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 9: GET /v1/dq/{batch_id} returns issues
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_get_batch_dq_returns_issues(dq_client, auth, db_conn, migrated_db):
+    """GET /v1/dq/{batch_id} returns the issues for a batch that has errors."""
+    from ootils_core.engine.dq.engine import run_dq
+    import psycopg as _psycopg
+
+    batch_id = _create_batch_with_rows(
+        db_conn,
+        "items",
+        [{"external_id": uid("get-test-item"), "item_type": "component", "uom": "EA", "status": "active"}],
+    )
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        run_dq(conn, batch_id)
+        conn.commit()
+
+    resp = dq_client.get(f"/v1/dq/{batch_id}", headers=auth)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["batch_id"] == batch_id
+    assert isinstance(data["issues"], list)
+    assert len(data["issues"]) > 0
+    assert data["issues"][0]["rule_code"] == "L1_MISSING_FIELD"
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 10: POST /v1/dq/run/{batch_id} works
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_post_run_dq_endpoint(dq_client, auth, db_conn):
+    """POST /v1/dq/run/{batch_id} triggers DQ and returns result."""
+    item_ext = uid("item-run-test")
+    loc_ext = uid("loc-run-test")
+    _insert_item(db_conn, item_ext)
+    _insert_location(db_conn, loc_ext)
+
+    batch_id = _create_batch_with_rows(
+        db_conn,
+        "on_hand",
+        [{
+            "item_external_id": item_ext,
+            "location_external_id": loc_ext,
+            "quantity": 99,
+            "uom": "EA",
+            "as_of_date": "2026-04-08",
+        }],
+    )
+
+    resp = dq_client.post(f"/v1/dq/run/{batch_id}", headers=auth)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["batch_id"] == batch_id
+    assert data["status"] == "completed"
+    assert data["total_rows"] == 1
+    assert data["batch_dq_status"] == "validated"
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 11: GET /v1/dq/issues filters by severity
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_get_issues_filter_by_severity(dq_client, auth, db_conn, migrated_db):
+    """GET /v1/dq/issues?severity=error returns only error-level issues."""
+    from ootils_core.engine.dq.engine import run_dq
+    import psycopg as _psycopg
+
+    # Create a batch with errors
+    batch_id = _create_batch_with_rows(
+        db_conn,
+        "items",
+        [{"external_id": uid("severity-filter-item"), "item_type": "component", "uom": "EA", "status": "active"}],
+    )
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        run_dq(conn, batch_id)
+        conn.commit()
+
+    resp = dq_client.get("/v1/dq/issues?severity=error", headers=auth)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] >= 1
+    # All returned issues must be errors
+    for issue in data["issues"]:
+        assert issue["severity"] == "error"
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 12: GET /v1/dq/issues filters by entity_type
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_get_issues_filter_by_entity_type(dq_client, auth, db_conn, migrated_db):
+    """GET /v1/dq/issues?entity_type=on_hand returns only on_hand issues."""
+    from ootils_core.engine.dq.engine import run_dq
+    import psycopg as _psycopg
+
+    # Create an on_hand batch with a missing field
+    batch_id = _create_batch_with_rows(
+        db_conn,
+        "on_hand",
+        [{
+            "item_external_id": uid("oh-filter-item"),
+            "location_external_id": uid("oh-filter-loc"),
+            "quantity": -1,  # invalid → error
+            "uom": "EA",
+            "as_of_date": "2026-04-08",
+        }],
+    )
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        run_dq(conn, batch_id)
+        conn.commit()
+
+    resp = dq_client.get("/v1/dq/issues?entity_type=on_hand", headers=auth)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] >= 1
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 13: run_dq on empty batch → validated, 0 issues
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_run_dq_empty_batch(db_conn, migrated_db):
+    """Batch with 0 rows → validated status, no issues generated."""
+    from ootils_core.engine.dq.engine import run_dq
+    import psycopg as _psycopg
+
+    batch_id = str(uuid4())
+    db_conn.execute(
+        """
+        INSERT INTO ingest_batches
+            (batch_id, entity_type, source_system, status, total_rows, submitted_by)
+        VALUES (%s, 'items', 'test', 'processing', 0, 'pytest')
+        """,
+        (batch_id,),
+    )
+    db_conn.commit()
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        result = run_dq(conn, batch_id)
+        conn.commit()
+
+    assert result.total_rows == 0
+    assert result.batch_dq_status == "validated"
+    assert len(result.issues) == 0
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 14: L2 purchase_orders — all 3 refs checked
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_l2_purchase_order_all_refs_checked(db_conn, migrated_db):
+    """PO with valid L1 but all 3 refs missing → 3 L2_UNKNOWN_REF issues."""
+    from ootils_core.engine.dq.engine import run_dq
+    import psycopg as _psycopg
+
+    batch_id = _create_batch_with_rows(
+        db_conn,
+        "purchase_orders",
+        [{
+            "external_id": uid("po-l2-test"),
+            "item_external_id": uid("ghost-item-po"),
+            "location_external_id": uid("ghost-loc-po"),
+            "supplier_external_id": uid("ghost-sup-po"),
+            "quantity": 100,
+            "uom": "EA",
+            "expected_delivery_date": "2026-05-01",
+            "status": "confirmed",
+        }],
+    )
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        result = run_dq(conn, batch_id)
+        conn.commit()
+
+    l2_issues = [i for i in result.issues if i.rule_code == "L2_UNKNOWN_REF"]
+    # Should have 3 L2 issues: item, location, supplier
+    assert len(l2_issues) == 3
+    fields = {i.field_name for i in l2_issues}
+    assert "item_external_id" in fields
+    assert "location_external_id" in fields
+    assert "supplier_external_id" in fields


### PR DESCRIPTION
Closes #92

## Changements

### 1. DQ Engine (`engine/dq/engine.py`)
- `run_dq(db, batch_id) → DQResult` : interface principale
- **L1** : missing fields, invalid types (date YYYY-MM-DD, numeric > 0, int > 0), string max 255 chars
- **L2** : FK checks batchés par entity_type (purchase_orders → 3 refs, forecast_demand/on_hand → 2 refs, supplier_items → 2 refs)
- Mise à jour `ingest_rows.dq_status` et `dq_level_reached`
- Mise à jour `ingest_batches.dq_status` (validated/rejected)
- Insertion dans `data_quality_issues`

### 2. Router DQ (`api/routers/dq.py`)
- `POST /v1/dq/run/{batch_id}` — lancer DQ sur un batch
- `GET /v1/dq/{batch_id}` — résultats DQ d'un batch
- `GET /v1/dq/issues` — issues non-résolues avec filtres (severity, dq_level, entity_type)

### 3. Auto-trigger post-ingest (`api/routers/ingest.py`)
- Chaque endpoint crée un `ingest_batch` + `ingest_rows` puis appelle `run_dq()`
- Helper `_create_ingest_batch()` + `_trigger_dq()`

### 4. Migration (`010_dq_engine.sql`)
- Ajout colonne `dq_status` sur `ingest_batches`
- Index sur `dq_status` et `rule_code`

### 5. Tests (`tests/integration/test_dq.py`)
14 tests couvrant : L1 missing field, invalid date, invalid numeric, string trop longue, L2 ref inconnue, L2 ref valide, batch status passed/rejected, GET /v1/dq/{batch_id}, POST /v1/dq/run/{batch_id}, filtres severity + entity_type, batch vide.