### PR TITLE
fix(ci): restore psycopg after APICS unit tests

### DIFF
--- a/src/ootils_core/api/routers/mrp_apics.py
+++ b/src/ootils_core/api/routers/mrp_apics.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 import time
-from datetime import date, timedelta
+from datetime import date
 from decimal import Decimal
 from typing import List, Optional
 from uuid import UUID
@@ -22,9 +22,8 @@ from pydantic import BaseModel, Field
 
 from ootils_core.api.dependencies import get_db, resolve_scenario_id, BASELINE_SCENARIO_ID
 from ootils_core.engine.mrp.mrp_apics_engine import MrpApicsEngine, MrpRunConfig
-from ootils_core.engine.mrp.forecast_consumer import ForecastConsumer, ForecastConsumerCore, ConsumptionStrategy
-from ootils_core.engine.mrp.lot_sizing import LotSizingEngine, LotSizeRule
-from ootils_core.engine.mrp.time_fences import TimeFenceChecker, TimeFenceZone
+from ootils_core.engine.mrp.forecast_consumer import ForecastConsumer
+from ootils_core.engine.mrp.lot_sizing import LotSizingEngine
 from ootils_core.engine.mrp.llc_calculator import LLCCalculator
 
 logger = logging.getLogger(__name__)

--- a/src/ootils_core/api/routers/simulate.py
+++ b/src/ootils_core/api/routers/simulate.py
@@ -4,7 +4,7 @@ POST /v1/simulate — Create a scenario with overrides and return delta.
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Optional
 from uuid import UUID
 
 import psycopg

--- a/src/ootils_core/engine/dq/agent/agent.py
+++ b/src/ootils_core/engine/dq/agent/agent.py
@@ -14,7 +14,7 @@ Sequence:
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from uuid import UUID, uuid4
 

--- a/src/ootils_core/engine/dq/agent/llm_reporter.py
+++ b/src/ootils_core/engine/dq/agent/llm_reporter.py
@@ -14,7 +14,6 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import Any
 from uuid import UUID
 
 from .stat_rules import AgentIssue

--- a/src/ootils_core/engine/kernel/calc/projection.py
+++ b/src/ootils_core/engine/kernel/calc/projection.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import Decimal
-from typing import Optional
 
 
 class ProjectionKernel:

--- a/src/ootils_core/engine/kernel/temporal/bridge.py
+++ b/src/ootils_core/engine/kernel/temporal/bridge.py
@@ -16,8 +16,7 @@ import logging
 from dataclasses import dataclass
 from datetime import date, timedelta
 from decimal import Decimal
-from typing import Optional
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import psycopg
 

--- a/src/ootils_core/engine/kernel/temporal/zone_transition.py
+++ b/src/ootils_core/engine/kernel/temporal/zone_transition.py
@@ -17,13 +17,12 @@ from __future__ import annotations
 import logging
 from datetime import date, timedelta
 from decimal import Decimal
-from typing import Optional
 from uuid import UUID, uuid4
 
 import psycopg
 
 from ootils_core.engine.kernel.graph.store import GraphStore
-from ootils_core.models import Node, NodeTypeTemporalPolicy
+from ootils_core.models import Node
 
 logger = logging.getLogger(__name__)
 

--- a/src/ootils_core/engine/mrp/forecast_consumer.py
+++ b/src/ootils_core/engine/mrp/forecast_consumer.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import date, timedelta
 from decimal import Decimal
 from enum import Enum
@@ -409,7 +409,7 @@ class ForecastConsumer:
             Dict[item_id, Dict[period_start, net_demand]]
         """
         # Resolve strategy (handles old DB enum values too)
-        strat = ConsumptionStrategy(strategy)
+        ConsumptionStrategy(strategy)
 
         items = self._get_items_with_forecast(location_id, horizon_days)
         results: Dict[UUID, Dict[date, Decimal]] = {}

--- a/src/ootils_core/engine/mrp/gross_to_net.py
+++ b/src/ootils_core/engine/mrp/gross_to_net.py
@@ -24,10 +24,10 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import date, timedelta
 from decimal import Decimal
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, List, Optional
 from uuid import UUID, uuid4
 
 import psycopg
@@ -304,7 +304,6 @@ class GrossToNetCalculator:
         # Re-chain: POH_after(t) = PAB(t) + POR(t)
         #           PAB(t+1)      = POH_after(t) + SR(t+1) - GR(t+1)
 
-        running = records[0].projected_on_hand  # initial PAB from gross-to-net
         # But this PAB doesn't include prior planned orders yet.
         # We need to re-compute from scratch using POR.
 

--- a/src/ootils_core/engine/mrp/llc_calculator.py
+++ b/src/ootils_core/engine/mrp/llc_calculator.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import logging
 import time
 from collections import defaultdict, deque
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Set, Tuple
 
 from uuid import UUID
@@ -336,7 +336,6 @@ class LLCCalculator:
         Returns:
             Dict mapping llc_level → [item_ids]
         """
-        location_filter = ""
         location_join = ""
         params: list = []
 

--- a/src/ootils_core/engine/mrp/lot_sizing.py
+++ b/src/ootils_core/engine/mrp/lot_sizing.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 import logging
 import math
 from enum import Enum
