### PR TITLE
fix: allocation priority, SQL injection prevention, migration runner with tracking

### DIFF
--- a/src/ootils_core/api/routers/ingest.py
+++ b/src/ootils_core/api/routers/ingest.py
@@ -25,6 +25,7 @@ from typing import Any, Optional
 from uuid import UUID, uuid4
 
 import psycopg
+from psycopg import sql
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field, field_validator
 
@@ -135,6 +136,13 @@ def _emit_ingestion_event(db: psycopg.Connection, scenario_id: UUID, node_id: UU
     )
 
 
+_ALLOWED_TABLES = {"items", "locations", "suppliers", "supplier_items", "resources"}
+_ALLOWED_COLUMNS = {
+    "external_id", "item_id", "location_id", "supplier_id",
+    "supplier_item_id", "resource_id",
+}
+
+
 def _batch_existing(
     db: psycopg.Connection,
     table: str,
@@ -142,13 +150,23 @@ def _batch_existing(
     pk_col: str,
     external_ids: list[str],
 ) -> dict[str, UUID]:
-    """Return {external_id: pk} for all rows matching the given external_ids."""
+    """Return {external_id: pk} for all rows matching the given external_ids.
+
+    Uses psycopg.sql.Identifier for table/column names to prevent SQL injection.
+    Table and column names are also validated against allowlists.
+    """
     if not external_ids:
         return {}
-    rows = db.execute(
-        f"SELECT {id_col}, {pk_col} FROM {table} WHERE {id_col} = ANY(%s)",
-        (external_ids,),
-    ).fetchall()
+    if table not in _ALLOWED_TABLES:
+        raise ValueError(f"Table '{table}' not in allowlist")
+    if id_col not in _ALLOWED_COLUMNS or pk_col not in _ALLOWED_COLUMNS:
+        raise ValueError(f"Column '{id_col}' or '{pk_col}' not in allowlist")
+    query = sql.SQL("SELECT {id_col}, {pk_col} FROM {table} WHERE {id_col} = ANY(%s)").format(
+        id_col=sql.Identifier(id_col),
+        pk_col=sql.Identifier(pk_col),
+        table=sql.Identifier(table),
+    )
+    rows = db.execute(query, (external_ids,)).fetchall()
     return {r[id_col]: r[pk_col] for r in rows}
 
 
@@ -359,8 +377,6 @@ class SupplierRow(BaseModel):
     # W-06: lead_time_days must be > 0 when provided
     lead_time_days: Optional[int] = Field(None, gt=0, description="Standard lead time in calendar days.")
     reliability_score: Optional[float] = Field(None, description="Reliability score [0.0–1.0]. 1.0 = perfect.")
-    moq: Optional[float] = None          # not a suppliers column, accepted but not persisted
-    currency: Optional[str] = None       # not a suppliers column, accepted but not persisted
     country: Optional[str] = None
     status: str = "active"
 

--- a/src/ootils_core/db/connection.py
+++ b/src/ootils_core/db/connection.py
@@ -65,39 +65,83 @@ class OotilsDB:
                 raise
 
     def _apply_migrations(self) -> None:
-        """Apply all .sql migration files in order. Idempotent (IF NOT EXISTS throughout)."""
+        """Apply pending .sql migration files in order.
+
+        Uses a schema_migrations tracking table so each migration runs
+        exactly once.  An advisory lock prevents concurrent migration
+        attempts from racing.
+        """
         import sys
 
         migration_files = sorted(MIGRATIONS_DIR.glob("*.sql"))
         if not migration_files:
             return
 
+        # Use advisory lock (key = hash of 'ootils_migrations') to prevent
+        # concurrent migration attempts from multiple app instances.
+        _LOCK_KEY = 8_037_421_901  # arbitrary fixed int64
+
         with psycopg.connect(self.database_url, autocommit=True) as conn:
-            for migration_path in migration_files:
-                sql = migration_path.read_text(encoding="utf-8")
-                try:
-                    # Use cursor.execute() to handle multi-statement SQL files,
-                    # including files with DO $$ ... $$ PL/pgSQL blocks.
-                    # autocommit=True ensures each statement commits independently.
-                    with conn.cursor() as cur:
-                        cur.execute(sql)
-                except Exception as e:
-                    err_msg = str(e).lower()
-                    # Ignore "already exists" errors — idempotent migrations
-                    if any(phrase in err_msg for phrase in [
-                        "already exists",
-                        "duplicate key",
-                        "relation already exists",
-                        "column already exists",
-                        "constraint already exists",
-                    ]):
-                        continue
-                    # Log real errors instead of silently ignoring them
-                    print(
-                        f"[MIGRATION ERROR] {migration_path.name}: {e}",
-                        file=sys.stderr,
+            # Acquire advisory lock (blocks until available)
+            conn.execute("SELECT pg_advisory_lock(%s)", (_LOCK_KEY,))
+            try:
+                # Ensure tracking table exists
+                conn.execute("""
+                    CREATE TABLE IF NOT EXISTS schema_migrations (
+                        version  TEXT PRIMARY KEY,
+                        applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
                     )
-                    raise
+                """)
+
+                # Load already-applied migrations
+                applied = {
+                    row["version"]
+                    for row in conn.execute(
+                        "SELECT version FROM schema_migrations"
+                    ).fetchall()
+                }
+
+                for migration_path in migration_files:
+                    version = migration_path.name
+                    if version in applied:
+                        continue
+
+                    migration_sql = migration_path.read_text(encoding="utf-8")
+                    try:
+                        with conn.cursor() as cur:
+                            cur.execute(migration_sql)
+                        # Record successful migration
+                        conn.execute(
+                            "INSERT INTO schema_migrations (version) VALUES (%s)",
+                            (version,),
+                        )
+                    except Exception as e:
+                        err_msg = str(e).lower()
+                        # Tolerate "already exists" only for initial bootstrap
+                        # where the tracking table didn't exist yet.
+                        if any(phrase in err_msg for phrase in [
+                            "already exists",
+                            "duplicate key",
+                            "relation already exists",
+                            "column already exists",
+                            "constraint already exists",
+                        ]):
+                            # Still record it so we don't retry
+                            try:
+                                conn.execute(
+                                    "INSERT INTO schema_migrations (version) VALUES (%s) ON CONFLICT DO NOTHING",
+                                    (version,),
+                                )
+                            except Exception:
+                                pass
+                            continue
+                        print(
+                            f"[MIGRATION ERROR] {migration_path.name}: {e}",
+                            file=sys.stderr,
+                        )
+                        raise
+            finally:
+                conn.execute("SELECT pg_advisory_unlock(%s)", (_LOCK_KEY,))
 
     def health_check(self) -> dict:
         """

--- a/src/ootils_core/engine/kernel/allocation/engine.py
+++ b/src/ootils_core/engine/kernel/allocation/engine.py
@@ -326,12 +326,13 @@ def _priority_key(node: Node) -> int:
     integer when the demand node type does not carry an explicit priority field.
     A lower integer means higher priority (P1 beats P2).
 
-    When quantity is None or non-integer, we fall back to 0 (highest priority)
-    to avoid hiding demands.
+    When quantity is None or non-integer, we fall back to 999999 (lowest
+    priority) so that demands with missing priority data do not accidentally
+    starve properly prioritized demands.
     """
     try:
         if node.quantity is not None:
             return int(node.quantity)
     except (ValueError, TypeError):
         pass
-    return 0
+    return 999999


### PR DESCRIPTION
## Summary

Three independent fixes for data integrity and safety issues identified in the code review.

## Changes

### 1. Allocation priority default: 0 → 999999
**File:** `engine/kernel/allocation/engine.py`

`_priority_key()` returned 0 (highest priority) for demands with missing/invalid priority data. This caused unprioritized demands to consume supply before properly prioritized ones. Changed to 999999 (lowest priority).

### 2. _batch_existing: f-string SQL → psycopg.sql.Identifier
**File:** `api/routers/ingest.py`

Table and column names were interpolated via f-string. Now uses `psycopg.sql.Identifier` for proper escaping, plus validation against allowlists. Also removed the silently-ignored `moq` and `currency` fields from `SupplierRow`.

### 3. Migration runner with schema_migrations table
**File:** `db/connection.py`

Previous runner re-executed ALL migrations on every app restart, relying on IF NOT EXISTS and error suppression. This caused migration 003 to DROP and recreate zone_transition_runs every time (data loss).

New runner:
- Creates a `schema_migrations` tracking table
- Each migration runs exactly once
- Advisory lock prevents concurrent migration attempts
- Existing databases bootstrap cleanly via error-tolerance path

## Test plan

- [ ] Verify allocation ordering: demands without priority should be allocated LAST
- [ ] Verify ingest endpoints still work (suppliers, items, locations, etc.)
- [ ] Verify migration runner: first start creates schema_migrations, subsequent starts skip already-applied migrations
- [ ] Verify concurrent app starts don't race on migrations (advisory lock)

Addresses #111, #129, #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)