### PR TITLE
Add Phase 1 E2E demo flow

### DIFF
--- a/docs/demo-phase1-e2e.md
+++ b/docs/demo-phase1-e2e.md
@@ -1,0 +1,66 @@
+# Phase 1 E2E Demo — Forecast → MPS → MRP → CRP → ATP
+
+This demo proves the user-facing Phase 1 planning chain through real FastAPI routers and PostgreSQL:
+
+1. Seed deterministic finished-good, plant, historical demand, work-center, routing, and operation data.
+2. Generate statistical demand forecast: `POST /v1/demand/forecast/generate`.
+3. Aggregate forecast into MPS: `POST /v1/mps/aggregate-demand`.
+4. Approve the MPS node for deterministic demo setup, then promote to MRP planned supply: `POST /v1/mps/{mps_id}/promote-to-mrp`.
+5. Calculate CRP load from released planned supply: `POST /v1/crp/calculate`.
+6. Check ATP for a customer quantity/date request: `POST /v1/atp/check`.
+
+The approval step is currently SQL-driven because an approval workflow endpoint is outside the current scope. All planning calculations still go through the real API routers.
+
+## Run on VM 201 with disposable DB
+
+```bash
+cd ~/ootils-core
+set -a && . ./.env && set +a
+
+docker compose exec -T postgres dropdb -U "$POSTGRES_USER" --if-exists ootils_demo_phase1
+docker compose exec -T postgres createdb -U "$POSTGRES_USER" ootils_demo_phase1
+
+DATABASE_URL="postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:5432/ootils_demo_phase1" \
+OOTILS_API_TOKEN="$OOTILS_API_TOKEN" \
+python3 scripts/demo_phase1_e2e.py
+```
+
+Use `--json` for compact machine-readable output.
+
+## Expected output shape
+
+```json
+{
+  "status": "ok",
+  "item_external_id": "DEMO-FG-...",
+  "location_external_id": "DEMO-PLANT-...",
+  "forecast": {
+    "buckets": 21,
+    "total_quantity": "...",
+    "method": "MA"
+  },
+  "mps": {
+    "mps_nodes_created": 3,
+    "total_demand": "...",
+    "first_mps_id": "..."
+  },
+  "mrp_promotion": {
+    "status": "RELEASED",
+    "planned_supplies_created": 1
+  },
+  "crp": {
+    "planned_orders_count": 1,
+    "work_centers_count": 1,
+    "load_profiles": 1
+  },
+  "atp": {
+    "requested_quantity": "5",
+    "quantity_available": "...",
+    "buckets": 30
+  }
+}
+```
+
+## Demo positioning
+
+This is the first clean product proof for Phase 1: Ootils can take historical demand, forecast it, turn it into a master schedule, release planned supply, compute capacity load, and answer whether a customer request can be promised.