-from decimal import Decimal, ROUND_UP
-from typing import Dict, List, Optional, Tuple
+from decimal import Decimal
+from typing import List, Optional, Tuple
 
 import psycopg
 

--- a/src/ootils_core/engine/mrp/mrp_apics_engine.py
+++ b/src/ootils_core/engine/mrp/mrp_apics_engine.py
@@ -26,9 +26,9 @@ import logging
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
-from datetime import date, timedelta
+from datetime import date
 from decimal import Decimal
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set
 from uuid import UUID, uuid4
 
 import psycopg
@@ -40,8 +40,8 @@ from ootils_core.engine.mrp.gross_to_net import (
     GrossToNetCalculator,
     TimeBucket,
 )
-from ootils_core.engine.mrp.forecast_consumer import ForecastConsumer, ConsumptionStrategy
-from ootils_core.engine.mrp.lot_sizing import LotSizingEngine, LotSizeRule
+from ootils_core.engine.mrp.forecast_consumer import ForecastConsumer
+from ootils_core.engine.mrp.lot_sizing import LotSizingEngine
 from ootils_core.engine.mrp.time_fences import TimeFenceChecker, TimeFenceZone
 from ootils_core.engine.mrp.graph_integration import GraphIntegration
 
@@ -132,9 +132,9 @@ class MrpApicsEngine:
 
             # 2. Calculate or retrieve LLCs
             if config.recalculate_llc:
-                llc_map = self.llc_calculator.calculate_all()
+                self.llc_calculator.calculate_all()
             else:
-                llc_map = self.llc_calculator.load_existing_llc()
+                self.llc_calculator.load_existing_llc()
 
             # Items with no BOM (finished goods) get LLC 0
             items_by_llc = self.llc_calculator.get_items_by_llc(config.location_id)
@@ -305,7 +305,6 @@ class MrpApicsEngine:
         time_buckets: List[TimeBucket],
     ):
         """Apply lot sizing and time fence rules to bucket records."""
-        lead_time_days = int(params.get("lead_time_total_days") or 0)
         time_fence = TimeFenceChecker.from_planning_params(params)
 
         for i, record in enumerate(records):
@@ -338,7 +337,6 @@ class MrpApicsEngine:
             record.projected_on_hand += lot_qty
 
             # Lead time offset: release date = receipt date - lead time
-            release_date = record.period_start - timedelta(days=lead_time_days)
             record.planned_order_releases = lot_qty
 
             # Handle frozen zone: push orders to frozen boundary

--- a/src/ootils_core/engine/mrp/time_fences.py
+++ b/src/ootils_core/engine/mrp/time_fences.py
@@ -15,10 +15,8 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import date, timedelta
-from decimal import Decimal
 from enum import Enum
 from typing import Optional
-from uuid import UUID
 
 logger = logging.getLogger(__name__)
 

--- a/src/ootils_core/engine/scenario/manager.py
+++ b/src/ootils_core/engine/scenario/manager.py
@@ -13,15 +13,12 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from decimal import Decimal
-from typing import Any, Optional
+from typing import Optional
 from uuid import UUID, uuid4
 
 import psycopg
 
 from ootils_core.models import (
-    Node,
-    PlanningEvent,
     Scenario,
     ScenarioDiff,
     ScenarioOverride,

--- a/src/ootils_core/tools/agent_tools.py
+++ b/src/ootils_core/tools/agent_tools.py
@@ -14,8 +14,6 @@ These tools wrap the graph-based kernel API for use by LLM agents.
 """
 from __future__ import annotations
 
-from typing import Any
-from uuid import UUID
 
 
 def get_active_issues(db, scenario_id: str = "00000000-0000-0000-0000-000000000001") -> list[dict]:

--- a/tests/test_lot_sizing_engine.py
+++ b/tests/test_lot_sizing_engine.py
@@ -23,12 +23,19 @@ from unittest.mock import MagicMock, patch
 import types
 import sys
 
-# Mock psycopg before importing
+# Mock psycopg only during import of the APICS modules, then restore it so the
+# later DB-backed tests in the full suite can import the real psycopg package.
+_psycopg_original = sys.modules.get('psycopg')
 psycopg_mock = types.ModuleType('psycopg')
 sys.modules['psycopg'] = psycopg_mock
 
 from ootils_core.engine.mrp.lot_sizing import LotSizingEngine, LotSizeRule
 from ootils_core.engine.mrp.gross_to_net import BucketRecord, TimeBucket
+
+if _psycopg_original is not None:
+    sys.modules['psycopg'] = _psycopg_original
+else:
+    sys.modules.pop('psycopg', None)
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- stop `tests/test_lot_sizing_engine.py` from leaking a fake `psycopg` module into the rest of the full suite
- clean the remaining Ruff issues currently failing the `src/` lint job
- revalidate the CI command locally on VM with a disposable PostgreSQL instance

## Root cause
The APICS lot-sizing unit test replaced `sys.modules['psycopg']` at module import time and never restored it. In the full test suite, later DB-backed tests imported that fake module and failed with:
- `AttributeError: module 'psycopg' has no attribute 'connect'`

## Validation
- `ruff check src/` → OK
- `python3 -m pytest tests/ -q --tb=short --ignore=tests/integration --ignore=tests/smoke` → `1330 passed, 22 warnings`
- replay executed on VM against a disposable PostgreSQL 16 container with CI-like env vars
