### PR TITLE
fix(db): make scenario FK retention policy explicit

### DIFF
--- a/docs/ADR-011-scenario-retention.md
+++ b/docs/ADR-011-scenario-retention.md
@@ -1,0 +1,71 @@
+# ADR-011: Scenario Retention Policy
+
+**Status:** Accepted
+**Date:** 2026-05-21
+**Author:** Nicolas GOINEAU
+
+---
+
+## Context
+
+The 2026-05 architecture review flagged "missing garbage collection for orphan scenarios" as a critical risk: scenarios are created by deep-copying ~600K nodes and ~1.5M edges from a parent, so each fork costs ~60 MB at 500 items. If scenarios were hard-deleted without cleanup, orphaned `nodes` / `edges` rows would accumulate and inflate the `nodes` and `edges` tables forever.
+
+Investigation surfaced an existing architectural decision documented in migration `015_schema_integrity.sql` (lines 7–10):
+
+> NOTE: ON DELETE CASCADE on scenarios intentionally NOT added.
+> Ootils uses soft-delete pattern (status='archived'). Hard-deleting a scenario
+> should be a deliberate admin operation with explicit table cleanup.
+
+This intent was carried by PostgreSQL's default `NO ACTION` on every FK pointing at `scenarios(scenario_id)` — silent at the schema level and easy to overlook.
+
+Three options were considered:
+
+| Option | Behavior on `DELETE FROM scenarios` | Trade-off |
+|---|---|---|
+| A — `ON DELETE RESTRICT` everywhere | Raises FK violation. Soft-delete via `status='archived'` remains the only path. | Codifies existing intent. Bloat risk remains, but is bounded by archive cadence, not deletion. |
+| B — `ON DELETE CASCADE` everywhere | Cascades to all child tables (nodes, edges, audit, projections). | Violates the migration 015 decision. Risk of accidental destructive delete of audit history. |
+| C — Hybrid (CASCADE on regenerable, RESTRICT on audit) | Splits children into two classes. | Most "correct" model, but requires per-table classification and a real ADR on what's audit vs. derived. Deferred. |
+
+A separate bug was also surfaced during investigation: migration `021_mrp_lot_sizing_params.sql:21` declares `mrp_runs.scenario_id UUID NOT NULL` but omits `REFERENCES scenarios(scenario_id)`, leaving the table referentially unprotected.
+
+---
+
+## Decision
+
+**Option A is adopted as the baseline retention policy.** All foreign keys pointing at `scenarios(scenario_id)` use `ON DELETE RESTRICT`. The missing FK on `mrp_runs.scenario_id` is added with the same policy.
+
+Hard-delete of a scenario is intentionally impossible through the API. The `DELETE /v1/scenarios/{id}` endpoint performs a soft-delete (sets `status='archived'`). Administrative hard-delete requires a deliberate, documented procedure that explicitly deletes from each child table in the correct order.
+
+**The bloat risk identified in the review remains open**, but is reframed: it is no longer "orphan rows accumulate after delete" (impossible now), but "archived scenarios retain their full deep-copied subgraph". A long-term cleanup strategy — scheduled purge, admin endpoint, or accepted unbounded retention — is left to a follow-up ADR once the operational picture is clearer (volumes, audit requirements, regulatory constraints).
+
+The hybrid model (option C) is not rejected; it is deferred until the cleanup strategy ADR forces a decision on what "regenerable" means in this codebase.
+
+---
+
+## Consequences
+
+### Positive
+- The retention intent is now visible in the schema (`pg_constraint` shows `RESTRICT` explicitly).
+- A future contributor reading the schema understands the policy without needing to read migration 015's comment.
+- `mrp_runs.scenario_id` is now referentially protected.
+- Any code path that tries to hard-delete a scenario fails fast with a clear FK violation, rather than silently leaving orphans (which `NO ACTION` would also do, but less explicitly).
+
+### Negative / dette
+- The storage bloat risk for archived scenarios is acknowledged but not solved.
+- The hybrid model is deferred — when the cleanup ADR lands, some of these FKs may flip to CASCADE.
+- No CI guardrail yet prevents a future migration from re-introducing a FK without `ON DELETE` clause.
+
+### Reste à faire
+- New ADR — `ADR-NNN-scenario-archive-cleanup.md` — addressing what to do with archived scenarios over time. Should answer: (1) does anyone need to read an archived scenario after N days/months? (2) how is "regenerable" defined? (3) admin endpoint vs. scheduled job?
+- Integration test (added in this PR) verifying that `DELETE FROM scenarios WHERE scenario_id = X` raises `ForeignKeyViolation` when X is referenced.
+- Lint / migration template enforcing `ON DELETE` on every new FK (lower priority).
+
+---
+
+## Code references
+
+- Migration: `src/ootils_core/db/migrations/032_scenario_fk_retention.sql`
+- Prior intent: `src/ootils_core/db/migrations/015_schema_integrity.sql:7-10`
+- Bug fixed: `src/ootils_core/db/migrations/021_mrp_lot_sizing_params.sql:21`
+- Test: `tests/integration/test_scenario_fk_retention.py`
+- Review source: `docs/REVIEW-2026-05.md`

