### PR TITLE
Persist Phase 1 demo run history

### DIFF
--- a/src/ootils_core/api/routers/demo.py
+++ b/src/ootils_core/api/routers/demo.py
@@ -2,17 +2,53 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from decimal import Decimal
 from typing import Any
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+import psycopg
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
 
 from ootils_core.api.auth import require_auth
+from ootils_core.api.dependencies import get_db
 from ootils_core.demo.phase1 import run_phase1_demo_from_env
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/demo", tags=["demo"])
+
+
+class DemoRunSummary(BaseModel):
+    demo_run_id: UUID
+    demo_name: str
+    status: str
+    item_external_id: str | None = None
+    location_external_id: str | None = None
+    forecast_total: Decimal | None = None
+    forecast_buckets: int | None = None
+    mps_nodes_created: int | None = None
+    mps_total_demand: Decimal | None = None
+    approval_status: str | None = None
+    mrp_status: str | None = None
+    planned_supplies_created: int | None = None
+    crp_planned_orders_count: int | None = None
+    crp_work_centers_count: int | None = None
+    crp_load_profiles: int | None = None
+    atp_requested_quantity: Decimal | None = None
+    atp_quantity_available: Decimal | None = None
+    atp_buckets: int | None = None
+    duration_ms: int
+    error: str | None = None
+    artifact: dict[str, Any]
+    created_at: datetime
+
+
+class DemoRunListResponse(BaseModel):
+    runs: list[DemoRunSummary]
+    total: int
+
 
 
 def _json_safe(value: Any) -> Any:
@@ -40,3 +76,39 @@ async def run_phase1_demo_endpoint(token: str = Depends(require_auth)) -> dict:
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Phase 1 demo flow failed",
         ) from exc
