### PR TITLE
Add MPS approval endpoint

### DIFF
--- a/docs/demo-phase1-e2e.md
+++ b/docs/demo-phase1-e2e.md
@@ -5,11 +5,12 @@ This demo proves the user-facing Phase 1 planning chain through real FastAPI rou
 1. Seed deterministic finished-good, plant, historical demand, work-center, routing, and operation data.
 2. Generate statistical demand forecast: `POST /v1/demand/forecast/generate`.
 3. Aggregate forecast into MPS: `POST /v1/mps/aggregate-demand`.
-4. Approve the MPS node for deterministic demo setup, then promote to MRP planned supply: `POST /v1/mps/{mps_id}/promote-to-mrp`.
-5. Calculate CRP load from released planned supply: `POST /v1/crp/calculate`.
-6. Check ATP for a customer quantity/date request: `POST /v1/atp/check`.
+4. Approve the MPS node: `POST /v1/mps/{mps_id}/approve`.
+5. Promote to MRP planned supply: `POST /v1/mps/{mps_id}/promote-to-mrp`.
+6. Calculate CRP load from released planned supply: `POST /v1/crp/calculate`.
+7. Check ATP for a customer quantity/date request: `POST /v1/atp/check`.
 
-The approval step is currently SQL-driven because an approval workflow endpoint is outside the current scope. All planning calculations still go through the real API routers.
+All planning workflow steps run through real API routers.
 
 ## Run on VM 201 with disposable DB
 
@@ -43,6 +44,10 @@ Use `--json` for compact machine-readable output.
     "mps_nodes_created": 3,
     "total_demand": "...",
     "first_mps_id": "..."
+  },
+  "approval": {
+    "previous_status": "DRAFT",
+    "status": "APPROVED"
   },
   "mrp_promotion": {
     "status": "RELEASED",

--- a/scripts/demo_phase1_e2e.py
+++ b/scripts/demo_phase1_e2e.py
@@ -160,12 +160,10 @@ def run_demo() -> dict:
         })
         mps_id = mps["mps_node_ids"][0]
 