--- a/docs/REVIEW-2026-05.md
+++ b/docs/REVIEW-2026-05.md
@@ -1,0 +1,89 @@
+# Architecture Review — May 2026
+
+**Reviewed commit:** `4a54ba5` (main, 2026-05-07)
+**Reviewers:** 5 specialized audit agents (architecture, tests, security, docs, DB/engine)
+**Status:** Open — findings tracked below
+
+---
+
+## Verdict
+
+Solid MVP, more mature than the documentation suggests. Architecture is clean, layering respected, no circular imports, tests use real PostgreSQL (no DB mocks), security basics correctly implemented. Synthetic score: **7.5/10** — alpha-ready, not multi-tenant-public-ready.
+
+---
+
+## Findings ranked by severity
+
+### Critical
+
+#### R1 — Scenario retention policy was implicit
+- **Description:** All FKs pointing at `scenarios(scenario_id)` relied on PostgreSQL's default `NO ACTION` to enforce the soft-delete intent documented only in migration 015's comment. A separate bug omitted the FK entirely on `mrp_runs.scenario_id`.
+- **Original review framing:** "Missing garbage collection for orphan scenarios — table bloat guaranteed." This framing was partially incorrect: hard-delete is not currently possible through the API. The real residual risk is unbounded retention of archived scenarios.
+- **Status:** **Resolved** — see [ADR-011](ADR-011-scenario-retention.md), migration `032_scenario_fk_retention.sql`. Long-term cleanup strategy deferred to a follow-up ADR.
+
+#### R2 — Propagation engine: O(N × ~15 queries) per dirty node
+- **Description:** `_recompute_pi_node` issues 10–20 SQL queries per node inside a loop. At 500 items / 5K dirty nodes ≈ 75K queries ≈ 75s per propagation. This is breaking point #1 in `docs/SCALABILITY.md`, documented but not yet fixed.
+- **Location:** `src/ootils_core/engine/orchestration/propagator.py:250-278`
+- **Fix (Tier 1):** Batch-load all edges + nodes for the dirty subgraph in ~2 queries, compute in-memory, batch-persist with `INSERT … ON CONFLICT`. Expected gain: ~15×.
+- **Status:** **Open** — next priority after R1.
+
+---
+
+### High
+
+#### R3 — No CORS / security headers / rate limiting
+- **Description:** `api/app.py` adds `X-Correlation-ID` and `X-API-Version` only. No `CORSMiddleware`, no `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options`, CSP. No rate limiting (Phase 3, issue #200).
+- **Location:** `src/ootils_core/api/app.py:194-212`
+- **Fix:** add `CORSMiddleware` configured against allowed origins, add a `SecurityHeadersMiddleware`, integrate `slowapi` or equivalent before any public exposure.
+- **Status:** **Open** — required before any prod / external alpha.
+
+#### R4 — Dependencies not pinned, no Dependabot
+- **Description:** `pyproject.toml` uses `>=` for all third-party deps (`fastapi>=0.111.0`, `openai>=1.0.0`, etc.). No `.github/dependabot.yml`. Risk of drift and unnoticed CVEs.
+- **Location:** `pyproject.toml:25-31`
+- **Fix:** pin with `==` or `~=`, add Dependabot configuration.
+- **Status:** **Open**.
+
+#### R5 — ROADMAP / SECURITY.md / actual code state drift
+- **Description:** `ROADMAP.md` shows all milestone checkboxes empty and says "Early Build Phase" while 50+ endpoints ship and 31 migrations exist. `SECURITY.md` says "pre-release / no production releases" while `INFRA-RUNBOOK.md` documents a live VM (Proxmox, 192.168.1.176). Contradictions confuse new contributors and external observers.
+- **Fix:** align the three documents to a single statement of project status.
+- **Status:** **Open**.
+
+---
+
+### Medium
+
+#### R6 — Local tooling absent
+- **Description:** No `Makefile`, no `.pre-commit-config.yaml`, no mypy configuration, no `pytest-cov --cov-fail-under`. CI tests Python 3.11 only, while the Docker image runs 3.12.
+- **Fix:** add a `Makefile` with canonical `make test`, `make lint`, `make coverage`; add pre-commit (ruff + mypy + black); add coverage threshold; matrix Python 3.11 + 3.12 in CI.
+- **Status:** **Open**.
+
+#### R7 — JSONB drift outside diagnostic scope
+- **Description:** The README states "JSONB only for diagnostic or staging payloads." Migration `012_dq_agent.sql` uses `summary JSONB` as a primary data column. Migrations 021 and 031 also use JSONB; 021 and 031 are diagnostic / demo and acceptable, but the discipline is at risk.
+- **Location:** `src/ootils_core/db/migrations/012_dq_agent.sql`
+- **Fix:** reclassify `dq_agent.summary` as typed columns, or formally accept it as diagnostic and document the carve-out.
+- **Status:** **Open**.
+
+---
+
+### Low
+
+#### R8 — Onboarding friction (~20–25 min, several papercuts)
+- **Description:** No documented way to generate `OOTILS_API_TOKEN` for local dev. `OOTILS_ENABLE_API_DOCS=1` activation is ambiguous (rebuild? restart?). Token usage in curl examples is illustrated but the prerequisite "how do I get a token" is missing.
+- **Fix:** `docs/QUICKSTART.md` separated from README, `examples/simple_propagation.py` covering ingest → propagate → shortages.
+- **Status:** **Open**.
+
+#### R9 — 50 docs files, no index
+- **Description:** `docs/` mixes ADRs, SPECs, REVIEWs, QCs, runbooks. Navigation is unstructured for newcomers.
+- **Fix:** `docs/INDEX.md` categorising files (Quickstart / Architecture / Specs / History).
+- **Status:** **Open**.
+
+#### R10 — Scenario "copy-on-write" is actually deep-copy
+- **Description:** The architecture and CLAUDE.md describe scenario branching as copy-on-write, but `engine/scenario/manager.py:59-280` performs an explicit deep-copy of nodes / edges / projections on fork. Acceptable for MVP, but the vocabulary should match the implementation.
+- **Fix:** either implement lazy materialization (overrides only, derive children on read), or rename "scenario forking" in docs to remove the CoW claim.
+- **Status:** **Open**.
+
+---
+
+## Follow-up review
+
+A re-review is appropriate after R2 (batch propagation) is merged, or after the next 10 PRs — whichever comes first.

--- a/src/ootils_core/db/migrations/032_scenario_fk_retention.sql
+++ b/src/ootils_core/db/migrations/032_scenario_fk_retention.sql
@@ -1,0 +1,90 @@
+-- ============================================================
+-- Migration 032: Make scenario FK retention policy explicit
+-- ============================================================
+-- Context
+--   Migration 015 documents the intent: "ON DELETE CASCADE on scenarios
+--   intentionally NOT added. Ootils uses soft-delete pattern (status='archived').
+--   Hard-deleting a scenario should be a deliberate admin operation."
+--
+--   That intent has been carried by PostgreSQL's default (NO ACTION), which
+--   behaves like RESTRICT but is silent at the schema level. This migration
+--   replaces every FK pointing at scenarios(scenario_id) with an explicit
+--   ON DELETE RESTRICT. No behavioral change — pure clarification.
+--
+--   It also fixes a missing FK on mrp_runs.scenario_id (migration 021 created
+--   the column UUID NOT NULL but forgot the REFERENCES clause), which left
+--   the table referentially unprotected.
+--
+-- See: docs/ADR-011-scenario-retention.md
+-- ============================================================
+
+BEGIN;
+
+-- ============================================================
+-- 1. Rewrite every FK on scenarios(scenario_id) with ON DELETE RESTRICT
+-- ============================================================
+-- Discover all FKs pointing at scenarios via pg_constraint, drop and recreate
+-- each with explicit RESTRICT. Idempotent: a re-run finds no NO_ACTION FKs
+-- (they all become RESTRICT) and the loop is a no-op.
+
+DO $$
+DECLARE
+    rec RECORD;
+BEGIN
+    FOR rec IN
+        SELECT
+            c.conname,
+            c.conrelid::regclass::text AS table_name,
+            a.attname                   AS col_name,
+            c.confdeltype               AS delete_action
+        FROM pg_constraint c
+        JOIN pg_attribute  a
+          ON a.attrelid = c.conrelid
+         AND a.attnum   = ANY (c.conkey)
+        WHERE c.contype  = 'f'
+          AND c.confrelid = 'scenarios'::regclass
+          AND c.confdeltype <> 'r'  -- 'r' = RESTRICT; skip already-correct FKs
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE %I DROP CONSTRAINT %I',
+            rec.table_name, rec.conname
+        );
+        EXECUTE format(
+            'ALTER TABLE %I ADD CONSTRAINT %I '
+            'FOREIGN KEY (%I) REFERENCES scenarios(scenario_id) ON DELETE RESTRICT',
+            rec.table_name, rec.conname, rec.col_name
+        );
+    END LOOP;
+END $$;
+
+-- ============================================================
+-- 2. Add the missing FK on mrp_runs.scenario_id
+-- ============================================================
+-- Migration 021 declared mrp_runs.scenario_id UUID NOT NULL but omitted
+-- REFERENCES scenarios(scenario_id). This adds the FK with the same RESTRICT
+-- policy as the rest of the schema.
+--
+-- Idempotent: ADD CONSTRAINT IF NOT EXISTS isn't supported for FKs, so we
+-- guard with pg_constraint lookup.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint c
+        JOIN pg_attribute  a
+          ON a.attrelid = c.conrelid
+         AND a.attnum   = ANY (c.conkey)
+        WHERE c.contype  = 'f'
+          AND c.conrelid = 'mrp_runs'::regclass
+          AND c.confrelid = 'scenarios'::regclass
+          AND a.attname  = 'scenario_id'
+    ) THEN
+        ALTER TABLE mrp_runs
+            ADD CONSTRAINT mrp_runs_scenario_id_fkey
+            FOREIGN KEY (scenario_id) REFERENCES scenarios(scenario_id)
+            ON DELETE RESTRICT;
+    END IF;
+END $$;
+
+COMMIT;

