### PR TITLE
Keep live Phase 1 demo metrics scoped

### DIFF
--- a/src/ootils_core/demo/phase1.py
+++ b/src/ootils_core/demo/phase1.py
@@ -53,6 +53,18 @@ def run_phase1_demo(database_url: str, token: str) -> dict:
     operation_id = uuid4()
 
     with psycopg.connect(database_url, row_factory=dict_row) as conn:
+        # Keep repeated live demo runs deterministic for CRP metrics. Previous
+        # demo supplies are not business data, so exclude them from future CRP
+        # calculations before seeding the next unique item/location pair.
+        conn.execute(
+            """
+            UPDATE planned_supply ps
+            SET status = 'CANCELLED', active = false
+            FROM items i
+            WHERE ps.item_id = i.item_id
+              AND i.external_id LIKE 'DEMO-FG-%'
+            """
+        )
         conn.execute(
             """
             INSERT INTO items (item_id, name, item_type, uom, status, external_id)
@@ -160,6 +172,7 @@ def run_phase1_demo(database_url: str, token: str) -> dict:
 
         crp = _post(client, "/v1/crp/calculate", auth, {
             "horizon_days": 30,
+            "work_center_ids": [str(work_center_id)],
             "scenario_id": BASELINE_SCENARIO_ID,
         })
 


### PR DESCRIPTION
Keeps repeated live demo runs deterministic by cancelling prior DEMO-FG planned supplies before each run and scoping CRP to the current demo work center.\n\nValidation on VM 201:\n- python3 -m ruff check src/ootils_core/demo/phase1.py\n- scripts/demo_phase1_e2e.py --json against live DB: CRP planned_orders_count=1, work_centers_count=1, load_profiles=1