### PR TITLE
fix(db): migration 014 — ingest_batches uses submitted_at not created_at

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,4 +22,4 @@ build/
 .env.*
 !.env.example
 .github/
-scripts/
+# scripts/ is intentionally included in the image (seed, export tools)

--- a/src/ootils_core/db/migrations/014_missing_indexes.sql
+++ b/src/ootils_core/db/migrations/014_missing_indexes.sql
@@ -41,7 +41,7 @@ CREATE INDEX IF NOT EXISTS idx_calc_runs_scenario_completed
 
 -- 6. DQ pipeline: batch by entity type and status
 CREATE INDEX IF NOT EXISTS idx_ingest_batches_entity_dq
-    ON ingest_batches (entity_type, dq_status, created_at DESC);
+    ON ingest_batches (entity_type, dq_status, submitted_at DESC);
 
 -- 7. DQ pipeline: rows by batch and row number
 CREATE INDEX IF NOT EXISTS idx_ingest_rows_batch_rownum


### PR DESCRIPTION
Migration 014 referenced `created_at` on `ingest_batches` but the column is `submitted_at`. Caused a migration failure blocking all API requests on redeploy.