-        with psycopg.connect(database_url, row_factory=dict_row) as conn:
-            conn.execute(
-                "UPDATE mps_nodes SET status = 'APPROVED', approved_at = now() WHERE mps_id = %s",
-                (mps_id,),
-            )
-            conn.commit()
+        approval = _post(client, f"/v1/mps/{mps_id}/approve", auth, {
+            "approved_by": "phase1-demo",
+            "notes": "Approved by Phase 1 demo flow",
+        })
 
         promoted = _post(client, f"/v1/mps/{mps_id}/promote-to-mrp", auth, {
             "explode_components": False,
@@ -205,6 +203,10 @@ def run_demo() -> dict:
             "mps_nodes_created": mps["mps_nodes_created"],
             "total_demand": mps["total_demand"],
             "first_mps_id": mps_id,
+        },
+        "approval": {
+            "previous_status": approval["previous_status"],
+            "status": approval["status"],
         },
         "mrp_promotion": {
             "status": promoted["status"],

--- a/src/ootils_core/mps/api.py
+++ b/src/ootils_core/mps/api.py
@@ -7,12 +7,13 @@ Endpoints:
   GET  /v1/mps/nodes/{mps_id}    — Get specific MPS node
   POST /v1/mps/capacity-check    — Check capacity feasibility for MPS nodes
   GET  /v1/mps/{id}/suggest-adjustments — Get adjustment suggestions
+  POST /v1/mps/{id}/approve        — Approve an MPS node for release
   POST /v1/mps/{id}/promote-to-mrp — Promote MPS to MRP and trigger BOM explosion
 """
 from __future__ import annotations
 
 import logging
-from datetime import date
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
 from uuid import UUID
@@ -760,6 +761,137 @@ async def suggest_adjustments(
     ]
     
     return suggestions_out
+
+
+# ─────────────────────────────────────────────────────────────
+# POST /v1/mps/{mps_id}/approve
+# ─────────────────────────────────────────────────────────────
+
+class ApproveMPSRequest(BaseModel):
+    """Request to approve an MPS node for release to MRP."""
+    reviewed_by: Optional[str] = Field(default=None, description="Reviewer identifier; defaults to approver/token")
+    approved_by: Optional[str] = Field(default=None, description="Approver identifier; defaults to auth token")
+    notes: Optional[str] = Field(default=None, description="Optional approval notes")
+
+
+class ApproveMPSResponse(BaseModel):
+    """Response from approve endpoint."""
+    mps_id: UUID
+    previous_status: str
+    status: str
+    reviewed_by: Optional[str]
+    approved_by: Optional[str]
+    reviewed_at: Optional[datetime]
+    approved_at: Optional[datetime]
+    notes: Optional[str]
+
+
+@router.post(
+    "/{mps_id}/approve",
+    response_model=ApproveMPSResponse,
+    summary="Approve MPS node",
+    description=(
+        "Approve an MPS node so it can be promoted to MRP.\\n\\n"
+        "Freshly aggregated MPS nodes are created as DRAFT. This endpoint performs "
+        "the operational approval step required before `/promote-to-mrp`. If the node "
+        "is DRAFT, it records both review and approval audit fields in one call; if it "
+        "is REVIEWED, it records approval only. APPROVED is idempotent. RELEASED is terminal."
+    ),
+)
+async def approve_mps_node(
+    mps_id: UUID,
+    body: ApproveMPSRequest,
+    db: psycopg.Connection = Depends(get_db),
+    token: str = Depends(require_auth),
+) -> ApproveMPSResponse:
+    """Approve an MPS node for MRP promotion."""
+    row = db.execute(
+        """
+        SELECT mps_id, status, reviewed_by, approved_by, reviewed_at, approved_at, notes
+        FROM mps_nodes
+        WHERE mps_id = %s AND active = TRUE
+        """,
+        (mps_id,),
+    ).fetchone()
+
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"MPS node '{mps_id}' not found or inactive",
+        )
+
+    previous_status = row["status"]
+    if previous_status == "RELEASED":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Released MPS nodes cannot be approved again",
+        )
+
+    if previous_status not in {"DRAFT", "REVIEWED", "APPROVED"}:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"MPS node cannot be approved from status {previous_status}",
+        )
+
+    approver = body.approved_by or token
+    reviewer = body.reviewed_by or row["reviewed_by"] or approver
+    now = datetime.now(timezone.utc)
+    notes = body.notes if body.notes is not None else row["notes"]
+
+    if previous_status == "APPROVED":
+        if body.notes is not None:
+            db.execute(
+                "UPDATE mps_nodes SET notes = %s, updated_at = %s WHERE mps_id = %s",
+                (notes, now, mps_id),
+            )
+        return ApproveMPSResponse(
+            mps_id=mps_id,
+            previous_status=previous_status,
+            status="APPROVED",
+            reviewed_by=row["reviewed_by"],
+            approved_by=row["approved_by"],
+            reviewed_at=row["reviewed_at"],
+            approved_at=row["approved_at"],
+            notes=notes,
+        )
+
+    reviewed_by = reviewer if previous_status == "DRAFT" else row["reviewed_by"]
+    reviewed_at = now if previous_status == "DRAFT" else row["reviewed_at"]
+
+    db.execute(
+        """
+        UPDATE mps_nodes
+        SET status = %s,
+            reviewed_by = %s,
+            reviewed_at = %s,
+            approved_by = %s,
+            approved_at = %s,
+            notes = %s,
+            updated_at = %s
+        WHERE mps_id = %s
+        """,
+        (
+            "APPROVED",
+            reviewed_by,
+            reviewed_at,
+            approver,
+            now,
+            notes,
+            now,
+            mps_id,
+        ),
+    )
+
+    return ApproveMPSResponse(
+        mps_id=mps_id,
+        previous_status=previous_status,
+        status="APPROVED",
+        reviewed_by=reviewed_by,
+        approved_by=approver,
+        reviewed_at=reviewed_at,
+        approved_at=now,
+        notes=notes,
+    )
 
 
 # ─────────────────────────────────────────────────────────────

--- a/tests/integration/test_phase1_e2e.py
+++ b/tests/integration/test_phase1_e2e.py
@@ -146,14 +146,15 @@ def test_phase1_forecast_mps_crp_atp_rest_e2e(api_client, auth, seeded_db):
     assert Decimal(str(mps["total_demand"])) > 0
     mps_id = mps["mps_node_ids"][0]
 
-    # Promotion requires an approved MPS node; approval workflow endpoint is not
-    # part of the current scope, so use direct SQL setup for deterministic E2E.
-    with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
-        conn.execute(
-            "UPDATE mps_nodes SET status = 'APPROVED', approved_at = now() WHERE mps_id = %s",
-            (mps_id,),
-        )
-        conn.commit()
+    approve_resp = api_client.post(
+        f"/v1/mps/{mps_id}/approve",
+        headers=auth,
+        json={"approved_by": "integration-test", "notes": "Phase 1 E2E approval"},
+    )
+    assert approve_resp.status_code == 200, approve_resp.text
+    approved = approve_resp.json()
+    assert approved["previous_status"] == "DRAFT"
+    assert approved["status"] == "APPROVED"
 
     promote_resp = api_client.post(
         f"/v1/mps/{mps_id}/promote-to-mrp",

--- a/tests/test_mps_approve.py
+++ b/tests/test_mps_approve.py
@@ -1,0 +1,163 @@
+"""Tests for MPS approval endpoint."""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from uuid import uuid4
+from unittest.mock import MagicMock
+
+import psycopg
+import pytest
+from fastapi import HTTPException
+
+from ootils_core.mps.api import ApproveMPSRequest, approve_mps_node
+
+
+def _make_result(row):
+    result = MagicMock()
+    result.fetchone.return_value = row
+    result.fetchall.return_value = [row] if row else []
+    result.rowcount = 1 if row else 0
+    return result
+
+
+def _make_db(first_row):
+    db = MagicMock(spec=psycopg.Connection)
+    db.execute = MagicMock(side_effect=[_make_result(first_row), _make_result(None)])
+    return db
+
+
+def test_approve_request_defaults():
+    req = ApproveMPSRequest()
+    assert req.reviewed_by is None
+    assert req.approved_by is None
+    assert req.notes is None
+
+
+def test_approve_draft_records_review_and_approval():
+    mps_id = uuid4()
+    db = _make_db({
+        "mps_id": mps_id,
+        "status": "DRAFT",
+        "reviewed_by": None,
+        "approved_by": None,
+        "reviewed_at": None,
+        "approved_at": None,
+        "notes": None,
+    })
+
+    resp = asyncio.run(approve_mps_node(
+        mps_id=mps_id,
+        body=ApproveMPSRequest(approved_by="director", notes="go"),
+        db=db,
+        token="token-user",
+    ))
+
+    assert resp.mps_id == mps_id
+    assert resp.previous_status == "DRAFT"
+    assert resp.status == "APPROVED"
+    assert resp.reviewed_by == "director"
+    assert resp.approved_by == "director"
+    assert resp.reviewed_at is not None
+    assert resp.approved_at is not None
+    assert resp.notes == "go"
+
+    update_args = db.execute.call_args_list[1].args
+    assert "UPDATE mps_nodes" in update_args[0]
+    assert update_args[1][0] == "APPROVED"
+    assert update_args[1][1] == "director"
+    assert update_args[1][3] == "director"
+    assert update_args[1][5] == "go"
+    assert update_args[1][7] == mps_id
+
+
+def test_approve_reviewed_preserves_reviewer():
+    mps_id = uuid4()
+    reviewed_at = datetime.now(timezone.utc)
+    db = _make_db({
+        "mps_id": mps_id,
+        "status": "REVIEWED",
+        "reviewed_by": "planner",
+        "approved_by": None,
+        "reviewed_at": reviewed_at,
+        "approved_at": None,
+        "notes": "reviewed",
+    })
+
+    resp = asyncio.run(approve_mps_node(
+        mps_id=mps_id,
+        body=ApproveMPSRequest(approved_by="director"),
+        db=db,
+        token="token-user",
+    ))
+
+    assert resp.previous_status == "REVIEWED"
+    assert resp.status == "APPROVED"
+    assert resp.reviewed_by == "planner"
+    assert resp.reviewed_at == reviewed_at
+    assert resp.approved_by == "director"
+    assert resp.notes == "reviewed"
+
+
+def test_approve_already_approved_is_idempotent():
+    mps_id = uuid4()
+    approved_at = datetime.now(timezone.utc)
+    db = _make_db({
+        "mps_id": mps_id,
+        "status": "APPROVED",
+        "reviewed_by": "planner",
+        "approved_by": "director",
+        "reviewed_at": approved_at,
+        "approved_at": approved_at,
+        "notes": "approved",
+    })
+
+    resp = asyncio.run(approve_mps_node(
+        mps_id=mps_id,
+        body=ApproveMPSRequest(),
+        db=db,
+        token="token-user",
+    ))
+
+    assert resp.previous_status == "APPROVED"
+    assert resp.status == "APPROVED"
+    assert resp.approved_by == "director"
+    assert db.execute.call_count == 1
+
+
+def test_approve_not_found_returns_404():
+    mps_id = uuid4()
+    db = _make_db(None)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(approve_mps_node(
+            mps_id=mps_id,
+            body=ApproveMPSRequest(),
+            db=db,
+            token="token-user",
+        ))
+
+    assert exc.value.status_code == 404
+
+
+def test_approve_released_returns_409():
+    mps_id = uuid4()
+    db = _make_db({
+        "mps_id": mps_id,
+        "status": "RELEASED",
+        "reviewed_by": "planner",
+        "approved_by": "director",
+        "reviewed_at": None,
+        "approved_at": None,
+        "notes": None,
+    })
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(approve_mps_node(
+            mps_id=mps_id,
+            body=ApproveMPSRequest(),
+            db=db,
+            token="token-user",
+        ))
+
+    assert exc.value.status_code == 409


### PR DESCRIPTION
Adds POST /v1/mps/{mps_id}/approve and removes the SQL approval hack from the Phase 1 E2E proof/demo.\n\nBehavior:\n- DRAFT -> APPROVED records review + approval audit fields in one API call\n- REVIEWED -> APPROVED records approval\n- APPROVED is idempotent\n- RELEASED returns 409\n\nValidation on VM 201:\n- python3 -m ruff check src/ tests/test_mps_approve.py scripts/demo_phase1_e2e.py\n- pytest MPS gate: 67 passed\n- tests/integration/test_phase1_e2e.py against disposable DB: 1 passed\n- scripts/demo_phase1_e2e.py --json against disposable DB: status ok, approval DRAFT -> APPROVED