### PR TITLE
[feat] DQ Agent V1 — stat + temporal + impact SC + GPT-4.1-mini

### DIFF
--- a/docs/SPEC-DQ-AGENT.md
+++ b/docs/SPEC-DQ-AGENT.md
@@ -1,0 +1,184 @@
+# SPEC-DQ-AGENT — Agent Data Quality V1
+
+**Statut :** DRAFT — 2026-04-08
+**Références :** ADR-009, SPEC-GHOSTS-TAGS, ShortageDetector, GraphStore
+
+---
+
+## 1. Vision
+
+Le DQ Engine (L1+L2) détecte les problèmes connus et déterministes. Il ne peut pas :
+- Détecter les anomalies statistiques (valeurs hors distribution historique)
+- Prioriser intelligemment selon l'impact supply chain réel
+- Relier une donnée corrompue à ses conséquences sur le plan
+
+L'Agent DQ comble ces trois lacunes. C'est la première pièce de la flotte d'agents Ootils.
+
+**Différenciation produit :** n'importe quel ETL fait L1/L2. Peu d'outils font la détection statistique correctement. **Personne ne relie automatiquement une anomalie de donnée à son impact sur le plan d'approvisionnement.** C'est le graph Ootils qui rend ça possible.
+
+---
+
+## 2. Périmètre V1
+
+### Catégorie 1 — Anomalies de valeur (statistiques)
+
+Comparaison du batch entrant vs historique des N derniers batches de même `entity_type` :
+
+| Rule code | Détection | Sévérité |
+|-----------|-----------|---------|
+| `STAT_LEAD_TIME_SPIKE` | lead_time_days dévie de >3σ vs historique item | ERROR |
+| `STAT_FORECAST_SPIKE` | forecast_qty × 10 vs moyenne historique | WARNING |
+| `STAT_PRICE_OUTLIER` | unit_price hors [Q1 - 1.5×IQR, Q3 + 1.5×IQR] | WARNING |
+| `STAT_SAFETY_STOCK_ZERO` | safety_stock_qty = 0 sur item critique (a des shortages actifs) | WARNING |
+| `STAT_NEGATIVE_ONHAND` | on_hand_qty < 0 après calcul | ERROR |
+
+### Catégorie 3 — Anomalies temporelles
+
+| Rule code | Détection | Sévérité |
+|-----------|-----------|---------|
+| `TEMP_DUPLICATE_BATCH` | batch avec >95% valeurs identiques au batch précédent même entity_type | WARNING |
+| `TEMP_PO_DATE_PAST` | PO expected_date dans le passé et status != 'received' | WARNING |
+| `TEMP_FORECAST_HORIZON_SHORT` | horizon forecast < max(lead_time_days) des items importés | WARNING |
+| `TEMP_MASS_CHANGE` | >30% des valeurs d'un champ changent entre deux batches successifs | ERROR |
+
+### Catégorie 4 — Impact SC (le différenciateur)
+
+Pour chaque issue DQ (L1/L2/stat/temporal) sur un item :
+
+1. **Graph traversal** : identifier tous les nœuds affectés via le graph Ootils (ShortageDetector + GraphStore)
+2. **Impact scoring** : compter les shortages actifs sur les items impactés
+3. **Propagation BOM** : si l'item est un composant, remonter aux produits finis impactés
+4. **Output** : enrichir chaque issue avec `impact_score`, `affected_items`, `active_shortages_count`
+
+Priorisation finale :
+```
+priority = severity_weight × (1 + log(1 + active_shortages_count))
+```
+
+---
+
+## 3. Architecture
+
+```
+POST /v1/ingest/*
+        ↓
+DQ Engine (L1+L2)              ← règles déterministes, synchrone
+        ↓
+DQ Agent (analyse async)       ← statistiques + impact SC
+        ↓
+data_quality_issues enrichies
+        ↓
+GET /v1/dq/agent/report/{batch_id}   ← rapport narratif + priorisé
+```
+
+### Modules
+
+```
+src/ootils_core/engine/dq/
+  engine.py          ← DQ Engine L1+L2 (existant après feat/dq-engine-v1)
+  agent/
+    agent.py         ← dispatcher principal run_dq_agent(db, batch_id)
+    stat_rules.py    ← catégorie 1 (statistiques)
+    temporal_rules.py ← catégorie 3 (temporel)
+    impact_scorer.py  ← catégorie 4 (graph traversal + scoring)
+    report.py         ← génération rapport narratif
+```
+
+### Pas d'appel LLM externe en V1
+
+L'agent V1 est **entièrement déterministe** — Python pur, pas d'API OpenAI/Claude.
+Les règles stat et l'impact scorer sont du code, pas du LLM.
+Le "rapport narratif" est un template structuré, pas du texte généré.
+
+Rationale : fiabilité, coût, latence. Le LLM arrive en V2 pour la couche de recommandation (suggérer des corrections, expliquer les anomalies en langage naturel).
+
+---
+
+## 4. API
+
+### POST /v1/dq/agent/run/{batch_id}
+Déclenche l'analyse agent sur un batch (async).
+```json
+Response: { "status": "queued", "batch_id": "...", "agent_run_id": "..." }
+```
+
+### GET /v1/dq/agent/report/{batch_id}
+Rapport complet du batch.
+```json
+{
+  "batch_id": "...",
+  "entity_type": "purchase_orders",
+  "analyzed_at": "...",
+  "summary": {
+    "total_rows": 120,
+    "issues_count": 7,
+    "critical_count": 2,
+    "affected_items_count": 5,
+    "active_shortages_impacted": 3
+  },
+  "issues": [
+    {
+      "rule_code": "STAT_LEAD_TIME_SPIKE",
+      "severity": "error",
+      "field": "lead_time_days",
+      "raw_value": "140",
+      "expected_range": "12–18",
+      "impact_score": 4.2,
+      "affected_shortages": ["shortage_id_1", "shortage_id_2"],
+      "message": "lead_time_days=140 dévie de 8.3σ vs historique (μ=14, σ=1.5)"
+    }
+  ],
+  "priority_actions": [
+    "Corriger lead_time_days pour VALVE-02 : impact direct sur 2 shortages actifs DC-LAX"
+  ]
+}
+```
+
+### GET /v1/dq/agent/runs
+Historique des runs agent (batch_id, status, score, issues_count).
+
+---
+
+## 5. Table DB
+
+```sql
+CREATE TABLE dq_agent_runs (
+    run_id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id        UUID NOT NULL REFERENCES ingest_batches(batch_id),
+    status          TEXT NOT NULL CHECK (status IN ('queued', 'running', 'completed', 'failed')),
+    started_at      TIMESTAMPTZ,
+    completed_at    TIMESTAMPTZ,
+    summary         JSONB,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+Issues enrichies : ajouter colonnes `impact_score NUMERIC`, `agent_run_id UUID` sur `data_quality_issues`.
+
+---
+
+## 6. Trigger
+
+L'agent est déclenché automatiquement après chaque run DQ Engine (L1+L2).
+Séquence complète post-ingest :
+```
+ingest → DQ Engine → DQ Agent → issues enrichies disponibles en ~2s
+```
+
+---
+
+## 7. UI
+
+Nouvelle section dans la page `/events` ou page dédiée `/dq` :
+- Feed des rapports agent par batch
+- Badge "⚠️ 2 critiques" sur les batches avec issues hautes priorité
+- Panel détail : issues triées par priority_score, avec affected_shortages linkés
+
+---
+
+## 8. V2 (hors scope V1)
+
+- LLM pour suggestions de correction en langage naturel
+- Règles L3 (métier SC) + L4 (croisé)
+- Auto-approbation des batches clean (0 erreur, 0 anomalie stat)
+- Apprentissage des patterns fournisseur (ML)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "uvicorn[standard]>=0.29.0",
     "psycopg[binary]>=3.1.0",
     "pydantic>=2.0.0",
+    "openai>=1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/ootils_core/api/routers/dq.py
+++ b/src/ootils_core/api/routers/dq.py
@@ -1,9 +1,12 @@
 """
 DQ Router — Data Quality pipeline endpoints.
 
-POST /v1/dq/run/{batch_id}  — Trigger DQ run on a batch (synchronous, returns result)
-GET  /v1/dq/{batch_id}      — Get DQ results for a batch
-GET  /v1/dq/issues          — List unresolved issues (filterable)
+POST /v1/dq/run/{batch_id}          — Trigger DQ run on a batch (synchronous, returns result)
+GET  /v1/dq/{batch_id}              — Get DQ results for a batch
+GET  /v1/dq/issues                  — List unresolved issues (filterable)
+POST /v1/dq/agent/run/{batch_id}    — Trigger DQ Agent on a batch
+GET  /v1/dq/agent/report/{batch_id} — Full agent report for a batch
+GET  /v1/dq/agent/runs              — History of agent runs
 """
 from __future__ import annotations
 
@@ -256,3 +259,254 @@ async def get_batch_dq(
         total_rows=batch["total_rows"] or 0,
         issues=issues,
     )
+
+
+# ─────────────────────────────────────────────────────────────
+# Agent response models
+# ─────────────────────────────────────────────────────────────
+
+class AgentRunRecord(BaseModel):
+    run_id: UUID
+    batch_id: UUID
+    status: str
+    model_used: Optional[str]
+    started_at: Any
+    completed_at: Any
+    summary: Optional[Any]
+    created_at: Any
+
+
+class AgentIssueOut(BaseModel):
+    issue_id: UUID
+    batch_id: UUID
+    row_id: Optional[UUID]
+    row_number: Optional[int]
+    dq_level: int
+    rule_code: str
+    severity: str
+    field_name: Optional[str]
+    raw_value: Optional[str]
+    message: str
+    impact_score: Optional[float]
+    agent_run_id: Optional[UUID]
+    llm_explanation: Optional[str]
+    llm_suggestion: Optional[str]
+
+
+class AgentReportResponse(BaseModel):
+    batch_id: UUID
+    entity_type: str
+    run_id: Optional[UUID]
+    status: Optional[str]
+    analyzed_at: Any
+    summary: Optional[Any]
+    narrative: Optional[str]
+    priority_actions: list[str]
+    issues: list[AgentIssueOut]
+
+
+class AgentRunResponse(BaseModel):
+    run_id: UUID
+    batch_id: UUID
+    status: str
+    agent_run_id: UUID
+
+
+class AgentRunsResponse(BaseModel):
+    total: int
+    runs: list[AgentRunRecord]
+
+
+# ─────────────────────────────────────────────────────────────
+# POST /v1/dq/agent/run/{batch_id}
+# ─────────────────────────────────────────────────────────────
+
+@router.post(
+    "/agent/run/{batch_id}",
+    response_model=AgentRunResponse,
+    summary="Trigger DQ Agent on a batch",
+    description=(
+        "Run the DQ Agent (stat + temporal + impact SC + LLM) on an already-ingested batch. "
+        "The agent enriches data_quality_issues with impact_score and LLM insights."
+    ),
+)
+async def run_agent_batch(
+    batch_id: UUID,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> AgentRunResponse:
+    # Verify batch exists
+    batch = db.execute(
+        "SELECT batch_id FROM ingest_batches WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+    if not batch:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Batch {batch_id} not found",
+        )
+
+    try:
+        from ootils_core.engine.dq.agent import run_dq_agent
+        result = run_dq_agent(db, batch_id)
+    except Exception as exc:
+        logger.exception("DQ Agent run failed for batch %s: %s", batch_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"DQ Agent run failed: {exc}",
+        )
+
+    return AgentRunResponse(
+        run_id=result.run_id,
+        batch_id=result.batch_id,
+        status=result.status,
+        agent_run_id=result.run_id,
+    )
+
+
+# ─────────────────────────────────────────────────────────────
+# GET /v1/dq/agent/report/{batch_id}  (must come BEFORE /agent/runs)
+# ─────────────────────────────────────────────────────────────
+
+@router.get(
+    "/agent/report/{batch_id}",
+    response_model=AgentReportResponse,
+    summary="Get DQ Agent report for a batch",
+    description="Returns the full agent report: narrative, priority actions, and enriched issues.",
+)
+async def get_agent_report(
+    batch_id: UUID,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> AgentReportResponse:
+    batch = db.execute(
+        "SELECT batch_id, entity_type FROM ingest_batches WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+    if not batch:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Batch {batch_id} not found",
+        )
+
+    # Get latest agent run for this batch
+    agent_run = db.execute(
+        """
+        SELECT run_id, status, completed_at, summary, llm_narrative
+        FROM dq_agent_runs
+        WHERE batch_id = %s
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        (batch_id,),
+    ).fetchone()
+
+    # Load all issues (L1/L2 + agent) with impact data
+    rows = db.execute(
+        """
+        SELECT issue_id, batch_id, row_id, row_number, dq_level, rule_code,
+               severity, field_name, raw_value, message,
+               impact_score, agent_run_id, llm_explanation, llm_suggestion
+        FROM data_quality_issues
+        WHERE batch_id = %s
+        ORDER BY impact_score DESC NULLS LAST, row_number NULLS LAST
+        """,
+        (batch_id,),
+    ).fetchall()
+
+    issues = [
+        AgentIssueOut(
+            issue_id=r["issue_id"],
+            batch_id=r["batch_id"],
+            row_id=r.get("row_id"),
+            row_number=r.get("row_number"),
+            dq_level=r["dq_level"],
+            rule_code=r["rule_code"],
+            severity=r["severity"],
+            field_name=r.get("field_name"),
+            raw_value=r.get("raw_value"),
+            message=r["message"],
+            impact_score=float(r["impact_score"]) if r.get("impact_score") is not None else None,
+            agent_run_id=r.get("agent_run_id"),
+            llm_explanation=r.get("llm_explanation"),
+            llm_suggestion=r.get("llm_suggestion"),
+        )
+        for r in rows
+    ]
+
+    summary = None
+    narrative = None
+    priority_actions: list[str] = []
+    run_id = None
+    run_status = None
+    analyzed_at = None
+
+    if agent_run:
+        run_id = agent_run["run_id"]
+        run_status = agent_run["status"]
+        analyzed_at = agent_run["completed_at"]
+        narrative = agent_run.get("llm_narrative")
+        raw_summary = agent_run.get("summary")
+        if raw_summary:
+            import json as _json
+            summary = _json.loads(raw_summary) if isinstance(raw_summary, str) else raw_summary
+            priority_actions = summary.get("priority_actions", []) if isinstance(summary, dict) else []
+
+    return AgentReportResponse(
+        batch_id=batch["batch_id"],
+        entity_type=batch["entity_type"],
+        run_id=run_id,
+        status=run_status,
+        analyzed_at=analyzed_at,
+        summary=summary,
+        narrative=narrative,
+        priority_actions=priority_actions,
+        issues=issues,
+    )
+
+
+# ─────────────────────────────────────────────────────────────
+# GET /v1/dq/agent/runs
+# ─────────────────────────────────────────────────────────────
+
+@router.get(
+    "/agent/runs",
+    response_model=AgentRunsResponse,
+    summary="List DQ Agent run history",
+    description="Returns the history of DQ Agent runs across all batches.",
+)
+async def list_agent_runs(
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> AgentRunsResponse:
+    total = db.execute(
+        "SELECT COUNT(*) AS cnt FROM dq_agent_runs"
+    ).fetchone()["cnt"]
+
+    rows = db.execute(
+        """
+        SELECT run_id, batch_id, status, model_used, started_at, completed_at, summary, created_at
+        FROM dq_agent_runs
+        ORDER BY created_at DESC
+        LIMIT %s OFFSET %s
+        """,
+        (limit, offset),
+    ).fetchall()
+
+    runs = [
+        AgentRunRecord(
+            run_id=r["run_id"],
+            batch_id=r["batch_id"],
+            status=r["status"],
+            model_used=r.get("model_used"),
+            started_at=r.get("started_at"),
+            completed_at=r.get("completed_at"),
+            summary=r.get("summary"),
+            created_at=r["created_at"],
+        )
+        for r in rows
+    ]
+
+    return AgentRunsResponse(total=total, runs=runs)

--- a/src/ootils_core/db/migrations/012_dq_agent.sql
+++ b/src/ootils_core/db/migrations/012_dq_agent.sql
@@ -1,0 +1,33 @@
+-- ============================================================
+-- Migration 012: DQ Agent V1 — agent runs + enriched issues
+-- ============================================================
+
+-- Table tracking each DQ Agent execution
+CREATE TABLE IF NOT EXISTS dq_agent_runs (
+    run_id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id        UUID NOT NULL REFERENCES ingest_batches(batch_id),
+    status          TEXT NOT NULL CHECK (status IN ('queued', 'running', 'completed', 'failed')),
+    model_used      TEXT,
+    started_at      TIMESTAMPTZ,
+    completed_at    TIMESTAMPTZ,
+    summary         JSONB,
+    llm_narrative   TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_dq_agent_runs_batch_id
+    ON dq_agent_runs (batch_id);
+CREATE INDEX IF NOT EXISTS idx_dq_agent_runs_status
+    ON dq_agent_runs (status, created_at DESC);
+
+-- Enrich data_quality_issues with agent columns
+ALTER TABLE data_quality_issues
+    ADD COLUMN IF NOT EXISTS impact_score   NUMERIC(8,4),
+    ADD COLUMN IF NOT EXISTS agent_run_id   UUID REFERENCES dq_agent_runs(run_id),
+    ADD COLUMN IF NOT EXISTS llm_explanation TEXT,
+    ADD COLUMN IF NOT EXISTS llm_suggestion  TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_dq_issues_agent_run_id
+    ON data_quality_issues (agent_run_id);
+CREATE INDEX IF NOT EXISTS idx_dq_issues_impact_score
+    ON data_quality_issues (impact_score DESC NULLS LAST);

--- a/src/ootils_core/engine/dq/agent/__init__.py
+++ b/src/ootils_core/engine/dq/agent/__init__.py
@@ -1,0 +1,4 @@
+"""DQ Agent — statistical, temporal, impact-scored anomaly detection."""
+from .agent import run_dq_agent, AgentResult
+
+__all__ = ["run_dq_agent", "AgentResult"]

--- a/src/ootils_core/engine/dq/agent/agent.py
+++ b/src/ootils_core/engine/dq/agent/agent.py
@@ -1,0 +1,315 @@
+"""
+agent.py — DQ Agent dispatcher.
+
+Entry point: run_dq_agent(db, batch_id) → AgentResult
+
+Sequence:
+  1. Load existing DQ issues (L1+L2) from data_quality_issues
+  2. Run stat_rules (category 1)
+  3. Run temporal_rules (category 3)
+  4. Run impact_scorer (category 4)
+  5. Call LLM reporter
+  6. Persist dq_agent_runs + enrich data_quality_issues
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+import psycopg
+
+from .stat_rules import AgentIssue, run_stat_rules
+from .temporal_rules import run_temporal_rules
+from .impact_scorer import score_issues
+from .llm_reporter import generate_llm_report, LLMReport
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AgentResult:
+    run_id: UUID
+    batch_id: UUID
+    status: str  # 'completed' | 'failed'
+    issues: list[AgentIssue]
+    summary: dict
+    narrative: str
+    priority_actions: list[str]
+    model_used: str | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+
+def _load_existing_issues(
+    db: psycopg.Connection,
+    batch_id: UUID,
+) -> list[AgentIssue]:
+    """Load L1+L2 issues already in data_quality_issues for this batch."""
+    rows = db.execute(
+        """
+        SELECT issue_id, batch_id, row_id, row_number, dq_level,
+               rule_code, severity, field_name, raw_value, message
+        FROM data_quality_issues
+        WHERE batch_id = %s
+        ORDER BY row_number NULLS LAST
+        """,
+        (batch_id,),
+    ).fetchall()
+
+    issues = []
+    for r in rows:
+        issues.append(AgentIssue(
+            issue_id=UUID(str(r["issue_id"])),
+            batch_id=UUID(str(r["batch_id"])),
+            row_id=UUID(str(r["row_id"])) if r.get("row_id") else None,
+            row_number=r.get("row_number"),
+            dq_level=r["dq_level"],
+            rule_code=r["rule_code"],
+            severity=r["severity"],
+            field_name=r.get("field_name"),
+            raw_value=r.get("raw_value"),
+            message=r["message"],
+        ))
+    return issues
+
+
+def _get_entity_type(db: psycopg.Connection, batch_id: UUID) -> str:
+    row = db.execute(
+        "SELECT entity_type, total_rows FROM ingest_batches WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+    return (row["entity_type"] if row else "", row["total_rows"] if row else 0)
+
+
+def _persist_agent_run(
+    db: psycopg.Connection,
+    run_id: UUID,
+    batch_id: UUID,
+    status: str,
+    started_at: datetime,
+    completed_at: datetime,
+    summary: dict,
+    narrative: str,
+    model_used: str | None,
+) -> None:
+    """Insert a record into dq_agent_runs."""
+    import json as _json
+    db.execute(
+        """
+        INSERT INTO dq_agent_runs
+            (run_id, batch_id, status, model_used, started_at, completed_at, summary, llm_narrative)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (run_id) DO UPDATE SET
+            status       = EXCLUDED.status,
+            model_used   = EXCLUDED.model_used,
+            completed_at = EXCLUDED.completed_at,
+            summary      = EXCLUDED.summary,
+            llm_narrative = EXCLUDED.llm_narrative
+        """,
+        (
+            run_id,
+            batch_id,
+            status,
+            model_used,
+            started_at,
+            completed_at,
+            _json.dumps(summary),
+            narrative,
+        ),
+    )
+
+
+def _persist_new_issues(
+    db: psycopg.Connection,
+    batch_id: UUID,
+    run_id: UUID,
+    issues: list[AgentIssue],
+) -> None:
+    """Persist agent-generated issues (stat/temporal) to data_quality_issues."""
+    for issue in issues:
+        db.execute(
+            """
+            INSERT INTO data_quality_issues
+                (issue_id, batch_id, row_id, row_number, dq_level, rule_code,
+                 severity, field_name, raw_value, message,
+                 impact_score, agent_run_id, llm_explanation, llm_suggestion)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (issue_id) DO NOTHING
+            """,
+            (
+                issue.issue_id,
+                batch_id,
+                issue.row_id,
+                issue.row_number,
+                issue.dq_level,
+                issue.rule_code,
+                issue.severity,
+                issue.field_name,
+                issue.raw_value,
+                issue.message,
+                issue.impact_score,
+                run_id,
+                issue.llm_explanation,
+                issue.llm_suggestion,
+            ),
+        )
+
+
+def _enrich_existing_issues(
+    db: psycopg.Connection,
+    run_id: UUID,
+    issues: list[AgentIssue],
+) -> None:
+    """Update L1+L2 issues with impact_score, agent_run_id, llm fields."""
+    for issue in issues:
+        db.execute(
+            """
+            UPDATE data_quality_issues
+            SET impact_score    = %s,
+                agent_run_id    = %s,
+                llm_explanation = %s,
+                llm_suggestion  = %s
+            WHERE issue_id = %s
+            """,
+            (
+                issue.impact_score,
+                run_id,
+                issue.llm_explanation,
+                issue.llm_suggestion,
+                issue.issue_id,
+            ),
+        )
+
+
+def run_dq_agent(
+    db: psycopg.Connection,
+    batch_id: UUID,
+) -> AgentResult:
+    """
+    Main DQ Agent dispatcher.
+
+    Steps:
+      1. Load existing L1+L2 issues
+      2. Run stat_rules
+      3. Run temporal_rules
+      4. Impact score all issues
+      5. LLM report
+      6. Persist everything
+    """
+    run_id = uuid4()
+    started_at = datetime.now(timezone.utc)
+
+    logger.info("dq_agent.run start batch_id=%s run_id=%s", batch_id, run_id)
+
+    # Mark run as running
+    db.execute(
+        """
+        INSERT INTO dq_agent_runs
+            (run_id, batch_id, status, started_at)
+        VALUES (%s, %s, 'running', %s)
+        """,
+        (run_id, batch_id, started_at),
+    )
+    db.commit()
+
+    try:
+        entity_type, total_rows = _get_entity_type(db, batch_id)
+
+        # 1. Load existing L1+L2 issues
+        existing_issues = _load_existing_issues(db, batch_id)
+
+        # 2. Stat rules
+        stat_issues = run_stat_rules(db, batch_id)
+
+        # 3. Temporal rules
+        temporal_issues = run_temporal_rules(db, batch_id)
+
+        # All agent-generated issues (to persist as new rows)
+        new_issues = stat_issues + temporal_issues
+
+        # All issues for scoring (existing L1/L2 + new agent issues)
+        all_issues = existing_issues + new_issues
+
+        # 4. Impact scoring on all issues
+        score_issues(db, batch_id, all_issues)
+
+        # 5. LLM report
+        report: LLMReport = generate_llm_report(
+            all_issues, entity_type, batch_id, total_rows
+        )
+
+        completed_at = datetime.now(timezone.utc)
+
+        # Build summary
+        summary = {
+            "total_rows": total_rows,
+            "issues_count": len(all_issues),
+            "critical_count": sum(1 for i in all_issues if i.severity == "error"),
+            "warning_count": sum(1 for i in all_issues if i.severity == "warning"),
+            "stat_issues": len(stat_issues),
+            "temporal_issues": len(temporal_issues),
+            "affected_items_count": len(
+                set(item for i in all_issues for item in i.affected_items)
+            ),
+            "active_shortages_impacted": max(
+                (i.active_shortages_count for i in all_issues), default=0
+            ),
+            "llm_available": report.llm_available,
+            "priority_actions": report.priority_actions,
+        }
+
+        # 6. Persist
+        # Update agent run record
+        _persist_agent_run(
+            db,
+            run_id=run_id,
+            batch_id=batch_id,
+            status="completed",
+            started_at=started_at,
+            completed_at=completed_at,
+            summary=summary,
+            narrative=report.narrative,
+            model_used=report.model_used,
+        )
+
+        # Persist new agent issues
+        _persist_new_issues(db, batch_id, run_id, new_issues)
+
+        # Enrich existing L1/L2 issues
+        _enrich_existing_issues(db, run_id, existing_issues)
+
+        db.commit()
+
+        logger.info(
+            "dq_agent.run complete batch_id=%s run_id=%s issues=%d stat=%d temporal=%d",
+            batch_id, run_id, len(all_issues), len(stat_issues), len(temporal_issues),
+        )
+
+        return AgentResult(
+            run_id=run_id,
+            batch_id=batch_id,
+            status="completed",
+            issues=all_issues,
+            summary=summary,
+            narrative=report.narrative,
+            priority_actions=report.priority_actions,
+            model_used=report.model_used,
+            started_at=started_at,
+            completed_at=completed_at,
+        )
+
+    except Exception as exc:
+        logger.exception("dq_agent.run failed batch_id=%s run_id=%s: %s", batch_id, run_id, exc)
+        completed_at = datetime.now(timezone.utc)
+        db.execute(
+            """
+            UPDATE dq_agent_runs
+            SET status = 'failed', completed_at = %s
+            WHERE run_id = %s
+            """,
+            (completed_at, run_id),
+        )
+        db.commit()
+        raise

--- a/src/ootils_core/engine/dq/agent/impact_scorer.py
+++ b/src/ootils_core/engine/dq/agent/impact_scorer.py
@@ -1,0 +1,199 @@
+"""
+impact_scorer.py — Catégorie 4 : impact supply chain.
+
+Pour chaque issue (L1/L2/stat/temporal) sur un item :
+  1. Traverser le graph pour trouver les shortages actifs liés à l'item
+  2. Remonter la BOM pour trouver les produits finis impactés
+  3. Calculer impact_score = severity_weight × (1 + log(1 + active_shortages_count))
+  4. Enrichir chaque issue avec impact_score, affected_items, active_shortages_count
+"""
+from __future__ import annotations
+
+import json
+import logging
+import math
+from dataclasses import dataclass
+from uuid import UUID
+
+import psycopg
+
+from .stat_rules import AgentIssue
+
+logger = logging.getLogger(__name__)
+
+# Severity weights
+SEVERITY_WEIGHTS = {
+    "error": 3.0,
+    "warning": 1.5,
+    "info": 0.5,
+}
+
+
+@dataclass
+class IssueImpact:
+    issue_id: UUID
+    impact_score: float
+    affected_items: list[str]
+    active_shortages_count: int
+
+
+def _get_item_ids_for_issue(
+    db: psycopg.Connection,
+    batch_id: UUID,
+    row_id: UUID | None,
+) -> list[str]:
+    """
+    Extract item external_ids relevant to this issue.
+    Looks at the row's content for item_external_id fields.
+    """
+    if row_id is None:
+        # Batch-level issue — look at all items in the batch
+        rows = db.execute(
+            "SELECT raw_content FROM ingest_rows WHERE batch_id = %s LIMIT 100",
+            (batch_id,),
+        ).fetchall()
+        items = []
+        for r in rows:
+            try:
+                content = json.loads(r["raw_content"]) if isinstance(r["raw_content"], str) else r["raw_content"]
+                for field in ("item_external_id", "external_id"):
+                    val = content.get(field)
+                    if val:
+                        items.append(str(val))
+            except Exception:
+                pass
+        return list(set(items))[:20]  # cap
+
+    row = db.execute(
+        "SELECT raw_content FROM ingest_rows WHERE row_id = %s",
+        (row_id,),
+    ).fetchone()
+    if not row:
+        return []
+    try:
+        content = json.loads(row["raw_content"]) if isinstance(row["raw_content"], str) else row["raw_content"]
+        for field in ("item_external_id", "external_id"):
+            val = content.get(field)
+            if val:
+                return [str(val)]
+    except Exception:
+        pass
+    return []
+
+
+def _get_active_shortages_for_items(
+    db: psycopg.Connection,
+    item_external_ids: list[str],
+) -> tuple[int, list[str]]:
+    """
+    Count active shortages for a list of item external_ids.
+    Returns (count, list_of_affected_external_ids).
+    """
+    if not item_external_ids:
+        return 0, []
+
+    rows = db.execute(
+        """
+        SELECT i.external_id, COUNT(s.shortage_id) AS shortage_count
+        FROM items i
+        JOIN shortages s ON s.item_id = i.item_id
+        WHERE i.external_id = ANY(%s)
+          AND s.status = 'active'
+        GROUP BY i.external_id
+        """,
+        (item_external_ids,),
+    ).fetchall()
+
+    total = sum(r["shortage_count"] for r in rows)
+    affected = [r["external_id"] for r in rows if r["shortage_count"] > 0]
+    return total, affected
+
+
+def _get_finished_goods_via_bom(
+    db: psycopg.Connection,
+    item_external_ids: list[str],
+) -> list[str]:
+    """
+    Traverse BOM upward to find finished goods impacted by component items.
+    Uses bom_component edges: component → parent.
+    """
+    if not item_external_ids:
+        return []
+
+    # Get item_ids from external_ids
+    rows = db.execute(
+        "SELECT item_id, external_id FROM items WHERE external_id = ANY(%s)",
+        (item_external_ids,),
+    ).fetchall()
+    component_ids = {UUID(str(r["item_id"])) for r in rows}
+
+    if not component_ids:
+        return []
+
+    visited: set[UUID] = set(component_ids)
+    queue: list[UUID] = list(component_ids)
+    finished_goods: set[str] = set()
+
+    # BOM is stored as edges: from=component → to=parent or from=parent → to=component
+    # The 'bom_component' edge type connects parent to child: parent -[bom_component]-> child
+    # So to go UP, we need edges where to_node_id = item_node_id
+    # GraphStore stores items as nodes via node_type='Item'
+    # We'll use the bom table directly if available
+    while queue:
+        batch_component_ids = queue[:50]
+        queue = queue[50:]
+
+        # Try bom table first (from migration 008)
+        bom_rows = db.execute(
+            """
+            SELECT DISTINCT b.parent_item_id, i.external_id
+            FROM bom_components b
+            JOIN items i ON i.item_id = b.parent_item_id
+            WHERE b.component_item_id = ANY(%s)
+            """,
+            (list(batch_component_ids),),
+        ).fetchall()
+
+        for r in bom_rows:
+            parent_id = UUID(str(r["parent_item_id"]))
+            if parent_id not in visited:
+                visited.add(parent_id)
+                queue.append(parent_id)
+                finished_goods.add(r["external_id"])
+
+    return list(finished_goods)
+
+
+def score_issues(
+    db: psycopg.Connection,
+    batch_id: UUID,
+    issues: list[AgentIssue],
+) -> list[AgentIssue]:
+    """
+    Enrich each issue with impact_score, affected_items, active_shortages_count.
+    Modifies issues in place and returns them.
+    """
+    for issue in issues:
+        item_ext_ids = _get_item_ids_for_issue(db, batch_id, issue.row_id)
+
+        shortages_count, items_with_shortages = _get_active_shortages_for_items(
+            db, item_ext_ids
+        )
+
+        # Also look at finished goods impacted via BOM
+        fg_items = _get_finished_goods_via_bom(db, item_ext_ids)
+        if fg_items:
+            fg_shortages, fg_with_shortages = _get_active_shortages_for_items(
+                db, fg_items
+            )
+            shortages_count += fg_shortages
+            items_with_shortages = list(set(items_with_shortages + fg_with_shortages))
+
+        severity_weight = SEVERITY_WEIGHTS.get(issue.severity, 1.0)
+        impact_score = severity_weight * (1.0 + math.log(1.0 + shortages_count))
+
+        issue.impact_score = round(impact_score, 4)
+        issue.affected_items = items_with_shortages
+        issue.active_shortages_count = shortages_count
+
+    return issues

--- a/src/ootils_core/engine/dq/agent/llm_reporter.py
+++ b/src/ootils_core/engine/dq/agent/llm_reporter.py
@@ -1,0 +1,217 @@
+"""
+llm_reporter.py — Rapport narratif LLM (OpenAI GPT-4.1-mini).
+
+Assemble le contexte DQ complet et génère :
+  - narrative markdown supply chain
+  - priority_actions (liste d'actions)
+  - llm_explanation / llm_suggestion par issue
+
+Fallback : si OPENAI_API_KEY absent ou API indisponible → rapport JSON sans narration.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
+
+from .stat_rules import AgentIssue
+
+logger = logging.getLogger(__name__)
+
+OPENAI_MODEL = "gpt-4.1-mini"
+
+_SYSTEM_PROMPT = """You are a senior supply chain expert specialized in data quality management.
+Your role is to analyze data quality issues detected in supply chain data (purchase orders, forecasts, 
+inventory, supplier lead times) and provide actionable recommendations.
+
+For each batch of DQ issues, you will:
+1. Write a concise executive narrative (markdown) summarizing the key risks
+2. List 3-5 priority actions the supply chain team should take immediately
+3. For each critical issue, provide a brief explanation and a concrete suggestion
+
+Focus on business impact: how each data quality problem affects inventory availability, 
+service levels, procurement costs, and production continuity.
+Be concise, direct, and action-oriented. Avoid generic advice.
+Always respond in the same language as the data context."""
+
+_USER_PROMPT_TEMPLATE = """Analyze the following supply chain data quality report and provide recommendations.
+
+Batch context:
+- entity_type: {entity_type}
+- batch_id: {batch_id}
+- total_rows: {total_rows}
+- issues_count: {issues_count}
+- critical_count: {critical_count}
+
+Top issues by impact score:
+{issues_json}
+
+Respond with a JSON object:
+{{
+  "narrative": "<markdown narrative>",
+  "priority_actions": ["action1", "action2", ...],
+  "issue_explanations": {{
+    "<issue_id>": {{
+      "explanation": "<why this matters>",
+      "suggestion": "<concrete fix>"
+    }}
+  }}
+}}"""
+
+
+@dataclass
+class LLMReport:
+    narrative: str
+    priority_actions: list[str]
+    issue_explanations: dict[str, dict[str, str]] = field(default_factory=dict)
+    model_used: str | None = None
+    llm_available: bool = True
+
+
+def _build_issues_context(issues: list[AgentIssue], max_issues: int = 10) -> str:
+    """Build a JSON-serializable summary of top issues for the LLM prompt."""
+    # Sort by impact_score descending
+    sorted_issues = sorted(
+        issues,
+        key=lambda i: i.impact_score or 0.0,
+        reverse=True,
+    )[:max_issues]
+
+    context = []
+    for issue in sorted_issues:
+        context.append({
+            "issue_id": str(issue.issue_id),
+            "rule_code": issue.rule_code,
+            "severity": issue.severity,
+            "field_name": issue.field_name,
+            "raw_value": issue.raw_value,
+            "message": issue.message,
+            "impact_score": issue.impact_score,
+            "active_shortages_count": issue.active_shortages_count,
+            "affected_items": issue.affected_items[:5],
+        })
+
+    return json.dumps(context, indent=2, default=str)
+
+
+def generate_llm_report(
+    issues: list[AgentIssue],
+    entity_type: str,
+    batch_id: UUID,
+    total_rows: int,
+) -> LLMReport:
+    """
+    Call OpenAI to generate a narrative report.
+    Falls back to a structured JSON report if API is unavailable.
+    """
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        logger.info("OPENAI_API_KEY not set — using fallback report")
+        return _fallback_report(issues, entity_type)
+
+    try:
+        from openai import OpenAI, APIError, APIConnectionError
+        client = OpenAI(api_key=api_key)
+
+        critical_count = sum(1 for i in issues if i.severity == "error")
+        issues_json = _build_issues_context(issues)
+
+        user_message = _USER_PROMPT_TEMPLATE.format(
+            entity_type=entity_type,
+            batch_id=str(batch_id),
+            total_rows=total_rows,
+            issues_count=len(issues),
+            critical_count=critical_count,
+            issues_json=issues_json,
+        )
+
+        response = client.chat.completions.create(
+            model=OPENAI_MODEL,
+            messages=[
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": user_message},
+            ],
+            response_format={"type": "json_object"},
+            temperature=0.2,
+            max_tokens=2000,
+        )
+
+        content = response.choices[0].message.content
+        data = json.loads(content)
+
+        report = LLMReport(
+            narrative=data.get("narrative", ""),
+            priority_actions=data.get("priority_actions", []),
+            issue_explanations=data.get("issue_explanations", {}),
+            model_used=OPENAI_MODEL,
+            llm_available=True,
+        )
+
+        # Apply explanations to issues
+        for issue in issues:
+            explanation = report.issue_explanations.get(str(issue.issue_id), {})
+            if explanation:
+                issue.llm_explanation = explanation.get("explanation")
+                issue.llm_suggestion = explanation.get("suggestion")
+
+        return report
+
+    except ImportError:
+        logger.warning("openai package not installed — using fallback report")
+        return _fallback_report(issues, entity_type)
+    except Exception as exc:
+        logger.warning("LLM API call failed (%s) — using fallback report", exc)
+        return _fallback_report(issues, entity_type)
+
+
+def _fallback_report(issues: list[AgentIssue], entity_type: str) -> LLMReport:
+    """Generate a structured report without LLM when API is unavailable."""
+    critical = [i for i in issues if i.severity == "error"]
+    warnings = [i for i in issues if i.severity == "warning"]
+
+    # Build rule summary
+    rule_counts: dict[str, int] = {}
+    for issue in issues:
+        rule_counts[issue.rule_code] = rule_counts.get(issue.rule_code, 0) + 1
+
+    rules_summary = ", ".join(
+        f"{code}: {count}" for code, count in sorted(rule_counts.items())
+    )
+
+    narrative = f"""## DQ Agent Report — {entity_type}
+
+**{len(issues)} issues détectées** ({len(critical)} erreurs, {len(warnings)} warnings)
+
+### Résumé par règle
+{rules_summary if rules_summary else "Aucune issue"}
+
+### Issues critiques
+"""
+    for issue in critical[:5]:
+        narrative += f"- **{issue.rule_code}**: {issue.message}\n"
+
+    if not critical:
+        narrative += "_Aucune erreur critique._\n"
+
+    priority_actions = []
+    if critical:
+        priority_actions.append(
+            f"Résoudre {len(critical)} erreur(s) critique(s) avant traitement du batch"
+        )
+    for issue in sorted(issues, key=lambda i: i.impact_score or 0, reverse=True)[:3]:
+        if issue.active_shortages_count > 0:
+            priority_actions.append(
+                f"Vérifier {issue.rule_code} sur {issue.field_name} "
+                f"(impact {issue.active_shortages_count} shortage(s) actif(s))"
+            )
+
+    return LLMReport(
+        narrative=narrative,
+        priority_actions=priority_actions,
+        issue_explanations={},
+        model_used=None,
+        llm_available=False,
+    )

--- a/src/ootils_core/engine/dq/agent/stat_rules.py
+++ b/src/ootils_core/engine/dq/agent/stat_rules.py
@@ -1,0 +1,451 @@
+"""
+stat_rules.py — Catégorie 1 : anomalies statistiques.
+
+Rules:
+  STAT_LEAD_TIME_SPIKE  : lead_time_days dévie de >3σ vs historique item
+  STAT_FORECAST_SPIKE   : forecast_qty > moyenne historique × 10
+  STAT_PRICE_OUTLIER    : unit_price hors [Q1 - 1.5×IQR, Q3 + 1.5×IQR]
+  STAT_SAFETY_STOCK_ZERO: safety_stock = 0 sur item avec shortages actifs
+  STAT_NEGATIVE_ONHAND  : on_hand_qty < 0
+"""
+from __future__ import annotations
+
+import json
+import logging
+import math
+import statistics
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+# Number of historical batches to load for comparison
+HISTORY_WINDOW = 10
+
+SEVERITY_ERROR = "error"
+SEVERITY_WARNING = "warning"
+
+
+@dataclass
+class AgentIssue:
+    """An issue raised by the DQ Agent (stat, temporal, or impact)."""
+    issue_id: UUID
+    batch_id: UUID
+    row_id: UUID | None
+    row_number: int | None
+    dq_level: int  # 3 = stat, 4 = impact
+    rule_code: str
+    severity: str
+    field_name: str | None
+    raw_value: str | None
+    message: str
+    # Impact fields (populated by impact_scorer)
+    impact_score: float | None = None
+    affected_items: list[str] = field(default_factory=list)
+    active_shortages_count: int = 0
+    llm_explanation: str | None = None
+    llm_suggestion: str | None = None
+
+
+def _load_history(
+    db: psycopg.Connection,
+    entity_type: str,
+    current_batch_id: UUID,
+    window: int = HISTORY_WINDOW,
+) -> list[dict]:
+    """
+    Load raw_content of rows from the N most recent completed batches
+    of the same entity_type (excluding the current batch).
+    Returns a flat list of content dicts.
+    """
+    rows = db.execute(
+        """
+        SELECT ir.raw_content
+        FROM ingest_rows ir
+        JOIN ingest_batches ib ON ib.batch_id = ir.batch_id
+        WHERE ib.entity_type = %s
+          AND ib.batch_id != %s
+          AND ib.dq_status IN ('validated', 'rejected')
+        ORDER BY ib.created_at DESC
+        LIMIT %s
+        """,
+        (entity_type, current_batch_id, window * 100),  # rough cap
+    ).fetchall()
+
+    result = []
+    for r in rows:
+        try:
+            content = json.loads(r["raw_content"]) if isinstance(r["raw_content"], str) else r["raw_content"]
+            if isinstance(content, dict):
+                result.append(content)
+        except Exception:
+            pass
+    return result
+
+
+def _load_current_rows(
+    db: psycopg.Connection,
+    batch_id: UUID,
+) -> list[tuple[UUID, int, dict]]:
+    """Load (row_id, row_number, content) for all rows in the current batch."""
+    rows = db.execute(
+        """
+        SELECT row_id, row_number, raw_content
+        FROM ingest_rows
+        WHERE batch_id = %s
+        ORDER BY row_number
+        """,
+        (batch_id,),
+    ).fetchall()
+
+    result = []
+    for r in rows:
+        try:
+            content = json.loads(r["raw_content"]) if isinstance(r["raw_content"], str) else r["raw_content"]
+            if isinstance(content, dict):
+                result.append((r["row_id"], r["row_number"], content))
+        except Exception:
+            pass
+    return result
+
+
+def _get_entity_type(db: psycopg.Connection, batch_id: UUID) -> str:
+    row = db.execute(
+        "SELECT entity_type FROM ingest_batches WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+    return row["entity_type"] if row else ""
+
+
+# ──────────────────────────────────────────────────────────────
+# STAT_LEAD_TIME_SPIKE
+# ──────────────────────────────────────────────────────────────
+
+def _check_lead_time_spike(
+    batch_id: UUID,
+    current_rows: list[tuple[UUID, int, dict]],
+    history: list[dict],
+) -> list[AgentIssue]:
+    """Z-score > 3σ on lead_time_days vs historical values per item."""
+    issues: list[AgentIssue] = []
+
+    # Build historical lead times per item
+    hist_by_item: dict[str, list[float]] = {}
+    for content in history:
+        item_ext = content.get("item_external_id") or content.get("external_id")
+        lt = content.get("lead_time_days")
+        if item_ext and lt is not None:
+            try:
+                hist_by_item.setdefault(item_ext, []).append(float(lt))
+            except (TypeError, ValueError):
+                pass
+
+    for row_id, row_number, content in current_rows:
+        item_ext = content.get("item_external_id") or content.get("external_id")
+        lt_raw = content.get("lead_time_days")
+        if item_ext is None or lt_raw is None:
+            continue
+        try:
+            lt = float(lt_raw)
+        except (TypeError, ValueError):
+            continue
+
+        hist = hist_by_item.get(item_ext, [])
+        if len(hist) < 3:
+            continue  # not enough data
+
+        mean = statistics.mean(hist)
+        stdev = statistics.stdev(hist)
+        if stdev == 0:
+            continue
+
+        z_score = abs(lt - mean) / stdev
+        if z_score > 3.0:
+            issues.append(AgentIssue(
+                issue_id=uuid4(),
+                batch_id=batch_id,
+                row_id=row_id,
+                row_number=row_number,
+                dq_level=3,
+                rule_code="STAT_LEAD_TIME_SPIKE",
+                severity=SEVERITY_ERROR,
+                field_name="lead_time_days",
+                raw_value=str(lt_raw),
+                message=(
+                    f"lead_time_days={lt} dévie de {z_score:.1f}σ vs historique item "
+                    f"(μ={mean:.1f}, σ={stdev:.1f})"
+                ),
+            ))
+
+    return issues
+
+
+# ──────────────────────────────────────────────────────────────
+# STAT_FORECAST_SPIKE
+# ──────────────────────────────────────────────────────────────
+
+def _check_forecast_spike(
+    batch_id: UUID,
+    current_rows: list[tuple[UUID, int, dict]],
+    history: list[dict],
+) -> list[AgentIssue]:
+    """forecast qty > moyenne historique × 10 par item."""
+    issues: list[AgentIssue] = []
+
+    # Historical forecast quantities per item
+    hist_by_item: dict[str, list[float]] = {}
+    for content in history:
+        item_ext = content.get("item_external_id")
+        qty_raw = content.get("quantity")
+        if item_ext and qty_raw is not None:
+            try:
+                hist_by_item.setdefault(item_ext, []).append(float(qty_raw))
+            except (TypeError, ValueError):
+                pass
+
+    for row_id, row_number, content in current_rows:
+        item_ext = content.get("item_external_id")
+        qty_raw = content.get("quantity")
+        if item_ext is None or qty_raw is None:
+            continue
+        try:
+            qty = float(qty_raw)
+        except (TypeError, ValueError):
+            continue
+
+        hist = hist_by_item.get(item_ext, [])
+        if len(hist) < 2:
+            continue
+
+        mean = statistics.mean(hist)
+        if mean <= 0:
+            continue
+
+        if qty > mean * 10:
+            issues.append(AgentIssue(
+                issue_id=uuid4(),
+                batch_id=batch_id,
+                row_id=row_id,
+                row_number=row_number,
+                dq_level=3,
+                rule_code="STAT_FORECAST_SPIKE",
+                severity=SEVERITY_WARNING,
+                field_name="quantity",
+                raw_value=str(qty_raw),
+                message=(
+                    f"forecast_qty={qty} est {qty/mean:.1f}× la moyenne historique "
+                    f"item {item_ext} (μ={mean:.1f})"
+                ),
+            ))
+
+    return issues
+
+
+# ──────────────────────────────────────────────────────────────
+# STAT_PRICE_OUTLIER
+# ──────────────────────────────────────────────────────────────
+
+def _check_price_outlier(
+    batch_id: UUID,
+    current_rows: list[tuple[UUID, int, dict]],
+    history: list[dict],
+) -> list[AgentIssue]:
+    """unit_price hors [Q1 - 1.5×IQR, Q3 + 1.5×IQR]."""
+    issues: list[AgentIssue] = []
+
+    hist_prices: dict[str, list[float]] = {}
+    for content in history:
+        item_ext = content.get("item_external_id") or content.get("external_id")
+        price = content.get("unit_price")
+        if item_ext and price is not None:
+            try:
+                hist_prices.setdefault(item_ext, []).append(float(price))
+            except (TypeError, ValueError):
+                pass
+
+    for row_id, row_number, content in current_rows:
+        item_ext = content.get("item_external_id") or content.get("external_id")
+        price_raw = content.get("unit_price")
+        if item_ext is None or price_raw is None:
+            continue
+        try:
+            price = float(price_raw)
+        except (TypeError, ValueError):
+            continue
+
+        hist = sorted(hist_prices.get(item_ext, []))
+        if len(hist) < 4:
+            continue
+
+        n = len(hist)
+        q1 = hist[n // 4]
+        q3 = hist[(3 * n) // 4]
+        iqr = q3 - q1
+        lower = q1 - 1.5 * iqr
+        upper = q3 + 1.5 * iqr
+
+        if price < lower or price > upper:
+            issues.append(AgentIssue(
+                issue_id=uuid4(),
+                batch_id=batch_id,
+                row_id=row_id,
+                row_number=row_number,
+                dq_level=3,
+                rule_code="STAT_PRICE_OUTLIER",
+                severity=SEVERITY_WARNING,
+                field_name="unit_price",
+                raw_value=str(price_raw),
+                message=(
+                    f"unit_price={price} hors plage attendue [{lower:.2f}, {upper:.2f}] "
+                    f"(Q1={q1:.2f}, Q3={q3:.2f})"
+                ),
+            ))
+
+    return issues
+
+
+# ──────────────────────────────────────────────────────────────
+# STAT_SAFETY_STOCK_ZERO
+# ──────────────────────────────────────────────────────────────
+
+def _check_safety_stock_zero(
+    db: psycopg.Connection,
+    batch_id: UUID,
+    current_rows: list[tuple[UUID, int, dict]],
+) -> list[AgentIssue]:
+    """safety_stock_qty = 0 sur item avec shortages actifs."""
+    issues: list[AgentIssue] = []
+
+    # Get items with active shortages
+    shortage_rows = db.execute(
+        """
+        SELECT DISTINCT i.external_id
+        FROM shortages s
+        JOIN items i ON i.item_id = s.item_id
+        WHERE s.status = 'active'
+        """,
+    ).fetchall()
+    items_with_shortages = {r["external_id"] for r in shortage_rows}
+
+    if not items_with_shortages:
+        return issues
+
+    for row_id, row_number, content in current_rows:
+        safety_raw = content.get("safety_stock_qty")
+        item_ext = content.get("item_external_id") or content.get("external_id")
+
+        if safety_raw is None or item_ext is None:
+            continue
+
+        try:
+            safety = float(safety_raw)
+        except (TypeError, ValueError):
+            continue
+
+        if safety == 0 and item_ext in items_with_shortages:
+            issues.append(AgentIssue(
+                issue_id=uuid4(),
+                batch_id=batch_id,
+                row_id=row_id,
+                row_number=row_number,
+                dq_level=3,
+                rule_code="STAT_SAFETY_STOCK_ZERO",
+                severity=SEVERITY_WARNING,
+                field_name="safety_stock_qty",
+                raw_value=str(safety_raw),
+                message=(
+                    f"safety_stock_qty=0 pour l'item {item_ext} "
+                    f"qui a des shortages actifs"
+                ),
+            ))
+
+    return issues
+
+
+# ──────────────────────────────────────────────────────────────
+# STAT_NEGATIVE_ONHAND
+# ──────────────────────────────────────────────────────────────
+
+def _check_negative_onhand(
+    batch_id: UUID,
+    current_rows: list[tuple[UUID, int, dict]],
+    entity_type: str,
+) -> list[AgentIssue]:
+    """on_hand_qty < 0 (L1 allows quantity=0 to pass; this checks for negative stock)."""
+    issues: list[AgentIssue] = []
+
+    if entity_type not in ("on_hand",):
+        return issues
+
+    for row_id, row_number, content in current_rows:
+        qty_raw = content.get("quantity")
+        if qty_raw is None:
+            continue
+        try:
+            qty = float(qty_raw)
+        except (TypeError, ValueError):
+            continue
+
+        if qty < 0:
+            item_ext = content.get("item_external_id", "?")
+            issues.append(AgentIssue(
+                issue_id=uuid4(),
+                batch_id=batch_id,
+                row_id=row_id,
+                row_number=row_number,
+                dq_level=3,
+                rule_code="STAT_NEGATIVE_ONHAND",
+                severity=SEVERITY_ERROR,
+                field_name="quantity",
+                raw_value=str(qty_raw),
+                message=(
+                    f"on_hand_qty={qty} est négatif pour l'item {item_ext}"
+                ),
+            ))
+
+    return issues
+
+
+# ──────────────────────────────────────────────────────────────
+# Main entry point
+# ──────────────────────────────────────────────────────────────
+
+def run_stat_rules(
+    db: psycopg.Connection,
+    batch_id: UUID,
+) -> list[AgentIssue]:
+    """Run all stat rules for a batch. Returns list of AgentIssue."""
+    entity_type = _get_entity_type(db, batch_id)
+    current_rows = _load_current_rows(db, batch_id)
+    history = _load_history(db, entity_type, batch_id)
+
+    issues: list[AgentIssue] = []
+
+    # STAT_LEAD_TIME_SPIKE — only for supplier_items
+    if entity_type in ("supplier_items",):
+        issues.extend(_check_lead_time_spike(batch_id, current_rows, history))
+
+    # STAT_FORECAST_SPIKE — only for forecast_demand / forecasts
+    if entity_type in ("forecast_demand", "forecasts"):
+        issues.extend(_check_forecast_spike(batch_id, current_rows, history))
+
+    # STAT_PRICE_OUTLIER — only for entities with unit_price field
+    if entity_type in ("purchase_orders", "supplier_items"):
+        issues.extend(_check_price_outlier(batch_id, current_rows, history))
+
+    # STAT_SAFETY_STOCK_ZERO — items with safety_stock_qty
+    if entity_type in ("items",):
+        issues.extend(_check_safety_stock_zero(db, batch_id, current_rows))
+
+    # STAT_NEGATIVE_ONHAND — on_hand batches
+    issues.extend(_check_negative_onhand(batch_id, current_rows, entity_type))
+
+    logger.info(
+        "stat_rules batch_id=%s entity=%s issues=%d",
+        batch_id, entity_type, len(issues),
+    )
+    return issues

--- a/src/ootils_core/engine/dq/agent/temporal_rules.py
+++ b/src/ootils_core/engine/dq/agent/temporal_rules.py
@@ -1,0 +1,356 @@
+"""
+temporal_rules.py — Catégorie 3 : anomalies temporelles.
+
+Rules:
+  TEMP_DUPLICATE_BATCH       : >95% valeurs identiques au batch précédent
+  TEMP_PO_DATE_PAST          : PO expected_date passée et status != 'received'
+  TEMP_FORECAST_HORIZON_SHORT: horizon < max(lead_time_days) des items
+  TEMP_MASS_CHANGE           : >30% des valeurs d'un champ changent vs batch précédent
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime
+from uuid import UUID, uuid4
+
+import psycopg
+
+from .stat_rules import AgentIssue, SEVERITY_WARNING, SEVERITY_ERROR
+
+logger = logging.getLogger(__name__)
+
+
+def _load_batch_rows(db: psycopg.Connection, batch_id: UUID) -> list[dict]:
+    """Load all row contents for a batch."""
+    rows = db.execute(
+        "SELECT raw_content FROM ingest_rows WHERE batch_id = %s ORDER BY row_number",
+        (batch_id,),
+    ).fetchall()
+    result = []
+    for r in rows:
+        try:
+            content = json.loads(r["raw_content"]) if isinstance(r["raw_content"], str) else r["raw_content"]
+            if isinstance(content, dict):
+                result.append(content)
+        except Exception:
+            pass
+    return result
+
+
+def _get_previous_batch_id(
+    db: psycopg.Connection,
+    entity_type: str,
+    current_batch_id: UUID,
+) -> UUID | None:
+    """Return the batch_id of the most recent completed batch before the current one."""
+    row = db.execute(
+        """
+        SELECT batch_id
+        FROM ingest_batches
+        WHERE entity_type = %s
+          AND batch_id != %s
+          AND dq_status IN ('validated', 'rejected')
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        (entity_type, current_batch_id),
+    ).fetchone()
+    return UUID(str(row["batch_id"])) if row else None
+
+
+def _get_entity_type(db: psycopg.Connection, batch_id: UUID) -> str:
+    row = db.execute(
+        "SELECT entity_type FROM ingest_batches WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+    return row["entity_type"] if row else ""
+
+
+def _row_fingerprint(content: dict) -> frozenset:
+    """Create a hashable fingerprint from a content dict."""
+    return frozenset((k, str(v)) for k, v in content.items())
+
+
+# ──────────────────────────────────────────────────────────────
+# TEMP_DUPLICATE_BATCH
+# ──────────────────────────────────────────────────────────────
+
+def _check_duplicate_batch(
+    db: psycopg.Connection,
+    batch_id: UUID,
+    entity_type: str,
+) -> list[AgentIssue]:
+    """Detect if >95% of batch values are identical to the previous batch."""
+    prev_batch_id = _get_previous_batch_id(db, entity_type, batch_id)
+    if prev_batch_id is None:
+        return []
+
+    current_rows = _load_batch_rows(db, batch_id)
+    prev_rows = _load_batch_rows(db, prev_batch_id)
+
+    if not current_rows or not prev_rows:
+        return []
+
+    current_fps = {_row_fingerprint(r) for r in current_rows}
+    prev_fps = {_row_fingerprint(r) for r in prev_rows}
+
+    intersection = current_fps & prev_fps
+    similarity = len(intersection) / len(current_fps) if current_fps else 0
+
+    if similarity > 0.95:
+        return [AgentIssue(
+            issue_id=uuid4(),
+            batch_id=batch_id,
+            row_id=None,
+            row_number=None,
+            dq_level=3,
+            rule_code="TEMP_DUPLICATE_BATCH",
+            severity=SEVERITY_WARNING,
+            field_name=None,
+            raw_value=None,
+            message=(
+                f"Batch dupliqué : {similarity:.0%} des lignes sont identiques "
+                f"au batch précédent ({prev_batch_id})"
+            ),
+        )]
+
+    return []
+
+
+# ──────────────────────────────────────────────────────────────
+# TEMP_PO_DATE_PAST
+# ──────────────────────────────────────────────────────────────
+
+def _check_po_date_past(
+    batch_id: UUID,
+    current_rows: list[tuple[UUID, int, dict]],
+    entity_type: str,
+) -> list[AgentIssue]:
+    """PO expected_date dans le passé et status != 'received'."""
+    issues: list[AgentIssue] = []
+    if entity_type not in ("purchase_orders",):
+        return issues
+
+    today = date.today()
+
+    for row_id, row_number, content in current_rows:
+        status = content.get("status", "")
+        if status == "received":
+            continue
+
+        date_raw = content.get("expected_delivery_date")
+        if date_raw is None:
+            continue
+
+        try:
+            if isinstance(date_raw, str):
+                expected = datetime.strptime(date_raw, "%Y-%m-%d").date()
+            elif isinstance(date_raw, date):
+                expected = date_raw
+            else:
+                continue
+        except ValueError:
+            continue
+
+        if expected < today:
+            issues.append(AgentIssue(
+                issue_id=uuid4(),
+                batch_id=batch_id,
+                row_id=row_id,
+                row_number=row_number,
+                dq_level=3,
+                rule_code="TEMP_PO_DATE_PAST",
+                severity=SEVERITY_WARNING,
+                field_name="expected_delivery_date",
+                raw_value=str(date_raw),
+                message=(
+                    f"PO expected_delivery_date={date_raw} est dans le passé "
+                    f"mais status='{status}' (non reçu)"
+                ),
+            ))
+
+    return issues
+
+
+# ──────────────────────────────────────────────────────────────
+# TEMP_FORECAST_HORIZON_SHORT
+# ──────────────────────────────────────────────────────────────
+
+def _check_forecast_horizon_short(
+    db: psycopg.Connection,
+    batch_id: UUID,
+    current_rows: list[tuple[UUID, int, dict]],
+    entity_type: str,
+) -> list[AgentIssue]:
+    """Horizon forecast < max(lead_time_days) des items importés."""
+    issues: list[AgentIssue] = []
+    if entity_type not in ("forecast_demand", "forecasts"):
+        return issues
+
+    # Get max lead_time_days across all items referenced in this batch
+    item_ext_ids = list({
+        c.get("item_external_id")
+        for _, _, c in current_rows
+        if c.get("item_external_id")
+    })
+    if not item_ext_ids:
+        return issues
+
+    row = db.execute(
+        """
+        SELECT MAX(si.lead_time_days) AS max_lt
+        FROM supplier_items si
+        JOIN items i ON i.item_id = si.item_id
+        WHERE i.external_id = ANY(%s)
+        """,
+        (item_ext_ids,),
+    ).fetchone()
+
+    max_lead_time = row["max_lt"] if row and row["max_lt"] else None
+    if max_lead_time is None:
+        return issues
+
+    today = date.today()
+
+    # Find max bucket_date across batch rows
+    max_bucket: date | None = None
+    for _, _, content in current_rows:
+        bd = content.get("bucket_date")
+        if bd:
+            try:
+                bd_date = datetime.strptime(bd, "%Y-%m-%d").date() if isinstance(bd, str) else bd
+                if max_bucket is None or bd_date > max_bucket:
+                    max_bucket = bd_date
+            except ValueError:
+                pass
+
+    if max_bucket is None:
+        return issues
+
+    horizon_days = (max_bucket - today).days
+    if horizon_days < max_lead_time:
+        issues.append(AgentIssue(
+            issue_id=uuid4(),
+            batch_id=batch_id,
+            row_id=None,
+            row_number=None,
+            dq_level=3,
+            rule_code="TEMP_FORECAST_HORIZON_SHORT",
+            severity=SEVERITY_WARNING,
+            field_name="bucket_date",
+            raw_value=str(max_bucket),
+            message=(
+                f"Horizon forecast={horizon_days} jours < max(lead_time_days)={max_lead_time} "
+                f"— couverture insuffisante pour planifier le réappro"
+            ),
+        ))
+
+    return issues
+
+
+# ──────────────────────────────────────────────────────────────
+# TEMP_MASS_CHANGE
+# ──────────────────────────────────────────────────────────────
+
+def _check_mass_change(
+    db: psycopg.Connection,
+    batch_id: UUID,
+    entity_type: str,
+) -> list[AgentIssue]:
+    """>30% des valeurs d'un champ changent entre deux batches successifs."""
+    issues: list[AgentIssue] = []
+
+    prev_batch_id = _get_previous_batch_id(db, entity_type, batch_id)
+    if prev_batch_id is None:
+        return []
+
+    current_rows = _load_batch_rows(db, batch_id)
+    prev_rows = _load_batch_rows(db, prev_batch_id)
+
+    if not current_rows or not prev_rows:
+        return []
+
+    # Collect all field names
+    all_fields: set[str] = set()
+    for r in current_rows + prev_rows:
+        all_fields.update(r.keys())
+
+    for field_name in all_fields:
+        current_vals = [str(r.get(field_name, "")) for r in current_rows]
+        prev_vals = [str(r.get(field_name, "")) for r in prev_rows]
+
+        # Compare values using a simple symmetric diff on sets
+        common_count = min(len(current_vals), len(prev_vals))
+        if common_count == 0:
+            continue
+
+        changes = sum(
+            1 for a, b in zip(current_vals[:common_count], prev_vals[:common_count])
+            if a != b
+        )
+        change_ratio = changes / common_count
+
+        if change_ratio > 0.30:
+            issues.append(AgentIssue(
+                issue_id=uuid4(),
+                batch_id=batch_id,
+                row_id=None,
+                row_number=None,
+                dq_level=3,
+                rule_code="TEMP_MASS_CHANGE",
+                severity=SEVERITY_ERROR,
+                field_name=field_name,
+                raw_value=None,
+                message=(
+                    f"Changement massif détecté sur champ '{field_name}' : "
+                    f"{change_ratio:.0%} des valeurs ont changé vs batch précédent"
+                ),
+            ))
+
+    return issues
+
+
+# ──────────────────────────────────────────────────────────────
+# Main entry point
+# ──────────────────────────────────────────────────────────────
+
+def run_temporal_rules(
+    db: psycopg.Connection,
+    batch_id: UUID,
+) -> list[AgentIssue]:
+    """Run all temporal rules for a batch. Returns list of AgentIssue."""
+    entity_type = _get_entity_type(db, batch_id)
+
+    # Load current rows for per-row rules
+    rows_data = db.execute(
+        """
+        SELECT row_id, row_number, raw_content
+        FROM ingest_rows
+        WHERE batch_id = %s
+        ORDER BY row_number
+        """,
+        (batch_id,),
+    ).fetchall()
+
+    current_rows: list[tuple[UUID, int, dict]] = []
+    for r in rows_data:
+        try:
+            content = json.loads(r["raw_content"]) if isinstance(r["raw_content"], str) else r["raw_content"]
+            if isinstance(content, dict):
+                current_rows.append((r["row_id"], r["row_number"], content))
+        except Exception:
+            pass
+
+    issues: list[AgentIssue] = []
+
+    issues.extend(_check_duplicate_batch(db, batch_id, entity_type))
+    issues.extend(_check_po_date_past(batch_id, current_rows, entity_type))
+    issues.extend(_check_forecast_horizon_short(db, batch_id, current_rows, entity_type))
+    issues.extend(_check_mass_change(db, batch_id, entity_type))
+
+    logger.info(
+        "temporal_rules batch_id=%s entity=%s issues=%d",
+        batch_id, entity_type, len(issues),
+    )
+    return issues

--- a/src/ootils_core/engine/dq/engine.py
+++ b/src/ootils_core/engine/dq/engine.py
@@ -643,6 +643,14 @@ def run_dq(db: psycopg.Connection, batch_id: UUID) -> DQResult:
         batch_id, entity_type, len(ingest_rows), passed_rows, failed_rows, warning_rows, len(all_issues),
     )
 
+    # Auto-trigger DQ Agent (stat + temporal + impact + LLM) after L1+L2
+    try:
+        from ootils_core.engine.dq.agent import run_dq_agent
+        run_dq_agent(db, batch_id)
+    except Exception as agent_exc:
+        # Agent failure must never break the core DQ result
+        logger.warning("dq_agent failed for batch %s (non-fatal): %s", batch_id, agent_exc)
+
     return DQResult(
         batch_id=batch_id,
         total_rows=len(ingest_rows),

--- a/tests/integration/test_dq_agent.py
+++ b/tests/integration/test_dq_agent.py
@@ -1,0 +1,502 @@
+"""
+tests/integration/test_dq_agent.py — Integration tests for DQ Agent V1.
+
+Tests:
+  1.  STAT_LEAD_TIME_SPIKE détecté
+  2.  STAT_NEGATIVE_ONHAND détecté
+  3.  TEMP_PO_DATE_PAST détecté
+  4.  TEMP_DUPLICATE_BATCH détecté
+  5.  impact_scorer enrichit les issues
+  6.  POST /v1/dq/agent/run/{batch_id} fonctionne
+  7.  GET /v1/dq/agent/report/{batch_id} retourne le rapport
+  8.  GET /v1/dq/agent/runs retourne l'historique
+  9.  Fallback LLM fonctionne (mock API indisponible)
+  10. dq_agent_runs créé en DB
+
+Requires PostgreSQL. Set DATABASE_URL before running.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import date, timedelta
+from uuid import uuid4
+
+import psycopg
+import pytest
+from psycopg.rows import dict_row
+
+from .conftest import requires_db, DB_AVAILABLE, TEST_DB_URL
+
+
+# ─────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def agent_client(migrated_db):
+    """Module-scoped TestClient with migrated DB for agent tests."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = "test-token"
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+    from fastapi.testclient import TestClient
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="module")
+def auth():
+    return {"Authorization": "Bearer test-token"}
+
+
+@pytest.fixture(scope="module")
+def agent_db_conn(migrated_db):
+    """Direct psycopg connection for DB assertions."""
+    conn = psycopg.connect(migrated_db, row_factory=dict_row)
+    yield conn
+    conn.close()
+
+
+PREFIX = "agt-" + str(uuid4())[:8]
+
+
+def uid(base: str) -> str:
+    return f"{PREFIX}-{base}"
+
+
+def _create_batch(db, entity_type: str, rows: list[dict], status: str = "processing") -> str:
+    """Insert an ingest_batch + ingest_rows, return batch_id."""
+    batch_id = str(uuid4())
+    db.execute(
+        """
+        INSERT INTO ingest_batches
+            (batch_id, entity_type, source_system, status, total_rows, submitted_by)
+        VALUES (%s, %s, 'test', %s, %s, 'pytest')
+        """,
+        (batch_id, entity_type, status, len(rows)),
+    )
+    for i, row in enumerate(rows):
+        db.execute(
+            """
+            INSERT INTO ingest_rows (row_id, batch_id, row_number, raw_content)
+            VALUES (%s, %s, %s, %s)
+            """,
+            (str(uuid4()), batch_id, i + 1, json.dumps(row)),
+        )
+    db.commit()
+    return batch_id
+
+
+def _mark_batch_validated(db, batch_id: str) -> None:
+    db.execute(
+        "UPDATE ingest_batches SET dq_status = 'validated' WHERE batch_id = %s",
+        (batch_id,),
+    )
+    db.commit()
+
+
+def _insert_item(db, external_id: str) -> str:
+    item_id = str(uuid4())
+    db.execute(
+        """
+        INSERT INTO items (item_id, external_id, name, item_type, uom, status)
+        VALUES (%s, %s, 'Test Item', 'component', 'EA', 'active')
+        ON CONFLICT (external_id) DO NOTHING
+        """,
+        (item_id, external_id),
+    )
+    db.commit()
+    return item_id
+
+
+def _insert_supplier(db, external_id: str) -> str:
+    sup_id = str(uuid4())
+    db.execute(
+        """
+        INSERT INTO suppliers (supplier_id, external_id, name, status)
+        VALUES (%s, %s, 'Test Supplier', 'active')
+        ON CONFLICT (external_id) DO NOTHING
+        """,
+        (sup_id, external_id),
+    )
+    db.commit()
+    return sup_id
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 1: STAT_LEAD_TIME_SPIKE détecté
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_stat_lead_time_spike_detected(agent_db_conn, migrated_db):
+    """STAT_LEAD_TIME_SPIKE : lead_time_days 8σ above historical avg → issue generated."""
+    from ootils_core.engine.dq.agent.stat_rules import run_stat_rules
+    import psycopg as _psycopg
+
+    item_ext = uid("lt-spike-item")
+    sup_ext = uid("lt-spike-sup")
+
+    # Create historical batches with lead_time=14 days (validated)
+    for i in range(4):
+        b_id = _create_batch(agent_db_conn, "supplier_items", [
+            {"item_external_id": item_ext, "supplier_external_id": sup_ext, "lead_time_days": 14},
+        ])
+        _mark_batch_validated(agent_db_conn, b_id)
+
+    # Create current batch with lead_time=200 (spike)
+    batch_id = _create_batch(agent_db_conn, "supplier_items", [
+        {"item_external_id": item_ext, "supplier_external_id": sup_ext, "lead_time_days": 200},
+    ])
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        issues = run_stat_rules(conn, batch_id)
+
+    spike_issues = [i for i in issues if i.rule_code == "STAT_LEAD_TIME_SPIKE"]
+    assert len(spike_issues) >= 1
+    assert spike_issues[0].severity == "error"
+    assert spike_issues[0].field_name == "lead_time_days"
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 2: STAT_NEGATIVE_ONHAND détecté
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_stat_negative_onhand_detected(agent_db_conn, migrated_db):
+    """STAT_NEGATIVE_ONHAND : quantity < 0 in on_hand batch → issue generated."""
+    from ootils_core.engine.dq.agent.stat_rules import run_stat_rules
+    import psycopg as _psycopg
+
+    item_ext = uid("neg-oh-item")
+    loc_ext = uid("neg-oh-loc")
+
+    # Note: L1 rejects negative qty, but STAT_NEGATIVE_ONHAND checks the raw content
+    batch_id = _create_batch(agent_db_conn, "on_hand", [
+        {
+            "item_external_id": item_ext,
+            "location_external_id": loc_ext,
+            "quantity": -50,
+            "uom": "EA",
+            "as_of_date": "2026-04-08",
+        }
+    ])
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        issues = run_stat_rules(conn, batch_id)
+
+    neg_issues = [i for i in issues if i.rule_code == "STAT_NEGATIVE_ONHAND"]
+    assert len(neg_issues) >= 1
+    assert neg_issues[0].severity == "error"
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 3: TEMP_PO_DATE_PAST détecté
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_temp_po_date_past_detected(agent_db_conn, migrated_db):
+    """TEMP_PO_DATE_PAST : PO expected_date in the past + status != received → issue."""
+    from ootils_core.engine.dq.agent.temporal_rules import run_temporal_rules
+    import psycopg as _psycopg
+
+    past_date = (date.today() - timedelta(days=30)).isoformat()
+
+    batch_id = _create_batch(agent_db_conn, "purchase_orders", [
+        {
+            "external_id": uid("po-past"),
+            "item_external_id": uid("po-item"),
+            "location_external_id": uid("po-loc"),
+            "supplier_external_id": uid("po-sup"),
+            "quantity": 100,
+            "uom": "EA",
+            "expected_delivery_date": past_date,
+            "status": "confirmed",  # not 'received'
+        }
+    ])
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        issues = run_temporal_rules(conn, batch_id)
+
+    past_issues = [i for i in issues if i.rule_code == "TEMP_PO_DATE_PAST"]
+    assert len(past_issues) >= 1
+    assert past_issues[0].severity == "warning"
+    assert past_issues[0].field_name == "expected_delivery_date"
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 4: TEMP_DUPLICATE_BATCH détecté
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_temp_duplicate_batch_detected(agent_db_conn, migrated_db):
+    """TEMP_DUPLICATE_BATCH : >95% identical rows to previous batch → issue."""
+    from ootils_core.engine.dq.agent.temporal_rules import run_temporal_rules
+    import psycopg as _psycopg
+
+    item_ext = uid("dup-item")
+    loc_ext = uid("dup-loc")
+
+    # Row data — same in both batches
+    row_data = [
+        {
+            "item_external_id": item_ext,
+            "location_external_id": loc_ext,
+            "quantity": 100,
+            "uom": "EA",
+            "as_of_date": "2026-04-08",
+        }
+        for _ in range(5)
+    ]
+
+    # Create first batch (validated = previous)
+    prev_batch_id = _create_batch(agent_db_conn, "on_hand", row_data)
+    _mark_batch_validated(agent_db_conn, prev_batch_id)
+
+    # Create second batch (identical)
+    current_batch_id = _create_batch(agent_db_conn, "on_hand", row_data)
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        issues = run_temporal_rules(conn, current_batch_id)
+
+    dup_issues = [i for i in issues if i.rule_code == "TEMP_DUPLICATE_BATCH"]
+    assert len(dup_issues) >= 1
+    assert dup_issues[0].severity == "warning"
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 5: impact_scorer enrichit les issues
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_impact_scorer_enriches_issues(agent_db_conn, migrated_db):
+    """impact_scorer assigns impact_score to all issues."""
+    from ootils_core.engine.dq.agent.stat_rules import AgentIssue
+    from ootils_core.engine.dq.agent.impact_scorer import score_issues
+    import psycopg as _psycopg
+
+    batch_id_uuid = uuid4()
+    batch_id_str = str(batch_id_uuid)
+
+    # Create a dummy batch in DB
+    agent_db_conn.execute(
+        """
+        INSERT INTO ingest_batches
+            (batch_id, entity_type, source_system, status, total_rows, submitted_by)
+        VALUES (%s, 'on_hand', 'test', 'processing', 1, 'pytest')
+        """,
+        (batch_id_str,),
+    )
+    row_id = uuid4()
+    agent_db_conn.execute(
+        """
+        INSERT INTO ingest_rows (row_id, batch_id, row_number, raw_content)
+        VALUES (%s, %s, 1, %s)
+        """,
+        (str(row_id), batch_id_str, json.dumps({"item_external_id": uid("scorer-item"), "quantity": -10})),
+    )
+    agent_db_conn.commit()
+
+    issue = AgentIssue(
+        issue_id=uuid4(),
+        batch_id=batch_id_uuid,
+        row_id=row_id,
+        row_number=1,
+        dq_level=3,
+        rule_code="STAT_NEGATIVE_ONHAND",
+        severity="error",
+        field_name="quantity",
+        raw_value="-10",
+        message="test issue",
+    )
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        scored = score_issues(conn, batch_id_uuid, [issue])
+
+    assert len(scored) == 1
+    # impact_score must be set (>= severity_weight × 1.0)
+    assert scored[0].impact_score is not None
+    assert scored[0].impact_score >= 1.5  # error weight is 3.0 × log(1+0)=3.0×1=3.0
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 6: POST /v1/dq/agent/run/{batch_id} fonctionne
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_post_agent_run_endpoint(agent_client, auth, agent_db_conn):
+    """POST /v1/dq/agent/run/{batch_id} triggers agent and returns run_id."""
+    batch_id = _create_batch(agent_db_conn, "on_hand", [
+        {
+            "item_external_id": uid("api-run-item"),
+            "location_external_id": uid("api-run-loc"),
+            "quantity": 100,
+            "uom": "EA",
+            "as_of_date": "2026-04-08",
+        }
+    ])
+
+    resp = agent_client.post(f"/v1/dq/agent/run/{batch_id}", headers=auth)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["batch_id"] == batch_id
+    assert data["status"] == "completed"
+    assert "agent_run_id" in data
+    assert data["agent_run_id"] is not None
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 7: GET /v1/dq/agent/report/{batch_id} retourne le rapport
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_get_agent_report_endpoint(agent_client, auth, agent_db_conn):
+    """GET /v1/dq/agent/report/{batch_id} returns full agent report."""
+    batch_id = _create_batch(agent_db_conn, "on_hand", [
+        {
+            "item_external_id": uid("report-item"),
+            "location_external_id": uid("report-loc"),
+            "quantity": -5,  # will trigger STAT_NEGATIVE_ONHAND
+            "uom": "EA",
+            "as_of_date": "2026-04-08",
+        }
+    ])
+
+    # Run agent first
+    agent_client.post(f"/v1/dq/agent/run/{batch_id}", headers=auth)
+
+    resp = agent_client.get(f"/v1/dq/agent/report/{batch_id}", headers=auth)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["batch_id"] == batch_id
+    assert data["entity_type"] == "on_hand"
+    assert "issues" in data
+    assert "summary" in data
+    assert "priority_actions" in data
+    assert isinstance(data["issues"], list)
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 8: GET /v1/dq/agent/runs retourne l'historique
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_get_agent_runs_history(agent_client, auth, agent_db_conn):
+    """GET /v1/dq/agent/runs returns list of agent run records."""
+    # Ensure at least one run exists
+    batch_id = _create_batch(agent_db_conn, "on_hand", [
+        {
+            "item_external_id": uid("runs-hist-item"),
+            "location_external_id": uid("runs-hist-loc"),
+            "quantity": 50,
+            "uom": "EA",
+            "as_of_date": "2026-04-08",
+        }
+    ])
+    agent_client.post(f"/v1/dq/agent/run/{batch_id}", headers=auth)
+
+    resp = agent_client.get("/v1/dq/agent/runs", headers=auth)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "runs" in data
+    assert "total" in data
+    assert data["total"] >= 1
+    assert len(data["runs"]) >= 1
+    run = data["runs"][0]
+    assert "run_id" in run
+    assert "batch_id" in run
+    assert "status" in run
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 9: Fallback LLM fonctionne (mock API indisponible)
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_llm_fallback_when_api_unavailable(agent_db_conn, migrated_db):
+    """LLM fallback generates a structured report when OPENAI_API_KEY is not set."""
+    from ootils_core.engine.dq.agent.llm_reporter import generate_llm_report
+    from ootils_core.engine.dq.agent.stat_rules import AgentIssue
+    import psycopg as _psycopg
+
+    # Temporarily remove API key
+    original_key = os.environ.pop("OPENAI_API_KEY", None)
+
+    try:
+        issue = AgentIssue(
+            issue_id=uuid4(),
+            batch_id=uuid4(),
+            row_id=None,
+            row_number=None,
+            dq_level=3,
+            rule_code="STAT_NEGATIVE_ONHAND",
+            severity="error",
+            field_name="quantity",
+            raw_value="-10",
+            message="on_hand_qty=-10",
+            impact_score=3.0,
+        )
+
+        report = generate_llm_report(
+            issues=[issue],
+            entity_type="on_hand",
+            batch_id=uuid4(),
+            total_rows=1,
+        )
+
+        assert report.llm_available is False
+        assert report.narrative is not None
+        assert len(report.narrative) > 0
+        assert report.model_used is None
+    finally:
+        if original_key:
+            os.environ["OPENAI_API_KEY"] = original_key
+
+
+# ─────────────────────────────────────────────────────────────
+# Test 10: dq_agent_runs créé en DB
+# ─────────────────────────────────────────────────────────────
+
+@requires_db
+def test_dq_agent_run_created_in_db(agent_db_conn, migrated_db):
+    """run_dq_agent creates a row in dq_agent_runs with status=completed."""
+    from ootils_core.engine.dq.agent import run_dq_agent
+    import psycopg as _psycopg
+
+    batch_id = _create_batch(agent_db_conn, "on_hand", [
+        {
+            "item_external_id": uid("db-run-item"),
+            "location_external_id": uid("db-run-loc"),
+            "quantity": 200,
+            "uom": "EA",
+            "as_of_date": "2026-04-08",
+        }
+    ])
+
+    with _psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        result = run_dq_agent(conn, batch_id)
+        conn.commit()
+
+    # Verify in DB
+    row = agent_db_conn.execute(
+        "SELECT run_id, status, completed_at FROM dq_agent_runs WHERE run_id = %s",
+        (str(result.run_id),),
+    ).fetchone()
+
+    assert row is not None
+    assert row["status"] == "completed"
+    assert row["completed_at"] is not None


### PR DESCRIPTION
Closes #99

## What

Implements DQ Agent V1 per SPEC-DQ-AGENT.md.

## Changes

### Migration
- `012_dq_agent.sql`: `dq_agent_runs` table + enriched `data_quality_issues` columns (impact_score, agent_run_id, llm_explanation, llm_suggestion)

### Engine
- `engine/dq/agent/stat_rules.py`: STAT_LEAD_TIME_SPIKE, STAT_FORECAST_SPIKE, STAT_PRICE_OUTLIER, STAT_SAFETY_STOCK_ZERO, STAT_NEGATIVE_ONHAND
- `engine/dq/agent/temporal_rules.py`: TEMP_DUPLICATE_BATCH, TEMP_PO_DATE_PAST, TEMP_FORECAST_HORIZON_SHORT, TEMP_MASS_CHANGE
- `engine/dq/agent/impact_scorer.py`: graph traversal + BOM propagation + priority scoring
- `engine/dq/agent/llm_reporter.py`: GPT-4.1-mini narrative + fallback
- `engine/dq/agent/agent.py`: dispatcher run_dq_agent()
- `engine/dq/engine.py`: auto-trigger after L1+L2

### API
- POST /v1/dq/agent/run/{batch_id}
- GET /v1/dq/agent/report/{batch_id}
- GET /v1/dq/agent/runs

### Tests
- 10 integration tests in `tests/integration/test_dq_agent.py`

### Docs
- `docs/SPEC-DQ-AGENT.md`