+
+
+@router.get(
+    "/phase1/runs",
+    response_model=DemoRunListResponse,
+    summary="List Phase 1 demo runs",
+    description="Return recent persisted Phase 1 demo proof artifacts.",
+)
+async def list_phase1_demo_runs(
+    limit: int = Query(default=5, ge=1, le=50),
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> DemoRunListResponse:
+    rows = db.execute(
+        """
+        SELECT
+            demo_run_id, demo_name, status, item_external_id, location_external_id,
+            forecast_total, forecast_buckets, mps_nodes_created, mps_total_demand,
+            approval_status, mrp_status, planned_supplies_created,
+            crp_planned_orders_count, crp_work_centers_count, crp_load_profiles,
+            atp_requested_quantity, atp_quantity_available, atp_buckets,
+            duration_ms, error, artifact, created_at
+        FROM demo_runs
+        WHERE demo_name = 'phase1'
+        ORDER BY created_at DESC
+        LIMIT %s
+        """,
+        (limit,),
+    ).fetchall()
+    total_row = db.execute(
+        "SELECT COUNT(*) AS total FROM demo_runs WHERE demo_name = 'phase1'"
+    ).fetchone()
+    return DemoRunListResponse(
+        runs=[DemoRunSummary(**row) for row in rows],
+        total=total_row["total"] if total_row else len(rows),
+    )

--- a/src/ootils_core/db/migrations/031_demo_runs.sql
+++ b/src/ootils_core/db/migrations/031_demo_runs.sql
@@ -1,0 +1,29 @@
+-- Demo run audit/history
+
+CREATE TABLE IF NOT EXISTS demo_runs (
+    demo_run_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    demo_name TEXT NOT NULL DEFAULT 'phase1',
+    status TEXT NOT NULL CHECK (status IN ('ok', 'error')),
+    item_external_id TEXT,
+    location_external_id TEXT,
+    forecast_total NUMERIC(18,6),
+    forecast_buckets INTEGER,
+    mps_nodes_created INTEGER,
+    mps_total_demand NUMERIC(18,6),
+    approval_status TEXT,
+    mrp_status TEXT,
+    planned_supplies_created INTEGER,
+    crp_planned_orders_count INTEGER,
+    crp_work_centers_count INTEGER,
+    crp_load_profiles INTEGER,
+    atp_requested_quantity NUMERIC(18,6),
+    atp_quantity_available NUMERIC(18,6),
+    atp_buckets INTEGER,
+    duration_ms INTEGER NOT NULL DEFAULT 0,
+    error TEXT,
+    artifact JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_demo_runs_name_created ON demo_runs(demo_name, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_demo_runs_status_created ON demo_runs(status, created_at DESC);

--- a/src/ootils_core/demo/phase1.py
+++ b/src/ootils_core/demo/phase1.py
@@ -7,6 +7,7 @@ flow can be triggered repeatedly from the demo UI.
 from __future__ import annotations
 
 import os
+import time
 from datetime import date, timedelta
 from decimal import Decimal
 from uuid import uuid4
@@ -21,7 +22,7 @@ def _post(client, path: str, auth: dict[str, str], payload: dict) -> dict:
     return response.json()
 
 
-def run_phase1_demo(database_url: str, token: str) -> dict:
+def _execute_phase1_demo(database_url: str, token: str) -> dict:
     """Run the Phase 1 demo chain and return compact proof metrics."""
     import psycopg
     from fastapi.testclient import TestClient
@@ -219,6 +220,83 @@ def run_phase1_demo(database_url: str, token: str) -> dict:
             "buckets": len(atp["buckets"]),
         },
     }
+
+
+def _record_demo_run(database_url: str, result: dict, duration_ms: int, error: str | None = None) -> None:
+    """Best-effort persistence for demo run history."""
+    try:
+        import psycopg
+        from psycopg.rows import dict_row
+        from psycopg.types.json import Jsonb
+
+        forecast = result.get("forecast", {})
+        mps = result.get("mps", {})
+        approval = result.get("approval", {})
+        mrp = result.get("mrp_promotion", {})
+        crp = result.get("crp", {})
+        atp = result.get("atp", {})
+
+        with psycopg.connect(database_url, row_factory=dict_row) as conn:
+            conn.execute(
+                """
+                INSERT INTO demo_runs (
+                    demo_name, status, item_external_id, location_external_id,
+                    forecast_total, forecast_buckets, mps_nodes_created, mps_total_demand,
+                    approval_status, mrp_status, planned_supplies_created,
+                    crp_planned_orders_count, crp_work_centers_count, crp_load_profiles,
+                    atp_requested_quantity, atp_quantity_available, atp_buckets,
+                    duration_ms, error, artifact
+                ) VALUES (
+                    'phase1', %s, %s, %s,
+                    %s, %s, %s, %s,
+                    %s, %s, %s,
+                    %s, %s, %s,
+                    %s, %s, %s,
+                    %s, %s, %s
+                )
+                """,
+                (
+                    result.get("status", "error"),
+                    result.get("item_external_id"),
+                    result.get("location_external_id"),
+                    forecast.get("total_quantity"),
+                    forecast.get("buckets"),
+                    mps.get("mps_nodes_created"),
+                    mps.get("total_demand"),
+                    approval.get("status"),
+                    mrp.get("status"),
+                    mrp.get("planned_supplies_created"),
+                    crp.get("planned_orders_count"),
+                    crp.get("work_centers_count"),
+                    crp.get("load_profiles"),
+                    atp.get("requested_quantity"),
+                    atp.get("quantity_available"),
+                    atp.get("buckets"),
+                    duration_ms,
+                    error,
+                    Jsonb(result),
+                ),
+            )
+            conn.commit()
+    except Exception:
+        # Demo history must never break the executable demo itself.
+        return
+
+
+def run_phase1_demo(database_url: str, token: str) -> dict:
+    """Run the Phase 1 demo chain, persist history, and return proof metrics."""
+    started = time.perf_counter()
+    try:
+        result = _execute_phase1_demo(database_url, token)
+        duration_ms = int((time.perf_counter() - started) * 1000)
+        result["duration_ms"] = duration_ms
+        _record_demo_run(database_url, result, duration_ms)
+        return result
+    except Exception as exc:
+        duration_ms = int((time.perf_counter() - started) * 1000)
+        error_result = {"status": "error", "duration_ms": duration_ms, "error": str(exc)}
+        _record_demo_run(database_url, error_result, duration_ms, str(exc))
+        raise
 
 
 def run_phase1_demo_from_env() -> dict:


### PR DESCRIPTION
Adds durable demo run history for the live Phase 1 demo.\n\nChanges:\n- migration 031_demo_runs.sql for demo_runs proof/audit records\n- Phase 1 demo runner persists success/error artifacts with metrics and duration\n- GET /v1/demo/phase1/runs returns recent persisted run artifacts\n\nValidation on VM 201:\n- ruff check demo router/service/script\n- targeted MPS tests: 18 passed\n- scripts/demo_phase1_e2e.py --json against disposable DB inserted demo_runs row with status ok, approval APPROVED, CRP load_profiles=1