### PR TITLE
fix: allocation race — SELECT FOR UPDATE on PI node closing_stock (#154)

### DIFF
--- a/src/ootils_core/engine/kernel/allocation/engine.py
+++ b/src/ootils_core/engine/kernel/allocation/engine.py
@@ -234,7 +234,10 @@ class AllocationEngine:
                 break
 
             pi_node_id = consumes_edge.to_node_id
-            pi_node = store.get_node(pi_node_id, scenario_id)
+            # for_update=True locks the row until our UPDATE on closing_stock
+            # commits, preventing concurrent allocation runs from double-deducting
+            # supply from the same PI node (fix for issue #154).
+            pi_node = store.get_node(pi_node_id, scenario_id, for_update=True)
 
             if pi_node is None:
                 logger.warning(

--- a/src/ootils_core/engine/kernel/graph/store.py
+++ b/src/ootils_core/engine/kernel/graph/store.py
@@ -39,12 +39,26 @@ class GraphStore:
     # Node reads
     # ------------------------------------------------------------------
 
-    def get_node(self, node_id: UUID, scenario_id: UUID) -> Optional[Node]:
-        """Fetch a single node by ID and scenario. Returns None if not found."""
+    def get_node(
+        self,
+        node_id: UUID,
+        scenario_id: UUID,
+        for_update: bool = False,
+    ) -> Optional[Node]:
+        """Fetch a single node by ID and scenario. Returns None if not found.
+
+        Args:
+            for_update: If True, appends FOR UPDATE to lock the row until the
+                current transaction commits. Use this during allocation to
+                prevent concurrent runners from reading stale closing_stock
+                and double-deducting supply (#154).
+        """
+        lock_clause = " FOR UPDATE" if for_update else ""
         row = self._conn.execute(
-            """
+            f"""
             SELECT * FROM nodes
             WHERE node_id = %s AND scenario_id = %s AND active = TRUE
+            {lock_clause}
             """,
             (node_id, scenario_id),
         ).fetchone()


### PR DESCRIPTION
## Problem
Two concurrent allocation runs could read the same `closing_stock` value and both deduct from it, resulting in negative inventory (issue #154).

## Fix
- `GraphStore.get_node()` gains `for_update: bool = False` — fully backward compatible, no callers affected
- `AllocationEngine._allocate_demand()` calls `get_node(..., for_update=True)` when reading PI node closing_stock

The row lock is held until the subsequent `update_node_closing_stock()` commits, serializing concurrent runners at the DB level.

## Note
AllocationEngine is not yet integrated into the propagation orchestrator, so this is preventive. The fix ensures correctness is guaranteed before that wiring happens.

Closes #154