### PR TITLE
fix(db): migration 014 — add 3 missing low-priority indexes

### DIFF
--- a/src/ootils_core/db/migrations/014_missing_indexes.sql
+++ b/src/ootils_core/db/migrations/014_missing_indexes.sql
@@ -110,3 +110,21 @@ DROP INDEX IF EXISTS idx_ghost_nodes_type;
 
 -- 4 distinct values — not selective enough to be useful
 DROP INDEX IF EXISTS idx_resources_type;
+
+-- ============================================================
+-- LOW: Active BOM header lookup
+-- Used by: bom.py _get_active_bom()
+-- ============================================================
+CREATE INDEX IF NOT EXISTS idx_bom_headers_parent_active
+    ON bom_headers (parent_item_id, effective_from DESC)
+    WHERE status = 'active';
+
+-- ============================================================
+-- LOW: Items/locations name lookup for API resolution
+-- Used by: graph.py, projection.py — resolve by name
+-- ============================================================
+CREATE INDEX IF NOT EXISTS idx_items_name
+    ON items (name);
+
+CREATE INDEX IF NOT EXISTS idx_locations_name
+    ON locations (name);


### PR DESCRIPTION
Adds the 3 indexes that were in PR #135 but not yet on main:
- `idx_bom_headers_parent_active` — active BOM lookup
- `idx_items_name` — API name resolution
- `idx_locations_name` — API name resolution

All use `IF NOT EXISTS`, fully idempotent.