### PR TITLE
fix(db): migration 015 — schema integrity constraints (#131)

### DIFF
--- a/src/ootils_core/db/migrations/015_schema_integrity.sql
+++ b/src/ootils_core/db/migrations/015_schema_integrity.sql
@@ -1,0 +1,121 @@
+-- ============================================================
+-- Migration 015: Schema integrity — constraints and indexes
+-- ============================================================
+-- Fixes broken UNIQUE constraints, adds missing CHECK constraints,
+-- and addresses UUID default gaps identified in DBA review #131.
+--
+-- NOTE: ON DELETE CASCADE on scenarios intentionally NOT added.
+-- Ootils uses soft-delete pattern (status='archived'). Hard-deleting a scenario
+-- should be a deliberate admin operation with explicit table cleanup.
+-- See docs/DBA-RUNBOOK.md for manual scenario cleanup procedure.
+-- ============================================================
+
+-- ============================================================
+-- 1. Fix node_type_policies UNIQUE constraint
+-- ============================================================
+-- Current UNIQUE(node_type, active) prevents multiple inactive policies
+-- for the same node_type (only one row with active=FALSE allowed per type).
+-- The business rule is: at most one ACTIVE policy per node_type.
+-- Replace the pair-wise UNIQUE with a partial unique index.
+
+ALTER TABLE node_type_policies
+    DROP CONSTRAINT IF EXISTS node_type_policies_node_type_active_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_node_type_policies_active
+    ON node_type_policies (node_type) WHERE active = TRUE;
+
+-- ============================================================
+-- 2. Fix uom_conversions NULL duplicate issue
+-- ============================================================
+-- NULL != NULL in standard SQL UNIQUE, so global conversions (item_id IS NULL)
+-- can be inserted multiple times on re-run without triggering uniqueness errors.
+-- Add a partial unique index covering only global (item_id IS NULL) rows.
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_uom_global
+    ON uom_conversions (from_uom, to_uom) WHERE item_id IS NULL;
+
+-- ============================================================
+-- 3. Missing edge uniqueness constraint
+-- ============================================================
+-- Prevents duplicate (from_node_id, to_node_id, edge_type, scenario_id) active edges.
+-- Uses partial unique index so soft-deleted (active=FALSE) edges are excluded,
+-- allowing re-activation patterns.
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_edges_composite
+    ON edges (from_node_id, to_node_id, edge_type, scenario_id)
+    WHERE active = TRUE;
+
+-- ============================================================
+-- 4. CHECK constraints for date ordering
+-- ============================================================
+-- Prevent valid_to <= valid_from and effective_to <= effective_from.
+-- Uses exception handler for idempotency (constraint already exists = no-op).
+
+DO $$ BEGIN
+    BEGIN
+        ALTER TABLE supplier_items
+            ADD CONSTRAINT chk_supplier_items_dates
+            CHECK (valid_to IS NULL OR valid_to > valid_from);
+    EXCEPTION WHEN duplicate_object THEN NULL;
+    END;
+END $$;
+
+DO $$ BEGIN
+    BEGIN
+        ALTER TABLE bom_headers
+            ADD CONSTRAINT chk_bom_headers_dates
+            CHECK (effective_to IS NULL OR effective_to > effective_from);
+    EXCEPTION WHEN duplicate_object THEN NULL;
+    END;
+END $$;
+
+-- ============================================================
+-- 5. resource_capacity_overrides: no negative capacity
+-- ============================================================
+-- Table may not exist in all environments (created later in the migration chain
+-- or in some deploy configurations).
+
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables
+               WHERE table_schema = 'public'
+                 AND table_name = 'resource_capacity_overrides') THEN
+        BEGIN
+            ALTER TABLE resource_capacity_overrides
+                ADD CONSTRAINT chk_capacity_nonneg CHECK (capacity >= 0);
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END;
+    END IF;
+END $$;
+
+-- ============================================================
+-- 6. Fix explanations/causal_steps missing DEFAULT uuid
+-- ============================================================
+-- If the PK columns were created without DEFAULT gen_random_uuid(),
+-- application code that omits the PK on INSERT will fail.
+-- Only alters if DEFAULT is currently absent.
+
+DO $$ BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name   = 'explanations'
+          AND column_name  = 'explanation_id'
+          AND column_default IS NULL
+    ) THEN
+        ALTER TABLE explanations
+            ALTER COLUMN explanation_id SET DEFAULT gen_random_uuid();
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name   = 'causal_steps'
+          AND column_name  = 'step_id'
+          AND column_default IS NULL
+    ) THEN
+        ALTER TABLE causal_steps
+            ALTER COLUMN step_id SET DEFAULT gen_random_uuid();
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary

Fixes broken UNIQUE constraints, adds missing CHECK constraints, and addresses UUID default gaps identified in DBA review.

### Changes

1. **node_type_policies UNIQUE fix** — Replace `UNIQUE(node_type, active)` pair constraint with `UNIQUE INDEX WHERE active=TRUE`. The old constraint prevented multiple inactive policies per type; the new one enforces the actual business rule (one active policy per type).

2. **uom_conversions NULL duplicate fix** — `NULL != NULL` in standard SQL UNIQUE, so global conversions (`item_id IS NULL`) could be inserted multiple times. Partial unique index on `(from_uom, to_uom) WHERE item_id IS NULL` closes this gap.

3. **Edge uniqueness constraint** — New partial unique index on `(from_node_id, to_node_id, edge_type, scenario_id) WHERE active=TRUE` prevents duplicate active edges.

4. **Date ordering CHECK constraints** — `supplier_items.valid_to > valid_from` and `bom_headers.effective_to > effective_from` (both nullable — NULL means open-ended).

5. **Non-negative capacity** — `resource_capacity_overrides.capacity >= 0` (conditional — table may not exist).

6. **UUID defaults** — Sets `gen_random_uuid()` DEFAULT on `explanations.explanation_id` and `causal_steps.step_id` if currently absent.

> **Note on CASCADEs**: ON DELETE CASCADE on scenarios intentionally NOT added. Ootils uses soft-delete pattern (`status='archived'`). Hard-deleting a scenario should be a deliberate admin operation. See `docs/DBA-RUNBOOK.md` for manual cleanup procedure.

## Tests
241 passed, 155 skipped.

Closes #131