### PR TITLE
fix: mark events processed=true after propagation

### DIFF
--- a/src/ootils_core/engine/orchestration/propagator.py
+++ b/src/ootils_core/engine/orchestration/propagator.py
@@ -94,6 +94,7 @@ class PropagationEngine:
 
             if trigger_node_id is None:
                 logger.info("Event %s has no trigger node — skipping propagation", event_id)
+                db.execute("UPDATE events SET processed = TRUE WHERE event_id = %s", (event_id,))
                 self._finish_run(calc_run, scenario_id, db)
                 return calc_run
 
@@ -172,6 +173,13 @@ class PropagationEngine:
             )
 
         self._calc_run_mgr.complete_calc_run(calc_run, scenario, db)
+
+        # Mark all events in this calc run as processed
+        if calc_run.event_ids:
+            db.execute(
+                "UPDATE events SET processed = TRUE WHERE event_id = ANY(%s)",
+                (list(calc_run.event_ids),),
+            )
 
         # Resolve stale shortages: any shortage from a previous calc_run
         # that was NOT re-detected in this run should be marked resolved.


### PR DESCRIPTION
Après propagation réussie, les événements sont marqués processed=TRUE.
- Cas 1 : événement avec trigger_node → marqué dans _finish_run via calc_run.event_ids
- Cas 2 : événement sans trigger_node (ingestion_complete, etc.) → marqué directement avant _finish_run