### PR TITLE
fix(db): migration 015 — dedup uom_conversions before unique index

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,4 +22,4 @@ build/
 .env.*
 !.env.example
 .github/
-scripts/
+# scripts/ is intentionally included in the image (seed, export tools)

--- a/src/ootils_core/db/migrations/015_schema_integrity.sql
+++ b/src/ootils_core/db/migrations/015_schema_integrity.sql
@@ -29,7 +29,17 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_node_type_policies_active
 -- ============================================================
 -- NULL != NULL in standard SQL UNIQUE, so global conversions (item_id IS NULL)
 -- can be inserted multiple times on re-run without triggering uniqueness errors.
--- Add a partial unique index covering only global (item_id IS NULL) rows.
+-- Deduplicate first (keep the row with the highest conversion_id), then add
+-- a partial unique index covering only global (item_id IS NULL) rows.
+
+DELETE FROM uom_conversions
+WHERE item_id IS NULL
+  AND ctid NOT IN (
+      SELECT MAX(ctid)
+      FROM uom_conversions
+      WHERE item_id IS NULL
+      GROUP BY from_uom, to_uom
+  );
 
 CREATE UNIQUE INDEX IF NOT EXISTS uq_uom_global
     ON uom_conversions (from_uom, to_uom) WHERE item_id IS NULL;


### PR DESCRIPTION
Migration 015 failed to create `uq_uom_global` because the seed inserted multiple identical global UOM conversions (BOX→EA, KG→G, PALLET→EA, T→KG each 10×). Added a DELETE to keep only one row per (from_uom, to_uom) before the index creation.