### PR TITLE
feat: safety stock detection in kernel and projection API (#122)

### DIFF
--- a/src/ootils_core/api/routers/projection.py
+++ b/src/ootils_core/api/routers/projection.py
@@ -32,6 +32,8 @@ class ProjectionBucket(BaseModel):
     closing_stock: Optional[Decimal]
     has_shortage: bool
     shortage_qty: Decimal
+    safety_stock_qty: Optional[Decimal] = None
+    severity_class: Optional[str] = None  # 'stockout' | 'below_safety_stock' | None
 
 
 class ProjectionResponse(BaseModel):
@@ -40,6 +42,7 @@ class ProjectionResponse(BaseModel):
     location_id: str
     scenario_id: UUID
     grain: Optional[str]
+    safety_stock_qty: Optional[Decimal] = None
     buckets: list[ProjectionBucket]
 
 
@@ -92,6 +95,41 @@ async def get_projection(
 
     nodes = store.get_nodes_by_series(series.series_id)
 
+    # Fetch safety stock for this item/location
+    safety_stock_qty: Optional[Decimal] = None
+    try:
+        ss_row = db.execute(
+            """
+            SELECT safety_stock_qty FROM item_planning_params
+            WHERE item_id = %s
+              AND (location_id = %s OR location_id IS NULL)
+              AND (effective_to IS NULL OR effective_to = '9999-12-31'::DATE)
+            ORDER BY location_id NULLS LAST
+            LIMIT 1
+            """,
+            (item_uuid, location_uuid),
+        ).fetchone()
+        if ss_row is not None:
+            raw_ss = ss_row["safety_stock_qty"]
+            if raw_ss is not None:
+                safety_stock_qty = Decimal(str(raw_ss))
+    except Exception:  # noqa: BLE001
+        # Safety stock fetch failure must not break projection
+        logger.warning(
+            "projection: failed to fetch safety_stock_qty for item=%s location=%s",
+            item_uuid,
+            location_uuid,
+        )
+
+    def _compute_severity_class(closing: Optional[Decimal]) -> Optional[str]:
+        if closing is None:
+            return None
+        if closing < Decimal("0"):
+            return "stockout"
+        if safety_stock_qty is not None and closing < safety_stock_qty:
+            return "below_safety_stock"
+        return None
+
     buckets = [
         ProjectionBucket(
             bucket_sequence=n.bucket_sequence,
@@ -104,17 +142,20 @@ async def get_projection(
             closing_stock=n.closing_stock,
             has_shortage=n.has_shortage,
             shortage_qty=n.shortage_qty,
+            safety_stock_qty=safety_stock_qty,
+            severity_class=_compute_severity_class(n.closing_stock),
         )
         for n in nodes
     ]
 
     logger.info(
-        "projection.fetched series=%s item=%s location=%s scenario=%s buckets=%d",
+        "projection.fetched series=%s item=%s location=%s scenario=%s buckets=%d safety_stock=%s",
         series.series_id,
         item_id,
         location_id,
         scenario_id,
         len(buckets),
+        safety_stock_qty,
     )
 
     return ProjectionResponse(
@@ -123,5 +164,6 @@ async def get_projection(
         location_id=location_id,
         scenario_id=scenario_id,
         grain=grain,
+        safety_stock_qty=safety_stock_qty,
         buckets=buckets,
     )

--- a/src/ootils_core/db/migrations/017_shortage_severity_class.sql
+++ b/src/ootils_core/db/migrations/017_shortage_severity_class.sql
@@ -1,0 +1,8 @@
+-- ============================================================
+-- Ootils Core — Migration 017: Add severity_class to shortages
+-- Issue #122: Safety stock detection in kernel
+-- ============================================================
+
+ALTER TABLE shortages
+    ADD COLUMN IF NOT EXISTS severity_class TEXT
+        CHECK (severity_class IN ('stockout', 'below_safety_stock'));

--- a/src/ootils_core/engine/kernel/shortage/detector.py
+++ b/src/ootils_core/engine/kernel/shortage/detector.py
@@ -45,15 +45,53 @@ class ShortageDetector:
         Inspect a PI node and return a ShortageRecord if closing_stock < 0.
 
         Returns None if no shortage exists.
+        Delegates to detect_with_params with no safety stock.
+        """
+        return self.detect_with_params(
+            pi_node=pi_node,
+            calc_run_id=calc_run_id,
+            scenario_id=scenario_id,
+            db=db,
+        )
 
-        severity_score = shortage_qty × days_in_bucket × unit_cost_proxy
-        days_in_bucket = (time_span_end - time_span_start).days if available, else 1
+    def detect_with_params(
+        self,
+        pi_node: Node,
+        calc_run_id: UUID,
+        scenario_id: UUID,
+        db,
+        safety_stock_qty: Optional[Decimal] = None,
+        unit_cost: Optional[Decimal] = None,
+    ) -> Optional[ShortageRecord]:
+        """
+        Enhanced detection: detects both stockouts (closing_stock < 0) and
+        below-safety-stock warnings (closing_stock < safety_stock_qty).
+
+        Returns ShortageRecord with severity_class:
+        - 'stockout': closing_stock < 0
+        - 'below_safety_stock': 0 <= closing_stock < safety_stock_qty
+        - None: no shortage
+
+        severity_score = shortage_qty × days_in_bucket × unit_cost (or proxy)
         """
         closing = pi_node.closing_stock
-        if closing is None or closing >= Decimal("0"):
+        if closing is None:
             return None
 
-        shortage_qty = abs(closing)
+        effective_unit_cost = unit_cost if unit_cost is not None else _UNIT_COST_PROXY
+
+        # Determine severity_class and shortage_qty
+        if closing < Decimal("0"):
+            severity_class = "stockout"
+            shortage_qty = abs(closing)
+        elif (
+            safety_stock_qty is not None
+            and Decimal("0") <= closing < safety_stock_qty
+        ):
+            severity_class = "below_safety_stock"
+            shortage_qty = safety_stock_qty - closing
+        else:
+            return None
 
         # Bucket duration
         if pi_node.time_span_start is not None and pi_node.time_span_end is not None:
@@ -63,7 +101,7 @@ class ShortageDetector:
         else:
             days_in_bucket = 1
 
-        severity_score = shortage_qty * Decimal(str(days_in_bucket)) * _UNIT_COST_PROXY
+        severity_score = shortage_qty * Decimal(str(days_in_bucket)) * effective_unit_cost
 
         shortage_date = pi_node.time_span_start or pi_node.time_ref
 
@@ -79,13 +117,15 @@ class ShortageDetector:
             explanation_id=None,  # linked post-build by ExplanationBuilder if needed
             calc_run_id=calc_run_id,
             status="active",
+            severity_class=severity_class,
         )
 
         logger.debug(
-            "Shortage detected on node %s — qty=%s severity=%s",
+            "Shortage detected on node %s — qty=%s severity=%s class=%s",
             pi_node.node_id,
             shortage_qty,
             severity_score,
+            severity_class,
         )
         return record
 
@@ -113,12 +153,13 @@ class ShortageDetector:
                 explanation_id,
                 calc_run_id,
                 status,
+                severity_class,
                 created_at,
                 updated_at
             ) VALUES (
                 %s, %s, %s, %s, %s,
                 %s, %s, %s, %s, %s,
-                %s, %s, %s
+                %s, %s, %s, %s
             )
             ON CONFLICT (pi_node_id, calc_run_id) DO UPDATE SET
                 shortage_qty    = EXCLUDED.shortage_qty,
@@ -126,6 +167,7 @@ class ShortageDetector:
                 shortage_date   = EXCLUDED.shortage_date,
                 explanation_id  = EXCLUDED.explanation_id,
                 status          = EXCLUDED.status,
+                severity_class  = EXCLUDED.severity_class,
                 updated_at      = EXCLUDED.updated_at
             """,
             (
@@ -140,6 +182,7 @@ class ShortageDetector:
                 shortage.explanation_id,
                 shortage.calc_run_id,
                 shortage.status,
+                shortage.severity_class,
                 shortage.created_at,
                 now,
             ),
@@ -210,6 +253,7 @@ class ShortageDetector:
                 explanation_id,
                 calc_run_id,
                 status,
+                severity_class,
                 created_at,
                 updated_at
             FROM shortages
@@ -242,6 +286,7 @@ def _row_to_shortage(row) -> ShortageRecord:
         explanation_id=UUID(str(row["explanation_id"])) if row.get("explanation_id") else None,
         calc_run_id=UUID(str(row["calc_run_id"])),
         status=row["status"],
+        severity_class=row.get("severity_class"),
         created_at=row.get("created_at"),
         updated_at=row.get("updated_at"),
     )

--- a/src/ootils_core/engine/orchestration/propagator.py
+++ b/src/ootils_core/engine/orchestration/propagator.py
@@ -431,11 +431,13 @@ class PropagationEngine:
                 # Reload node to get freshly persisted state
                 fresh_node = self._store.get_node(node_id, scenario_id)
                 if fresh_node is not None:
-                    shortage = self._shortage_detector.detect(
+                    safety_stock = self._get_safety_stock(fresh_node, db)
+                    shortage = self._shortage_detector.detect_with_params(
                         pi_node=fresh_node,
                         calc_run_id=calc_run_id,
                         scenario_id=scenario_id,
                         db=db,
+                        safety_stock_qty=safety_stock,
                     )
                     if shortage is not None:
                         self._shortage_detector.persist(shortage, db)
@@ -448,3 +450,30 @@ class PropagationEngine:
                 )
 
         return changed
+
+    def _get_safety_stock(self, node: Node, db) -> Optional[Decimal]:
+        """Fetch safety_stock_qty from item_planning_params for this node's item/location."""
+        if node.item_id is None:
+            return None
+        try:
+            row = db.execute(
+                """
+                SELECT safety_stock_qty FROM item_planning_params
+                WHERE item_id = %s
+                  AND (location_id = %s OR location_id IS NULL)
+                  AND (effective_to IS NULL OR effective_to = '9999-12-31'::DATE)
+                ORDER BY location_id NULLS LAST
+                LIMIT 1
+                """,
+                (node.item_id, node.location_id),
+            ).fetchone()
+            if row and row["safety_stock_qty"] is not None:
+                return Decimal(str(row["safety_stock_qty"]))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "_get_safety_stock: failed for node %s item=%s: %s",
+                node.node_id,
+                node.item_id,
+                exc,
+            )
+        return None

--- a/src/ootils_core/models/__init__.py
+++ b/src/ootils_core/models/__init__.py
@@ -289,6 +289,7 @@ class ShortageRecord:
     explanation_id: Optional[UUID]  # FK to explanations (M3)
     calc_run_id: UUID
     status: str = "active"  # active | resolved
+    severity_class: Optional[str] = None  # 'stockout' | 'below_safety_stock'
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 

--- a/tests/test_m4_shortage.py
+++ b/tests/test_m4_shortage.py
@@ -376,7 +376,7 @@ class TestPropagatorIntegration:
 
         shortage_detector = MagicMock()
         mock_shortage = MagicMock(spec=ShortageRecord)
-        shortage_detector.detect.return_value = mock_shortage
+        shortage_detector.detect_with_params.return_value = mock_shortage
 
         engine, store, kernel = self._make_propagator(shortage_detector=shortage_detector)
 
@@ -412,16 +412,16 @@ class TestPropagatorIntegration:
             db=db,
         )
 
-        # detect() should have been called
-        shortage_detector.detect.assert_called_once()
-        detect_call = shortage_detector.detect.call_args
-        # detect() is called with keyword args: pi_node=, calc_run_id=, scenario_id=, db=
-        pi_node_arg = detect_call.kwargs.get("pi_node") or detect_call[1].get("pi_node")
+        # detect_with_params() should have been called (propagator uses enhanced detection)
+        shortage_detector.detect_with_params.assert_called_once()
+        detect_call = shortage_detector.detect_with_params.call_args
+        # detect_with_params() is called with keyword args: pi_node=, calc_run_id=, scenario_id=, db=
+        pi_node_arg = detect_call.kwargs.get("pi_node") or (detect_call[0][0] if detect_call[0] else None)
         assert pi_node_arg is not None
         assert pi_node_arg.node_id == node_id
 
         # persist() should have been called with the mock shortage
-        shortage_detector.persist.assert_called_once_with(mock_shortage, db)
+        shortage_detector.persist.assert_called_once_with(shortage_detector.detect_with_params.return_value, db)
 
     def test_shortage_detector_not_called_when_none(self):
         """No crash and no call when shortage_detector is None (backward-compat)."""
@@ -464,7 +464,7 @@ class TestPropagatorIntegration:
         calc_run_id = uuid4()
 
         shortage_detector = MagicMock()
-        shortage_detector.detect.return_value = None  # No shortage
+        shortage_detector.detect_with_params.return_value = None  # No shortage
 
         engine, store, kernel = self._make_propagator(shortage_detector=shortage_detector)
 
@@ -496,7 +496,7 @@ class TestPropagatorIntegration:
             db=db,
         )
 
-        shortage_detector.detect.assert_called_once()
+        shortage_detector.detect_with_params.assert_called_once()
         shortage_detector.persist.assert_not_called()
 
     def test_propagator_backward_compatible_without_shortage_detector(self):


### PR DESCRIPTION
Closes #122

## Changes

- **ShortageDetector.detect_with_params()**: détecte stockout (closing_stock < 0) ET below_safety_stock (0 ≤ closing_stock < safety_stock_qty)
- **severity_class** ajouté à ShortageRecord (Optional[str]: 'stockout' | 'below_safety_stock')
- **Migration 017**: colonne severity_class sur la table shortages
- **Propagateur**: _get_safety_stock() fetche depuis item_planning_params, appelle detect_with_params au lieu de detect
- **ProjectionBucket**: expose safety_stock_qty et severity_class par bucket
- **Tests**: mis à jour pour mocker detect_with_params