### PR TITLE
[feat] Ghosts V1 — phase_transition + capacity_aggregate (ADR-010)

### DIFF
--- a/src/ootils_core/api/app.py
+++ b/src/ootils_core/api/app.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
-from ootils_core.api.routers import bom, calendars, dq, events, explain, graph, ingest, issues, projection, rccp, simulate
+from ootils_core.api.routers import bom, calendars, dq, events, explain, ghosts, graph, ingest, issues, projection, rccp, simulate
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +53,7 @@ def create_app() -> FastAPI:
     application.include_router(bom.router)
     application.include_router(calendars.router)
     application.include_router(rccp.router)
+    application.include_router(ghosts.router)
 
     @application.exception_handler(Exception)
     async def generic_exception_handler(request, exc: Exception) -> JSONResponse:

--- a/src/ootils_core/api/routers/ghosts.py
+++ b/src/ootils_core/api/routers/ghosts.py
@@ -1,0 +1,519 @@
+"""
+Ghosts API router — ADR-010 V1
+
+Endpoints:
+  POST /v1/ingest/ghosts       — upsert ghost_node + members + graph node + edges
+  GET  /v1/ghosts              — list all ghosts with members
+  GET  /v1/ghosts/{ghost_id}   — detail: ghost + members + graph node
+  POST /v1/ghosts/{ghost_id}/run — run ghost logic over a time window
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import Any, Optional
+from uuid import UUID, uuid4
+
+import psycopg
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field, field_validator
+
+from ootils_core.api.auth import require_auth
+from ootils_core.api.dependencies import get_db
+from ootils_core.engine.ghost.ghost_engine import run_ghost
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["ghosts"])
+
+BASELINE_SCENARIO_ID = UUID("00000000-0000-0000-0000-000000000001")
+
+# ─────────────────────────────────────────────────────────────
+# Pydantic models
+# ─────────────────────────────────────────────────────────────
+
+VALID_GHOST_TYPES = {"phase_transition", "capacity_aggregate"}
+VALID_GHOST_STATUSES = {"active", "archived", "draft"}
+VALID_ROLES = {"incoming", "outgoing", "member"}
+VALID_CURVES = {"linear", "step", "sigmoid"}
+
+
+class GhostMemberInput(BaseModel):
+    item_id: UUID = Field(..., description="UUID of the member item.")
+    role: str = Field(..., description="Role: incoming | outgoing | member.")
+    transition_start_date: Optional[date] = None
+    transition_end_date: Optional[date] = None
+    transition_curve: str = Field("linear", description="Transition curve: linear | step | sigmoid.")
+    weight_at_start: float = Field(1.0, ge=0.0, le=1.0)
+    weight_at_end: float = Field(0.0, ge=0.0, le=1.0)
+
+    @field_validator("role")
+    @classmethod
+    def validate_role(cls, v: str) -> str:
+        if v not in VALID_ROLES:
+            raise ValueError(f"role must be one of {sorted(VALID_ROLES)}")
+        return v
+
+    @field_validator("transition_curve")
+    @classmethod
+    def validate_curve(cls, v: str) -> str:
+        if v not in VALID_CURVES:
+            raise ValueError(f"transition_curve must be one of {sorted(VALID_CURVES)}")
+        return v
+
+
+class IngestGhostRequest(BaseModel):
+    name: str = Field(..., description="Ghost name (non-empty).")
+    ghost_type: str = Field(..., description="Ghost type: phase_transition | capacity_aggregate.")
+    scenario_id: Optional[UUID] = None
+    resource_id: Optional[UUID] = None
+    status: str = Field("active", description="Ghost status: active | archived | draft.")
+    description: Optional[str] = None
+    members: list[GhostMemberInput] = Field(default_factory=list)
+
+    @field_validator("name")
+    @classmethod
+    def non_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("name must not be empty")
+        return v
+
+    @field_validator("ghost_type")
+    @classmethod
+    def validate_ghost_type(cls, v: str) -> str:
+        if v not in VALID_GHOST_TYPES:
+            raise ValueError(f"ghost_type must be one of {sorted(VALID_GHOST_TYPES)}")
+        return v
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str) -> str:
+        if v not in VALID_GHOST_STATUSES:
+            raise ValueError(f"status must be one of {sorted(VALID_GHOST_STATUSES)}")
+        return v
+
+
+class GhostRunRequest(BaseModel):
+    scenario_id: UUID
+    from_date: date
+    to_date: date
+
+
+# ─────────────────────────────────────────────────────────────
+# Membership constraint validation
+# ─────────────────────────────────────────────────────────────
+
+def _validate_membership(ghost_type: str, members: list[GhostMemberInput]) -> list[str]:
+    """
+    Enforce membership constraints per ADR-010 D2:
+      phase_transition: exactly 1 outgoing + 1 incoming
+      capacity_aggregate: N members with role='member', N >= 1
+    Returns list of error messages (empty if valid).
+    """
+    errors: list[str] = []
+
+    if ghost_type == "phase_transition":
+        outgoing_count = sum(1 for m in members if m.role == "outgoing")
+        incoming_count = sum(1 for m in members if m.role == "incoming")
+        member_count = sum(1 for m in members if m.role == "member")
+
+        if outgoing_count != 1:
+            errors.append(
+                f"phase_transition requires exactly 1 member with role='outgoing', got {outgoing_count}"
+            )
+        if incoming_count != 1:
+            errors.append(
+                f"phase_transition requires exactly 1 member with role='incoming', got {incoming_count}"
+            )
+        if member_count > 0:
+            errors.append("phase_transition cannot have members with role='member'")
+
+    elif ghost_type == "capacity_aggregate":
+        member_count = sum(1 for m in members if m.role == "member")
+        non_member = [m for m in members if m.role != "member"]
+
+        if member_count < 1:
+            errors.append(
+                f"capacity_aggregate requires at least 1 member with role='member', got {member_count}"
+            )
+        if non_member:
+            bad_roles = [m.role for m in non_member]
+            errors.append(
+                f"capacity_aggregate cannot have roles 'incoming'/'outgoing', got: {bad_roles}"
+            )
+
+    return errors
+
+
+# ─────────────────────────────────────────────────────────────
+# POST /v1/ingest/ghosts
+# ─────────────────────────────────────────────────────────────
+
+@router.post(
+    "/v1/ingest/ghosts",
+    status_code=status.HTTP_201_CREATED,
+    summary="Ingest ghost",
+    description="Create or update a ghost_node with its members. Also creates Ghost node + edges in the graph.",
+)
+async def ingest_ghost(
+    body: IngestGhostRequest,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> dict[str, Any]:
+    """
+    Upsert ghost + members. Validates membership constraints before any write.
+    Creates/updates a Ghost node in the graph and ghost_member edges.
+    """
+    # 1. Validate membership constraints (only if members provided)
+    if body.members:
+        errors = _validate_membership(body.ghost_type, body.members)
+        if errors:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=errors,
+            )
+
+    # 2. Validate all item_ids exist
+    if body.members:
+        item_ids = [str(m.item_id) for m in body.members]
+        rows = db.execute(
+            "SELECT item_id FROM items WHERE item_id = ANY(%s)",
+            (item_ids,),
+        ).fetchall()
+        found_ids = {str(r["item_id"]) for r in rows}
+        missing = [iid for iid in item_ids if iid not in found_ids]
+        if missing:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=[f"item_id not found: {iid}" for iid in missing],
+            )
+
+    # 3. Validate resource_id if provided
+    if body.resource_id:
+        res_row = db.execute(
+            "SELECT resource_id FROM resources WHERE resource_id = %s",
+            (str(body.resource_id),),
+        ).fetchone()
+        if res_row is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=[f"resource_id not found: {body.resource_id}"],
+            )
+
+    # 4. Upsert ghost_node: keyed by (name, ghost_type, scenario_id)
+    existing_ghost = db.execute(
+        """
+        SELECT ghost_id, node_id FROM ghost_nodes
+        WHERE name = %s AND ghost_type = %s
+          AND (scenario_id = %s OR (scenario_id IS NULL AND %s IS NULL))
+        LIMIT 1
+        """,
+        (body.name, body.ghost_type, body.scenario_id, body.scenario_id),
+    ).fetchone()
+
+    if existing_ghost:
+        ghost_id = existing_ghost["ghost_id"]
+        node_id = existing_ghost["node_id"]
+        db.execute(
+            """
+            UPDATE ghost_nodes
+            SET resource_id = %s, status = %s, description = %s, updated_at = now()
+            WHERE ghost_id = %s
+            """,
+            (body.resource_id, body.status, body.description, ghost_id),
+        )
+        action = "updated"
+    else:
+        ghost_id = uuid4()
+        # Create the Ghost node in the graph first
+        node_id = uuid4()
+        scenario_id_for_node = body.scenario_id if body.scenario_id else BASELINE_SCENARIO_ID
+        db.execute(
+            """
+            INSERT INTO nodes (node_id, node_type, scenario_id, active)
+            VALUES (%s, 'Ghost', %s, TRUE)
+            """,
+            (node_id, scenario_id_for_node),
+        )
+        db.execute(
+            """
+            INSERT INTO ghost_nodes
+                (ghost_id, name, ghost_type, scenario_id, resource_id, node_id, status, description)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                ghost_id, body.name, body.ghost_type, body.scenario_id,
+                body.resource_id, node_id, body.status, body.description,
+            ),
+        )
+        action = "inserted"
+
+    # 5. Upsert members (delete-and-reinsert for idempotence)
+    if body.members:
+        db.execute("DELETE FROM ghost_members WHERE ghost_id = %s", (ghost_id,))
+        if node_id:
+            db.execute(
+                "DELETE FROM edges WHERE from_node_id = %s AND edge_type = 'ghost_member'",
+                (node_id,),
+            )
+
+        for m in body.members:
+            member_id = uuid4()
+            db.execute(
+                """
+                INSERT INTO ghost_members
+                    (member_id, ghost_id, item_id, role,
+                     transition_start_date, transition_end_date,
+                     transition_curve, weight_at_start, weight_at_end)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    member_id, ghost_id, m.item_id, m.role,
+                    m.transition_start_date, m.transition_end_date,
+                    m.transition_curve, m.weight_at_start, m.weight_at_end,
+                ),
+            )
+
+            # Create ghost_member edge in the graph (Ghost node → Item node)
+            if node_id:
+                item_node = db.execute(
+                    """
+                    SELECT node_id FROM nodes
+                    WHERE node_type = 'Item' AND item_id = %s AND active = TRUE
+                    LIMIT 1
+                    """,
+                    (m.item_id,),
+                ).fetchone()
+
+                if item_node:
+                    edge_id = uuid4()
+                    db.execute(
+                        """
+                        INSERT INTO edges (edge_id, from_node_id, to_node_id, edge_type, weight_ratio, active)
+                        VALUES (%s, %s, %s, 'ghost_member', %s, TRUE)
+                        ON CONFLICT DO NOTHING
+                        """,
+                        (edge_id, node_id, item_node["node_id"], float(m.weight_at_start)),
+                    )
+
+    logger.info("ingest.ghost ghost_id=%s action=%s", ghost_id, action)
+
+    return {
+        "ghost_id": str(ghost_id),
+        "node_id": str(node_id) if node_id else None,
+        "action": action,
+        "member_count": len(body.members),
+    }
+
+
+# ─────────────────────────────────────────────────────────────
+# GET /v1/ghosts
+# ─────────────────────────────────────────────────────────────
+
+@router.get(
+    "/v1/ghosts",
+    summary="List ghosts",
+    description="List all ghost_nodes with their members.",
+)
+async def list_ghosts(
+    ghost_type: Optional[str] = None,
+    scenario_id: Optional[UUID] = None,
+    ghost_status: Optional[str] = None,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> dict[str, Any]:
+    """Return all ghosts filtered by optional ghost_type, scenario_id, status."""
+    params: list[Any] = []
+    where_clauses: list[str] = []
+
+    if ghost_type:
+        where_clauses.append("g.ghost_type = %s")
+        params.append(ghost_type)
+    if scenario_id:
+        where_clauses.append("g.scenario_id = %s")
+        params.append(scenario_id)
+    if ghost_status:
+        where_clauses.append("g.status = %s")
+        params.append(ghost_status)
+
+    where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+
+    ghost_rows = db.execute(
+        f"""
+        SELECT ghost_id, name, ghost_type, scenario_id, resource_id,
+               node_id, status, description, created_at, updated_at
+        FROM ghost_nodes g
+        {where_sql}
+        ORDER BY created_at DESC
+        """,
+        params,
+    ).fetchall()
+
+    results = []
+    for g in ghost_rows:
+        members = db.execute(
+            """
+            SELECT member_id, item_id, role,
+                   transition_start_date, transition_end_date,
+                   transition_curve, weight_at_start, weight_at_end
+            FROM ghost_members WHERE ghost_id = %s
+            """,
+            (g["ghost_id"],),
+        ).fetchall()
+
+        results.append({
+            "ghost_id": str(g["ghost_id"]),
+            "name": g["name"],
+            "ghost_type": g["ghost_type"],
+            "scenario_id": str(g["scenario_id"]) if g["scenario_id"] else None,
+            "resource_id": str(g["resource_id"]) if g["resource_id"] else None,
+            "node_id": str(g["node_id"]) if g["node_id"] else None,
+            "status": g["status"],
+            "description": g["description"],
+            "created_at": g["created_at"].isoformat() if g["created_at"] else None,
+            "updated_at": g["updated_at"].isoformat() if g["updated_at"] else None,
+            "members": [_serialize_member(m) for m in members],
+        })
+
+    return {"ghosts": results, "total": len(results)}
+
+
+# ─────────────────────────────────────────────────────────────
+# GET /v1/ghosts/{ghost_id}
+# ─────────────────────────────────────────────────────────────
+
+@router.get(
+    "/v1/ghosts/{ghost_id}",
+    summary="Get ghost detail",
+    description="Get a ghost's detail including members and graph node.",
+)
+async def get_ghost(
+    ghost_id: UUID,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> dict[str, Any]:
+    """Return a single ghost with its members and graph node."""
+    g = db.execute(
+        """
+        SELECT ghost_id, name, ghost_type, scenario_id, resource_id,
+               node_id, status, description, created_at, updated_at
+        FROM ghost_nodes WHERE ghost_id = %s
+        """,
+        (str(ghost_id),),
+    ).fetchone()
+
+    if g is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Ghost {ghost_id} not found",
+        )
+
+    members = db.execute(
+        """
+        SELECT member_id, item_id, role,
+               transition_start_date, transition_end_date,
+               transition_curve, weight_at_start, weight_at_end
+        FROM ghost_members WHERE ghost_id = %s
+        ORDER BY role
+        """,
+        (str(ghost_id),),
+    ).fetchall()
+
+    # Graph node detail
+    graph_node = None
+    if g["node_id"]:
+        node_row = db.execute(
+            "SELECT node_id, node_type, scenario_id, active FROM nodes WHERE node_id = %s",
+            (g["node_id"],),
+        ).fetchone()
+        if node_row:
+            edges = db.execute(
+                """
+                SELECT edge_id, to_node_id, edge_type, weight_ratio
+                FROM edges
+                WHERE from_node_id = %s AND edge_type = 'ghost_member' AND active = TRUE
+                """,
+                (g["node_id"],),
+            ).fetchall()
+            graph_node = {
+                "node_id": str(node_row["node_id"]),
+                "node_type": node_row["node_type"],
+                "active": node_row["active"],
+                "edges": [
+                    {
+                        "edge_id": str(e["edge_id"]),
+                        "to_node_id": str(e["to_node_id"]),
+                        "edge_type": e["edge_type"],
+                        "weight_ratio": float(e["weight_ratio"]) if e["weight_ratio"] is not None else None,
+                    }
+                    for e in edges
+                ],
+            }
+
+    return {
+        "ghost_id": str(g["ghost_id"]),
+        "name": g["name"],
+        "ghost_type": g["ghost_type"],
+        "scenario_id": str(g["scenario_id"]) if g["scenario_id"] else None,
+        "resource_id": str(g["resource_id"]) if g["resource_id"] else None,
+        "node_id": str(g["node_id"]) if g["node_id"] else None,
+        "status": g["status"],
+        "description": g["description"],
+        "created_at": g["created_at"].isoformat() if g["created_at"] else None,
+        "updated_at": g["updated_at"].isoformat() if g["updated_at"] else None,
+        "members": [_serialize_member(m) for m in members],
+        "graph_node": graph_node,
+    }
+
+
+# ─────────────────────────────────────────────────────────────
+# POST /v1/ghosts/{ghost_id}/run
+# ─────────────────────────────────────────────────────────────
+
+@router.post(
+    "/v1/ghosts/{ghost_id}/run",
+    summary="Run ghost logic",
+    description="Execute ghost engine over a time window. Returns alerts and summary.",
+)
+async def run_ghost_endpoint(
+    ghost_id: UUID,
+    body: GhostRunRequest,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> dict[str, Any]:
+    """
+    Execute ghost logic (phase_transition or capacity_aggregate) over [from_date, to_date].
+    Returns: { ghost_id, ghost_type, alerts: [...], summary: {...} }
+    """
+    try:
+        result = run_ghost(
+            db=db,
+            ghost_id=str(ghost_id),
+            scenario_id=str(body.scenario_id),
+            from_date=body.from_date,
+            to_date=body.to_date,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        )
+
+    return result
+
+
+# ─────────────────────────────────────────────────────────────
+# Helper
+# ─────────────────────────────────────────────────────────────
+
+def _serialize_member(m: Any) -> dict[str, Any]:
+    return {
+        "member_id": str(m["member_id"]),
+        "item_id": str(m["item_id"]),
+        "role": m["role"],
+        "transition_start_date": m["transition_start_date"].isoformat() if m["transition_start_date"] else None,
+        "transition_end_date": m["transition_end_date"].isoformat() if m["transition_end_date"] else None,
+        "transition_curve": m["transition_curve"],
+        "weight_at_start": float(m["weight_at_start"]),
+        "weight_at_end": float(m["weight_at_end"]),
+    }

--- a/src/ootils_core/db/migrations/011_ghosts.sql
+++ b/src/ootils_core/db/migrations/011_ghosts.sql
@@ -1,0 +1,138 @@
+-- ============================================================
+-- Ootils Core — Migration 011: Ghost nodes + Ghost members
+-- ADR-010: Ghosts V1 — phase_transition + capacity_aggregate
+-- ============================================================
+
+-- ============================================================
+-- 1. Table ghost_nodes
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS ghost_nodes (
+    ghost_id        UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    name            TEXT        NOT NULL,
+    ghost_type      TEXT        NOT NULL
+                    CHECK (ghost_type IN ('phase_transition', 'capacity_aggregate')),
+    scenario_id     UUID        REFERENCES scenarios(scenario_id),
+    resource_id     UUID        REFERENCES resources(resource_id),
+    node_id         UUID        REFERENCES nodes(node_id),
+    status          TEXT        NOT NULL DEFAULT 'active'
+                    CHECK (status IN ('active', 'archived', 'draft')),
+    description     TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ghost_nodes_scenario  ON ghost_nodes (scenario_id);
+CREATE INDEX IF NOT EXISTS idx_ghost_nodes_resource  ON ghost_nodes (resource_id);
+CREATE INDEX IF NOT EXISTS idx_ghost_nodes_type      ON ghost_nodes (ghost_type);
+CREATE INDEX IF NOT EXISTS idx_ghost_nodes_status    ON ghost_nodes (status);
+
+
+-- ============================================================
+-- 2. Table ghost_members
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS ghost_members (
+    member_id               UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    ghost_id                UUID        NOT NULL REFERENCES ghost_nodes(ghost_id) ON DELETE CASCADE,
+    item_id                 UUID        NOT NULL REFERENCES items(item_id),
+    role                    TEXT        NOT NULL
+                            CHECK (role IN ('incoming', 'outgoing', 'member')),
+    transition_start_date   DATE,
+    transition_end_date     DATE,
+    transition_curve        TEXT        NOT NULL DEFAULT 'linear'
+                            CHECK (transition_curve IN ('linear', 'step', 'sigmoid')),
+    weight_at_start         NUMERIC(5,4) NOT NULL DEFAULT 1.0
+                            CHECK (weight_at_start BETWEEN 0.0 AND 1.0),
+    weight_at_end           NUMERIC(5,4) NOT NULL DEFAULT 0.0
+                            CHECK (weight_at_end BETWEEN 0.0 AND 1.0),
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (ghost_id, item_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ghost_members_ghost   ON ghost_members (ghost_id);
+CREATE INDEX IF NOT EXISTS idx_ghost_members_item    ON ghost_members (item_id);
+CREATE INDEX IF NOT EXISTS idx_ghost_members_role    ON ghost_members (role);
+
+
+-- ============================================================
+-- 3. Ensure 'Ghost' in nodes.node_type CHECK constraint
+--    (added in migration 009 already — idempotent check)
+-- ============================================================
+
+DO $$
+DECLARE
+    v_constraint_def TEXT;
+BEGIN
+    SELECT pg_get_constraintdef(c.oid)
+    INTO v_constraint_def
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    WHERE c.contype = 'c'
+      AND c.conname LIKE '%node_type%'
+      AND t.relname = 'nodes'
+      AND t.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+    LIMIT 1;
+
+    IF v_constraint_def IS NOT NULL AND v_constraint_def NOT LIKE '%Ghost%' THEN
+        ALTER TABLE nodes DROP CONSTRAINT IF EXISTS nodes_node_type_check;
+        ALTER TABLE nodes ADD CONSTRAINT nodes_node_type_check CHECK (
+            node_type IN (
+                'Item', 'Location', 'PurchaseOrderSupply', 'OnHandSupply',
+                'ProjectedInventory', 'ForecastDemand', 'CustomerOrderDemand',
+                'WorkOrderSupply', 'TransferSupply', 'PlannedSupply',
+                'DependentDemand', 'TransferDemand', 'Shortage', 'Ghost', 'Resource'
+            )
+        );
+    ELSIF v_constraint_def IS NULL THEN
+        ALTER TABLE nodes ADD CONSTRAINT nodes_node_type_check CHECK (
+            node_type IN (
+                'Item', 'Location', 'PurchaseOrderSupply', 'OnHandSupply',
+                'ProjectedInventory', 'ForecastDemand', 'CustomerOrderDemand',
+                'WorkOrderSupply', 'TransferSupply', 'PlannedSupply',
+                'DependentDemand', 'TransferDemand', 'Shortage', 'Ghost', 'Resource'
+            )
+        );
+    END IF;
+END $$;
+
+
+-- ============================================================
+-- 4. Ensure 'ghost_member' in edges.edge_type CHECK constraint
+--    (added in migration 009 already — idempotent check)
+-- ============================================================
+
+DO $$
+DECLARE
+    v_constraint_def TEXT;
+BEGIN
+    SELECT pg_get_constraintdef(c.oid)
+    INTO v_constraint_def
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    WHERE c.contype = 'c'
+      AND c.conname LIKE '%edge_type%'
+      AND t.relname = 'edges'
+      AND t.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+    LIMIT 1;
+
+    IF v_constraint_def IS NOT NULL AND v_constraint_def NOT LIKE '%ghost_member%' THEN
+        ALTER TABLE edges DROP CONSTRAINT IF EXISTS edges_edge_type_check;
+        ALTER TABLE edges ADD CONSTRAINT edges_edge_type_check CHECK (
+            edge_type IN (
+                'replenishes', 'transfers', 'requires', 'substitutes',
+                'fulfills', 'consumes', 'produces', 'ghost_member',
+                'bom_component', 'consumes_resource'
+            )
+        );
+    ELSIF v_constraint_def IS NULL THEN
+        ALTER TABLE edges ADD CONSTRAINT edges_edge_type_check CHECK (
+            edge_type IN (
+                'replenishes', 'transfers', 'requires', 'substitutes',
+                'fulfills', 'consumes', 'produces', 'ghost_member',
+                'bom_component', 'consumes_resource'
+            )
+        );
+    END IF;
+END $$;

--- a/src/ootils_core/engine/ghost/__init__.py
+++ b/src/ootils_core/engine/ghost/__init__.py
@@ -1,0 +1,1 @@
+# Ghost engine package — phase_transition + capacity_aggregate

--- a/src/ootils_core/engine/ghost/capacity_aggregate.py
+++ b/src/ootils_core/engine/ghost/capacity_aggregate.py
@@ -1,0 +1,146 @@
+"""
+capacity_aggregate.py — Ghost capacity_aggregate engine.
+
+Aggregates supply load (WorkOrderSupply + PlannedSupply) from all member items,
+compares against the linked resource's capacity_per_day.
+
+Alert emitted: capacity_overload
+  when aggregated load > resource capacity for a given day.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any
+
+import psycopg
+
+
+def run_capacity_aggregate(
+    db: psycopg.Connection,
+    ghost_id: str,
+    scenario_id: str,
+    from_date: date,
+    to_date: date,
+) -> dict[str, Any]:
+    """
+    Evaluate a capacity_aggregate ghost over [from_date, to_date].
+
+    Returns:
+      {
+        "ghost_id": ...,
+        "ghost_type": "capacity_aggregate",
+        "alerts": [{"type": "capacity_overload", "date": ..., "load": ..., "capacity": ..., "slack": ...}],
+        "summary": {
+          "from_date": ..., "to_date": ...,
+          "resource_id": ...,
+          "capacity_per_day": ...,
+          "periods": [{"date": ..., "load_total": ..., "capacity": ..., "slack": ..., "overloaded": bool, "member_breakdown": [...]}]
+        }
+      }
+    """
+    # Load ghost
+    ghost = db.execute(
+        "SELECT ghost_id, ghost_type, resource_id FROM ghost_nodes WHERE ghost_id = %s",
+        (ghost_id,),
+    ).fetchone()
+    if ghost is None:
+        raise ValueError(f"Ghost {ghost_id} not found")
+    if ghost["ghost_type"] != "capacity_aggregate":
+        raise ValueError(f"Ghost {ghost_id} is not a capacity_aggregate ghost")
+
+    # Load resource capacity
+    resource_id = ghost["resource_id"]
+    capacity_per_day = _get_resource_capacity(db, str(resource_id)) if resource_id else 0.0
+
+    # Load members
+    members = db.execute(
+        "SELECT item_id FROM ghost_members WHERE ghost_id = %s AND role = 'member'",
+        (ghost_id,),
+    ).fetchall()
+
+    if not members:
+        raise ValueError(f"Ghost {ghost_id} has no members")
+
+    item_ids = [str(m["item_id"]) for m in members]
+
+    alerts = []
+    periods = []
+
+    # Day-by-day load aggregation
+    current = from_date
+    while current <= to_date:
+        member_loads = []
+        for item_id in item_ids:
+            load = _get_supply_load(db, item_id, scenario_id, current)
+            member_loads.append({"item_id": item_id, "load": load})
+
+        load_total = sum(ml["load"] for ml in member_loads)
+        slack = capacity_per_day - load_total
+        overloaded = slack < 0
+
+        period = {
+            "date": current.isoformat(),
+            "load_total": round(load_total, 4),
+            "capacity": capacity_per_day,
+            "slack": round(slack, 4),
+            "overloaded": overloaded,
+            "member_breakdown": member_loads,
+        }
+        periods.append(period)
+
+        if overloaded:
+            alerts.append({
+                "type": "capacity_overload",
+                "date": current.isoformat(),
+                "load": round(load_total, 4),
+                "capacity": capacity_per_day,
+                "slack": round(slack, 4),
+            })
+
+        current += timedelta(days=1)
+
+    return {
+        "ghost_id": ghost_id,
+        "ghost_type": "capacity_aggregate",
+        "alerts": alerts,
+        "summary": {
+            "from_date": from_date.isoformat(),
+            "to_date": to_date.isoformat(),
+            "resource_id": str(resource_id) if resource_id else None,
+            "capacity_per_day": capacity_per_day,
+            "periods": periods,
+        },
+    }
+
+
+def _get_resource_capacity(db: psycopg.Connection, resource_id: str) -> float:
+    """Return capacity_per_day for a resource."""
+    row = db.execute(
+        "SELECT capacity_per_day FROM resources WHERE resource_id = %s",
+        (resource_id,),
+    ).fetchone()
+    return float(row["capacity_per_day"]) if row else 0.0
+
+
+def _get_supply_load(
+    db: psycopg.Connection,
+    item_id: str,
+    scenario_id: str,
+    ref_date: date,
+) -> float:
+    """
+    Sum quantity of WorkOrderSupply + PlannedSupply nodes for an item/scenario on a specific date.
+    """
+    row = db.execute(
+        """
+        SELECT COALESCE(SUM(quantity), 0) AS load_qty
+        FROM nodes
+        WHERE node_type IN ('WorkOrderSupply', 'PlannedSupply')
+          AND item_id = %s
+          AND scenario_id = %s
+          AND active = TRUE
+          AND time_ref = %s
+        """,
+        (item_id, scenario_id, ref_date),
+    ).fetchone()
+    return float(row["load_qty"]) if row else 0.0

--- a/src/ootils_core/engine/ghost/ghost_engine.py
+++ b/src/ootils_core/engine/ghost/ghost_engine.py
@@ -1,0 +1,46 @@
+"""
+ghost_engine.py — Ghost dispatcher.
+
+run_ghost(db, ghost_id, scenario_id, from_date, to_date)
+  → dispatches to phase_transition or capacity_aggregate engine based on ghost_type.
+"""
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import psycopg
+
+from .phase_transition import run_phase_transition
+from .capacity_aggregate import run_capacity_aggregate
+
+
+def run_ghost(
+    db: psycopg.Connection,
+    ghost_id: str,
+    scenario_id: str,
+    from_date: date,
+    to_date: date,
+) -> dict[str, Any]:
+    """
+    Dispatcher: load ghost_type and delegate to the appropriate engine.
+
+    Raises:
+      ValueError if ghost not found or ghost_type unknown.
+    """
+    row = db.execute(
+        "SELECT ghost_type FROM ghost_nodes WHERE ghost_id = %s",
+        (ghost_id,),
+    ).fetchone()
+
+    if row is None:
+        raise ValueError(f"Ghost {ghost_id} not found")
+
+    ghost_type = row["ghost_type"]
+
+    if ghost_type == "phase_transition":
+        return run_phase_transition(db, ghost_id, scenario_id, from_date, to_date)
+    elif ghost_type == "capacity_aggregate":
+        return run_capacity_aggregate(db, ghost_id, scenario_id, from_date, to_date)
+    else:
+        raise ValueError(f"Unknown ghost_type: {ghost_type}")

--- a/src/ootils_core/engine/ghost/phase_transition.py
+++ b/src/ootils_core/engine/ghost/phase_transition.py
@@ -1,0 +1,221 @@
+"""
+phase_transition.py — Ghost phase_transition engine.
+
+Computes weight_A(t) / weight_B(t) dynamically based on the transition curve
+and checks supply coherence between outgoing and incoming members.
+
+Supported curves:
+  linear  — linear interpolation between weight_at_start and weight_at_end
+  step    — stays at weight_at_start until transition_end_date, then weight_at_end
+  sigmoid — Hermite smoothstep (3t² - 2t³)
+
+Alert emitted: transition_inconsistency
+  when |ProjectedInventory(A) + ProjectedInventory(B) - baseline| > 10% of baseline
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any
+
+import psycopg
+
+
+# ---------------------------------------------------------------------------
+# Weight calculation (O(1) per date — ADR-010 D3)
+# ---------------------------------------------------------------------------
+
+def compute_weight(
+    t: date,
+    transition_start_date: date | None,
+    transition_end_date: date | None,
+    transition_curve: str,
+    weight_at_start: float,
+    weight_at_end: float,
+) -> float:
+    """
+    Return weight for a member at date t given transition parameters.
+
+    Outside the transition window:
+      t <= start → weight_at_start
+      t >= end   → weight_at_end
+    """
+    if transition_start_date is None or transition_end_date is None:
+        return weight_at_start
+
+    if t <= transition_start_date:
+        return weight_at_start
+    if t >= transition_end_date:
+        return weight_at_end
+
+    # Inside the transition window
+    total_days = (transition_end_date - transition_start_date).days
+    if total_days <= 0:
+        return weight_at_end
+
+    ratio = (t - transition_start_date).days / total_days  # [0, 1)
+
+    if transition_curve == "linear":
+        return weight_at_start + ratio * (weight_at_end - weight_at_start)
+    elif transition_curve == "step":
+        # Stay at weight_at_start until end_date, then flip
+        return weight_at_start
+    elif transition_curve == "sigmoid":
+        # Hermite smoothstep: 3r² - 2r³
+        smooth = 3 * ratio**2 - 2 * ratio**3
+        return weight_at_start + smooth * (weight_at_end - weight_at_start)
+    else:
+        # fallback: linear
+        return weight_at_start + ratio * (weight_at_end - weight_at_start)
+
+
+# ---------------------------------------------------------------------------
+# Phase transition engine
+# ---------------------------------------------------------------------------
+
+INCONSISTENCY_THRESHOLD = 0.10  # 10% deviation triggers alert
+
+
+def run_phase_transition(
+    db: psycopg.Connection,
+    ghost_id: str,
+    scenario_id: str,
+    from_date: date,
+    to_date: date,
+) -> dict[str, Any]:
+    """
+    Evaluate a phase_transition ghost over [from_date, to_date].
+
+    Returns:
+      {
+        "ghost_id": ...,
+        "ghost_type": "phase_transition",
+        "alerts": [{"type": "transition_inconsistency", "date": ..., "delta": ..., "delta_pct": ...}],
+        "summary": {
+          "from_date": ..., "to_date": ...,
+          "outgoing_item_id": ..., "incoming_item_id": ...,
+          "transition_curve": ...,
+          "weight_samples": [{"date": ..., "weight_outgoing": ..., "weight_incoming": ...}]
+        }
+      }
+    """
+    # Load ghost
+    ghost = db.execute(
+        "SELECT ghost_id, ghost_type, scenario_id FROM ghost_nodes WHERE ghost_id = %s",
+        (ghost_id,),
+    ).fetchone()
+    if ghost is None:
+        raise ValueError(f"Ghost {ghost_id} not found")
+    if ghost["ghost_type"] != "phase_transition":
+        raise ValueError(f"Ghost {ghost_id} is not a phase_transition ghost")
+
+    # Load members
+    members = db.execute(
+        """
+        SELECT member_id, item_id, role,
+               transition_start_date, transition_end_date,
+               transition_curve, weight_at_start, weight_at_end
+        FROM ghost_members
+        WHERE ghost_id = %s
+        ORDER BY role
+        """,
+        (ghost_id,),
+    ).fetchall()
+
+    outgoing = next((m for m in members if m["role"] == "outgoing"), None)
+    incoming = next((m for m in members if m["role"] == "incoming"), None)
+
+    if outgoing is None or incoming is None:
+        raise ValueError(f"Ghost {ghost_id} missing outgoing or incoming member")
+
+    alerts = []
+    weight_samples = []
+
+    # Iterate day by day
+    current = from_date
+    while current <= to_date:
+        w_out = compute_weight(
+            current,
+            outgoing["transition_start_date"],
+            outgoing["transition_end_date"],
+            outgoing["transition_curve"],
+            float(outgoing["weight_at_start"]),
+            float(outgoing["weight_at_end"]),
+        )
+        w_in = 1.0 - w_out
+
+        weight_samples.append({
+            "date": current.isoformat(),
+            "weight_outgoing": round(w_out, 4),
+            "weight_incoming": round(w_in, 4),
+        })
+
+        # Check projected inventory coherence
+        proj_a = _get_projected_inventory(db, str(outgoing["item_id"]), scenario_id, current)
+        proj_b = _get_projected_inventory(db, str(incoming["item_id"]), scenario_id, current)
+
+        if proj_a is not None and proj_b is not None:
+            observed = proj_a + proj_b
+            # Baseline: proj_a / w_out gives the "full" volume A would have had alone
+            if w_out > 0:
+                baseline = proj_a / w_out
+            elif proj_b > 0:
+                baseline = proj_b
+            else:
+                baseline = 0.0
+
+            if baseline > 0:
+                delta = observed - baseline
+                delta_pct = abs(delta) / baseline
+                if delta_pct > INCONSISTENCY_THRESHOLD:
+                    alerts.append({
+                        "type": "transition_inconsistency",
+                        "date": current.isoformat(),
+                        "projected_a": proj_a,
+                        "projected_b": proj_b,
+                        "observed": observed,
+                        "baseline": round(baseline, 4),
+                        "delta": round(delta, 4),
+                        "delta_pct": round(delta_pct, 4),
+                    })
+
+        current += timedelta(days=1)
+
+    return {
+        "ghost_id": ghost_id,
+        "ghost_type": "phase_transition",
+        "alerts": alerts,
+        "summary": {
+            "from_date": from_date.isoformat(),
+            "to_date": to_date.isoformat(),
+            "outgoing_item_id": str(outgoing["item_id"]),
+            "incoming_item_id": str(incoming["item_id"]),
+            "transition_curve": outgoing["transition_curve"],
+            "weight_samples": weight_samples,
+        },
+    }
+
+
+def _get_projected_inventory(
+    db: psycopg.Connection,
+    item_id: str,
+    scenario_id: str,
+    ref_date: date,
+) -> float | None:
+    """
+    Get the most recent ProjectedInventory node quantity for an item/scenario on or before ref_date.
+    Returns None if no projection found.
+    """
+    row = db.execute(
+        """
+        SELECT quantity FROM nodes
+        WHERE node_type = 'ProjectedInventory'
+          AND item_id = %s
+          AND scenario_id = %s
+          AND active = TRUE
+          AND time_ref <= %s
+        ORDER BY time_ref DESC
+        LIMIT 1
+        """,
+        (item_id, scenario_id, ref_date),
+    ).fetchone()
+    return float(row["quantity"]) if row else None

--- a/tests/integration/test_ghosts.py
+++ b/tests/integration/test_ghosts.py
@@ -1,0 +1,606 @@
+"""
+tests/integration/test_ghosts.py — Ghosts V1 integration tests (ADR-010).
+
+Covers:
+  1.  Migration OK — ghost_nodes table exists
+  2.  Migration OK — ghost_members table exists
+  3.  ghost_nodes columns correct
+  4.  ghost_members columns correct
+  5.  Ingest ghost phase_transition (valid)
+  6.  Ingest ghost phase_transition (membership constraint violation → 422)
+  7.  Ingest ghost phase_transition (only 1 member → violation)
+  8.  Ingest ghost capacity_aggregate (valid)
+  9.  GET /v1/ghosts (list)
+  10. GET /v1/ghosts/{ghost_id} (detail)
+  11. GET /v1/ghosts/{ghost_id} (404)
+  12. Calcul weight linear — correct interpolation
+  13. Calcul weight linear inverse (0→1)
+  14. Calcul weight step — stays at start until end
+  15. Calcul weight step after end
+  16. Calcul weight — no dates → weight_at_start
+  17. POST /v1/ghosts/{ghost_id}/run phase_transition
+  18. POST /v1/ghosts/{ghost_id}/run capacity_aggregate
+  19. Alerte transition_inconsistency générée
+  20. Alerte capacity_overload générée
+  21. Ghost node créé dans la table nodes
+"""
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+from uuid import uuid4
+
+import pytest
+
+from .conftest import requires_db, DB_AVAILABLE, TEST_DB_URL
+
+# FastAPI test client
+try:
+    from fastapi.testclient import TestClient
+    from ootils_core.api.app import app
+
+    client = TestClient(app, raise_server_exceptions=False)
+    AUTH_HEADERS = {"Authorization": "Bearer dev-token"}
+    APP_AVAILABLE = True
+except Exception:
+    APP_AVAILABLE = False
+
+requires_app = pytest.mark.skipif(not APP_AVAILABLE, reason="App not importable")
+
+# ─────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────
+
+def _tables(conn) -> set[str]:
+    rows = conn.execute(
+        "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+    ).fetchall()
+    return {r["tablename"] for r in rows}
+
+
+def _columns(conn, table: str) -> set[str]:
+    rows = conn.execute(
+        """
+        SELECT column_name FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = %s
+        """,
+        (table,),
+    ).fetchall()
+    return {r["column_name"] for r in rows}
+
+
+def _create_item(conn, external_id: str = None) -> str:
+    item_id = str(uuid4())
+    ext_id = external_id or f"ITEM-{item_id[:8]}"
+    conn.execute(
+        """
+        INSERT INTO items (item_id, external_id, name, item_type, uom, status)
+        VALUES (%s, %s, %s, 'finished_good', 'EA', 'active')
+        ON CONFLICT (external_id) DO NOTHING
+        """,
+        (item_id, ext_id, f"Test Item {ext_id}"),
+    )
+    row = conn.execute("SELECT item_id FROM items WHERE external_id = %s", (ext_id,)).fetchone()
+    conn.commit()
+    return str(row["item_id"])
+
+
+def _create_resource(conn, capacity: float = 100.0) -> str:
+    resource_id = str(uuid4())
+    ext_id = f"RES-{resource_id[:8]}"
+    conn.execute(
+        """
+        INSERT INTO resources (resource_id, external_id, name, resource_type, capacity_per_day)
+        VALUES (%s, %s, %s, 'line', %s)
+        """,
+        (resource_id, ext_id, f"Resource {ext_id}", capacity),
+    )
+    conn.commit()
+    return resource_id
+
+
+# ─────────────────────────────────────────────────────────────
+# Tests 1-4 — Migration
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_migration_ghost_nodes_table_exists(migrated_db, conn):
+    """Migration creates ghost_nodes table."""
+    assert "ghost_nodes" in _tables(conn)
+
+
+@requires_db
+def test_migration_ghost_members_table_exists(migrated_db, conn):
+    """Migration creates ghost_members table."""
+    assert "ghost_members" in _tables(conn)
+
+
+@requires_db
+def test_migration_ghost_nodes_columns(migrated_db, conn):
+    """ghost_nodes has all required columns."""
+    cols = _columns(conn, "ghost_nodes")
+    for col in ("ghost_id", "name", "ghost_type", "scenario_id", "resource_id",
+                "node_id", "status", "description", "created_at", "updated_at"):
+        assert col in cols, f"Column {col!r} missing from ghost_nodes"
+
+
+@requires_db
+def test_migration_ghost_members_columns(migrated_db, conn):
+    """ghost_members has all required columns."""
+    cols = _columns(conn, "ghost_members")
+    for col in ("member_id", "ghost_id", "item_id", "role",
+                "transition_start_date", "transition_end_date",
+                "transition_curve", "weight_at_start", "weight_at_end"):
+        assert col in cols, f"Column {col!r} missing from ghost_members"
+
+
+# ─────────────────────────────────────────────────────────────
+# Tests 5-8 — Ingest
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+@requires_app
+def test_ingest_ghost_phase_transition_valid(migrated_db, conn):
+    """POST /v1/ingest/ghosts — valid phase_transition with 1 outgoing + 1 incoming."""
+    item_a = _create_item(conn, "PT-VALID-A")
+    item_b = _create_item(conn, "PT-VALID-B")
+
+    resp = client.post(
+        "/v1/ingest/ghosts",
+        json={
+            "name": "Valid PT Ghost",
+            "ghost_type": "phase_transition",
+            "members": [
+                {
+                    "item_id": item_a, "role": "outgoing",
+                    "transition_start_date": "2026-05-01",
+                    "transition_end_date": "2026-08-31",
+                    "transition_curve": "linear",
+                    "weight_at_start": 1.0, "weight_at_end": 0.0,
+                },
+                {
+                    "item_id": item_b, "role": "incoming",
+                    "transition_start_date": "2026-05-01",
+                    "transition_end_date": "2026-08-31",
+                    "transition_curve": "linear",
+                    "weight_at_start": 0.0, "weight_at_end": 1.0,
+                },
+            ],
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert "ghost_id" in data
+    assert data["action"] == "inserted"
+    assert data["member_count"] == 2
+
+
+@requires_db
+@requires_app
+def test_ingest_ghost_phase_transition_violation_two_incoming(migrated_db, conn):
+    """POST /v1/ingest/ghosts — 2 incoming (no outgoing) → 422."""
+    item_a = _create_item(conn, "PT-VIO1-A")
+    item_b = _create_item(conn, "PT-VIO1-B")
+
+    resp = client.post(
+        "/v1/ingest/ghosts",
+        json={
+            "name": "Bad PT Ghost 2inc",
+            "ghost_type": "phase_transition",
+            "members": [
+                {"item_id": item_a, "role": "incoming"},
+                {"item_id": item_b, "role": "incoming"},
+            ],
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@requires_db
+@requires_app
+def test_ingest_ghost_phase_transition_violation_one_member(migrated_db, conn):
+    """POST /v1/ingest/ghosts — phase_transition with 1 outgoing only → 422."""
+    item_a = _create_item(conn, "PT-VIO2-A")
+
+    resp = client.post(
+        "/v1/ingest/ghosts",
+        json={
+            "name": "Bad PT Ghost 1out",
+            "ghost_type": "phase_transition",
+            "members": [{"item_id": item_a, "role": "outgoing"}],
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@requires_db
+@requires_app
+def test_ingest_ghost_capacity_aggregate(migrated_db, conn):
+    """POST /v1/ingest/ghosts — valid capacity_aggregate with 2 members."""
+    item_a = _create_item(conn, "CA-VALID-A")
+    item_b = _create_item(conn, "CA-VALID-B")
+    resource_id = _create_resource(conn)
+
+    resp = client.post(
+        "/v1/ingest/ghosts",
+        json={
+            "name": "Valid CA Ghost",
+            "ghost_type": "capacity_aggregate",
+            "resource_id": resource_id,
+            "members": [
+                {"item_id": item_a, "role": "member"},
+                {"item_id": item_b, "role": "member"},
+            ],
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["member_count"] == 2
+    assert data["action"] == "inserted"
+
+
+# ─────────────────────────────────────────────────────────────
+# Tests 9-11 — GET endpoints
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+@requires_app
+def test_list_ghosts(migrated_db, conn):
+    """GET /v1/ghosts returns list."""
+    resp = client.get("/v1/ghosts", headers=AUTH_HEADERS)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert "ghosts" in data
+    assert isinstance(data["ghosts"], list)
+    assert "total" in data
+
+
+@requires_db
+@requires_app
+def test_get_ghost_detail(migrated_db, conn):
+    """GET /v1/ghosts/{ghost_id} returns detail with members and graph_node."""
+    item_a = _create_item(conn, "DET-A")
+    item_b = _create_item(conn, "DET-B")
+
+    create = client.post(
+        "/v1/ingest/ghosts",
+        json={
+            "name": "Detail Test Ghost",
+            "ghost_type": "phase_transition",
+            "members": [
+                {"item_id": item_a, "role": "outgoing", "weight_at_start": 1.0, "weight_at_end": 0.0},
+                {"item_id": item_b, "role": "incoming", "weight_at_start": 0.0, "weight_at_end": 1.0},
+            ],
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert create.status_code == 201
+    ghost_id = create.json()["ghost_id"]
+
+    resp = client.get(f"/v1/ghosts/{ghost_id}", headers=AUTH_HEADERS)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["ghost_id"] == ghost_id
+    assert data["ghost_type"] == "phase_transition"
+    assert len(data["members"]) == 2
+    assert "graph_node" in data
+    assert data["graph_node"]["node_type"] == "Ghost"
+
+
+@requires_db
+@requires_app
+def test_get_ghost_not_found(migrated_db):
+    """GET /v1/ghosts/{ghost_id} → 404 for unknown id."""
+    resp = client.get(f"/v1/ghosts/{uuid4()}", headers=AUTH_HEADERS)
+    assert resp.status_code == 404
+
+
+# ─────────────────────────────────────────────────────────────
+# Tests 12-16 — Weight calculation (pure unit tests, no DB)
+# ─────────────────────────────────────────────────────────────
+
+def test_weight_linear_at_midpoint():
+    """Linear weight ≈ 0.5 at midpoint of transition window."""
+    from ootils_core.engine.ghost.phase_transition import compute_weight
+
+    start = date(2026, 6, 1)
+    end = date(2026, 6, 21)  # 20 days
+    mid = date(2026, 6, 11)  # 10 days in = 50%
+
+    w = compute_weight(mid, start, end, "linear", 1.0, 0.0)
+    assert abs(w - 0.5) < 0.01, f"Expected ~0.5 at midpoint, got {w}"
+
+
+def test_weight_linear_inverse():
+    """Linear inverse: 0.0 → 1.0 transition."""
+    from ootils_core.engine.ghost.phase_transition import compute_weight
+
+    start = date(2026, 6, 1)
+    end = date(2026, 9, 1)
+
+    assert compute_weight(date(2026, 4, 1), start, end, "linear", 0.0, 1.0) == 0.0
+    assert compute_weight(date(2026, 10, 1), start, end, "linear", 0.0, 1.0) == 1.0
+    mid_days = (end - start).days // 2
+    w = compute_weight(start + timedelta(days=mid_days), start, end, "linear", 0.0, 1.0)
+    assert 0.4 < w < 0.6
+
+
+def test_weight_step_during_transition():
+    """Step curve stays at weight_at_start during transition."""
+    from ootils_core.engine.ghost.phase_transition import compute_weight
+
+    start = date(2026, 5, 1)
+    end = date(2026, 9, 1)
+
+    w = compute_weight(date(2026, 6, 15), start, end, "step", 1.0, 0.0)
+    assert w == 1.0, f"Expected 1.0 during step, got {w}"
+
+
+def test_weight_step_after_end():
+    """Step curve flips to weight_at_end after transition_end_date."""
+    from ootils_core.engine.ghost.phase_transition import compute_weight
+
+    start = date(2026, 5, 1)
+    end = date(2026, 9, 1)
+
+    w = compute_weight(date(2026, 10, 1), start, end, "step", 1.0, 0.0)
+    assert w == 0.0, f"Expected 0.0 after step end, got {w}"
+
+
+def test_weight_no_dates():
+    """No transition dates → always weight_at_start."""
+    from ootils_core.engine.ghost.phase_transition import compute_weight
+
+    w = compute_weight(date(2026, 6, 1), None, None, "linear", 0.75, 0.25)
+    assert w == 0.75
+
+
+# ─────────────────────────────────────────────────────────────
+# Tests 17-18 — /run endpoints
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+@requires_app
+def test_run_ghost_phase_transition(migrated_db, conn):
+    """POST /v1/ghosts/{ghost_id}/run — phase_transition returns 7 weight samples."""
+    item_a = _create_item(conn, "RUN-PT-A")
+    item_b = _create_item(conn, "RUN-PT-B")
+
+    create = client.post(
+        "/v1/ingest/ghosts",
+        json={
+            "name": "Run PT",
+            "ghost_type": "phase_transition",
+            "members": [
+                {
+                    "item_id": item_a, "role": "outgoing",
+                    "transition_start_date": "2026-06-01",
+                    "transition_end_date": "2026-06-30",
+                    "weight_at_start": 1.0, "weight_at_end": 0.0,
+                },
+                {
+                    "item_id": item_b, "role": "incoming",
+                    "transition_start_date": "2026-06-01",
+                    "transition_end_date": "2026-06-30",
+                    "weight_at_start": 0.0, "weight_at_end": 1.0,
+                },
+            ],
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert create.status_code == 201
+    ghost_id = create.json()["ghost_id"]
+
+    run = client.post(
+        f"/v1/ghosts/{ghost_id}/run",
+        json={
+            "scenario_id": "00000000-0000-0000-0000-000000000001",
+            "from_date": "2026-06-01",
+            "to_date": "2026-06-07",
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert run.status_code == 200, run.text
+    data = run.json()
+    assert data["ghost_type"] == "phase_transition"
+    assert isinstance(data["alerts"], list)
+    assert len(data["summary"]["weight_samples"]) == 7
+
+
+@requires_db
+@requires_app
+def test_run_ghost_capacity_aggregate(migrated_db, conn):
+    """POST /v1/ghosts/{ghost_id}/run — capacity_aggregate returns 3 periods."""
+    item_a = _create_item(conn, "RUN-CA-A")
+    item_b = _create_item(conn, "RUN-CA-B")
+    resource_id = _create_resource(conn)
+
+    create = client.post(
+        "/v1/ingest/ghosts",
+        json={
+            "name": "Run CA",
+            "ghost_type": "capacity_aggregate",
+            "resource_id": resource_id,
+            "members": [
+                {"item_id": item_a, "role": "member"},
+                {"item_id": item_b, "role": "member"},
+            ],
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert create.status_code == 201
+    ghost_id = create.json()["ghost_id"]
+
+    run = client.post(
+        f"/v1/ghosts/{ghost_id}/run",
+        json={
+            "scenario_id": "00000000-0000-0000-0000-000000000001",
+            "from_date": "2026-06-01",
+            "to_date": "2026-06-03",
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert run.status_code == 200, run.text
+    data = run.json()
+    assert data["ghost_type"] == "capacity_aggregate"
+    assert len(data["summary"]["periods"]) == 3
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 19 — transition_inconsistency alert
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_transition_inconsistency_alert(migrated_db, conn):
+    """Engine generates transition_inconsistency when sum deviates > 10% from baseline."""
+    from ootils_core.engine.ghost.phase_transition import run_phase_transition
+
+    import psycopg
+    from psycopg.rows import dict_row
+
+    item_a = _create_item(conn, "INC-A")
+    item_b = _create_item(conn, "INC-B")
+    ghost_id = str(uuid4())
+    scenario_id = "00000000-0000-0000-0000-000000000001"
+
+    conn.execute(
+        """INSERT INTO ghost_nodes (ghost_id, name, ghost_type, status)
+           VALUES (%s, 'Inc Ghost', 'phase_transition', 'active')""",
+        (ghost_id,),
+    )
+    conn.execute(
+        """INSERT INTO ghost_members
+               (ghost_id, item_id, role, transition_start_date, transition_end_date,
+                transition_curve, weight_at_start, weight_at_end)
+           VALUES (%s, %s, 'outgoing', '2026-06-01', '2026-06-30', 'linear', 1.0, 0.0)""",
+        (ghost_id, item_a),
+    )
+    conn.execute(
+        """INSERT INTO ghost_members
+               (ghost_id, item_id, role, transition_start_date, transition_end_date,
+                transition_curve, weight_at_start, weight_at_end)
+           VALUES (%s, %s, 'incoming', '2026-06-01', '2026-06-30', 'linear', 0.0, 1.0)""",
+        (ghost_id, item_b),
+    )
+    # At 2026-06-15: ratio ≈ 0.467, weight_A ≈ 0.533
+    # proj_a = 500 → baseline = 500 / 0.533 ≈ 938
+    # proj_b = 700 → observed = 1200, delta_pct ≈ 28% > 10%
+    conn.execute(
+        """INSERT INTO nodes (node_id, node_type, scenario_id, item_id, quantity, time_grain, time_ref, active)
+           VALUES (%s, 'ProjectedInventory', %s, %s, 500, 'day', '2026-06-15', TRUE)""",
+        (str(uuid4()), scenario_id, item_a),
+    )
+    conn.execute(
+        """INSERT INTO nodes (node_id, node_type, scenario_id, item_id, quantity, time_grain, time_ref, active)
+           VALUES (%s, 'ProjectedInventory', %s, %s, 700, 'day', '2026-06-15', TRUE)""",
+        (str(uuid4()), scenario_id, item_b),
+    )
+    conn.commit()
+
+    with psycopg.connect(TEST_DB_URL, row_factory=dict_row) as c:
+        result = run_phase_transition(
+            c, ghost_id, scenario_id,
+            date(2026, 6, 15), date(2026, 6, 15),
+        )
+
+    assert len(result["alerts"]) > 0, "Expected transition_inconsistency alert"
+    assert result["alerts"][0]["type"] == "transition_inconsistency"
+    assert result["alerts"][0]["delta_pct"] > 0.10
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 20 — capacity_overload alert
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_capacity_overload_alert(migrated_db, conn):
+    """Engine generates capacity_overload when load 80+60=140 > capacity 100."""
+    from ootils_core.engine.ghost.capacity_aggregate import run_capacity_aggregate
+
+    import psycopg
+    from psycopg.rows import dict_row
+
+    item_a = _create_item(conn, "OVL-A")
+    item_b = _create_item(conn, "OVL-B")
+    resource_id = _create_resource(conn, capacity=100.0)
+    ghost_id = str(uuid4())
+    scenario_id = "00000000-0000-0000-0000-000000000001"
+
+    conn.execute(
+        """INSERT INTO ghost_nodes (ghost_id, name, ghost_type, resource_id, status)
+           VALUES (%s, 'Overload Ghost', 'capacity_aggregate', %s, 'active')""",
+        (ghost_id, resource_id),
+    )
+    conn.execute(
+        "INSERT INTO ghost_members (ghost_id, item_id, role) VALUES (%s, %s, 'member')",
+        (ghost_id, item_a),
+    )
+    conn.execute(
+        "INSERT INTO ghost_members (ghost_id, item_id, role) VALUES (%s, %s, 'member')",
+        (ghost_id, item_b),
+    )
+    conn.execute(
+        """INSERT INTO nodes (node_id, node_type, scenario_id, item_id, quantity, time_grain, time_ref, active)
+           VALUES (%s, 'WorkOrderSupply', %s, %s, 80, 'day', '2026-06-10', TRUE)""",
+        (str(uuid4()), scenario_id, item_a),
+    )
+    conn.execute(
+        """INSERT INTO nodes (node_id, node_type, scenario_id, item_id, quantity, time_grain, time_ref, active)
+           VALUES (%s, 'WorkOrderSupply', %s, %s, 60, 'day', '2026-06-10', TRUE)""",
+        (str(uuid4()), scenario_id, item_b),
+    )
+    conn.commit()
+
+    with psycopg.connect(TEST_DB_URL, row_factory=dict_row) as c:
+        result = run_capacity_aggregate(
+            c, ghost_id, scenario_id,
+            date(2026, 6, 10), date(2026, 6, 10),
+        )
+
+    assert len(result["alerts"]) > 0, "Expected capacity_overload alert"
+    assert result["alerts"][0]["type"] == "capacity_overload"
+    assert result["alerts"][0]["load"] == 140.0
+    assert result["alerts"][0]["slack"] == -40.0
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 21 — Ghost node in nodes table
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+@requires_app
+def test_ghost_node_in_nodes_table(migrated_db, conn):
+    """Ingest creates a node with node_type='Ghost' in the nodes table."""
+    item_a = _create_item(conn, "NODECHK-A")
+    item_b = _create_item(conn, "NODECHK-B")
+
+    create = client.post(
+        "/v1/ingest/ghosts",
+        json={
+            "name": "Node Check Ghost",
+            "ghost_type": "phase_transition",
+            "members": [
+                {"item_id": item_a, "role": "outgoing", "weight_at_start": 1.0, "weight_at_end": 0.0},
+                {"item_id": item_b, "role": "incoming", "weight_at_start": 0.0, "weight_at_end": 1.0},
+            ],
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert create.status_code == 201, create.text
+    node_id = create.json().get("node_id")
+    assert node_id is not None
+
+    import psycopg
+    from psycopg.rows import dict_row
+
+    with psycopg.connect(TEST_DB_URL, row_factory=dict_row) as c:
+        row = c.execute(
+            "SELECT node_type FROM nodes WHERE node_id = %s", (node_id,)
+        ).fetchone()
+
+    assert row is not None, f"Node {node_id} not found in nodes table"
+    assert row["node_type"] == "Ghost"


### PR DESCRIPTION
Closes #96

## Changements

### Migration 011
- Crée `ghost_nodes` et `ghost_members` avec toutes les contraintes
- Idempotent : vérifie que 'Ghost' et 'ghost_member' sont dans les CHECK constraints existants

### Engine `src/ootils_core/engine/ghost/`
- **`phase_transition.py`** : calcul poids A/B à chaque date (linear, step, sigmoid), alerte `transition_inconsistency` si déviation > 10%
- **`capacity_aggregate.py`** : agrégation charge WorkOrderSupply/PlannedSupply vs `capacity_per_day`, alerte `capacity_overload`
- **`ghost_engine.py`** : dispatcher `run_ghost()`

### API `src/ootils_core/api/routers/ghosts.py`
- `POST /v1/ingest/ghosts` : upsert ghost + membres + nœud Ghost dans graph + edges ghost_member
- `GET /v1/ghosts` : liste avec filtres ghost_type/scenario_id/status
- `GET /v1/ghosts/{ghost_id}` : détail + membres + graph node + edges
- `POST /v1/ghosts/{ghost_id}/run` : exécution sur fenêtre temporelle

### Contraintes enforced applicativement
- phase_transition : exactement 1 outgoing + 1 incoming
- capacity_aggregate : N members role='member', N >= 1

### Tests (21)
- 4 tests migration
- 4 tests ingest (valid + violations)
- 3 tests GET endpoints
- 5 tests calcul poids (unit, sans DB)
- 2 tests /run endpoints
- 2 tests alertes (transition_inconsistency + capacity_overload)
- 1 test Ghost node dans nodes table