### PR TITLE
feat: event propagation, graph wiring, simulate delta (#119 #120 #121)

### DIFF
--- a/src/ootils_core/api/app.py
+++ b/src/ootils_core/api/app.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from ootils_core.api.routers import bom, calendars, dq, events, explain, ghosts, graph, ingest, issues, planning_params, projection, rccp, simulate
+from ootils_core.api.routers import bom, calc, calendars, dq, events, explain, ghosts, graph, ingest, issues, planning_params, projection, rccp, scenarios, simulate
 from ootils_core.api.routers.graph import nodes_router
 
 logger = logging.getLogger(__name__)
@@ -81,6 +81,8 @@ def create_app() -> FastAPI:
     application.include_router(rccp.router)
     application.include_router(ghosts.router)
     application.include_router(planning_params.router)
+    application.include_router(scenarios.router)
+    application.include_router(calc.router)
 
     @application.exception_handler(Exception)
     async def generic_exception_handler(request, exc: Exception) -> JSONResponse:

--- a/src/ootils_core/api/routers/calc.py
+++ b/src/ootils_core/api/routers/calc.py
@@ -1,0 +1,121 @@
+"""
+POST /v1/calc/run — Manually trigger propagation for a scenario.
+"""
+from __future__ import annotations
+
+import logging
+from uuid import UUID, uuid4
+from datetime import datetime, timezone
+from typing import Optional
+
+import psycopg
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel
+
+from ootils_core.api.auth import require_auth
+from ootils_core.api.dependencies import get_db, resolve_scenario_id
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/v1/calc", tags=["calc"])
+
+
+class CalcRunRequest(BaseModel):
+    full_recompute: bool = False
+
+
+class CalcRunResponse(BaseModel):
+    calc_run_id: Optional[UUID] = None
+    scenario_id: UUID
+    status: str
+    nodes_recalculated: int
+    nodes_unchanged: int
+    message: str
+
+
+@router.post("/run", response_model=CalcRunResponse)
+async def trigger_calc_run(
+    body: CalcRunRequest,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+    scenario_id: UUID = Depends(resolve_scenario_id),
+) -> CalcRunResponse:
+    """Consume all unprocessed events for a scenario and run propagation."""
+    from ootils_core.api.routers.events import _build_propagation_engine
+    from ootils_core.engine.orchestration.calc_run import CalcRunManager
+    from ootils_core.engine.kernel.graph.dirty import DirtyFlagManager
+    from ootils_core.engine.kernel.graph.store import GraphStore
+
+    # Create a trigger event
+    trigger_event_id = uuid4()
+    db.execute(
+        """
+        INSERT INTO events (event_id, event_type, scenario_id, processed, source, created_at)
+        VALUES (%s, 'calc_triggered', %s, FALSE, 'api', %s)
+        """,
+        (trigger_event_id, scenario_id, datetime.now(timezone.utc)),
+    )
+
+    engine = _build_propagation_engine(db)
+
+    if body.full_recompute:
+        calc_run_mgr = CalcRunManager()
+        calc_run = calc_run_mgr.start_calc_run(
+            scenario_id=scenario_id,
+            event_ids=[trigger_event_id],
+            db=db,
+        )
+        if calc_run is None:
+            return CalcRunResponse(
+                calc_run_id=None,
+                scenario_id=scenario_id,
+                status="locked",
+                nodes_recalculated=0,
+                nodes_unchanged=0,
+                message="Another calc run is in progress for this scenario",
+            )
+
+        dirty_mgr = DirtyFlagManager()
+        all_pi = db.execute(
+            "SELECT node_id FROM nodes WHERE scenario_id = %s AND node_type = 'ProjectedInventory' AND active = TRUE",
+            (scenario_id,),
+        ).fetchall()
+        all_pi_ids = {UUID(str(r["node_id"])) for r in all_pi}
+
+        if all_pi_ids:
+            dirty_mgr.mark_dirty(all_pi_ids, scenario_id, calc_run.calc_run_id, db)
+            dirty_mgr.flush_to_postgres(calc_run.calc_run_id, scenario_id, db)
+            engine._propagate(calc_run, all_pi_ids, db)
+
+        engine._finish_run(calc_run, scenario_id, db)
+        return CalcRunResponse(
+            calc_run_id=calc_run.calc_run_id,
+            scenario_id=scenario_id,
+            status="completed",
+            nodes_recalculated=calc_run.nodes_recalculated or 0,
+            nodes_unchanged=calc_run.nodes_unchanged or 0,
+            message=f"Full recompute: {calc_run.nodes_recalculated or 0} nodes recalculated",
+        )
+    else:
+        # Process all pending events
+        calc_run = engine.process_event(
+            event_id=trigger_event_id,
+            scenario_id=scenario_id,
+            db=db,
+        )
+        if calc_run is None:
+            return CalcRunResponse(
+                calc_run_id=None,
+                scenario_id=scenario_id,
+                status="locked",
+                nodes_recalculated=0,
+                nodes_unchanged=0,
+                message="Another calc run is in progress for this scenario",
+            )
+        return CalcRunResponse(
+            calc_run_id=calc_run.calc_run_id,
+            scenario_id=scenario_id,
+            status="completed",
+            nodes_recalculated=calc_run.nodes_recalculated or 0,
+            nodes_unchanged=calc_run.nodes_unchanged or 0,
+            message=f"{calc_run.nodes_recalculated or 0} nodes recalculated",
+        )

--- a/src/ootils_core/api/routers/events.py
+++ b/src/ootils_core/api/routers/events.py
@@ -19,6 +19,34 @@ from ootils_core.api.dependencies import get_db, resolve_scenario_id
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1/events", tags=["events"])
 
+
+def _build_propagation_engine(db) -> "PropagationEngine":
+    """Build a PropagationEngine instance wired to the given DB connection."""
+    from ootils_core.engine.kernel.graph.store import GraphStore
+    from ootils_core.engine.kernel.graph.traversal import GraphTraversal
+    from ootils_core.engine.kernel.graph.dirty import DirtyFlagManager
+    from ootils_core.engine.orchestration.calc_run import CalcRunManager
+    from ootils_core.engine.kernel.calc.projection import ProjectionKernel
+    from ootils_core.engine.kernel.shortage.detector import ShortageDetector
+    from ootils_core.engine.orchestration.propagator import PropagationEngine
+
+    store = GraphStore(db)
+    traversal = GraphTraversal(store)
+    dirty = DirtyFlagManager()
+    calc_run_mgr = CalcRunManager()
+    kernel = ProjectionKernel()
+    shortage_detector = ShortageDetector()
+
+    return PropagationEngine(
+        store=store,
+        traversal=traversal,
+        dirty=dirty,
+        calc_run_mgr=calc_run_mgr,
+        kernel=kernel,
+        shortage_detector=shortage_detector,
+    )
+
+
 # Must stay in sync with events.event_type CHECK constraint in migrations 002 + 006.
 # Any new event type requires both a DB migration (ALTER TABLE ... ADD CONSTRAINT)
 # and an addition here.
@@ -139,11 +167,27 @@ async def create_event(
         effective_scenario_id,
     )
 
+    # Synchronous propagation
+    affected_nodes = 0
+    if body.trigger_node_id is not None:
+        try:
+            engine = _build_propagation_engine(db)
+            calc_run = engine.process_event(
+                event_id=event_id,
+                scenario_id=effective_scenario_id,
+                db=db,
+            )
+            if calc_run is not None:
+                affected_nodes = calc_run.nodes_recalculated or 0
+        except Exception as exc:
+            logger.warning("propagation failed for event %s: %s", event_id, exc)
+            # Don't fail the request — event is recorded, propagation is best-effort
+
     return EventResponse(
         event_id=event_id,
-        status="queued",
+        status="processed" if affected_nodes > 0 else "queued",
         scenario_id=effective_scenario_id,
-        affected_nodes_estimate=0,
+        affected_nodes_estimate=affected_nodes,
     )
 
 

--- a/src/ootils_core/api/routers/ingest.py
+++ b/src/ootils_core/api/routers/ingest.py
@@ -123,6 +123,150 @@ def _trigger_dq(db: psycopg.Connection, batch_id: UUID) -> str:
         return "unknown"
 
 
+def _ensure_projection_series(
+    db: psycopg.Connection,
+    item_id: UUID,
+    location_id: UUID,
+    scenario_id: UUID,
+) -> bool:
+    """
+    Ensure a ProjectionSeries + PI bucket nodes exist for (item, location, scenario).
+    Creates them if missing. Returns True if created, False if already existed.
+    """
+    from datetime import date, timedelta
+
+    existing = db.execute(
+        """
+        SELECT series_id FROM projection_series
+        WHERE item_id = %s AND location_id = %s AND scenario_id = %s
+        """,
+        (item_id, location_id, scenario_id),
+    ).fetchone()
+
+    if existing:
+        return False
+
+    series_id = uuid4()
+    today = date.today()
+    horizon_start = today
+    horizon_end = today + timedelta(days=90)
+
+    db.execute(
+        """
+        INSERT INTO projection_series (series_id, item_id, location_id, scenario_id, horizon_start, horizon_end, created_at, updated_at)
+        VALUES (%s, %s, %s, %s, %s, %s, now(), now())
+        ON CONFLICT (item_id, location_id, scenario_id) DO NOTHING
+        """,
+        (series_id, item_id, location_id, scenario_id, horizon_start, horizon_end),
+    )
+
+    row = db.execute(
+        "SELECT series_id FROM projection_series WHERE item_id = %s AND location_id = %s AND scenario_id = %s",
+        (item_id, location_id, scenario_id),
+    ).fetchone()
+    actual_series_id = UUID(str(row["series_id"])) if row else series_id
+
+    for i in range(90):
+        day_start = today + timedelta(days=i)
+        day_end = day_start + timedelta(days=1)
+        db.execute(
+            """
+            INSERT INTO nodes (
+                node_id, node_type, scenario_id, item_id, location_id,
+                time_grain, time_span_start, time_span_end, time_ref,
+                projection_series_id, bucket_sequence,
+                opening_stock, inflows, outflows, closing_stock,
+                has_shortage, shortage_qty, is_dirty, active,
+                created_at, updated_at
+            ) VALUES (
+                %s, 'ProjectedInventory', %s, %s, %s,
+                'day', %s, %s, %s,
+                %s, %s,
+                0, 0, 0, 0,
+                FALSE, 0, TRUE, TRUE,
+                now(), now()
+            )
+            ON CONFLICT DO NOTHING
+            """,
+            (
+                uuid4(), scenario_id, item_id, location_id,
+                day_start, day_end, day_start,
+                actual_series_id, i,
+            ),
+        )
+
+    logger.info(
+        "_ensure_projection_series: created series + 90 PI buckets for item=%s loc=%s",
+        item_id, location_id,
+    )
+    return True
+
+
+def _wire_node_to_pi(
+    db: psycopg.Connection,
+    node_id: UUID,
+    node_type: str,
+    item_id: UUID,
+    location_id: UUID,
+    scenario_id: UUID,
+    time_ref: date,
+) -> int:
+    """
+    Connect a supply/demand node to the matching PI bucket via an edge.
+    Returns number of edges created.
+    """
+    if node_type in ("PurchaseOrderSupply", "WorkOrderSupply", "PlannedSupply", "TransferSupply", "OnHandSupply"):
+        edge_type = "replenishes"
+        direction = "supply"
+    elif node_type in ("ForecastDemand", "CustomerOrderDemand"):
+        edge_type = "consumes"
+        direction = "demand"
+    else:
+        return 0
+
+    pi_row = db.execute(
+        """
+        SELECT node_id FROM nodes
+        WHERE node_type = 'ProjectedInventory'
+          AND item_id = %s
+          AND location_id = %s
+          AND scenario_id = %s
+          AND active = TRUE
+          AND time_span_start <= %s
+          AND time_span_end > %s
+        ORDER BY time_span_start ASC
+        LIMIT 1
+        """,
+        (item_id, location_id, scenario_id, time_ref, time_ref),
+    ).fetchone()
+
+    if pi_row is None:
+        logger.debug(
+            "_wire_node_to_pi: no PI bucket found for item=%s loc=%s date=%s",
+            item_id, location_id, time_ref,
+        )
+        return 0
+
+    pi_node_id = pi_row["node_id"]
+    edge_id = uuid4()
+    from_id, to_id = node_id, pi_node_id
+
+    db.execute(
+        """
+        INSERT INTO edges (edge_id, edge_type, from_node_id, to_node_id, scenario_id, active, created_at)
+        VALUES (%s, %s, %s, %s, %s, TRUE, now())
+        ON CONFLICT DO NOTHING
+        """,
+        (edge_id, edge_type, from_id, to_id, scenario_id),
+    )
+
+    logger.debug(
+        "_wire_node_to_pi: wired node=%s (%s) → PI=%s via %s",
+        node_id, node_type, pi_node_id, edge_type,
+    )
+    return 1
+
+
 def _emit_ingestion_event(db: psycopg.Connection, scenario_id: UUID, node_id: UUID) -> None:
     """Create an unprocessed ingestion_complete event to trigger recalculation."""
     from datetime import datetime, timezone
@@ -633,6 +777,9 @@ async def ingest_on_hand(
         item_id = item_map[row.item_external_id]
         location_id = loc_map[row.location_external_id]
 
+        # Ensure PI series exists for this (item, location)
+        _ensure_projection_series(db, item_id, location_id, BASELINE_SCENARIO_ID)
+
         # Upsert: one OnHandSupply node per (item, location, scenario)
         existing = db.execute(
             """
@@ -657,6 +804,7 @@ async def ingest_on_hand(
                 (row.quantity, row.uom, row.as_of_date, node_id),
             )
             _emit_ingestion_event(db, BASELINE_SCENARIO_ID, node_id)
+            _wire_node_to_pi(db, node_id, "OnHandSupply", item_id, location_id, BASELINE_SCENARIO_ID, row.as_of_date)
             results.append({
                 "item_external_id": row.item_external_id,
                 "location_external_id": row.location_external_id,
@@ -677,6 +825,7 @@ async def ingest_on_hand(
                  row.quantity, row.uom, row.as_of_date),
             )
             _emit_ingestion_event(db, BASELINE_SCENARIO_ID, node_id)
+            _wire_node_to_pi(db, node_id, "OnHandSupply", item_id, location_id, BASELINE_SCENARIO_ID, row.as_of_date)
             results.append({
                 "item_external_id": row.item_external_id,
                 "location_external_id": row.location_external_id,
@@ -782,6 +931,9 @@ async def ingest_purchase_orders(
         location_id = loc_map[po.location_external_id]
         active = po.status != "cancelled"
 
+        # Ensure PI series exists for this (item, location)
+        _ensure_projection_series(db, item_id, location_id, BASELINE_SCENARIO_ID)
+
         if po.external_id in existing_refs:
             node_id = existing_refs[po.external_id]
             db.execute(
@@ -794,6 +946,7 @@ async def ingest_purchase_orders(
                 (po.quantity, po.uom, po.expected_delivery_date, active, node_id),
             )
             _emit_ingestion_event(db, BASELINE_SCENARIO_ID, node_id)
+            _wire_node_to_pi(db, node_id, "PurchaseOrderSupply", item_id, location_id, BASELINE_SCENARIO_ID, po.expected_delivery_date)
             results.append({"external_id": po.external_id, "node_id": str(node_id), "action": "updated"})
             updated += 1
         else:
@@ -809,6 +962,7 @@ async def ingest_purchase_orders(
                  po.quantity, po.uom, po.expected_delivery_date, active),
             )
             _emit_ingestion_event(db, BASELINE_SCENARIO_ID, node_id)
+            _wire_node_to_pi(db, node_id, "PurchaseOrderSupply", item_id, location_id, BASELINE_SCENARIO_ID, po.expected_delivery_date)
             # Register external reference
             db.execute(
                 """
@@ -933,6 +1087,9 @@ async def ingest_forecast_demand(
         item_id = item_map[fc.item_external_id]
         location_id = loc_map[fc.location_external_id]
 
+        # Ensure PI series exists for this (item, location)
+        _ensure_projection_series(db, item_id, location_id, BASELINE_SCENARIO_ID)
+
         existing = db.execute(
             """
             SELECT node_id FROM nodes
@@ -957,6 +1114,7 @@ async def ingest_forecast_demand(
                 (fc.quantity, fc_node_id),
             )
             _emit_ingestion_event(db, BASELINE_SCENARIO_ID, fc_node_id)
+            _wire_node_to_pi(db, fc_node_id, "ForecastDemand", item_id, location_id, BASELINE_SCENARIO_ID, fc.bucket_date)
             results.append({
                 "item_external_id": fc.item_external_id,
                 "bucket_date": str(fc.bucket_date),
@@ -977,6 +1135,7 @@ async def ingest_forecast_demand(
                  fc.quantity, fc.time_grain, fc.bucket_date),
             )
             _emit_ingestion_event(db, BASELINE_SCENARIO_ID, node_id)
+            _wire_node_to_pi(db, node_id, "ForecastDemand", item_id, location_id, BASELINE_SCENARIO_ID, fc.bucket_date)
             results.append({
                 "item_external_id": fc.item_external_id,
                 "bucket_date": str(fc.bucket_date),

--- a/src/ootils_core/api/routers/scenarios.py
+++ b/src/ootils_core/api/routers/scenarios.py
@@ -1,0 +1,116 @@
+"""
+GET /v1/scenarios — List, inspect, and delete scenarios.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+from uuid import UUID
+
+import psycopg
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
+
+from ootils_core.api.auth import require_auth
+from ootils_core.api.dependencies import get_db, BASELINE_SCENARIO_ID
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/v1/scenarios", tags=["scenarios"])
+
+
+class ScenarioOut(BaseModel):
+    scenario_id: UUID
+    name: str
+    status: str
+    is_baseline: bool
+    parent_scenario_id: Optional[UUID] = None
+    created_at: str
+    updated_at: str
+
+
+class ScenariosListResponse(BaseModel):
+    scenarios: list[ScenarioOut]
+    total: int
+
+
+@router.get("", response_model=ScenariosListResponse)
+async def list_scenarios(
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+    status_filter: Optional[str] = Query(default=None, alias="status"),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> ScenariosListResponse:
+    conditions = []
+    params: list = []
+    if status_filter:
+        conditions.append("status = %s")
+        params.append(status_filter)
+    where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+    total_row = db.execute(
+        f"SELECT COUNT(*) AS cnt FROM scenarios {where}",
+        params if params else None,
+    ).fetchone()
+    total = int(total_row["cnt"]) if total_row else 0
+    rows = db.execute(
+        f"SELECT * FROM scenarios {where} ORDER BY created_at DESC LIMIT %s OFFSET %s",
+        (params + [limit, offset]) if params else [limit, offset],
+    ).fetchall()
+    return ScenariosListResponse(
+        scenarios=[
+            ScenarioOut(
+                scenario_id=UUID(str(r["scenario_id"])),
+                name=r["name"],
+                status=r["status"],
+                is_baseline=bool(r["is_baseline"]),
+                parent_scenario_id=UUID(str(r["parent_scenario_id"])) if r.get("parent_scenario_id") else None,
+                created_at=r["created_at"].isoformat() if hasattr(r["created_at"], "isoformat") else str(r["created_at"]),
+                updated_at=r["updated_at"].isoformat() if hasattr(r["updated_at"], "isoformat") else str(r["updated_at"]),
+            )
+            for r in rows
+        ],
+        total=total,
+    )
+
+
+@router.get("/{scenario_id}", response_model=ScenarioOut)
+async def get_scenario(
+    scenario_id: UUID,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> ScenarioOut:
+    row = db.execute("SELECT * FROM scenarios WHERE scenario_id = %s", (scenario_id,)).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail=f"Scenario {scenario_id} not found")
+    return ScenarioOut(
+        scenario_id=UUID(str(row["scenario_id"])),
+        name=row["name"],
+        status=row["status"],
+        is_baseline=bool(row["is_baseline"]),
+        parent_scenario_id=UUID(str(row["parent_scenario_id"])) if row.get("parent_scenario_id") else None,
+        created_at=row["created_at"].isoformat() if hasattr(row["created_at"], "isoformat") else str(row["created_at"]),
+        updated_at=row["updated_at"].isoformat() if hasattr(row["updated_at"], "isoformat") else str(row["updated_at"]),
+    )
+
+
+@router.delete("/{scenario_id}", status_code=204)
+async def delete_scenario(
+    scenario_id: UUID,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> None:
+    if scenario_id == BASELINE_SCENARIO_ID:
+        raise HTTPException(status_code=400, detail="Cannot delete the baseline scenario")
+    row = db.execute(
+        "SELECT scenario_id, is_baseline FROM scenarios WHERE scenario_id = %s",
+        (scenario_id,),
+    ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail=f"Scenario {scenario_id} not found")
+    if row["is_baseline"]:
+        raise HTTPException(status_code=400, detail="Cannot delete a baseline scenario")
+    db.execute(
+        "UPDATE scenarios SET status = 'archived', updated_at = now() WHERE scenario_id = %s",
+        (scenario_id,),
+    )
+    logger.info("scenario.archived scenario_id=%s", scenario_id)

--- a/src/ootils_core/api/routers/simulate.py
+++ b/src/ootils_core/api/routers/simulate.py
@@ -41,12 +41,31 @@ class SimulateRequest(BaseModel):
     overrides: list[OverrideIn] = []
 
 
+class ShortageChange(BaseModel):
+    node_id: UUID
+    item_id: Optional[UUID] = None
+    location_id: Optional[UUID] = None
+    shortage_date: Optional[str] = None
+    shortage_qty: Optional[float] = None
+    severity_score: Optional[float] = None
+
+
+class SimulateDelta(BaseModel):
+    new_shortages: list[ShortageChange] = []
+    resolved_shortages: list[ShortageChange] = []
+    net_shortage_change: int = 0
+
+
 class SimulateResponse(BaseModel):
     scenario_id: UUID
     scenario_name: str
     status: str
     override_count: int
+    failed_overrides: list[dict] = []
     base_scenario_id: UUID
+    calc_run_id: Optional[UUID] = None
+    nodes_recalculated: int = 0
+    delta: SimulateDelta = SimulateDelta()
 
 
 @router.post("", response_model=SimulateResponse, status_code=status.HTTP_201_CREATED)
@@ -123,10 +142,115 @@ async def create_simulation(
         applied,
     )
 
+    # Propagation + delta computation
+    from ootils_core.api.routers.events import _build_propagation_engine
+    from ootils_core.engine.kernel.shortage.detector import ShortageDetector
+
+    calc_run_id = None
+    nodes_recalculated = 0
+    delta = SimulateDelta()
+
+    if applied > 0:
+        try:
+            # Get baseline shortages before propagation
+            detector = ShortageDetector()
+            baseline_shortages = {
+                str(s.pi_node_id): s
+                for s in detector.get_active_shortages(base_id, db)
+            }
+
+            # Create a trigger event for full recompute
+            from uuid import uuid4
+            from datetime import datetime, timezone
+            trigger_event_id = uuid4()
+            db.execute(
+                """
+                INSERT INTO events (event_id, event_type, scenario_id, processed, source, created_at)
+                VALUES (%s, 'calc_triggered', %s, FALSE, 'api', %s)
+                """,
+                (trigger_event_id, scenario.scenario_id, datetime.now(timezone.utc)),
+            )
+
+            # Run propagation — full recompute for new scenario
+            engine = _build_propagation_engine(db)
+
+            from ootils_core.engine.orchestration.calc_run import CalcRunManager
+            from ootils_core.engine.kernel.graph.dirty import DirtyFlagManager
+
+            calc_run_mgr = CalcRunManager()
+            calc_run = calc_run_mgr.start_calc_run(
+                scenario_id=scenario.scenario_id,
+                event_ids=[trigger_event_id],
+                db=db,
+            )
+
+            if calc_run is not None:
+                # Mark ALL PI nodes as dirty for full recompute
+                all_pi_nodes = db.execute(
+                    """
+                    SELECT node_id FROM nodes
+                    WHERE scenario_id = %s AND node_type = 'ProjectedInventory' AND active = TRUE
+                    """,
+                    (scenario.scenario_id,),
+                ).fetchall()
+                all_pi_ids = {UUID(str(r["node_id"])) for r in all_pi_nodes}
+
+                if all_pi_ids:
+                    dirty_mgr = DirtyFlagManager()
+                    dirty_mgr.mark_dirty(all_pi_ids, scenario.scenario_id, calc_run.calc_run_id, db)
+                    dirty_mgr.flush_to_postgres(calc_run.calc_run_id, scenario.scenario_id, db)
+                    engine._propagate(calc_run, all_pi_ids, db)
+
+                engine._finish_run(calc_run, scenario.scenario_id, db)
+                calc_run_id = calc_run.calc_run_id
+                nodes_recalculated = calc_run.nodes_recalculated or 0
+
+                # Compute delta
+                new_shortages = detector.get_active_shortages(scenario.scenario_id, db)
+                scenario_shortage_ids = {str(s.pi_node_id) for s in new_shortages}
+                baseline_shortage_ids = set(baseline_shortages.keys())
+
+                new_ids = scenario_shortage_ids - baseline_shortage_ids
+                resolved_ids = baseline_shortage_ids - scenario_shortage_ids
+
+                delta = SimulateDelta(
+                    new_shortages=[
+                        ShortageChange(
+                            node_id=s.pi_node_id,
+                            item_id=s.item_id,
+                            location_id=s.location_id,
+                            shortage_date=str(s.shortage_date) if s.shortage_date else None,
+                            shortage_qty=float(s.shortage_qty),
+                            severity_score=float(s.severity_score),
+                        )
+                        for s in new_shortages if str(s.pi_node_id) in new_ids
+                    ],
+                    resolved_shortages=[
+                        ShortageChange(
+                            node_id=baseline_shortages[sid].pi_node_id,
+                            item_id=baseline_shortages[sid].item_id,
+                            location_id=baseline_shortages[sid].location_id,
+                            shortage_date=str(baseline_shortages[sid].shortage_date) if baseline_shortages[sid].shortage_date else None,
+                            shortage_qty=float(baseline_shortages[sid].shortage_qty),
+                            severity_score=float(baseline_shortages[sid].severity_score),
+                        )
+                        for sid in resolved_ids
+                    ],
+                    net_shortage_change=len(new_ids) - len(resolved_ids),
+                )
+
+        except Exception as exc:
+            logger.warning("simulate.propagation_failed scenario=%s: %s", scenario.scenario_id, exc)
+            # Don't fail the simulate call — scenario is created, propagation is best-effort
+
     return SimulateResponse(
         scenario_id=scenario.scenario_id,
         scenario_name=body.scenario_name,
         status="created",
         override_count=applied,
+        failed_overrides=failed_overrides,
         base_scenario_id=base_id,
+        calc_run_id=calc_run_id,
+        nodes_recalculated=nodes_recalculated,
+        delta=delta,
     )

--- a/src/ootils_core/db/migrations/014_missing_indexes.sql
+++ b/src/ootils_core/db/migrations/014_missing_indexes.sql
@@ -1,0 +1,112 @@
+-- ============================================================
+-- Migration 014: Missing indexes — hot path optimisation
+-- ============================================================
+-- Adds critical and medium-priority indexes identified in DBA review #130.
+-- Drops redundant / low-cardinality indexes that waste write amplification.
+-- All CREATE INDEX statements use IF NOT EXISTS for idempotency.
+-- Conditional tables (ghost_nodes, dq_agent_runs, data_quality_issues)
+-- are wrapped in existence checks.
+-- ============================================================
+
+-- ============================================================
+-- CRITICAL INDEXES
+-- ============================================================
+
+-- 1. Edge 4-column composite lookup (allocation upsert per demand node)
+CREATE INDEX IF NOT EXISTS idx_edges_composite_lookup
+    ON edges (from_node_id, to_node_id, edge_type, scenario_id);
+
+-- 2. Node supply load for ghost engines (day-by-day loop)
+CREATE INDEX IF NOT EXISTS idx_nodes_item_scenario_type_timeref
+    ON nodes (item_id, scenario_id, node_type, time_ref)
+    WHERE active = TRUE;
+
+-- 3. Active shortages by scenario (post-propagation hot path)
+CREATE INDEX IF NOT EXISTS idx_shortages_scenario_active
+    ON shortages (scenario_id, severity_score DESC)
+    WHERE status = 'active';
+
+-- 4. Active shortages by item (impact scoring)
+CREATE INDEX IF NOT EXISTS idx_shortages_item_active
+    ON shortages (item_id) WHERE status = 'active';
+
+-- 5. Latest completed calc_run per scenario
+CREATE INDEX IF NOT EXISTS idx_calc_runs_scenario_completed
+    ON calc_runs (scenario_id, completed_at DESC)
+    WHERE status = 'completed';
+
+-- ============================================================
+-- MEDIUM PRIORITY INDEXES
+-- ============================================================
+
+-- 6. DQ pipeline: batch by entity type and status
+CREATE INDEX IF NOT EXISTS idx_ingest_batches_entity_dq
+    ON ingest_batches (entity_type, dq_status, created_at DESC);
+
+-- 7. DQ pipeline: rows by batch and row number
+CREATE INDEX IF NOT EXISTS idx_ingest_rows_batch_rownum
+    ON ingest_rows (batch_id, row_number);
+
+-- 8. DQ issues by batch and impact (table may not exist in all environments)
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables
+               WHERE table_schema = 'public' AND table_name = 'data_quality_issues') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_indexes
+                       WHERE schemaname = 'public'
+                         AND indexname = 'idx_dq_issues_batch_impact') THEN
+            EXECUTE 'CREATE INDEX idx_dq_issues_batch_impact
+                         ON data_quality_issues (batch_id, impact_score DESC NULLS LAST)';
+        END IF;
+    END IF;
+END $$;
+
+-- 9. Ghost nodes lookup (table may not exist in all environments)
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables
+               WHERE table_schema = 'public' AND table_name = 'ghost_nodes') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_indexes
+                       WHERE schemaname = 'public'
+                         AND indexname = 'idx_ghost_nodes_name_type_scenario') THEN
+            EXECUTE 'CREATE INDEX idx_ghost_nodes_name_type_scenario
+                         ON ghost_nodes (name, ghost_type, scenario_id)';
+        END IF;
+    END IF;
+END $$;
+
+-- 10. DQ agent runs by batch (table may not exist in all environments)
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables
+               WHERE table_schema = 'public' AND table_name = 'dq_agent_runs') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_indexes
+                       WHERE schemaname = 'public'
+                         AND indexname = 'idx_dq_agent_runs_batch_created') THEN
+            EXECUTE 'CREATE INDEX idx_dq_agent_runs_batch_created
+                         ON dq_agent_runs (batch_id, created_at DESC)';
+        END IF;
+    END IF;
+END $$;
+
+-- ============================================================
+-- DROP REDUNDANT / LOW-CARDINALITY INDEXES
+-- ============================================================
+
+-- Duplicated by shortages_scenario_id_idx (already covers scenario_id lookup)
+DROP INDEX IF EXISTS idx_shortages_scenario;
+
+-- Duplicated by existing UNIQUE constraint on projection_series
+DROP INDEX IF EXISTS idx_projection_series_lookup;
+
+-- Duplicated by existing UNIQUE constraint on resources.external_id
+DROP INDEX IF EXISTS idx_resources_external_id;
+
+-- 3 distinct values — not selective enough to be useful
+DROP INDEX IF EXISTS idx_ghost_members_role;
+
+-- 3 distinct values — not selective enough to be useful
+DROP INDEX IF EXISTS idx_ghost_nodes_status;
+
+-- 2 distinct values — boolean-like, not selective enough
+DROP INDEX IF EXISTS idx_ghost_nodes_type;
+
+-- 4 distinct values — not selective enough to be useful
+DROP INDEX IF EXISTS idx_resources_type;


### PR DESCRIPTION
Closes #119
Closes #120
Closes #121

## Changes

### #120 — POST /v1/events triggers propagation synchronously
### #119 — Ingest auto-wires nodes + creates PI series if missing
### #121 — Simulate runs propagation + returns shortage delta

Also adds:
- POST /v1/calc/run — manual propagation trigger
- GET/DELETE /v1/scenarios — scenario management