--- a/tests/integration/test_scenario_fk_retention.py
+++ b/tests/integration/test_scenario_fk_retention.py
@@ -1,0 +1,147 @@
+"""
+tests/integration/test_scenario_fk_retention.py — Lot Ootils Review R1: FK retention policy.
+
+Verifies the schema-level guarantees introduced by migration 032:
+  1. Every FK pointing at scenarios(scenario_id) declares ON DELETE RESTRICT.
+  2. mrp_runs.scenario_id now has a FK to scenarios (was missing).
+  3. DELETE FROM scenarios fails with ForeignKeyViolation when the scenario
+     is referenced — soft-delete via status='archived' remains the only path.
+
+See: docs/ADR-011-scenario-retention.md, docs/REVIEW-2026-05.md (R1).
+"""
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from .conftest import requires_db
+
+
+# ---------------------------------------------------------------------------
+# Schema-level guarantees
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_all_scenario_fks_are_restrict(conn):
+    """Every FK referencing scenarios(scenario_id) declares ON DELETE RESTRICT."""
+    rows = conn.execute(
+        """
+        SELECT
+            c.conrelid::regclass::text AS table_name,
+            c.conname                  AS constraint_name,
+            c.confdeltype              AS delete_action
+        FROM pg_constraint c
+        WHERE c.contype  = 'f'
+          AND c.confrelid = 'scenarios'::regclass
+        ORDER BY table_name, constraint_name
+        """
+    ).fetchall()
+
+    assert rows, "no FKs pointing at scenarios found — migration did not run"
+
+    offenders = [r for r in rows if r["delete_action"] != "r"]
+    assert offenders == [], (
+        f"FKs without ON DELETE RESTRICT remain: {offenders}"
+    )
+
+
+@requires_db
+def test_mrp_runs_scenario_id_has_fk(conn):
+    """mrp_runs.scenario_id now has the FK that migration 021 forgot."""
+    row = conn.execute(
+        """
+        SELECT c.conname, c.confdeltype
+        FROM pg_constraint c
+        JOIN pg_attribute  a
+          ON a.attrelid = c.conrelid
+         AND a.attnum   = ANY (c.conkey)
+        WHERE c.contype  = 'f'
+          AND c.conrelid = 'mrp_runs'::regclass
+          AND c.confrelid = 'scenarios'::regclass
+          AND a.attname  = 'scenario_id'
+        """
+    ).fetchone()
+
+    assert row is not None, "mrp_runs.scenario_id is still missing its FK"
+    assert row["confdeltype"] == "r", (
+        f"mrp_runs.scenario_id FK has delete action {row['confdeltype']!r}, expected 'r' (RESTRICT)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behavioral guarantee: hard-delete is blocked when scenario is referenced
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_delete_scenario_with_node_raises_fk_violation(conn):
+    """DELETE on a scenario referenced by a node fails with ForeignKeyViolation."""
+    import psycopg
+
+    scenario_id = uuid4()
+    item_id = uuid4()
+    location_id = uuid4()
+
+    conn.execute(
+        "INSERT INTO scenarios (scenario_id, name, status) VALUES (%s, %s, 'active')",
+        (scenario_id, f"test-fk-retention-{scenario_id}"),
+    )
+    conn.execute(
+        "INSERT INTO items (item_id, name) VALUES (%s, 'fk-test-item')",
+        (item_id,),
+    )
+    conn.execute(
+        "INSERT INTO locations (location_id, name) VALUES (%s, 'fk-test-loc')",
+        (location_id,),
+    )
+    conn.execute(
+        """
+        INSERT INTO nodes (node_id, node_type, scenario_id, item_id, location_id)
+        VALUES (%s, 'Item', %s, %s, %s)
+        """,
+        (uuid4(), scenario_id, item_id, location_id),
+    )
+
+    with pytest.raises(psycopg.errors.ForeignKeyViolation):
+        conn.execute("DELETE FROM scenarios WHERE scenario_id = %s", (scenario_id,))
+
+
+@requires_db
+def test_delete_scenario_with_mrp_run_raises_fk_violation(conn):
+    """The newly-added FK on mrp_runs.scenario_id blocks scenario hard-delete."""
+    import psycopg
+
+    scenario_id = uuid4()
+
+    conn.execute(
+        "INSERT INTO scenarios (scenario_id, name, status) VALUES (%s, %s, 'active')",
+        (scenario_id, f"test-mrp-fk-{scenario_id}"),
+    )
+    conn.execute(
+        """
+        INSERT INTO mrp_runs (run_id, scenario_id, run_type, status, horizon_days, bucket_type)
+        VALUES (%s, %s, 'APICS_FULL', 'completed', 90, 'WEEK')
+        """,
+        (uuid4(), scenario_id),
+    )
+
+    with pytest.raises(psycopg.errors.ForeignKeyViolation):
+        conn.execute("DELETE FROM scenarios WHERE scenario_id = %s", (scenario_id,))
+
+
+@requires_db
+def test_delete_unreferenced_scenario_succeeds(conn):
+    """A scenario with no children can still be hard-deleted (sanity check)."""
+    scenario_id = uuid4()
+
+    conn.execute(
+        "INSERT INTO scenarios (scenario_id, name, status) VALUES (%s, %s, 'active')",
+        (scenario_id, f"test-orphan-{scenario_id}"),
+    )
+
+    result = conn.execute(
+        "DELETE FROM scenarios WHERE scenario_id = %s", (scenario_id,)
+    )
+    assert result.rowcount == 1


### PR DESCRIPTION
## Summary

Resolves **R1** of [REVIEW-2026-05](docs/REVIEW-2026-05.md): scenario FK retention policy was implicit and one FK was missing entirely.

- **Migration 032** rewrites every FK on `scenarios(scenario_id)` with explicit `ON DELETE RESTRICT`, replacing PostgreSQL's silent `NO ACTION` default. The intent ("soft-delete only, hard-delete is a deliberate admin op") was previously documented only in a comment on migration 015 — now it's visible in `pg_constraint`.
- **Bug fix**: `mrp_runs.scenario_id` was declared `UUID NOT NULL` in migration 021 but the `REFERENCES scenarios(scenario_id)` clause was omitted. Before this PR, a `DELETE FROM scenarios` referenced by an `mrp_runs` row would have succeeded silently and left orphans. Now blocked by the new FK.
- **ADR-011** records the decision; long-term cleanup strategy for archived scenarios deferred to a follow-up ADR.
- **REVIEW-2026-05.md** anchors the 7 findings of the May 2026 architecture review in the repo (R1 resolved, R2–R10 open).

## Schema before / after

| | Before | After |
|---|---|---|
| FKs to `scenarios(scenario_id)` | 18 (all NO_ACTION) | 19 (all RESTRICT) |
| `mrp_runs.scenario_id` FK | absent | present, RESTRICT |

## Test plan

- [x] Unit tests pass locally (`pytest tests/ --ignore=tests/integration`): **1681 passed, 20 skipped**
- [x] Migration applied + verified against live `ootils_dev` DB (5 schema/behavioral assertions all green)
- [ ] Integration tests pass in CI (`tests/integration/test_scenario_fk_retention.py`)
- [ ] Manual: verify `INFO_RUNBOOK.md` / `DBA-RUNBOOK.md` if they mention scenario hard-delete (out of scope for this PR — flag for follow-up if applicable)

## Out of scope

- Hybrid retention model (option C: CASCADE on regenerable, RESTRICT on audit). Deferred per ADR-011 — needs operational input (volume, audit, regulatory) before deciding.
- Long-term cleanup of archived scenarios. Will get its own ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)