### PR TITLE
fix(db): migration 019 — feeds_forward missing from edge_type CHECK constraint

### DIFF
--- a/src/ootils_core/db/migrations/019_feeds_forward_edges.sql
+++ b/src/ootils_core/db/migrations/019_feeds_forward_edges.sql
@@ -1,4 +1,4 @@
--- Migration 019: create feeds_forward edges between consecutive PI nodes
+-- Migration 019: add feeds_forward to edge_type CHECK constraint + create edges
 --
 -- The propagator chains PI buckets via 'feeds_forward' edges:
 --   PI[bucket_sequence=N].closing_stock → PI[bucket_sequence=N+1].opening_stock
@@ -11,6 +11,18 @@
 -- ProjectedInventory nodes across all scenarios, using projection_series_id
 -- + bucket_sequence to identify consecutive pairs.
 
+-- Step 1: Add feeds_forward to the edge_type CHECK constraint
+ALTER TABLE edges DROP CONSTRAINT IF EXISTS edges_edge_type_check;
+ALTER TABLE edges ADD CONSTRAINT edges_edge_type_check CHECK (
+    edge_type = ANY (ARRAY[
+        'replenishes', 'transfers', 'requires', 'substitutes',
+        'fulfills', 'consumes', 'produces', 'ghost_member',
+        'bom_component', 'consumes_resource', 'feeds_forward',
+        'pegged_to'
+    ])
+);
+
+-- Step 2: Create feeds_forward edges between consecutive PI nodes
 INSERT INTO edges (
     edge_id,
     edge_type,


### PR DESCRIPTION
edges_edge_type_check didn't include 'feeds_forward' or 'pegged_to'. Migration 019 now drops and recreates the constraint with both types before inserting the edges.