--- a/scripts/demo_phase1_e2e.py
+++ b/scripts/demo_phase1_e2e.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+Demo Phase 1 E2E API flow: Forecast -> MPS -> MRP planned supply -> CRP -> ATP.
+
+Runs against the DATABASE_URL database using the real FastAPI app/TestClient and
+PostgreSQL. Use a disposable migrated test database; the script inserts demo rows.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import date, timedelta
+from decimal import Decimal
+from uuid import uuid4
+
+BASELINE_SCENARIO_ID = "00000000-0000-0000-0000-000000000001"
+
+
+def _decimal_default(value):
+    if isinstance(value, Decimal):
+        return str(value)
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing {name}. Set it to a disposable PostgreSQL test database.")
+    return value
+
+
+def _post(client, path: str, auth: dict[str, str], payload: dict) -> dict:
+    response = client.post(path, headers=auth, json=payload)
+    if response.status_code != 200:
+        raise RuntimeError(f"POST {path} failed: {response.status_code} {response.text}")
+    return response.json()
+
+
+def run_demo() -> dict:
+    database_url = _require_env("DATABASE_URL")
+    token = os.environ.setdefault("OOTILS_API_TOKEN", "phase1-demo-token")
+
+    import psycopg
+    from fastapi.testclient import TestClient
+    from psycopg.rows import dict_row
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+
+    # Apply migrations using the same DB wrapper as production/tests.
+    OotilsDB(database_url)
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(database_url)
+        with db.conn() as conn:
+            yield conn
+
+    app.dependency_overrides[get_db] = override_db
+
+    today = date.today()
+    item_external_id = f"DEMO-FG-{uuid4().hex[:8]}"
+    location_external_id = f"DEMO-PLANT-{uuid4().hex[:8]}"
+    item_id = uuid4()
+    location_id = uuid4()
+    work_center_id = uuid4()
+    routing_id = uuid4()
+    operation_id = uuid4()
+
+    with psycopg.connect(database_url, row_factory=dict_row) as conn:
+        conn.execute(
+            """
+            INSERT INTO items (item_id, name, item_type, uom, status, external_id)
+            VALUES (%s, %s, 'finished_good', 'EA', 'active', %s)
+            """,
+            (item_id, "Demo Finished Good", item_external_id),
+        )
+        conn.execute(
+            """
+            INSERT INTO locations (location_id, name, location_type, country, external_id)
+            VALUES (%s, %s, 'plant', 'US', %s)
+            """,
+            (location_id, "Demo Plant", location_external_id),
+        )
+
+        historical = []
+        for days_ago in range(28, 0, -1):
+            demand_date = today - timedelta(days=days_ago)
+            # Slightly non-flat pattern so forecast output is demo-friendly.
+            qty = Decimal("12") + Decimal(days_ago % 5)
+            historical.append((
+                uuid4(), "CustomerOrderDemand", BASELINE_SCENARIO_ID,
+                item_id, location_id, qty, "EA", "day", demand_date,
+                demand_date, demand_date + timedelta(days=1), True,
+            ))
+        with conn.cursor() as cur:
+            cur.executemany(
+                """
+                INSERT INTO nodes (
+                    node_id, node_type, scenario_id, item_id, location_id,
+                    quantity, qty_uom, time_grain, time_ref, time_span_start,
+                    time_span_end, active
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                historical,
+            )
+
+        conn.execute(
+            """
+            INSERT INTO work_centers (work_center_id, code, description, capacity_per_day, efficiency, active)
+            VALUES (%s, %s, 'Demo assembly cell', 80, 1.0, true)
+            """,
+            (work_center_id, f"DEMO-WC-{uuid4().hex[:8]}"),
+        )
+        conn.execute(
+            """
+            INSERT INTO routings (routing_id, item_id, sequence, description, active)
+            VALUES (%s, %s, 1, 'Demo routing', true)
+            """,
+            (routing_id, item_id),
+        )
+        conn.execute(
+            """
+            INSERT INTO routing_operations (
+                operation_id, routing_id, sequence, work_center_id,
+                setup_time, run_time_per_unit, description, active
+            ) VALUES (%s, %s, 10, %s, 2, 0.5, 'Assemble', true)
+            """,
+            (operation_id, routing_id, work_center_id),
+        )
+        conn.commit()
+
+    auth = {"Authorization": f"Bearer {token}"}
+    horizon_start = today + timedelta(days=1)
+    horizon_end = horizon_start + timedelta(days=20)
+
+    with TestClient(app) as client:
+        forecast = _post(client, "/v1/demand/forecast/generate", auth, {
+            "item_id": item_external_id,
+            "location_id": location_external_id,
+            "horizon_days": 21,
+            "granularity": "daily",
+            "method": "MA",
+            "scenario_id": "baseline",
+        })
+
+        mps = _post(client, "/v1/mps/aggregate-demand", auth, {
+            "item_id": item_external_id,
+            "location_id": location_external_id,
+            "scenario_id": "baseline",
+            "horizon_start": horizon_start.isoformat(),
+            "horizon_end": horizon_end.isoformat(),
+            "time_grain": "weekly",
+            "forecast_weight": "1.0",
+            "orders_weight": "0.0",
+            "clear_existing": True,
+        })
+        mps_id = mps["mps_node_ids"][0]
+
+        with psycopg.connect(database_url, row_factory=dict_row) as conn:
+            conn.execute(
+                "UPDATE mps_nodes SET status = 'APPROVED', approved_at = now() WHERE mps_id = %s",
+                (mps_id,),
+            )
+            conn.commit()
+
+        promoted = _post(client, f"/v1/mps/{mps_id}/promote-to-mrp", auth, {
+            "explode_components": False,
+            "dry_run": False,
+            "run_crp": False,
+        })
+
+        with psycopg.connect(database_url, row_factory=dict_row) as conn:
+            conn.execute("UPDATE planned_supply SET status = 'RELEASED' WHERE source_id = %s", (mps_id,))
+            conn.commit()
+
+        crp = _post(client, "/v1/crp/calculate", auth, {
+            "horizon_days": 30,
+            "scenario_id": BASELINE_SCENARIO_ID,
+        })
+
+        atp = _post(client, "/v1/atp/check", auth, {
+            "item_id": item_external_id,
+            "location_id": location_external_id,
+            "quantity": "5",
+            "requested_date": horizon_start.isoformat(),
+            "horizon_days": 30,
+        })
+
+    app.dependency_overrides.clear()
+
+    return {
+        "status": "ok",
+        "item_external_id": item_external_id,
+        "location_external_id": location_external_id,
+        "forecast": {
+            "buckets": len(forecast["values"]),
+            "total_quantity": forecast["total_quantity"],
+            "method": forecast.get("method"),
+        },
+        "mps": {
+            "mps_nodes_created": mps["mps_nodes_created"],
+            "total_demand": mps["total_demand"],
+            "first_mps_id": mps_id,
+        },
+        "mrp_promotion": {
+            "status": promoted["status"],
+            "planned_supplies_created": promoted["planned_supplies_created"],
+        },
+        "crp": {
+            "planned_orders_count": crp["planned_orders_count"],
+            "work_centers_count": crp["work_centers_count"],
+            "load_profiles": len(crp["load_profiles"]),
+        },
+        "atp": {
+            "requested_quantity": atp["requested_quantity"],
+            "quantity_available": atp["quantity_available"],
+            "buckets": len(atp["buckets"]),
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the Ootils Phase 1 E2E demo flow.")
+    parser.add_argument("--json", action="store_true", help="Print compact JSON only.")
+    args = parser.parse_args()
+
+    result = run_demo()
+    if args.json:
+        print(json.dumps(result, default=_decimal_default, separators=(",", ":")))
+        return
+
+    print(json.dumps(result, default=_decimal_default, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a disposable-DB demo script and short doc for the Phase 1 Forecast → MPS → MRP planned supply → CRP → ATP flow.\n\nLocal/VM validation:\n- python3 -m ruff check scripts/demo_phase1_e2e.py\n- python3 -m py_compile scripts/demo_phase1_e2e.py\n- git diff --check\n- DATABASE_URL=... OOTILS_API_TOKEN=... python3 scripts/demo_phase1_e2e.py --json → status ok