### PR TITLE
fix(docker): remove scripts/ from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,4 +22,4 @@ build/
 .env.*
 !.env.example
 .github/
-scripts/
+# scripts/ is intentionally included in the image (seed, export tools)


### PR DESCRIPTION
Dockerfile COPY scripts/ fails because .dockerignore excluded it. Scripts directory is needed in the image (seed_demo_data.py, export_openapi.py).