### PR TITLE
feat: working agent_tools + WO/CO/Transfer ingest endpoints (#118 #124)

### DIFF
--- a/src/ootils_core/api/routers/ingest.py
+++ b/src/ootils_core/api/routers/ingest.py
@@ -1304,3 +1304,430 @@ async def ingest_resources(
         len(body.resources), inserted, updated,
     )
     return _ok(inserted, updated, len(body.resources), results)
+
+
+# ─────────────────────────────────────────────────────────────
+# 9. POST /v1/ingest/work-orders
+# ─────────────────────────────────────────────────────────────
+
+VALID_WORK_ORDER_STATUSES = {"planned", "in_progress", "completed", "cancelled"}
+
+
+class WorkOrderRow(BaseModel):
+    external_id: str = Field(..., description="ERP work order number. Upsert key.")
+    item_external_id: str = Field(..., description="Produced item.")
+    location_external_id: str = Field(..., description="Producing plant/site.")
+    quantity: float = Field(..., gt=0, description="Planned output quantity (> 0).")
+    scheduled_completion_date: date = Field(..., description="Expected completion date (YYYY-MM-DD).")
+    status: str = "planned"
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str) -> str:
+        if v not in VALID_WORK_ORDER_STATUSES:
+            raise ValueError(f"status must be one of {VALID_WORK_ORDER_STATUSES}")
+        return v
+
+
+class IngestWorkOrdersRequest(BaseModel):
+    work_orders: list[WorkOrderRow]
+    dry_run: bool = False
+
+
+@router.post(
+    "/work-orders",
+    response_model=IngestResponse,
+    summary="Import work orders",
+    description="Upsert work orders (WorkOrderSupply) with ERP external_id tracking.",
+)
+async def ingest_work_orders(
+    body: IngestWorkOrdersRequest,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> IngestResponse:
+    """Upsert WorkOrderSupply nodes, tracked via external_references. All-or-nothing: any error → HTTP 422."""
+    item_ext_ids = list({wo.item_external_id for wo in body.work_orders})
+    loc_ext_ids = list({wo.location_external_id for wo in body.work_orders})
+
+    item_map = _batch_existing(db, "items", "external_id", "item_id", item_ext_ids)
+    loc_map = _batch_existing(db, "locations", "external_id", "location_id", loc_ext_ids)
+
+    errors: list[dict] = []
+    for i, wo in enumerate(body.work_orders):
+        row_errs = []
+        if wo.item_external_id not in item_map:
+            row_errs.append(f"item_external_id '{wo.item_external_id}' not found in DB")
+        if wo.location_external_id not in loc_map:
+            row_errs.append(f"location_external_id '{wo.location_external_id}' not found in DB")
+        if row_errs:
+            errors.append({"external_id": wo.external_id, "row": i, "errors": row_errs})
+
+    if errors:
+        _raise_422(errors)
+
+    if body.dry_run:
+        return IngestResponse(
+            status="dry_run",
+            summary=IngestSummary(total=len(body.work_orders), inserted=0, updated=0, errors=0),
+            results=[{"external_id": wo.external_id, "action": "dry_run"} for wo in body.work_orders],
+        )
+
+    wo_ext_ids = [wo.external_id for wo in body.work_orders]
+    existing_refs_rows = db.execute(
+        """
+        SELECT external_id, internal_id FROM external_references
+        WHERE entity_type = 'work_order' AND external_id = ANY(%s)
+        """,
+        (wo_ext_ids,),
+    ).fetchall()
+    existing_refs: dict[str, UUID] = {r["external_id"]: r["internal_id"] for r in existing_refs_rows}
+
+    results: list[dict] = []
+    inserted = updated = 0
+
+    for wo in body.work_orders:
+        item_id = item_map[wo.item_external_id]
+        location_id = loc_map[wo.location_external_id]
+        active = wo.status not in ("completed", "cancelled")
+
+        _ensure_projection_series(db, item_id, location_id, BASELINE_SCENARIO_ID)
+
+        if wo.external_id in existing_refs:
+            node_id = existing_refs[wo.external_id]
+            db.execute(
+                """
+                UPDATE nodes
+                SET quantity = %s, time_ref = %s,
+                    active = %s, is_dirty = TRUE, updated_at = now()
+                WHERE node_id = %s
+                """,
+                (wo.quantity, wo.scheduled_completion_date, active, node_id),
+            )
+            _emit_ingestion_event(db, BASELINE_SCENARIO_ID, node_id)
+            _wire_node_to_pi(db, node_id, "WorkOrderSupply", item_id, location_id, BASELINE_SCENARIO_ID, wo.scheduled_completion_date)
+            results.append({"external_id": wo.external_id, "node_id": str(node_id), "action": "updated"})
+            updated += 1
+        else:
+            node_id = uuid4()
+            db.execute(
+                """
+                INSERT INTO nodes
+                    (node_id, node_type, scenario_id, item_id, location_id,
+                     quantity, time_grain, time_ref, is_dirty, active)
+                VALUES (%s, 'WorkOrderSupply', %s, %s, %s, %s, 'exact_date', %s, TRUE, %s)
+                """,
+                (node_id, BASELINE_SCENARIO_ID, item_id, location_id,
+                 wo.quantity, wo.scheduled_completion_date, active),
+            )
+            _emit_ingestion_event(db, BASELINE_SCENARIO_ID, node_id)
+            _wire_node_to_pi(db, node_id, "WorkOrderSupply", item_id, location_id, BASELINE_SCENARIO_ID, wo.scheduled_completion_date)
+            db.execute(
+                """
+                INSERT INTO external_references
+                    (entity_type, external_id, source_system, internal_id)
+                VALUES ('work_order', %s, 'ingest_api', %s)
+                ON CONFLICT (entity_type, external_id, source_system) DO UPDATE
+                    SET internal_id = EXCLUDED.internal_id, updated_at = now()
+                """,
+                (wo.external_id, node_id),
+            )
+            results.append({"external_id": wo.external_id, "node_id": str(node_id), "action": "inserted"})
+            inserted += 1
+
+    logger.info(
+        "ingest.work_orders total=%d inserted=%d updated=%d",
+        len(body.work_orders), inserted, updated,
+    )
+    batch_id = _create_ingest_batch(db, "work_orders", [wo.model_dump() for wo in body.work_orders])
+    dq_status = _trigger_dq(db, batch_id)
+    return _ok(inserted, updated, len(body.work_orders), results, batch_id=batch_id, dq_status=dq_status)
+
+
+# ─────────────────────────────────────────────────────────────
+# 10. POST /v1/ingest/customer-orders
+# ─────────────────────────────────────────────────────────────
+
+VALID_CUSTOMER_ORDER_STATUSES = {"open", "confirmed", "shipped", "delivered", "cancelled"}
+
+
+class CustomerOrderRow(BaseModel):
+    external_id: str = Field(..., description="ERP sales order number. Upsert key.")
+    item_external_id: str = Field(..., description="Ordered item.")
+    location_external_id: str = Field(..., description="Shipping/consuming location.")
+    quantity: float = Field(..., gt=0, description="Ordered quantity (> 0).")
+    requested_delivery_date: date = Field(..., description="Customer requested delivery date (YYYY-MM-DD).")
+    status: str = "open"
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str) -> str:
+        if v not in VALID_CUSTOMER_ORDER_STATUSES:
+            raise ValueError(f"status must be one of {VALID_CUSTOMER_ORDER_STATUSES}")
+        return v
+
+
+class IngestCustomerOrdersRequest(BaseModel):
+    customer_orders: list[CustomerOrderRow]
+    dry_run: bool = False
+
+
+@router.post(
+    "/customer-orders",
+    response_model=IngestResponse,
+    summary="Import customer orders",
+    description="Upsert customer orders (CustomerOrderDemand) with ERP external_id tracking.",
+)
+async def ingest_customer_orders(
+    body: IngestCustomerOrdersRequest,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> IngestResponse:
+    """Upsert CustomerOrderDemand nodes, tracked via external_references. All-or-nothing: any error → HTTP 422."""
+    item_ext_ids = list({co.item_external_id for co in body.customer_orders})
+    loc_ext_ids = list({co.location_external_id for co in body.customer_orders})
+
+    item_map = _batch_existing(db, "items", "external_id", "item_id", item_ext_ids)
+    loc_map = _batch_existing(db, "locations", "external_id", "location_id", loc_ext_ids)
+
+    errors: list[dict] = []
+    for i, co in enumerate(body.customer_orders):
+        row_errs = []
+        if co.item_external_id not in item_map:
+            row_errs.append(f"item_external_id '{co.item_external_id}' not found in DB")
+        if co.location_external_id not in loc_map:
+            row_errs.append(f"location_external_id '{co.location_external_id}' not found in DB")
+        if row_errs:
+            errors.append({"external_id": co.external_id, "row": i, "errors": row_errs})
+
+    if errors:
+        _raise_422(errors)
+
+    if body.dry_run:
+        return IngestResponse(
+            status="dry_run",
+            summary=IngestSummary(total=len(body.customer_orders), inserted=0, updated=0, errors=0),
+            results=[{"external_id": co.external_id, "action": "dry_run"} for co in body.customer_orders],
+        )
+
+    co_ext_ids = [co.external_id for co in body.customer_orders]
+    existing_refs_rows = db.execute(
+        """
+        SELECT external_id, internal_id FROM external_references
+        WHERE entity_type = 'customer_order' AND external_id = ANY(%s)
+        """,
+        (co_ext_ids,),
+    ).fetchall()
+    existing_refs: dict[str, UUID] = {r["external_id"]: r["internal_id"] for r in existing_refs_rows}
+
+    results: list[dict] = []
+    inserted = updated = 0
+
+    for co in body.customer_orders:
+        item_id = item_map[co.item_external_id]
+        location_id = loc_map[co.location_external_id]
+        active = co.status not in ("delivered", "cancelled")
+
+        _ensure_projection_series(db, item_id, location_id, BASELINE_SCENARIO_ID)
+
+        if co.external_id in existing_refs:
+            node_id = existing_refs[co.external_id]
+            db.execute(
+                """
+                UPDATE nodes
+                SET quantity = %s, time_ref = %s,
+                    active = %s, is_dirty = TRUE, updated_at = now()
+                WHERE node_id = %s
+                """,
+                (co.quantity, co.requested_delivery_date, active, node_id),
+            )
+            _emit_ingestion_event(db, BASELINE_SCENARIO_ID, node_id)
+            _wire_node_to_pi(db, node_id, "CustomerOrderDemand", item_id, location_id, BASELINE_SCENARIO_ID, co.requested_delivery_date)
+            results.append({"external_id": co.external_id, "node_id": str(node_id), "action": "updated"})
+            updated += 1
+        else:
+            node_id = uuid4()
+            db.execute(
+                """
+                INSERT INTO nodes
+                    (node_id, node_type, scenario_id, item_id, location_id,
+                     quantity, time_grain, time_ref, is_dirty, active)
+                VALUES (%s, 'CustomerOrderDemand', %s, %s, %s, %s, 'exact_date', %s, TRUE, %s)
+                """,
+                (node_id, BASELINE_SCENARIO_ID, item_id, location_id,
+                 co.quantity, co.requested_delivery_date, active),
+            )
+            _emit_ingestion_event(db, BASELINE_SCENARIO_ID, node_id)
+            _wire_node_to_pi(db, node_id, "CustomerOrderDemand", item_id, location_id, BASELINE_SCENARIO_ID, co.requested_delivery_date)
+            db.execute(
+                """
+                INSERT INTO external_references
+                    (entity_type, external_id, source_system, internal_id)
+                VALUES ('customer_order', %s, 'ingest_api', %s)
+                ON CONFLICT (entity_type, external_id, source_system) DO UPDATE
+                    SET internal_id = EXCLUDED.internal_id, updated_at = now()
+                """,
+                (co.external_id, node_id),
+            )
+            results.append({"external_id": co.external_id, "node_id": str(node_id), "action": "inserted"})
+            inserted += 1
+
+    logger.info(
+        "ingest.customer_orders total=%d inserted=%d updated=%d",
+        len(body.customer_orders), inserted, updated,
+    )
+    batch_id = _create_ingest_batch(db, "customer_orders", [co.model_dump() for co in body.customer_orders])
+    dq_status = _trigger_dq(db, batch_id)
+    return _ok(inserted, updated, len(body.customer_orders), results, batch_id=batch_id, dq_status=dq_status)
+
+
+# ─────────────────────────────────────────────────────────────
+# 11. POST /v1/ingest/transfers
+# ─────────────────────────────────────────────────────────────
+
+VALID_TRANSFER_STATUSES = {"planned", "in_transit", "delivered", "cancelled"}
+
+
+class TransferRow(BaseModel):
+    external_id: str = Field(..., description="ERP transfer/STO number. Upsert key.")
+    item_external_id: str = Field(..., description="Transferred item.")
+    from_location_external_id: str = Field(..., description="Shipping location.")
+    to_location_external_id: str = Field(..., description="Receiving location.")
+    quantity: float = Field(..., gt=0, description="Transfer quantity (> 0).")
+    expected_delivery_date: date = Field(..., description="Expected arrival date at destination (YYYY-MM-DD).")
+    status: str = "planned"
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str) -> str:
+        if v not in VALID_TRANSFER_STATUSES:
+            raise ValueError(f"status must be one of {VALID_TRANSFER_STATUSES}")
+        return v
+
+
+class IngestTransfersRequest(BaseModel):
+    transfers: list[TransferRow]
+    dry_run: bool = False
+
+
+@router.post(
+    "/transfers",
+    response_model=IngestResponse,
+    summary="Import transfers",
+    description=(
+        "Upsert stock transfers (TransferSupply) between two locations. "
+        "The node is wired to the PI of the **destination** (to_location)."
+    ),
+)
+async def ingest_transfers(
+    body: IngestTransfersRequest,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> IngestResponse:
+    """Upsert TransferSupply nodes, tracked via external_references. All-or-nothing: any error → HTTP 422."""
+    item_ext_ids = list({t.item_external_id for t in body.transfers})
+    from_loc_ext_ids = list({t.from_location_external_id for t in body.transfers})
+    to_loc_ext_ids = list({t.to_location_external_id for t in body.transfers})
+    all_loc_ext_ids = list(set(from_loc_ext_ids) | set(to_loc_ext_ids))
+
+    item_map = _batch_existing(db, "items", "external_id", "item_id", item_ext_ids)
+    loc_map = _batch_existing(db, "locations", "external_id", "location_id", all_loc_ext_ids)
+
+    errors: list[dict] = []
+    for i, t in enumerate(body.transfers):
+        row_errs = []
+        if t.item_external_id not in item_map:
+            row_errs.append(f"item_external_id '{t.item_external_id}' not found in DB")
+        if t.from_location_external_id not in loc_map:
+            row_errs.append(f"from_location_external_id '{t.from_location_external_id}' not found in DB")
+        if t.to_location_external_id not in loc_map:
+            row_errs.append(f"to_location_external_id '{t.to_location_external_id}' not found in DB")
+        if row_errs:
+            errors.append({"external_id": t.external_id, "row": i, "errors": row_errs})
+
+    if errors:
+        _raise_422(errors)
+
+    if body.dry_run:
+        return IngestResponse(
+            status="dry_run",
+            summary=IngestSummary(total=len(body.transfers), inserted=0, updated=0, errors=0),
+            results=[{"external_id": t.external_id, "action": "dry_run"} for t in body.transfers],
+        )
+
+    tr_ext_ids = [t.external_id for t in body.transfers]
+    existing_refs_rows = db.execute(
+        """
+        SELECT external_id, internal_id FROM external_references
+        WHERE entity_type = 'transfer' AND external_id = ANY(%s)
+        """,
+        (tr_ext_ids,),
+    ).fetchall()
+    existing_refs: dict[str, UUID] = {r["external_id"]: r["internal_id"] for r in existing_refs_rows}
+
+    results: list[dict] = []
+    inserted = updated = 0
+
+    for t in body.transfers:
+        item_id = item_map[t.item_external_id]
+        from_location_id = loc_map[t.from_location_external_id]
+        to_location_id = loc_map[t.to_location_external_id]
+        active = t.status not in ("delivered", "cancelled")
+
+        # Wire to destination PI (to_location is the receiving side)
+        _ensure_projection_series(db, item_id, to_location_id, BASELINE_SCENARIO_ID)
+
+        if t.external_id in existing_refs:
+            node_id = existing_refs[t.external_id]
+            db.execute(
+                """
+                UPDATE nodes
+                SET quantity = %s, time_ref = %s,
+                    active = %s, is_dirty = TRUE, updated_at = now()
+                WHERE node_id = %s
+                """,
+                (t.quantity, t.expected_delivery_date, active, node_id),
+            )
+            _emit_ingestion_event(db, BASELINE_SCENARIO_ID, node_id)
+            _wire_node_to_pi(db, node_id, "TransferSupply", item_id, to_location_id, BASELINE_SCENARIO_ID, t.expected_delivery_date)
+            results.append({"external_id": t.external_id, "node_id": str(node_id), "action": "updated"})
+            updated += 1
+        else:
+            node_id = uuid4()
+            db.execute(
+                """
+                INSERT INTO nodes
+                    (node_id, node_type, scenario_id, item_id, location_id,
+                     quantity, time_grain, time_ref, is_dirty, active)
+                VALUES (%s, 'TransferSupply', %s, %s, %s, %s, 'exact_date', %s, TRUE, %s)
+                """,
+                (node_id, BASELINE_SCENARIO_ID, item_id, to_location_id,
+                 t.quantity, t.expected_delivery_date, active),
+            )
+            _emit_ingestion_event(db, BASELINE_SCENARIO_ID, node_id)
+            _wire_node_to_pi(db, node_id, "TransferSupply", item_id, to_location_id, BASELINE_SCENARIO_ID, t.expected_delivery_date)
+            db.execute(
+                """
+                INSERT INTO external_references
+                    (entity_type, external_id, source_system, internal_id)
+                VALUES ('transfer', %s, 'ingest_api', %s)
+                ON CONFLICT (entity_type, external_id, source_system) DO UPDATE
+                    SET internal_id = EXCLUDED.internal_id, updated_at = now()
+                """,
+                (t.external_id, node_id),
+            )
+            results.append({
+                "external_id": t.external_id,
+                "node_id": str(node_id),
+                "from_location": t.from_location_external_id,
+                "to_location": t.to_location_external_id,
+                "action": "inserted",
+            })
+            inserted += 1
+
+    logger.info(
+        "ingest.transfers total=%d inserted=%d updated=%d",
+        len(body.transfers), inserted, updated,
+    )
+    batch_id = _create_ingest_batch(db, "transfers", [t.model_dump() for t in body.transfers])
+    dq_status = _trigger_dq(db, batch_id)
+    return _ok(inserted, updated, len(body.transfers), results, batch_id=batch_id, dq_status=dq_status)

--- a/src/ootils_core/engine/decision_engine.py
+++ b/src/ootils_core/engine/decision_engine.py
@@ -1,6 +1,12 @@
 """
 Core supply chain decision engine.
 
+.. deprecated::
+    This module is **legacy** and no longer the primary engine.
+    The current planning engine uses a graph-based kernel located under
+    ``ootils_core.engine.kernel``. This file is retained for backward
+    compatibility only and should not be used in new code.
+
 The :class:`SupplyChainDecisionEngine` is the main entry-point. It combines
 inventory policy calculations (EOQ, reorder point, safety stock) with supplier
 selection logic to produce :class:`~ootils_core.models.OrderRecommendation`

--- a/src/ootils_core/tools/agent_tools.py
+++ b/src/ootils_core/tools/agent_tools.py
@@ -1,539 +1,152 @@
 """
-AI agent tool interface for the supply chain decision engine.
+agent_tools.py — Tools for AI agents to interact with the Ootils planning engine.
 
-:class:`SupplyChainTools` exposes the engine's capabilities as a collection
-of strongly-typed callable methods. Each method accepts and returns plain
-Python dictionaries so that they can be serialised to JSON and consumed
-directly by LLM function-calling APIs (OpenAI tools, Anthropic tool use,
-Google Gemini function declarations, etc.).
+These tools wrap the graph-based kernel API for use by LLM agents.
 
-All tool methods follow the same contract:
+.. note::
+    The old ``SupplyChainTools`` class (which wrapped the legacy
+    ``decision_engine.py`` / ``policies.py`` API) has been replaced.
+    Use the module-level functions below instead:
 
-* **Input**: a flat dictionary of primitive values.
-* **Output**: a dictionary with a ``"status"`` key (``"ok"`` or ``"error"``)
-  and either a ``"result"`` key containing the answer or an ``"error"``
-  key containing a human-readable error message.
-
-Example (OpenAI-style agent)::
-
-    tools = SupplyChainTools()
-    result = tools.calculate_reorder_point({
-        "daily_demand": 50,
-        "lead_time_days": 14,
-        "demand_std_daily": 8,
-        "lead_time_std_days": 2,
-        "service_level": 0.95,
-    })
-    # result -> {"status": "ok", "result": {"reorder_point": ..., "safety_stock": ...}}
+    - :func:`get_active_issues` — query active shortages for a scenario
+    - :func:`simulate_override` — create a simulation scenario with one override
+    - :func:`trigger_recalculation` — force a full recompute for a scenario
 """
-
 from __future__ import annotations
 
-import math
 from typing import Any
-
-from ootils_core.engine.decision_engine import SupplyChainDecisionEngine
-from ootils_core.engine.policies import (
-    economic_order_quantity,
-    reorder_point,
-    safety_stock,
-    urgency_level,
-)
-from ootils_core.engine.supplier_selection import rank_suppliers
-from ootils_core.models import InventoryState, Product, Supplier
+from uuid import UUID
 
 
-class SupplyChainTools:
-    """A collection of callable tools designed for AI agent consumption.
+def get_active_issues(db, scenario_id: str = "00000000-0000-0000-0000-000000000001") -> list[dict]:
+    """Return active shortages for a scenario.
 
-    Each public method represents one "tool" that an agent can invoke.  The
-    methods are intentionally coarse-grained (one tool per decision type) so
-    agents can pick the most relevant one rather than having to orchestrate
-    many low-level calls.
+    Args:
+        db: A psycopg3 connection (sync).
+        scenario_id: UUID string of the scenario to query. Defaults to the
+            baseline scenario.
 
-    The class is stateless and thread-safe.
+    Returns:
+        A list of shortage dicts with keys:
+        ``node_id``, ``item_id``, ``location_id``, ``shortage_qty``,
+        ``severity_score``, ``shortage_date``.
     """
+    from ootils_core.engine.kernel.shortage.detector import ShortageDetector
+    from uuid import UUID as _UUID
 
-    _engine = SupplyChainDecisionEngine()
+    detector = ShortageDetector()
+    shortages = detector.get_active_shortages(_UUID(scenario_id), db)
+    return [
+        {
+            "node_id": str(s.pi_node_id),
+            "item_id": str(s.item_id) if s.item_id else None,
+            "location_id": str(s.location_id) if s.location_id else None,
+            "shortage_qty": float(s.shortage_qty),
+            "severity_score": float(s.severity_score),
+            "shortage_date": str(s.shortage_date) if s.shortage_date else None,
+        }
+        for s in shortages
+    ]
 
-    # ------------------------------------------------------------------
-    # Tool: calculate_reorder_point
-    # ------------------------------------------------------------------
 
-    def calculate_reorder_point(self, params: dict[str, Any]) -> dict[str, Any]:
-        """Calculate the reorder point and safety stock for a product.
+def simulate_override(
+    db,
+    node_id: str,
+    field_name: str,
+    new_value: str,
+    scenario_name: str = "agent-sim",
+    base_scenario_id: str = "00000000-0000-0000-0000-000000000001",
+) -> dict:
+    """Create a simulation scenario with a single override and return delta.
 
-        Args:
-            params: Dictionary with keys:
+    Args:
+        db: A psycopg3 connection (sync).
+        node_id: UUID string of the graph node to override.
+        field_name: The node field to change (e.g. ``"expected_delivery_date"``).
+        new_value: The new value as a string.
+        scenario_name: Prefix for the new scenario name.
+        base_scenario_id: UUID string of the scenario to branch from.
 
-                * ``daily_demand`` (float): Average daily demand in units.
-                * ``lead_time_days`` (float): Supplier lead time in days.
-                * ``demand_std_daily`` (float, optional): Std-dev of daily
-                  demand. Defaults to ``0``.
-                * ``lead_time_std_days`` (float, optional): Std-dev of lead
-                  time. Defaults to ``0``.
-                * ``service_level`` (float, optional): Desired service level
-                  in (0, 1). Defaults to ``0.95``.
+    Returns:
+        A dict with ``scenario_id``, ``scenario_name``, ``status``, and
+        ``override_applied`` keys.
+    """
+    from ootils_core.engine.scenario.manager import ScenarioManager
+    from uuid import UUID as _UUID, uuid4
 
-        Returns:
-            ``{"status": "ok", "result": {"reorder_point": float, "safety_stock": float}}``
-            on success, or ``{"status": "error", "error": str}`` on failure.
-        """
-        try:
-            daily_demand = float(params["daily_demand"])
-            lead_time_days = float(params["lead_time_days"])
-            demand_std_daily = float(params.get("demand_std_daily", 0))
-            lead_time_std_days = float(params.get("lead_time_std_days", 0))
-            service_level = float(params.get("service_level", 0.95))
+    manager = ScenarioManager()
+    base_id = _UUID(base_scenario_id)
 
-            ss = safety_stock(
-                daily_demand=daily_demand,
-                demand_std_daily=demand_std_daily,
-                lead_time_days=lead_time_days,
-                lead_time_std_days=lead_time_std_days,
-                service_level=service_level,
-            )
-            rop = reorder_point(
-                daily_demand=daily_demand,
-                lead_time_days=lead_time_days,
-                safety_stock=ss,
-            )
-            return {
-                "status": "ok",
-                "result": {
-                    "reorder_point": round(rop, 2),
-                    "safety_stock": round(ss, 2),
-                    "average_demand_during_lead_time": round(daily_demand * lead_time_days, 2),
-                },
-            }
-        except Exception as exc:  # noqa: BLE001
-            return {"status": "error", "error": str(exc)}
+    scenario = manager.create_scenario(
+        name=scenario_name + "-" + str(uuid4())[:8],
+        parent_scenario_id=base_id,
+        db=db,
+    )
+    manager.apply_override(
+        scenario_id=scenario.scenario_id,
+        node_id=_UUID(node_id),
+        field_name=field_name,
+        new_value=new_value,
+        applied_by="agent",
+        db=db,
+    )
+    return {
+        "scenario_id": str(scenario.scenario_id),
+        "scenario_name": scenario.name,
+        "status": "created",
+        "override_applied": True,
+    }
 
-    # ------------------------------------------------------------------
-    # Tool: calculate_eoq
-    # ------------------------------------------------------------------
 
-    def calculate_eoq(self, params: dict[str, Any]) -> dict[str, Any]:
-        """Calculate the Economic Order Quantity (EOQ).
+def trigger_recalculation(db, scenario_id: str = "00000000-0000-0000-0000-000000000001") -> dict:
+    """Trigger a full recompute for a scenario and return affected node count.
 
-        Args:
-            params: Dictionary with keys:
+    Args:
+        db: A psycopg3 connection (sync).
+        scenario_id: UUID string of the scenario to recompute.
 
-                * ``annual_demand`` (float): Annual demand in units.
-                * ``ordering_cost`` (float): Fixed cost per purchase order.
-                * ``unit_cost`` (float): Cost per unit.
-                * ``holding_cost_rate`` (float, optional): Annual holding cost
-                  as a fraction of unit cost. Defaults to ``0.25``.
+    Returns:
+        A dict with ``status``, ``calc_run_id``, and ``nodes_recalculated``.
+        If a calc run is already in progress, ``status`` will be ``"locked"``
+        and ``nodes_recalculated`` will be ``0``.
+    """
+    from ootils_core.api.routers.events import _build_propagation_engine
+    from ootils_core.engine.orchestration.calc_run import CalcRunManager
+    from ootils_core.engine.kernel.graph.dirty import DirtyFlagManager
+    from uuid import UUID as _UUID, uuid4
+    from datetime import datetime, timezone
 
-        Returns:
-            ``{"status": "ok", "result": {"eoq": float, "annual_total_cost": float}}``
-        """
-        try:
-            annual_demand = float(params["annual_demand"])
-            ordering_cost = float(params["ordering_cost"])
-            unit_cost = float(params["unit_cost"])
-            holding_cost_rate = float(params.get("holding_cost_rate", 0.25))
+    sid = _UUID(scenario_id)
+    engine = _build_propagation_engine(db)
 
-            eoq = economic_order_quantity(
-                annual_demand=annual_demand,
-                ordering_cost=ordering_cost,
-                unit_cost=unit_cost,
-                holding_cost_rate=holding_cost_rate,
-            )
-            holding_cost_per_unit = unit_cost * holding_cost_rate
-            annual_total_cost = (
-                (annual_demand / eoq) * ordering_cost + (eoq / 2) * holding_cost_per_unit
-                if eoq > 0
-                else 0.0
-            )
-            return {
-                "status": "ok",
-                "result": {
-                    "eoq": round(eoq, 2),
-                    "annual_ordering_cost": round((annual_demand / eoq) * ordering_cost, 2)
-                    if eoq > 0
-                    else 0.0,
-                    "annual_holding_cost": round((eoq / 2) * holding_cost_per_unit, 2),
-                    "annual_total_cost": round(annual_total_cost, 2),
-                },
-            }
-        except Exception as exc:  # noqa: BLE001
-            return {"status": "error", "error": str(exc)}
+    trigger_event_id = uuid4()
+    db.execute(
+        "INSERT INTO events (event_id, event_type, scenario_id, processed, source, created_at) VALUES (%s, 'calc_triggered', %s, FALSE, 'agent', %s)",
+        (trigger_event_id, sid, datetime.now(timezone.utc)),
+    )
 
-    # ------------------------------------------------------------------
-    # Tool: recommend_order
-    # ------------------------------------------------------------------
+    calc_run_mgr = CalcRunManager()
+    dirty_mgr = DirtyFlagManager()
+    calc_run = calc_run_mgr.start_calc_run(scenario_id=sid, event_ids=[trigger_event_id], db=db)
 
-    def recommend_order(self, params: dict[str, Any]) -> dict[str, Any]:
-        """Generate a full purchase order recommendation for a product.
+    if calc_run is None:
+        return {"status": "locked", "nodes_recalculated": 0}
 
-        This is the primary decision tool.  It combines inventory policy
-        calculations with supplier selection to produce a single actionable
-        recommendation.
+    all_pi = db.execute(
+        "SELECT node_id FROM nodes WHERE scenario_id = %s AND node_type = 'ProjectedInventory' AND active = TRUE",
+        (sid,),
+    ).fetchall()
+    all_pi_ids = {_UUID(str(r["node_id"])) for r in all_pi}
 
-        Args:
-            params: Dictionary with keys:
+    if all_pi_ids:
+        dirty_mgr.mark_dirty(all_pi_ids, sid, calc_run.calc_run_id, db)
+        dirty_mgr.flush_to_postgres(calc_run.calc_run_id, sid, db)
+        engine._propagate(calc_run, all_pi_ids, db)
 
-                * ``sku`` (str): Product SKU.
-                * ``name`` (str): Product name.
-                * ``unit_cost`` (float): Product unit cost.
-                * ``current_stock`` (float): On-hand inventory.
-                * ``daily_demand`` (float): Average daily demand.
-                * ``demand_std_daily`` (float, optional): Demand std-dev.
-                * ``open_order_quantity`` (float, optional): In-transit units.
-                * ``holding_cost_rate`` (float, optional): Defaults to 0.25.
-                * ``ordering_cost`` (float, optional): Defaults to 50.
-                * ``service_level`` (float, optional): Defaults to 0.95.
-                * ``lead_time_days`` (float, optional): Defaults to 14.
-                * ``lead_time_std_days`` (float, optional): Defaults to 2.
-                * ``suppliers`` (list[dict]): Each dict may contain:
-                    - ``name`` (str, required)
-                    - ``lead_time_days`` (float, required)
-                    - ``lead_time_std_days`` (float, optional)
-                    - ``reliability_score`` (float, optional)
-                    - ``unit_price_multiplier`` (float, optional)
-                    - ``min_order_quantity`` (int, optional)
-                    - ``max_order_quantity`` (int, optional)
+    engine._finish_run(calc_run, sid, db)
 
-        Returns:
-            ``{"status": "ok", "result": {...}}`` with the recommendation
-            details, or ``{"status": "no_action"}`` if no order is needed,
-            or ``{"status": "error", "error": str}`` on failure.
-        """
-        try:
-            product = Product(
-                sku=str(params["sku"]),
-                name=str(params["name"]),
-                unit_cost=float(params["unit_cost"]),
-                holding_cost_rate=float(params.get("holding_cost_rate", 0.25)),
-                ordering_cost=float(params.get("ordering_cost", 50.0)),
-                service_level=float(params.get("service_level", 0.95)),
-                lead_time_days=float(params.get("lead_time_days", 14.0)),
-                lead_time_std_days=float(params.get("lead_time_std_days", 2.0)),
-            )
-            state = InventoryState(
-                product=product,
-                current_stock=float(params["current_stock"]),
-                daily_demand=float(params["daily_demand"]),
-                demand_std_daily=float(params.get("demand_std_daily", 0.0)),
-                open_order_quantity=float(params.get("open_order_quantity", 0.0)),
-            )
-
-            raw_suppliers = params.get("suppliers", [])
-            if not raw_suppliers:
-                return {"status": "error", "error": "At least one supplier is required."}
-
-            suppliers = [
-                Supplier(
-                    name=str(s["name"]),
-                    lead_time_days=float(s["lead_time_days"]),
-                    lead_time_std_days=float(s.get("lead_time_std_days", 2.0)),
-                    reliability_score=float(s.get("reliability_score", 1.0)),
-                    unit_price_multiplier=float(s.get("unit_price_multiplier", 1.0)),
-                    min_order_quantity=int(s.get("min_order_quantity", 1)),
-                    max_order_quantity=int(s["max_order_quantity"])
-                    if s.get("max_order_quantity") is not None
-                    else None,
-                )
-                for s in raw_suppliers
-            ]
-
-            recommendation = self._engine.decide(state, suppliers)
-
-            if recommendation is None:
-                return {
-                    "status": "no_action",
-                    "result": {
-                        "message": "Stock levels are adequate. No order is required at this time.",
-                        "effective_stock": state.effective_stock,
-                        "days_of_supply": round(state.days_of_supply, 1)
-                        if not math.isinf(state.days_of_supply)
-                        else None,
-                    },
-                }
-
-            return {
-                "status": "ok",
-                "result": {
-                    "sku": recommendation.product.sku,
-                    "supplier": recommendation.supplier.name,
-                    "order_quantity": recommendation.order_quantity,
-                    "urgency": recommendation.urgency,
-                    "reorder_point": round(recommendation.reorder_point, 2),
-                    "safety_stock": round(recommendation.safety_stock, 2),
-                    "economic_order_quantity": round(recommendation.economic_order_quantity, 2),
-                    "rationale": recommendation.rationale,
-                    "metadata": recommendation.metadata,
-                },
-            }
-        except Exception as exc:  # noqa: BLE001
-            return {"status": "error", "error": str(exc)}
-
-    # ------------------------------------------------------------------
-    # Tool: rank_suppliers
-    # ------------------------------------------------------------------
-
-    def rank_suppliers(self, params: dict[str, Any]) -> dict[str, Any]:
-        """Rank a list of suppliers for a product by composite score.
-
-        Args:
-            params: Dictionary with keys:
-
-                * ``unit_cost`` (float): Base unit cost of the product.
-                * ``suppliers`` (list[dict]): Supplier dictionaries (same
-                  schema as in :meth:`recommend_order`).
-
-        Returns:
-            ``{"status": "ok", "result": {"ranked_suppliers": [...]}}``
-            where each entry has ``name``, ``score``, ``lead_time_days``,
-            ``reliability_score``, and ``effective_unit_cost``.
-        """
-        try:
-            unit_cost = float(params["unit_cost"])
-            raw_suppliers = params.get("suppliers", [])
-            if not raw_suppliers:
-                return {"status": "error", "error": "At least one supplier is required."}
-
-            suppliers = [
-                Supplier(
-                    name=str(s["name"]),
-                    lead_time_days=float(s["lead_time_days"]),
-                    lead_time_std_days=float(s.get("lead_time_std_days", 2.0)),
-                    reliability_score=float(s.get("reliability_score", 1.0)),
-                    unit_price_multiplier=float(s.get("unit_price_multiplier", 1.0)),
-                    min_order_quantity=int(s.get("min_order_quantity", 1)),
-                )
-                for s in raw_suppliers
-            ]
-
-            ranked = rank_suppliers(suppliers, unit_cost)
-            return {
-                "status": "ok",
-                "result": {
-                    "ranked_suppliers": [
-                        {
-                            "name": s.name,
-                            "score": round(score, 6),
-                            "lead_time_days": s.lead_time_days,
-                            "reliability_score": s.reliability_score,
-                            "effective_unit_cost": round(s.effective_unit_cost(unit_cost), 4),
-                        }
-                        for s, score in ranked
-                    ]
-                },
-            }
-        except Exception as exc:  # noqa: BLE001
-            return {"status": "error", "error": str(exc)}
-
-    # ------------------------------------------------------------------
-    # Tool: assess_risk
-    # ------------------------------------------------------------------
-
-    def assess_risk(self, params: dict[str, Any]) -> dict[str, Any]:
-        """Assess supply chain risk for a given inventory snapshot.
-
-        Provides a structured risk assessment that agents can use to
-        prioritise their actions without making a full ordering decision.
-
-        Args:
-            params: Dictionary with keys:
-
-                * ``current_stock`` (float): On-hand inventory.
-                * ``daily_demand`` (float): Average daily demand.
-                * ``reorder_point`` (float): Calculated or known reorder point.
-                * ``safety_stock`` (float): Safety stock level.
-                * ``lead_time_days`` (float, optional): For coverage calculation.
-
-        Returns:
-            ``{"status": "ok", "result": {...}}`` with ``urgency``,
-            ``days_of_supply``, ``stock_coverage_days``, and a plain-English
-            ``assessment``.
-        """
-        try:
-            current_stock = float(params["current_stock"])
-            daily_demand = float(params["daily_demand"])
-            rop = float(params["reorder_point"])
-            ss = float(params["safety_stock"])
-            lead_time_days = float(params.get("lead_time_days", 0))
-
-            urgency = urgency_level(
-                current_stock=current_stock,
-                daily_demand=daily_demand,
-                reorder_point=rop,
-                safety_stock=ss,
-            )
-
-            days = current_stock / daily_demand if daily_demand > 0 else None
-
-            stock_below_safety = current_stock < ss
-            stock_below_rop = current_stock <= rop
-            coverage_ok = days is None or days >= lead_time_days
-
-            parts = []
-            if urgency == "critical":
-                parts.append("Stock is critically low or exhausted.")
-            elif urgency == "high":
-                parts.append("Stock is below safety stock threshold — risk of imminent stock-out.")
-            elif urgency == "medium":
-                parts.append("Stock has crossed the reorder point — replenishment should begin.")
-            else:
-                parts.append("Stock levels are within acceptable bounds.")
-
-            if not coverage_ok:
-                parts.append(
-                    f"Stock covers only {days:.1f} days, which is less than "
-                    f"the {lead_time_days:.0f}-day lead time."
-                )
-
-            return {
-                "status": "ok",
-                "result": {
-                    "urgency": urgency,
-                    "days_of_supply": round(days, 1) if days is not None else None,
-                    "stock_below_safety_stock": stock_below_safety,
-                    "stock_below_reorder_point": stock_below_rop,
-                    "lead_time_coverage_adequate": coverage_ok,
-                    "assessment": " ".join(parts),
-                },
-            }
-        except Exception as exc:  # noqa: BLE001
-            return {"status": "error", "error": str(exc)}
-
-    # ------------------------------------------------------------------
-    # Schema helper
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def tool_schemas() -> list[dict[str, Any]]:
-        """Return OpenAI-compatible tool schemas for all public tool methods.
-
-        Agents can pass these schemas directly to an LLM's ``tools`` parameter
-        to enable function calling.
-
-        Returns:
-            A list of tool schema dictionaries.
-        """
-        return [
-            {
-                "type": "function",
-                "function": {
-                    "name": "calculate_reorder_point",
-                    "description": (
-                        "Calculate the inventory reorder point and safety stock "
-                        "required to meet a target service level."
-                    ),
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "daily_demand": {"type": "number", "description": "Average daily demand (units)."},
-                            "lead_time_days": {"type": "number", "description": "Supplier lead time in days."},
-                            "demand_std_daily": {"type": "number", "description": "Std-dev of daily demand (units). Default 0."},
-                            "lead_time_std_days": {"type": "number", "description": "Std-dev of lead time in days. Default 0."},
-                            "service_level": {"type": "number", "description": "Target service level (0–1). Default 0.95."},
-                        },
-                        "required": ["daily_demand", "lead_time_days"],
-                    },
-                },
-            },
-            {
-                "type": "function",
-                "function": {
-                    "name": "calculate_eoq",
-                    "description": "Calculate the Economic Order Quantity (EOQ) that minimises total ordering and holding costs.",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "annual_demand": {"type": "number", "description": "Annual demand in units."},
-                            "ordering_cost": {"type": "number", "description": "Fixed cost per purchase order."},
-                            "unit_cost": {"type": "number", "description": "Purchase cost per unit."},
-                            "holding_cost_rate": {"type": "number", "description": "Annual holding cost as fraction of unit cost. Default 0.25."},
-                        },
-                        "required": ["annual_demand", "ordering_cost", "unit_cost"],
-                    },
-                },
-            },
-            {
-                "type": "function",
-                "function": {
-                    "name": "recommend_order",
-                    "description": (
-                        "Generate a complete purchase order recommendation for a product, "
-                        "including supplier selection, order quantity, and rationale."
-                    ),
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "sku": {"type": "string", "description": "Product SKU."},
-                            "name": {"type": "string", "description": "Product name."},
-                            "unit_cost": {"type": "number", "description": "Product unit cost."},
-                            "current_stock": {"type": "number", "description": "Current on-hand inventory."},
-                            "daily_demand": {"type": "number", "description": "Average daily demand."},
-                            "demand_std_daily": {"type": "number", "description": "Demand standard deviation. Default 0."},
-                            "open_order_quantity": {"type": "number", "description": "Units already on order. Default 0."},
-                            "suppliers": {
-                                "type": "array",
-                                "description": "List of candidate suppliers.",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "name": {"type": "string"},
-                                        "lead_time_days": {"type": "number"},
-                                        "reliability_score": {"type": "number"},
-                                        "unit_price_multiplier": {"type": "number"},
-                                        "min_order_quantity": {"type": "integer"},
-                                        "max_order_quantity": {"type": "integer"},
-                                    },
-                                    "required": ["name", "lead_time_days"],
-                                },
-                            },
-                        },
-                        "required": ["sku", "name", "unit_cost", "current_stock", "daily_demand", "suppliers"],
-                    },
-                },
-            },
-            {
-                "type": "function",
-                "function": {
-                    "name": "rank_suppliers",
-                    "description": "Rank suppliers by a composite score balancing cost, lead time, and reliability.",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "unit_cost": {"type": "number", "description": "Base unit cost of the product."},
-                            "suppliers": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "name": {"type": "string"},
-                                        "lead_time_days": {"type": "number"},
-                                        "reliability_score": {"type": "number"},
-                                        "unit_price_multiplier": {"type": "number"},
-                                    },
-                                    "required": ["name", "lead_time_days"],
-                                },
-                            },
-                        },
-                        "required": ["unit_cost", "suppliers"],
-                    },
-                },
-            },
-            {
-                "type": "function",
-                "function": {
-                    "name": "assess_risk",
-                    "description": "Assess supply chain risk for a given inventory snapshot, returning urgency level and a plain-English assessment.",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "current_stock": {"type": "number", "description": "Current on-hand inventory."},
-                            "daily_demand": {"type": "number", "description": "Average daily demand."},
-                            "reorder_point": {"type": "number", "description": "Inventory reorder point."},
-                            "safety_stock": {"type": "number", "description": "Safety stock level."},
-                            "lead_time_days": {"type": "number", "description": "Supplier lead time in days."},
-                        },
-                        "required": ["current_stock", "daily_demand", "reorder_point", "safety_stock"],
-                    },
-                },
-            },
-        ]
+    return {
+        "status": "completed",
+        "calc_run_id": str(calc_run.calc_run_id),
+        "nodes_recalculated": calc_run.nodes_recalculated or 0,
+    }


### PR DESCRIPTION
Closes #118
Closes #124

## Changes

### #118
- agent_tools.py rewritten: get_active_issues(), simulate_override(), trigger_recalculation() now use current kernel
- decision_engine.py marked as deprecated

### #124
- POST /v1/ingest/work-orders — WorkOrderSupply nodes
- POST /v1/ingest/customer-orders — CustomerOrderDemand nodes
- POST /v1/ingest/transfers — TransferSupply nodes (from→to location)