### PR TITLE
Enrich Phase 1 demo artifact trace

### DIFF
--- a/src/ootils_core/demo/phase1.py
+++ b/src/ootils_core/demo/phase1.py
@@ -219,6 +219,28 @@ def _execute_phase1_demo(database_url: str, token: str) -> dict:
             "quantity_available": atp["quantity_available"],
             "buckets": len(atp["buckets"]),
         },
+        "trace": {
+            "item_id": str(item_id),
+            "location_id": str(location_id),
+            "work_center_id": str(work_center_id),
+            "routing_id": str(routing_id),
+            "operation_id": str(operation_id),
+            "mps_id": mps_id,
+            "planned_supply_id": promoted.get("summary", {}).get("planned_supply_id"),
+            "crp_calculation_id": crp.get("calculation_id"),
+            "customer_request": {
+                "quantity": "5",
+                "requested_date": horizon_start.isoformat(),
+            },
+            "decision_path": [
+                {"step": "Forecast", "evidence": f"{len(forecast['values'])} buckets / {forecast['total_quantity']} EA"},
+                {"step": "MPS", "evidence": f"{mps['mps_nodes_created']} nodes / first MPS {mps_id}"},
+                {"step": "Approval", "evidence": f"{approval['previous_status']} -> {approval['status']}"},
+                {"step": "MRP", "evidence": f"planned supply {promoted.get('summary', {}).get('planned_supply_id')} released"},
+                {"step": "CRP", "evidence": f"{len(crp['load_profiles'])} load profile / calculation {crp.get('calculation_id')}"},
+                {"step": "ATP", "evidence": f"{atp['quantity_available']} available vs {atp['requested_quantity']} requested"},
+            ],
+        },
     }
 
 


### PR DESCRIPTION
Adds explainability IDs and decision path to the Phase 1 demo artifact.\n\nTrace includes item/location UUIDs, work center/routing/operation IDs, MPS ID, planned supply ID, CRP calculation ID, customer request, and a human-readable decision path from Forecast -> ATP.\n\nValidation on VM 201:\n- ruff check demo service/script\n- targeted MPS tests: 18 passed\n- scripts/demo_phase1_e2e.py --json on live DB returns trace with MPS/planned_supply/CRP IDs