### PR TITLE
chore(deps): pin deps and enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+# Dependabot configuration
+# See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+# Resolves R4 of docs/REVIEW-2026-05.md.
+
+version: 2
+updates:
+  # Python deps declared in pyproject.toml (PEP 621)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  # GitHub Actions used by .github/workflows/
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+
+  # Base image used by the runtime Docker container
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(docker)"
+      include: "scope"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,17 +21,20 @@ classifiers = [
     "Topic :: Office/Business",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
+# Compatible-release pins (PEP 440 `~=`): allow minor + patch updates, block
+# the next major. Dependabot opens PRs weekly to bump within these ranges.
+# See docs/REVIEW-2026-05.md R4.
 dependencies = [
-    "fastapi>=0.111.0",
-    "uvicorn[standard]>=0.29.0",
-    "psycopg[binary]>=3.1.0",
-    "psycopg-pool>=3.2.0",
-    "pydantic>=2.0.0",
-    "openai>=1.0.0",
+    "fastapi ~= 0.128",
+    "uvicorn[standard] ~= 0.40",
+    "psycopg[binary] ~= 3.3",
+    "psycopg-pool ~= 3.3",
+    "pydantic ~= 2.12",
+    "openai ~= 2.15",
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "pytest-cov>=5.0", "httpx>=0.27.0"]
+dev = ["pytest ~= 9.0", "pytest-cov ~= 7.1", "httpx ~= 0.28"]
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
## Summary

Resolves **R4** of [REVIEW-2026-05](https://github.com/ngoineau/ootils-core/pull/215/files#diff-eaf45ba6e1b5e7f5a8e7e69e98b1f4f3) (file lands in #215 — forward reference).

- Replace `>=` floors in `pyproject.toml` with PEP 440 `~=` compatible-release pins on the currently-installed `major.minor`. Blocks surprise major upgrades while letting minor/patch flow.
- Add `.github/dependabot.yml` with three weekly streams: pip (`pyproject.toml`), GitHub Actions, and Docker base image.
- Each stream gets its own commit prefix (`chore(deps|ci|docker)`) so the history stays readable.

## Pin map

| Package | Before | After | Reason |
|---|---|---|---|
| fastapi | `>=0.111.0` | `~= 0.128` | 0.x: any 0.X is allowed, blocks 1.0 |
| uvicorn[standard] | `>=0.29.0` | `~= 0.40` | same |
| psycopg[binary] | `>=3.1.0` | `~= 3.3` | block psycopg 4.x |
| psycopg-pool | `>=3.2.0` | `~= 3.3` | same |
| pydantic | `>=2.0.0` | `~= 2.12` | block pydantic 3.x |
| openai | `>=1.0.0` | `~= 2.15` | block openai 3.x (and bumps the actual floor — 1.0 was stale) |
| pytest (dev) | `>=8.0` | `~= 9.0` | block 10.x |
| pytest-cov (dev) | `>=5.0` | `~= 7.1` | block 8.x |
| httpx (dev) | `>=0.27.0` | `~= 0.28` | 0.x range |

## Test plan

- [x] `pip install -e .[dev]` succeeds against the new pins
- [x] Unit tests pass (`pytest tests/ --ignore=tests/integration`): **1681 passed, 20 skipped**
- [ ] CI green
- [ ] First Dependabot run after merge produces sane PRs (verify within 1 week)

## Notes

- This PR sits ahead of #215. After #215 merges, this branch will rebase and the forward reference in `dependabot.yml` (`Resolves R4 of docs/REVIEW-2026-05.md`) will resolve.
- Dependabot will likely propose pip upgrades in its first run; merge them as they come.
- No prod behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)