### PR TITLE
fix: include SQL migrations in package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dev = ["pytest>=8.0", "pytest-cov>=5.0", "httpx>=0.27.0"]
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+"ootils_core" = ["db/migrations/*.sql"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v"


### PR DESCRIPTION
Setuptools was not bundling the migrations/*.sql files in the installed package. OotilsDB._apply_migrations() was looking in an empty directory.\n\nFix: add package-data config so migrations are included in the wheel.