### PR TITLE
fix: DQ L2 — chunk ANY() array to avoid PostgreSQL 32k limit (#157)

### DIFF
--- a/src/ootils_core/engine/dq/engine.py
+++ b/src/ootils_core/engine/dq/engine.py
@@ -303,35 +303,44 @@ def _check_l1(
 # L2 — Referential checks
 # ──────────────────────────────────────────────────────────────
 
-def _batch_resolve_items(db: psycopg.Connection, external_ids: list[str]) -> set[str]:
-    """Return set of external_ids that exist in items table."""
+_BATCH_CHUNK_SIZE = 10_000  # safe below PostgreSQL's ANY() array limit (~32 767)
+
+
+def _chunked_resolve(
+    db: psycopg.Connection,
+    table: str,
+    external_ids: list[str],
+) -> set[str]:
+    """Return set of external_ids that exist in *table*.
+
+    Chunks the input into batches of _BATCH_CHUNK_SIZE to avoid hitting
+    PostgreSQL's array size limit (~32 767 elements) on large batch imports
+    (fix for issue #157).
+    """
     if not external_ids:
         return set()
-    rows = db.execute(
-        "SELECT external_id FROM items WHERE external_id = ANY(%s)",
-        (external_ids,),
-    ).fetchall()
-    return {r["external_id"] for r in rows}
+    found: set[str] = set()
+    for i in range(0, len(external_ids), _BATCH_CHUNK_SIZE):
+        chunk = external_ids[i : i + _BATCH_CHUNK_SIZE]
+        rows = db.execute(
+            f"SELECT external_id FROM {table} WHERE external_id = ANY(%s)",  # noqa: S608
+            (chunk,),
+        ).fetchall()
+        found.update(r["external_id"] for r in rows)
+    return found
+
+
+def _batch_resolve_items(db: psycopg.Connection, external_ids: list[str]) -> set[str]:
+    """Return set of external_ids that exist in items table."""
+    return _chunked_resolve(db, "items", external_ids)
 
 
 def _batch_resolve_locations(db: psycopg.Connection, external_ids: list[str]) -> set[str]:
-    if not external_ids:
-        return set()
-    rows = db.execute(
-        "SELECT external_id FROM locations WHERE external_id = ANY(%s)",
-        (external_ids,),
-    ).fetchall()
-    return {r["external_id"] for r in rows}
+    return _chunked_resolve(db, "locations", external_ids)
 
 
 def _batch_resolve_suppliers(db: psycopg.Connection, external_ids: list[str]) -> set[str]:
-    if not external_ids:
-        return set()
-    rows = db.execute(
-        "SELECT external_id FROM suppliers WHERE external_id = ANY(%s)",
-        (external_ids,),
-    ).fetchall()
-    return {r["external_id"] for r in rows}
+    return _chunked_resolve(db, "suppliers", external_ids)
 
 
 def _check_l2(


### PR DESCRIPTION
## Problem
`_batch_resolve_items/locations/suppliers` passed unbounded `external_ids` lists directly to `ANY(%s)`. PostgreSQL's limit is ~32,767 elements per array — any batch import above that threshold crashed during L2 DQ validation (issue #157).

## Fix
- New `_chunked_resolve(db, table, external_ids)` helper that iterates in chunks of 10,000 and unions results
- All three `_batch_resolve_*` functions now delegate to it (3-line bodies each)
- `_BATCH_CHUNK_SIZE = 10_000` constant for easy tuning
- Zero change to callers or behavior for lists under 10k

Closes #157