### PR TITLE
chore: iterative quality pass — 10 cycles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+# Pre-commit hooks for ootils-core.
+# Install: pip install pre-commit && pre-commit install
+# Run all hooks against the whole repo: pre-commit run --all-files
+#
+# Mirrors what CI enforces (ruff on src/) plus light hygiene hooks.
+# See REVIEW-2026-05 R6 — full local tooling (Makefile, mypy, coverage
+# threshold) is a follow-up.
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.13.0
+    hooks:
+      - id: ruff
+        name: ruff check (src)
+        args: [--fix, src/]
+        pass_filenames: false
+      - id: ruff
+        name: ruff check (tests, non-blocking)
+        # tests/ is still wider than CI scope; surface issues without blocking.
+        args: [--exit-zero, tests/]
+        pass_filenames: false
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: mixed-line-ending
+        args: [--fix=lf]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Target-architecture notes may appear below. Verify runtime reality before treati
 
 ## Project
 
-`ootils-core` — a graph-based supply chain decision engine. FastAPI REST API on top of a Python kernel that models supply chains as typed nodes + edges, persisted in PostgreSQL 16. Core capabilities: incremental propagation, shortage detection, MRP explosion, scenario branching (copy-on-write), RCCP, a ghost/virtual-supply engine, and a data quality (DQ) pipeline.
+`ootils-core` — a graph-based supply chain decision engine. FastAPI REST API on top of a Python kernel that models supply chains as typed nodes + edges, persisted in PostgreSQL 16. Core capabilities: incremental propagation, shortage detection, MRP explosion, scenario branching (deep-copy fork — historically labelled "copy-on-write"; see [REVIEW-2026-05 R10](docs/REVIEW-2026-05.md)), RCCP, a ghost/virtual-supply engine, and a data quality (DQ) pipeline.
 
 ## Commands
 
@@ -52,12 +52,12 @@ HTTP request → Bearer-token auth (`api/auth.py`) → router in `api/routers/<d
 - `kernel/calc/` — `projection` (ProjectionKernel), `calendar`.
 - `kernel/shortage/`, `kernel/explanation/`, `kernel/allocation/`, `kernel/temporal/` — specialized kernels.
 - `orchestration/propagator.py` — `PropagationEngine.process_event()` is the main entry point: acquires advisory lock → expands dirty subgraph → topo sort → compute → persist → cascade. Pairs with `orchestration/calc_run.py` which tracks run status.
-- `scenario/manager.py` — copy-on-write scenario branching.
+- `scenario/manager.py` — scenario forking via deep-copy (the original CoW vocabulary doesn't match the implementation; see REVIEW-2026-05 R10).
 - `dq/`, `ghost/`, `mrp/` — capability modules; the `dq/agent/` subtree is an LLM-driven remediation agent.
 
 ### Storage
 - PostgreSQL 16 via `psycopg[binary]` 3.x — **not** SQLite (ADR-005 proposes SQLite but the project has moved past the proof stage).
-- UUID PKs, `TIMESTAMPTZ` UTC, **no JSONB**. Typed columns, 21 numbered SQL migrations under `src/ootils_core/db/migrations/`.
+- UUID PKs, `TIMESTAMPTZ` UTC, **no JSONB** for business data (diagnostic / staging only — see REVIEW-2026-05 R7). Typed columns, 32 numbered SQL migrations under `src/ootils_core/db/migrations/`.
 - Migrations auto-apply on `OotilsDB()` construction (i.e. at API startup), serialized by a PG advisory lock (`_LOCK_KEY = 8_037_421_901`), tracked in `schema_migrations`. A migration that fails with an "already exists"-family error is recorded as applied rather than re-run — so new migrations must be idempotent in that sense.
 
 ### Auth

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 │  │   propagation (dirty-flag pattern)        │
 │  ├── Shortage detection + severity scoring   │
 │  ├── MRP explosion (BOM + lead times)        │
-│  ├── Scenario branching (copy-on-write)      │
+│  ├── Scenario branching (deep-copy fork)     │
 │  ├── RCCP (rough-cut capacity planning)      │
 │  ├── Ghost engine (virtual supply nodes)     │
 │  └── DQ agent (data quality pipeline)       │
@@ -183,7 +183,7 @@ src/ootils_core/
 ├── engine/
 │   ├── propagator.py       # Incremental graph propagation
 │   ├── shortage/           # Shortage detection + severity scoring
-│   ├── scenario/           # Scenario branching + copy-on-write
+│   ├── scenario/           # Scenario branching (deep-copy fork)
 │   ├── dq/                 # Data quality pipeline + DQ agent
 │   └── ghosts/             # Ghost node engine
 └── models/                 # Pydantic request/response schemas

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,107 @@
+# `docs/` index
+
+Navigation map for `docs/`. Group by purpose, not by date. Read top-to-bottom for onboarding, jump by section for reference.
+
+Resolves R9 of [REVIEW-2026-05.md](REVIEW-2026-05.md).
+
+---
+
+## Start here
+
+- [`../README.md`](../README.md) — Quick start, capabilities, API surface.
+- [`../CLAUDE.md`](../CLAUDE.md) — Context for Claude Code sessions: conventions, commands, architecture map.
+- [`../ROADMAP.md`](../ROADMAP.md) — V1 milestones.
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — How to contribute.
+- [`STRATEGY.md`](STRATEGY.md) — Product strategy and positioning.
+
+## Architecture decisions (ADRs)
+
+The current-state ADRs to read first:
+
+- [`ADR-001-graph-model.md`](ADR-001-graph-model.md) — The graph model: nodes, edges, scenarios.
+- [`ADR-003-incremental-propagation.md`](ADR-003-incremental-propagation.md) — Deterministic incremental propagation.
+- [`ADR-004-explainability.md`](ADR-004-explainability.md) — Causal step traces for shortage roots.
+- [`ADR-011-scenario-retention.md`](ADR-011-scenario-retention.md) — FK retention policy; soft-delete only.
+
+Elastic time (sprint of iteration, ADR-002 is the final version to read):
+
+- [`ADR-002d-elastic-time-final.md`](ADR-002d-elastic-time-final.md) — **Authoritative.**
+- `ADR-002-elastic-time.md` / `ADR-002b…d-elastic-time-*.md` — Historical iterations.
+
+Operational concerns:
+
+- [`ADR-005-storage-layer.md`](ADR-005-storage-layer.md) — Storage. **Marked superseded** — kept for history, runtime is Postgres via psycopg3.
+- [`ADR-006-blockers-resolution.md`](ADR-006-blockers-resolution.md), [`ADR-007-showstoppers-resolution.md`](ADR-007-showstoppers-resolution.md), [`ADR-008-agent-operability-fixes.md`](ADR-008-agent-operability-fixes.md) — Punctual decisions during sprint hardening.
+- [`ADR-009-import-pipeline.md`](ADR-009-import-pipeline.md) — Ingest pipeline shape.
+- [`ADR-010-ghosts-tags.md`](ADR-010-ghosts-tags.md) — Ghost nodes and tags.
+
+## Feature specs (SPEC-*)
+
+Read the SPEC matching the feature you are touching. SPECs are written before or during implementation; some have drifted from code — when in doubt, the code is authoritative.
+
+- [`SPEC-INTERFACES.md`](SPEC-INTERFACES.md) — Inbound/outbound interfaces.
+- [`SPEC-IMPORT-STATIC.md`](SPEC-IMPORT-STATIC.md) — Static (master) data import.
+- [`SPEC-IMPORT-DYNAMIC.md`](SPEC-IMPORT-DYNAMIC.md) — Dynamic (transactional) data import.
+- [`SPEC-INTEGRATION-STRATEGY.md`](SPEC-INTEGRATION-STRATEGY.md) — How import streams compose.
+- [`SPEC-VALIDATION-HARNESS.md`](SPEC-VALIDATION-HARNESS.md) — Validation harness for inbound data.
+- [`SPEC-STATIC-DATA-UI.md`](SPEC-STATIC-DATA-UI.md) — UI for static data review.
+- [`SPEC-DQ-AGENT.md`](SPEC-DQ-AGENT.md) — Data Quality LLM agent.
+- [`SPEC-HIERARCHIES.md`](SPEC-HIERARCHIES.md) — Hierarchy model (FR + EN).
+- [`SPEC-GHOSTS-TAGS.md`](SPEC-GHOSTS-TAGS.md) — Ghost engine spec.
+
+## API & data dictionaries
+
+- [`api-spec.md`](api-spec.md) / [`openapi.json`](openapi.json) — REST surface.
+- [`node-dictionary.md`](node-dictionary.md) — All `node_type` values and meaning.
+- [`edge-dictionary.md`](edge-dictionary.md) — All `edge_type` values.
+
+## Operations
+
+- [`INFRA-RUNBOOK.md`](INFRA-RUNBOOK.md) — Deployment, backup, ops procedures.
+- [`INFRA-vm-spec-validated.md`](INFRA-vm-spec-validated.md) — VM spec for the live deployment.
+- [`SECURITY-vm-hardening.md`](SECURITY-vm-hardening.md) — Hardening checklist.
+- [`SCALABILITY.md`](SCALABILITY.md) — Volume projections, known breaking points, fix roadmap.
+
+## User-facing
+
+- [`MANUEL-UTILISATEUR-DRAFT.md`](MANUEL-UTILISATEUR-DRAFT.md) — User manual (draft, FR).
+
+## Reviews & retrospectives
+
+The most recent first:
+
+- [`REVIEW-2026-05.md`](REVIEW-2026-05.md) — May 2026 architecture review (10 findings, R1 + R4 resolved).
+- [`REVIEW-BRANCHES-2026-04-07.md`](REVIEW-BRANCHES-2026-04-07.md) — Cross-branch state review.
+- [`REVIEW-IMPORT-ARCHITECTURE.md`](REVIEW-IMPORT-ARCHITECTURE.md), [`REVIEW-IMPORT-DATA-ENGINEERING.md`](REVIEW-IMPORT-DATA-ENGINEERING.md), [`REVIEW-IMPORT-SC-EXPERT.md`](REVIEW-IMPORT-SC-EXPERT.md) — Import pipeline triple review.
+- [`REVIEW-agent-operability.md`](REVIEW-agent-operability.md) — Agent operability deep-dive.
+- [`REVIEW-conceptual-validation.md`](REVIEW-conceptual-validation.md) — Conceptual model audit.
+- [`REVIEW-market-gtm.md`](REVIEW-market-gtm.md) — Market positioning.
+- [`REVIEW-qc-validation.md`](REVIEW-qc-validation.md) — QC validation.
+
+## Quality / proof artifacts
+
+- [`QC-V1-COMPLETE.md`](QC-V1-COMPLETE.md) — V1 QC.
+- [`QC-SPRINT1-REVIEW.md`](QC-SPRINT1-REVIEW.md) — Sprint 1 QC.
+- [`QC-code-quality-review.md`](QC-code-quality-review.md) — Code quality pass.
+- [`QC-live-deployment.md`](QC-live-deployment.md) — Live deployment QC.
+- [`PROOF-OF-ARCHITECTURE-V1.md`](PROOF-OF-ARCHITECTURE-V1.md) — Proof-of-architecture artifact.
+- [`PROPOSAL-engine-execution-model.md`](PROPOSAL-engine-execution-model.md) — Execution model proposal.
+
+## Demos & milestones
+
+- [`demo-phase1-e2e.md`](demo-phase1-e2e.md) — Phase 1 end-to-end demo notes.
+- [`test-report-phase1.md`](test-report-phase1.md) — Phase 1 test report.
+- [`DEMO-M7-ARCHITECTURE-VALIDATION.md`](DEMO-M7-ARCHITECTURE-VALIDATION.md), [`DEMO-M7-RESULTS.md`](DEMO-M7-RESULTS.md) — M7 demo.
+
+## Specific topics
+
+- [`EXPERT-dirty-flags-and-scenarios.md`](EXPERT-dirty-flags-and-scenarios.md) — Expert note on dirty flags + scenarios interaction.
+- [`BACKLOG-calendar-architecture.md`](BACKLOG-calendar-architecture.md), [`CALENDAR-INTEGRATION-POINTS.md`](CALENDAR-INTEGRATION-POINTS.md) — Calendar model design.
+- [`mrp-unification-tech-note.md`](mrp-unification-tech-note.md) — MRP endpoint unification (APICS mode).
+- [`BIBLIOGRAPHY.md`](BIBLIOGRAPHY.md) — References used during design.
+
+---
+
+## Maintenance
+
+When you add a doc, add it to the section that matches its purpose. When you supersede an ADR, mark the old one `Superseded by ADR-XXX` in its front matter and move it to a sub-bullet of its replacement here.

--- a/docs/REVIEW-2026-05.md
+++ b/docs/REVIEW-2026-05.md
@@ -19,7 +19,7 @@ Solid MVP, more mature than the documentation suggests. Architecture is clean, l
 #### R1 — Scenario retention policy was implicit
 - **Description:** All FKs pointing at `scenarios(scenario_id)` relied on PostgreSQL's default `NO ACTION` to enforce the soft-delete intent documented only in migration 015's comment. A separate bug omitted the FK entirely on `mrp_runs.scenario_id`.
 - **Original review framing:** "Missing garbage collection for orphan scenarios — table bloat guaranteed." This framing was partially incorrect: hard-delete is not currently possible through the API. The real residual risk is unbounded retention of archived scenarios.
-- **Status:** **Resolved** — see [ADR-011](ADR-011-scenario-retention.md), migration `032_scenario_fk_retention.sql`. Long-term cleanup strategy deferred to a follow-up ADR.
+- **Status:** **Resolved** — PR #215 (merged 2026-05-22). See [ADR-011](ADR-011-scenario-retention.md), migration `032_scenario_fk_retention.sql`. Long-term cleanup strategy for archived scenarios deferred to a follow-up ADR.
 
 #### R2 — Propagation engine: O(N × ~15 queries) per dirty node
 - **Description:** `_recompute_pi_node` issues 10–20 SQL queries per node inside a loop. At 500 items / 5K dirty nodes ≈ 75K queries ≈ 75s per propagation. This is breaking point #1 in `docs/SCALABILITY.md`, documented but not yet fixed.
@@ -41,7 +41,7 @@ Solid MVP, more mature than the documentation suggests. Architecture is clean, l
 - **Description:** `pyproject.toml` uses `>=` for all third-party deps (`fastapi>=0.111.0`, `openai>=1.0.0`, etc.). No `.github/dependabot.yml`. Risk of drift and unnoticed CVEs.
 - **Location:** `pyproject.toml:25-31`
 - **Fix:** pin with `==` or `~=`, add Dependabot configuration.
-- **Status:** **Open**.
+- **Status:** **Resolved** — PR #216 (merged 2026-05-22). Pins use PEP 440 `~=` on `major.minor`; Dependabot covers pip, github-actions, and docker on a weekly schedule.
 
 #### R5 — ROADMAP / SECURITY.md / actual code state drift
 - **Description:** `ROADMAP.md` shows all milestone checkboxes empty and says "Early Build Phase" while 50+ endpoints ship and 31 migrations exist. `SECURITY.md` says "pre-release / no production releases" while `INFRA-RUNBOOK.md` documents a live VM (Proxmox, 192.168.1.176). Contradictions confuse new contributors and external observers.
@@ -81,6 +81,12 @@ Solid MVP, more mature than the documentation suggests. Architecture is clean, l
 - **Description:** The architecture and CLAUDE.md describe scenario branching as copy-on-write, but `engine/scenario/manager.py:59-280` performs an explicit deep-copy of nodes / edges / projections on fork. Acceptable for MVP, but the vocabulary should match the implementation.
 - **Fix:** either implement lazy materialization (overrides only, derive children on read), or rename "scenario forking" in docs to remove the CoW claim.
 - **Status:** **Open**.
+
+#### R11 — CI integration job runs only one test file
+- **Description:** `.github/workflows/ci.yml` invokes `pytest tests/integration/test_phase1_e2e.py` — the 13 other files under `tests/integration/` (including `test_scenario_fk_retention.py` added in #215, `test_migrations.py`, `test_dq.py`, `test_ghosts.py`, etc.) are never exercised by CI. Surfaced during the cycle-5 coverage pass.
+- **Location:** `.github/workflows/ci.yml` (integration job).
+- **Fix:** widen the command to `pytest tests/integration/ -q --tb=short`, then quarantine any test that breaks under the new scope.
+- **Status:** **Open** — discovered 2026-05-22, added during the iterative quality pass.
 
 ---
 

--- a/src/ootils_core/engine/orchestration/calc_run.py
+++ b/src/ootils_core/engine/orchestration/calc_run.py
@@ -13,6 +13,8 @@ from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID, uuid4
 
+import psycopg
+
 from ootils_core.models import CalcRun, Scenario
 
 
@@ -27,7 +29,7 @@ class CalcRunManager:
         self,
         scenario_id: UUID,
         event_ids: list[UUID],
-        db,
+        db: psycopg.Connection,
     ) -> Optional[CalcRun]:
         """
         Try to acquire an advisory lock for this scenario and start a calc run.
@@ -107,7 +109,7 @@ class CalcRunManager:
         self,
         run: CalcRun,
         scenario: Scenario,
-        db,
+        db: psycopg.Connection,
     ) -> None:
         """
         Mark a calc run as completed or completed_stale.
@@ -163,7 +165,7 @@ class CalcRunManager:
         self,
         run: CalcRun,
         error: str,
-        db,
+        db: psycopg.Connection,
     ) -> None:
         """Mark a calc run as failed with an error message.
 
@@ -205,7 +207,7 @@ class CalcRunManager:
         except Exception:
             pass
 
-    def recover_pending_runs(self, db) -> list[CalcRun]:
+    def recover_pending_runs(self, db: psycopg.Connection) -> list[CalcRun]:
         """
         On startup: transition all 'running' runs to 'interrupted'.
         Return all replayable runs (pending + interrupted) so the engine can retry them.

--- a/src/ootils_core/engine/orchestration/propagator.py
+++ b/src/ootils_core/engine/orchestration/propagator.py
@@ -13,6 +13,8 @@ from decimal import Decimal
 from typing import Optional
 from uuid import UUID
 
+import psycopg
+
 from ootils_core.models import CalcRun, Node, Scenario
 from ootils_core.engine.kernel.graph.store import GraphStore
 from ootils_core.engine.kernel.graph.traversal import GraphTraversal
@@ -56,7 +58,7 @@ class PropagationEngine:
         self,
         event_id: UUID,
         scenario_id: UUID,
-        db,
+        db: psycopg.Connection,
     ) -> Optional[CalcRun]:
         """
         Main entry point. Acquires advisory lock, expands dirty subgraph, propagates.
@@ -169,7 +171,7 @@ class PropagationEngine:
             self._calc_run_mgr.fail_calc_run(calc_run, str(exc), db)
             raise
 
-    def _finish_run(self, calc_run: CalcRun, scenario_id: UUID, db) -> None:
+    def _finish_run(self, calc_run: CalcRun, scenario_id: UUID, db: psycopg.Connection) -> None:
         """Load scenario and complete the calc run."""
         scenario_row = db.execute(
             "SELECT * FROM scenarios WHERE scenario_id = %s",
@@ -230,7 +232,7 @@ class PropagationEngine:
         self,
         calc_run: CalcRun,
         dirty_nodes: set[UUID],
-        db,
+        db: psycopg.Connection,
     ) -> None:
         """
         Topological sort over dirty nodes, then compute each one in order.
@@ -282,7 +284,7 @@ class PropagationEngine:
         node_id: UUID,
         scenario_id: UUID,
         calc_run_id: UUID,
-        db,
+        db: psycopg.Connection,
     ) -> bool:
         """
         Recompute a single PI node.
@@ -481,7 +483,7 @@ class PropagationEngine:
 
         return changed
 
-    def _get_safety_stock(self, node: Node, db) -> Optional[Decimal]:
+    def _get_safety_stock(self, node: Node, db: psycopg.Connection) -> Optional[Decimal]:
         """Fetch safety_stock_qty from item_planning_params for this node's item/location."""
         if node.item_id is None:
             return None

--- a/tests/fixtures/forecast_data.py
+++ b/tests/fixtures/forecast_data.py
@@ -7,9 +7,9 @@ and routing definitions used in Phase 1 integration tests.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import date, timedelta
+from datetime import date
 from decimal import Decimal
-from typing import List, Dict, Any
+from typing import List
 from uuid import UUID, uuid4
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,8 +10,6 @@ Set DATABASE_URL to a *test* database before running:
 from __future__ import annotations
 
 import os
-import subprocess
-import sys
 
 import pytest
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -61,7 +61,7 @@ def migrated_db():
 
     try:
         from ootils_core.db.connection import OotilsDB
-        db = OotilsDB(TEST_DB_URL)
+        OotilsDB(TEST_DB_URL)
     except Exception as exc:
         pytest.skip(f"Failed to apply migrations: {exc}")
 

--- a/tests/integration/test_api_db.py
+++ b/tests/integration/test_api_db.py
@@ -146,7 +146,7 @@ def test_20_issues_filters(api_client, auth, seeded_db):
         pytest.skip("No items in DB to filter on")
 
     item_id = str(item_row["item_id"])
-    location_id = str(loc_row["location_id"]) if loc_row else None
+    str(loc_row["location_id"]) if loc_row else None
 
     # Severity filter
     for sev in ("low", "medium", "high", "all"):

--- a/tests/integration/test_api_db.py
+++ b/tests/integration/test_api_db.py
@@ -16,7 +16,7 @@ from uuid import uuid4
 
 import pytest
 
-from .conftest import requires_db, DB_AVAILABLE, TEST_DB_URL
+from .conftest import requires_db, TEST_DB_URL
 
 SEED_SCRIPT = Path(__file__).parents[2] / "scripts" / "seed_demo_data.py"
 

--- a/tests/integration/test_bom.py
+++ b/tests/integration/test_bom.py
@@ -21,7 +21,7 @@ from uuid import uuid4
 
 import pytest
 
-from .conftest import requires_db, DB_AVAILABLE, TEST_DB_URL
+from .conftest import requires_db
 
 # ─────────────────────────────────────────────────────────────
 # Fixtures

--- a/tests/integration/test_calendars.py
+++ b/tests/integration/test_calendars.py
@@ -13,12 +13,11 @@ Set DATABASE_URL before running:
 from __future__ import annotations
 
 import os
-from datetime import date, timedelta
 from uuid import uuid4
 
 import pytest
 
-from .conftest import requires_db, DB_AVAILABLE, TEST_DB_URL
+from .conftest import requires_db
 
 # ─────────────────────────────────────────────────────────────
 # Fixtures

--- a/tests/integration/test_dq.py
+++ b/tests/integration/test_dq.py
@@ -28,7 +28,7 @@ import pytest
 import psycopg
 from psycopg.rows import dict_row
 
-from .conftest import requires_db, DB_AVAILABLE, TEST_DB_URL
+from .conftest import requires_db
 
 # ─────────────────────────────────────────────────────────────
 # Fixtures

--- a/tests/integration/test_dq_agent.py
+++ b/tests/integration/test_dq_agent.py
@@ -26,7 +26,7 @@ import psycopg
 import pytest
 from psycopg.rows import dict_row
 
-from .conftest import requires_db, DB_AVAILABLE, TEST_DB_URL
+from .conftest import requires_db
 
 
 # ─────────────────────────────────────────────────────────────
@@ -431,7 +431,6 @@ def test_llm_fallback_when_api_unavailable(agent_db_conn, migrated_db):
     """LLM fallback generates a structured report when OPENAI_API_KEY is not set."""
     from ootils_core.engine.dq.agent.llm_reporter import generate_llm_report
     from ootils_core.engine.dq.agent.stat_rules import AgentIssue
-    import psycopg as _psycopg
 
     # Temporarily remove API key
     original_key = os.environ.pop("OPENAI_API_KEY", None)

--- a/tests/integration/test_events_read.py
+++ b/tests/integration/test_events_read.py
@@ -10,11 +10,10 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from uuid import uuid4
 
 import pytest
 
-from .conftest import requires_db, DB_AVAILABLE, TEST_DB_URL
+from .conftest import requires_db, TEST_DB_URL
 
 SEED_SCRIPT = Path(__file__).parents[2] / "scripts" / "seed_demo_data.py"
 BASELINE_SCENARIO_ID = "00000000-0000-0000-0000-000000000001"
@@ -243,7 +242,7 @@ def test_36_get_events_filter_processed(api_client, auth):
     data = resp.json()
     for event in data["events"]:
         assert event["processed"] is False, (
-            f"Processed event returned for processed=false filter"
+            "Processed event returned for processed=false filter"
         )
 
     # processed=true — should return 200 (list may be empty)

--- a/tests/integration/test_ghosts.py
+++ b/tests/integration/test_ghosts.py
@@ -26,13 +26,12 @@ Covers:
 """
 from __future__ import annotations
 
-import os
 from datetime import date, timedelta
 from uuid import uuid4
 
 import pytest
 
-from .conftest import requires_db, DB_AVAILABLE, TEST_DB_URL
+from .conftest import requires_db, TEST_DB_URL
 
 # FastAPI test client
 try:

--- a/tests/integration/test_ingest.py
+++ b/tests/integration/test_ingest.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 
 import pytest
 
-from .conftest import requires_db, DB_AVAILABLE, TEST_DB_URL
+from .conftest import requires_db
 
 # ─────────────────────────────────────────────────────────────
 # Fixtures

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -8,11 +8,10 @@ Skip all tests if DATABASE_URL is not configured.
 """
 from __future__ import annotations
 
-import os
 
 import pytest
 
-from .conftest import requires_db, DB_AVAILABLE, TEST_DB_URL
+from .conftest import requires_db
 
 
 # ---------------------------------------------------------------------------
@@ -218,7 +217,6 @@ def test_07_migration_002_deferrable_fk_on_nodes_projection_series(conn):
     to verify the happy path works end-to-end.
     """
     import uuid
-    import psycopg
 
     scenario_id = "00000000-0000-0000-0000-000000000001"
     item_id = str(uuid.uuid4())

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -270,7 +270,7 @@ def test_08_bootstrap_rerun_is_idempotent(migrated_db):
     from ootils_core.db.connection import OotilsDB
 
     # Second instantiation — should be a no-op (IF NOT EXISTS throughout)
-    db2 = OotilsDB(migrated_db)
+    OotilsDB(migrated_db)
 
     with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
         tables = _tables(conn)

--- a/tests/integration/test_phase1_e2e.py
+++ b/tests/integration/test_phase1_e2e.py
@@ -6,15 +6,12 @@ Forecast → MPS aggregate → approve/promote to planned supply → CRP → ATP
 """
 from __future__ import annotations
 
-import os
 from datetime import date, timedelta
 from decimal import Decimal
 from uuid import uuid4
 
-import pytest
 
 from .conftest import requires_db
-from .test_api_db import auth, api_client, seeded_db  # re-use real DB/TestClient fixtures
 
 BASELINE_SCENARIO_ID = "00000000-0000-0000-0000-000000000001"
 

--- a/tests/integration/test_rccp.py
+++ b/tests/integration/test_rccp.py
@@ -176,7 +176,7 @@ def test_01b_migration_009_columns(conn):
 def test_02_ingest_resource_insert(conn):
     """Ingest resource crée une entrée dans resources ET un nœud Resource dans nodes."""
     ext_id = f"RES-INSERT-{uuid4().hex[:6]}"
-    ids = _insert_resource(conn, ext_id, capacity_per_day=8.0, resource_type="line")
+    _insert_resource(conn, ext_id, capacity_per_day=8.0, resource_type="line")
 
     # Vérifier resource créée
     row = conn.execute(

--- a/tests/integration/test_rccp.py
+++ b/tests/integration/test_rccp.py
@@ -17,13 +17,12 @@ Skip all tests si DATABASE_URL non configuré.
 """
 from __future__ import annotations
 
-import os
 from datetime import date, timedelta
 from uuid import uuid4
 
 import pytest
 
-from .conftest import requires_db, DB_AVAILABLE, TEST_DB_URL
+from .conftest import requires_db
 
 BASELINE_SCENARIO_ID = "00000000-0000-0000-0000-000000000001"
 
@@ -428,7 +427,7 @@ def test_08_rccp_grain_week_vs_day(conn):
     Grain=week → une semaine est un bucket.
     Vérifie que les buckets sont générés correctement.
     """
-    from ootils_core.api.routers.rccp import _generate_buckets, _bucket_start
+    from ootils_core.api.routers.rccp import _generate_buckets
 
     # Grain=day : 7 jours → 7 buckets
     from_date = date(2026, 8, 3)  # lundi

--- a/tests/legacy/test_models.py
+++ b/tests/legacy/test_models.py
@@ -6,7 +6,7 @@ pytestmark = pytest.mark.skip(reason="Legacy pre-graph API — InventoryState re
 
 import pytest
 
-from ootils_core.models import InventoryState, OrderRecommendation, Product, Supplier
+from ootils_core.models import InventoryState, Product, Supplier
 
 
 class TestProduct:

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1,0 +1,253 @@
+"""
+tests/test_agent_tools.py — Unit tests for ootils_core.tools.agent_tools.
+
+The module exposes three functions for LLM agents to drive the planning engine.
+Before this file, the module was at 0% coverage — its only tests lived under
+tests/legacy/ which targets a removed SupplyChainTools class.
+
+These tests mock the underlying detector / manager / propagation engine to
+isolate the tool wrappers. They do not touch a real DB.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from ootils_core.models import Scenario, ShortageRecord
+from ootils_core.tools.agent_tools import (
+    get_active_issues,
+    simulate_override,
+    trigger_recalculation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_shortage(
+    *,
+    pi_node_id: UUID | None = None,
+    item_id: UUID | None = None,
+    location_id: UUID | None = None,
+    shortage_qty: Decimal = Decimal("10"),
+    severity_score: Decimal = Decimal("100"),
+    shortage_date: date | None = None,
+) -> ShortageRecord:
+    return ShortageRecord(
+        shortage_id=uuid4(),
+        scenario_id=uuid4(),
+        pi_node_id=pi_node_id or uuid4(),
+        item_id=item_id,
+        location_id=location_id,
+        shortage_date=shortage_date or date(2026, 6, 1),
+        shortage_qty=shortage_qty,
+        severity_score=severity_score,
+        explanation_id=None,
+        calc_run_id=uuid4(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_active_issues
+# ---------------------------------------------------------------------------
+
+
+def test_get_active_issues_returns_serialized_dicts():
+    item_id = uuid4()
+    location_id = uuid4()
+    node_id = uuid4()
+    shortage = _make_shortage(
+        pi_node_id=node_id,
+        item_id=item_id,
+        location_id=location_id,
+        shortage_qty=Decimal("42.5"),
+        severity_score=Decimal("1234.5"),
+    )
+
+    detector_mock = MagicMock()
+    detector_mock.get_active_shortages.return_value = [shortage]
+
+    with patch("ootils_core.engine.kernel.shortage.detector.ShortageDetector", return_value=detector_mock):
+        result = get_active_issues(db=MagicMock(), scenario_id=str(uuid4()))
+
+    assert result == [
+        {
+            "node_id": str(node_id),
+            "item_id": str(item_id),
+            "location_id": str(location_id),
+            "shortage_qty": 42.5,
+            "severity_score": 1234.5,
+            "shortage_date": "2026-06-01",
+        }
+    ]
+
+
+def test_get_active_issues_uses_baseline_scenario_by_default():
+    detector_mock = MagicMock()
+    detector_mock.get_active_shortages.return_value = []
+    db = MagicMock()
+
+    with patch("ootils_core.engine.kernel.shortage.detector.ShortageDetector", return_value=detector_mock):
+        get_active_issues(db=db)
+
+    detector_mock.get_active_shortages.assert_called_once()
+    scenario_arg = detector_mock.get_active_shortages.call_args.args[0]
+    assert scenario_arg == UUID("00000000-0000-0000-0000-000000000001")
+
+
+def test_get_active_issues_handles_missing_item_and_location():
+    shortage = _make_shortage(item_id=None, location_id=None)
+    detector_mock = MagicMock()
+    detector_mock.get_active_shortages.return_value = [shortage]
+
+    with patch("ootils_core.engine.kernel.shortage.detector.ShortageDetector", return_value=detector_mock):
+        result = get_active_issues(db=MagicMock(), scenario_id=str(uuid4()))
+
+    assert result[0]["item_id"] is None
+    assert result[0]["location_id"] is None
+
+
+def test_get_active_issues_passes_db_to_detector():
+    detector_mock = MagicMock()
+    detector_mock.get_active_shortages.return_value = []
+    db = MagicMock()
+
+    with patch("ootils_core.engine.kernel.shortage.detector.ShortageDetector", return_value=detector_mock):
+        get_active_issues(db=db, scenario_id=str(uuid4()))
+
+    detector_mock.get_active_shortages.assert_called_once()
+    assert detector_mock.get_active_shortages.call_args.args[1] is db
+
+
+# ---------------------------------------------------------------------------
+# simulate_override
+# ---------------------------------------------------------------------------
+
+
+def test_simulate_override_creates_scenario_and_applies_override():
+    new_scenario_id = uuid4()
+    parent_scenario_id = UUID("00000000-0000-0000-0000-000000000001")
+    target_node_id = uuid4()
+
+    scenario = Scenario(
+        scenario_id=new_scenario_id,
+        name="agent-sim-abcd1234",
+        parent_scenario_id=parent_scenario_id,
+        is_baseline=False,
+        status="active",
+        created_at=datetime.now(timezone.utc),
+    )
+
+    manager_mock = MagicMock()
+    manager_mock.create_scenario.return_value = scenario
+
+    with patch("ootils_core.engine.scenario.manager.ScenarioManager", return_value=manager_mock):
+        result = simulate_override(
+            db=MagicMock(),
+            node_id=str(target_node_id),
+            field_name="time_ref",
+            new_value="2026-07-01",
+        )
+
+    manager_mock.create_scenario.assert_called_once()
+    manager_mock.apply_override.assert_called_once()
+    override_kwargs = manager_mock.apply_override.call_args.kwargs
+    assert override_kwargs["scenario_id"] == new_scenario_id
+    assert override_kwargs["node_id"] == target_node_id
+    assert override_kwargs["field_name"] == "time_ref"
+    assert override_kwargs["new_value"] == "2026-07-01"
+    assert override_kwargs["applied_by"] == "agent"
+
+    assert result == {
+        "scenario_id": str(new_scenario_id),
+        "scenario_name": "agent-sim-abcd1234",
+        "status": "created",
+        "override_applied": True,
+    }
+
+
+def test_simulate_override_uses_baseline_as_default_parent():
+    scenario = Scenario(
+        scenario_id=uuid4(),
+        name="agent-sim-xx",
+        parent_scenario_id=UUID("00000000-0000-0000-0000-000000000001"),
+        is_baseline=False,
+        status="active",
+        created_at=datetime.now(timezone.utc),
+    )
+    manager_mock = MagicMock()
+    manager_mock.create_scenario.return_value = scenario
+
+    with patch("ootils_core.engine.scenario.manager.ScenarioManager", return_value=manager_mock):
+        simulate_override(
+            db=MagicMock(),
+            node_id=str(uuid4()),
+            field_name="quantity",
+            new_value="100",
+        )
+
+    parent = manager_mock.create_scenario.call_args.kwargs["parent_scenario_id"]
+    assert parent == UUID("00000000-0000-0000-0000-000000000001")
+
+
+# ---------------------------------------------------------------------------
+# trigger_recalculation
+# ---------------------------------------------------------------------------
+
+
+def test_trigger_recalculation_returns_locked_when_calc_run_in_progress():
+    db = MagicMock()
+    db.execute.return_value.fetchall.return_value = []
+
+    calc_run_mgr_mock = MagicMock()
+    calc_run_mgr_mock.start_calc_run.return_value = None  # lock held
+    engine_mock = MagicMock()
+
+    with patch("ootils_core.api.routers.events._build_propagation_engine", return_value=engine_mock), \
+         patch("ootils_core.engine.orchestration.calc_run.CalcRunManager", return_value=calc_run_mgr_mock), \
+         patch("ootils_core.engine.kernel.graph.dirty.DirtyFlagManager"):
+        result = trigger_recalculation(db=db, scenario_id=str(uuid4()))
+
+    assert result == {"status": "locked", "nodes_recalculated": 0}
+
+
+def test_trigger_recalculation_completes_and_returns_run_id():
+    scenario_id = uuid4()
+    calc_run_id = uuid4()
+    node_id = uuid4()
+
+    calc_run = MagicMock()
+    calc_run.calc_run_id = calc_run_id
+    calc_run.nodes_recalculated = 7
+
+    calc_run_mgr_mock = MagicMock()
+    calc_run_mgr_mock.start_calc_run.return_value = calc_run
+
+    dirty_mgr_mock = MagicMock()
+    engine_mock = MagicMock()
+
+    db = MagicMock()
+    # First call: INSERT INTO events (no return value used)
+    # Second call: SELECT node_id FROM nodes ... → fetchall returns one row
+    db.execute.return_value.fetchall.return_value = [{"node_id": str(node_id)}]
+
+    with patch("ootils_core.api.routers.events._build_propagation_engine", return_value=engine_mock), \
+         patch("ootils_core.engine.orchestration.calc_run.CalcRunManager", return_value=calc_run_mgr_mock), \
+         patch("ootils_core.engine.kernel.graph.dirty.DirtyFlagManager", return_value=dirty_mgr_mock):
+        result = trigger_recalculation(db=db, scenario_id=str(scenario_id))
+
+    assert result == {
+        "status": "completed",
+        "calc_run_id": str(calc_run_id),
+        "nodes_recalculated": 7,
+    }
+    dirty_mgr_mock.mark_dirty.assert_called_once()
+    dirty_mgr_mock.flush_to_postgres.assert_called_once()
+    engine_mock._propagate.assert_called_once()
+    engine_mock._finish_run.assert_called_once_with(calc_run, scenario_id, db)

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -15,8 +15,6 @@ from decimal import Decimal
 from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
-import pytest
-
 from ootils_core.models import Scenario, ShortageRecord
 from ootils_core.tools.agent_tools import (
     get_active_issues,

--- a/tests/test_allocation_engine.py
+++ b/tests/test_allocation_engine.py
@@ -9,19 +9,16 @@ Covers:
 """
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, timezone
 from decimal import Decimal
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
-import pytest
 
 from ootils_core.engine.kernel.allocation.engine import (
     AllocationEngine,
     _priority_key,
     _ZERO,
-    _SENTINEL_DATE,
-    _DEMAND_TYPES,
 )
 from ootils_core.models import AllocationResult, Edge, Node
 

--- a/tests/test_atp_api.py
+++ b/tests/test_atp_api.py
@@ -13,9 +13,8 @@ All DB calls are mocked via FastAPI dependency_overrides.
 import os
 from datetime import date, timedelta
 from decimal import Decimal
-from typing import Any
 from unittest.mock import MagicMock, patch
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 from fastapi import status

--- a/tests/test_atp_api.py
+++ b/tests/test_atp_api.py
@@ -70,7 +70,7 @@ class TestATPCheckEndpoint:
         """ATP check requires authentication (verified via middleware)."""
         # Auth is enforced by require_auth dependency which is always active
         # This test verifies the endpoint exists and auth dependency is configured
-        app = create_app()
+        create_app()
         # Check that require_auth is used in the endpoint
         from ootils_core.atp import routers
         # Verify router has auth dependency configured
@@ -182,7 +182,7 @@ class TestATPCheckEndpoint:
                     assert response.status_code == status.HTTP_200_OK
 
                     data = response.json()
-                    assert data["available"] == True
+                    assert data["available"]
                     # quantity_available is returned as string (Decimal serialization)
                     assert data["quantity_available"] in [100.0, "100", 100]
                     assert data["requested_quantity"] in [100.0, "100", 100]
@@ -220,7 +220,7 @@ class TestATPCheckEndpoint:
                     assert response.status_code == status.HTTP_200_OK
 
                     data = response.json()
-                    assert data["available"] == False
+                    assert not data["available"]
                     assert data["quantity_available"] in [50.0, "50", 50]
                     assert data["backorder_quantity"] in [50.0, "50", 50]
 
@@ -254,7 +254,7 @@ class TestATPCheckEndpoint:
                     assert response.status_code == status.HTTP_200_OK
 
                     data = response.json()
-                    assert data["available"] == False
+                    assert not data["available"]
                     assert data["quantity_available"] in [75.0, "75", 75]
                     assert data["backorder_quantity"] in [25.0, "25", 25]
 
@@ -325,8 +325,8 @@ class TestCTPCheckEndpoint:
                     assert response.status_code == status.HTTP_200_OK
 
                     data = response.json()
-                    assert data["available"] == True
-                    assert data["capacity_feasible"] == True
+                    assert data["available"]
+                    assert data["capacity_feasible"]
                     assert data["violations"] == []
                     assert "critical_resources" in data
 
@@ -374,8 +374,8 @@ class TestCTPCheckEndpoint:
                     assert response.status_code == status.HTTP_200_OK
 
                     data = response.json()
-                    assert data["available"] == True
-                    assert data["capacity_feasible"] == False
+                    assert data["available"]
+                    assert not data["capacity_feasible"]
                     assert len(data["violations"]) == 1
                     assert data["violations"][0]["resource_name"] == "CNC Machine 1"
                     assert data["violations"][0]["overload_pct"] == 150.0

--- a/tests/test_atp_engine.py
+++ b/tests/test_atp_engine.py
@@ -13,10 +13,9 @@ import unittest
 from datetime import date, timedelta
 from decimal import Decimal
 from unittest.mock import MagicMock, Mock, patch
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from ootils_core.atp.engine import ATPEngine
-from ootils_core.atp.models import ATPBucket, ATPConfig, ATPSupply, ATPDemand
 
 
 class TestATPEngineCalculate(unittest.TestCase):

--- a/tests/test_calc_run.py
+++ b/tests/test_calc_run.py
@@ -11,10 +11,9 @@ Covers every method and branch:
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
-import pytest
 
 from ootils_core.engine.orchestration.calc_run import CalcRunManager, _row_to_calc_run
 from ootils_core.models import CalcRun, Scenario

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import date, timedelta
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 
 import pytest

--- a/tests/test_crp_engine.py
+++ b/tests/test_crp_engine.py
@@ -1071,7 +1071,7 @@ class TestCRPEdgeCases:
         ]
         
         engine = CRPEngine(db_conn=conn)
-        result = engine.calculate(horizon_days=30)
+        engine.calculate(horizon_days=30)
         
         # Inactive operations should be filtered out during scheduling
         # The operation won't be added to load buckets

--- a/tests/test_crp_engine.py
+++ b/tests/test_crp_engine.py
@@ -14,9 +14,8 @@ from __future__ import annotations
 import pytest
 from datetime import date, timedelta
 from decimal import Decimal
-from uuid import uuid4, UUID
-from unittest.mock import Mock, MagicMock, patch
-from typing import List, Dict, Any
+from uuid import uuid4
+from unittest.mock import Mock
 
 from ootils_core.crp.engine import (
     CRPEngine,

--- a/tests/test_crp_integration.py
+++ b/tests/test_crp_integration.py
@@ -13,10 +13,10 @@ import pytest
 from datetime import date, timedelta
 from decimal import Decimal
 from uuid import uuid4
-from unittest.mock import Mock, MagicMock, patch
+from unittest.mock import Mock
 
-from ootils_core.crp.engine import CRPEngine, CRPResult, LoadProfile, Overload, LoadBucket
-from ootils_core.crp.models import WorkCenter, Routing, Operation
+from ootils_core.crp.engine import CRPEngine, CRPResult, LoadProfile, LoadBucket
+from ootils_core.crp.models import WorkCenter
 from ootils_core.mps.api import PromoteToMRPRequest, PromoteToMRPResponse
 
 
@@ -323,7 +323,7 @@ class TestCRPResponseModels:
     
     def test_crp_calculate_response(self, sample_work_center):
         """Test CRPCalculateResponse model."""
-        from ootils_core.crp.routers import CRPCalculateResponse, LoadProfileOut, LoadBucketOut
+        from ootils_core.crp.routers import CRPCalculateResponse
         
         response = CRPCalculateResponse(
             calculation_id="calc-001",

--- a/tests/test_crp_models.py
+++ b/tests/test_crp_models.py
@@ -3,10 +3,9 @@ Unit tests for CRP (Capacity Requirements Planning) models.
 
 Tests WorkCenter, Routing, Operation, and edge models.
 """
-import pytest
 from decimal import Decimal
 from uuid import uuid4
-from datetime import datetime, timezone
+from datetime import datetime
 
 from ootils_core.crp.models import (
     WorkCenter,

--- a/tests/test_dirty_flags.py
+++ b/tests/test_dirty_flags.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 from uuid import uuid4
 
-import pytest
 
 from ootils_core.engine.kernel.graph.dirty import DirtyFlagManager
 

--- a/tests/test_dq_agent.py
+++ b/tests/test_dq_agent.py
@@ -6,10 +6,9 @@ _get_entity_type, _persist_agent_run, _persist_new_issues, _enrich_existing_issu
 """
 from __future__ import annotations
 
-import json
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch, call
-from uuid import UUID, uuid4
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import pytest
 

--- a/tests/test_dq_engine.py
+++ b/tests/test_dq_engine.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 from unittest.mock import MagicMock, patch
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 

--- a/tests/test_dq_impact_scorer.py
+++ b/tests/test_dq_impact_scorer.py
@@ -9,10 +9,9 @@ from __future__ import annotations
 
 import json
 import math
-from unittest.mock import MagicMock, patch
-from uuid import UUID, uuid4
+from unittest.mock import MagicMock
+from uuid import uuid4
 
-import pytest
 
 from ootils_core.engine.dq.agent.impact_scorer import (
     score_issues,
@@ -20,7 +19,6 @@ from ootils_core.engine.dq.agent.impact_scorer import (
     _get_active_shortages_for_items,
     _get_finished_goods_via_bom,
     SEVERITY_WEIGHTS,
-    IssueImpact,
 )
 from ootils_core.engine.dq.agent.stat_rules import AgentIssue
 

--- a/tests/test_dq_llm_reporter.py
+++ b/tests/test_dq_llm_reporter.py
@@ -158,7 +158,7 @@ class TestFallbackReport:
         issues = [_make_issue(severity="error", rule_code=f"R{i}") for i in range(10)]
         report = _fallback_report(issues, "items")
         # Count bullet points in narrative
-        critical_lines = [l for l in report.narrative.split("\n") if l.startswith("- **")]
+        critical_lines = [line for line in report.narrative.split("\n") if line.startswith("- **")]
         assert len(critical_lines) == 5
 
 
@@ -298,7 +298,7 @@ class TestGenerateLlmReport:
 
         with patch("openai.OpenAI", return_value=mock_client):
             issue = _make_issue()
-            report = generate_llm_report([issue], "items", uuid4(), 10)
+            generate_llm_report([issue], "items", uuid4(), 10)
 
         assert issue.llm_explanation is None
         assert issue.llm_suggestion is None

--- a/tests/test_dq_llm_reporter.py
+++ b/tests/test_dq_llm_reporter.py
@@ -8,10 +8,9 @@ from __future__ import annotations
 
 import json
 import os
-from unittest.mock import MagicMock, patch, PropertyMock
-from uuid import UUID, uuid4
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
-import pytest
 
 from ootils_core.engine.dq.agent.llm_reporter import (
     generate_llm_report,

--- a/tests/test_drp_models.py
+++ b/tests/test_drp_models.py
@@ -3,10 +3,9 @@ Unit tests for DRP (Distribution Requirements Planning) models.
 
 Tests DistributionLink, TransportationLane, and edge models.
 """
-import pytest
 from decimal import Decimal
 from uuid import uuid4
-from datetime import datetime, timezone
+from datetime import datetime
 
 from ootils_core.drp.models import (
     DistributionLink,

--- a/tests/test_forecast_consumer.py
+++ b/tests/test_forecast_consumer.py
@@ -11,14 +11,12 @@ Architecture: Tests hit ForecastConsumerCore (pure logic, no DB).
 The DB-backed ForecastConsumer is a thin wrapper tested via integration tests.
 """
 
-import pytest
 from datetime import date, timedelta
 from decimal import Decimal
 
 from ootils_core.engine.mrp.forecast_consumer import (
     ForecastConsumerCore,
     ConsumptionStrategy,
-    ConsumedBucket,
 )
 
 # ─── Fixtures ──────────────────────────────────────────────────────────────────

--- a/tests/test_forecasting_api.py
+++ b/tests/test_forecasting_api.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import os
 from datetime import date, timedelta
-from decimal import Decimal
 from uuid import uuid4
 
 import pytest

--- a/tests/test_ghost_engine.py
+++ b/tests/test_ghost_engine.py
@@ -6,9 +6,8 @@ capacity overload detection, phase transition inconsistency alerts, and dispatch
 """
 from __future__ import annotations
 
-import math
-from datetime import date, timedelta
-from unittest.mock import MagicMock, patch, call
+from datetime import date
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -22,7 +21,6 @@ from ootils_core.engine.ghost.phase_transition import (
     compute_weight,
     run_phase_transition,
     _get_projected_inventory,
-    INCONSISTENCY_THRESHOLD,
 )
 
 

--- a/tests/test_ghost_engine.py
+++ b/tests/test_ghost_engine.py
@@ -186,7 +186,7 @@ class TestComputeWeight:
     def test_total_days_zero_returns_end(self):
         # start == end effectively, but t is between them (same day)
         # total_days = 0 -> return weight_at_end
-        d = date(2024, 3, 1)
+        date(2024, 3, 1)
         # We need t > start and t < end, with start < end but total_days=0 is impossible
         # with dates. Instead test when start == end - 0 days conceptually.
         # Actually total_days = (end - start).days; if start == date(2024,3,1) and

--- a/tests/test_graph_store.py
+++ b/tests/test_graph_store.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 from datetime import date, datetime, timezone
 from decimal import Decimal
-from unittest.mock import MagicMock, call
-from uuid import UUID, uuid4
+from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
 

--- a/tests/test_gross_to_net.py
+++ b/tests/test_gross_to_net.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import unittest
 from datetime import date, timedelta
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
 from ootils_core.engine.mrp.gross_to_net import (

--- a/tests/test_llc_calculator.py
+++ b/tests/test_llc_calculator.py
@@ -435,11 +435,16 @@ class TestPerformance:
         # Level 3: 3000 sub-components
         # Level 4: 3500 raw materials
         idx = 0
-        roots = items[idx:idx + 500]; idx += 500
-        level1 = items[idx:idx + 1000]; idx += 1000
-        level2 = items[idx:idx + 2000]; idx += 2000
-        level3 = items[idx:idx + 3000]; idx += 3000
-        level4 = items[idx:idx + 3500]; idx += 3500
+        roots = items[idx:idx + 500]
+        idx += 500
+        level1 = items[idx:idx + 1000]
+        idx += 1000
+        level2 = items[idx:idx + 2000]
+        idx += 2000
+        level3 = items[idx:idx + 3000]
+        idx += 3000
+        level4 = items[idx:idx + 3500]
+        idx += 3500
 
         # Each root → 2 level1 items
         for i, root in enumerate(roots):
@@ -500,7 +505,7 @@ class TestPerformance:
 
 _psycopg_available = False
 try:
-    import psycopg
+    import psycopg  # noqa: F401
     _psycopg_available = True
 except ImportError:
     pass

--- a/tests/test_llc_calculator.py
+++ b/tests/test_llc_calculator.py
@@ -16,11 +16,9 @@ Reference: APICS CPIM Part 2, Module 3 — BOM Structure & Low-Level Code
 from __future__ import annotations
 
 import time
-from collections import defaultdict
-from decimal import Decimal
-from typing import Any, Dict, List, Optional
-from unittest.mock import MagicMock, patch
-from uuid import UUID, uuid4
+from typing import List
+from unittest.mock import MagicMock
+from uuid import UUID
 
 import pytest
 
@@ -30,7 +28,6 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from ootils_core.engine.mrp.llc_calculator import (
-    LLCResult,
     LLCCalculator,
     CycleDetectedError,
     compute_llc_pure,

--- a/tests/test_lot_sizing_engine.py
+++ b/tests/test_lot_sizing_engine.py
@@ -15,11 +15,10 @@ Plus integration tests:
 - Edge cases and boundary conditions
 """
 
-import pytest
 from decimal import Decimal
 from datetime import date, timedelta
 from uuid import uuid4
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 import types
 import sys
 
@@ -30,7 +29,7 @@ psycopg_mock = types.ModuleType('psycopg')
 sys.modules['psycopg'] = psycopg_mock
 
 from ootils_core.engine.mrp.lot_sizing import LotSizingEngine, LotSizeRule
-from ootils_core.engine.mrp.gross_to_net import BucketRecord, TimeBucket
+from ootils_core.engine.mrp.gross_to_net import BucketRecord
 
 if _psycopg_original is not None:
     sys.modules['psycopg'] = _psycopg_original

--- a/tests/test_lot_sizing_engine.py
+++ b/tests/test_lot_sizing_engine.py
@@ -596,7 +596,7 @@ class TestApplyToRecords:
     def _make_weekly_records(self, gross_reqs, start_date=date(2025, 1, 6)):
         """Create a sequence of BucketRecords from gross requirement list."""
         records = []
-        on_hand = Decimal("0")
+        Decimal("0")
         for i, gr in enumerate(gross_reqs):
             gr = Decimal(str(gr))
             rec = make_record(

--- a/tests/test_m3_explanations.py
+++ b/tests/test_m3_explanations.py
@@ -10,14 +10,12 @@ Covers:
 """
 from __future__ import annotations
 
-import uuid
 from datetime import date, datetime, timezone
 from decimal import Decimal
 from typing import Optional
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
-import pytest
 
 from ootils_core.models import (
     CausalStep,

--- a/tests/test_m4_shortage.py
+++ b/tests/test_m4_shortage.py
@@ -11,14 +11,12 @@ Covers:
 """
 from __future__ import annotations
 
-import uuid
 from datetime import date, datetime, timezone
 from decimal import Decimal
 from typing import Optional
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
-import pytest
 
 from ootils_core.models import (
     Node,

--- a/tests/test_m5_scenarios.py
+++ b/tests/test_m5_scenarios.py
@@ -13,11 +13,9 @@ All tests use mocks — no real DB required.
 """
 from __future__ import annotations
 
-import uuid
 from datetime import date, datetime, timezone
-from decimal import Decimal
-from typing import Any, Optional
-from unittest.mock import MagicMock, call, patch
+from typing import Optional
+from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
 import pytest

--- a/tests/test_m5_scenarios.py
+++ b/tests/test_m5_scenarios.py
@@ -149,7 +149,7 @@ class TestCreateScenario:
         ]
 
         manager = ScenarioManager()
-        scenario = manager.create_scenario(
+        manager.create_scenario(
             name="S1",
             parent_scenario_id=parent_id,
             db=db,

--- a/tests/test_m7_agent.py
+++ b/tests/test_m7_agent.py
@@ -17,13 +17,11 @@ Coverage:
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Dict, List
-from unittest.mock import patch
 from uuid import UUID, uuid4
 
 import httpx
-import pytest
 
 from ootils_core.agent.demo_agent import OotilsAgent, _find_supply_root_cause, _contains_delay
 from ootils_core.models import AgentReport, AgentRecommendation

--- a/tests/test_mps_aggregate_demand.py
+++ b/tests/test_mps_aggregate_demand.py
@@ -11,20 +11,15 @@ Couverture:
 """
 
 import pytest
-from datetime import date, timedelta
+from datetime import date
 from decimal import Decimal
 from uuid import uuid4
 
-import psycopg
 
 from ootils_core.mps.engine import (
     AggregateDemandEngine,
     DemandSource,
-    TimeBucketDemand,
-    AggregateDemandRequest,
-    AggregateDemandResult,
 )
-from ootils_core.mps.models import MPSStatus
 
 
 class TestGenerateTimeBuckets:

--- a/tests/test_mps_capacity_check.py
+++ b/tests/test_mps_capacity_check.py
@@ -10,7 +10,7 @@ Couverture:
 """
 
 import pytest
-from datetime import date, timedelta
+from datetime import date
 from decimal import Decimal
 from uuid import uuid4
 from unittest.mock import MagicMock

--- a/tests/test_mps_models.py
+++ b/tests/test_mps_models.py
@@ -3,7 +3,7 @@ Unit tests for MPS (Master Production Schedule) models.
 MPS-001: MPS Node Model and Time Buckets
 """
 import pytest
-from datetime import date, datetime, timezone
+from datetime import date
 from decimal import Decimal
 from uuid import uuid4
 

--- a/tests/test_mps_promote_to_mrp.py
+++ b/tests/test_mps_promote_to_mrp.py
@@ -73,16 +73,16 @@ class TestPromoteToMRPRequestValidation:
         from ootils_core.mps.api import PromoteToMRPRequest
         
         req = PromoteToMRPRequest()
-        assert req.explode_components == True
-        assert req.dry_run == False
+        assert req.explode_components
+        assert not req.dry_run
     
     def test_promote_request_custom_values(self):
         """Test custom values for promote request."""
         from ootils_core.mps.api import PromoteToMRPRequest
         
         req = PromoteToMRPRequest(explode_components=False, dry_run=True)
-        assert req.explode_components == False
-        assert req.dry_run == True
+        assert not req.explode_components
+        assert req.dry_run
 
 
 # ─────────────────────────────────────────────────────────────
@@ -166,7 +166,7 @@ class TestPromoteToMRPEngineMethod:
         assert result.status == "RELEASED"
         assert result.planned_supplies_created == 0
         assert result.components_exploded == 0
-        assert result.summary["dry_run"] == True
+        assert result.summary["dry_run"]
     
     def test_promote_mps_not_found(self):
         """Test error when MPS node doesn't exist."""
@@ -277,8 +277,8 @@ class TestPromoteToMRPEndpoint:
         from ootils_core.mps.api import PromoteToMRPRequest
         
         req = PromoteToMRPRequest(explode_components=True, dry_run=False)
-        assert req.explode_components == True
-        assert req.dry_run == False
+        assert req.explode_components
+        assert not req.dry_run
 
 
 # ─────────────────────────────────────────────────────────────

--- a/tests/test_mps_promote_to_mrp.py
+++ b/tests/test_mps_promote_to_mrp.py
@@ -5,7 +5,7 @@ Tests the POST /v1/mps/{id}/promote-to-mrp endpoint and related engine methods.
 Uses mock database connections following the pattern from test_mps_capacity_check.py.
 """
 import pytest
-from datetime import date, datetime, timezone
+from datetime import date
 from decimal import Decimal
 from uuid import uuid4
 from unittest.mock import MagicMock

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -15,17 +15,15 @@ from __future__ import annotations
 import time
 from datetime import date, timedelta
 from decimal import Decimal
-from typing import List
-from uuid import UUID, uuid4
+from uuid import uuid4
 from unittest.mock import Mock, patch
 
 import pytest
 
 from ootils_core.forecasting.engine import ForecastingEngine, ForecastMethod, ForecastResult
 from ootils_core.mps.engine import AggregateDemandEngine, AggregateDemandRequest, AggregateDemandResult
-from ootils_core.mps.models import MPSNode, MPSStatus
+from ootils_core.mps.models import MPSNode
 from ootils_core.crp.engine import CRPEngine, CRPResult
-from ootils_core.crp.models import WorkCenter, Routing, Operation
 from ootils_core.atp.engine import ATPEngine
 from ootils_core.atp.models import ATPConfig, ATPResult
 

--- a/tests/test_phase1_integration.py
+++ b/tests/test_phase1_integration.py
@@ -20,30 +20,20 @@ from __future__ import annotations
 import time
 from datetime import date, timedelta
 from decimal import Decimal
-from typing import List
-from uuid import UUID, uuid4
-from unittest.mock import Mock, MagicMock, patch
+from uuid import uuid4
+from unittest.mock import Mock, patch
 
 import pytest
 
 from ootils_core.forecasting.engine import ForecastingEngine, ForecastMethod, ForecastResult
-from ootils_core.forecasting.algorithms import (
-    MovingAverageForecaster,
-    ExponentialSmoothingForecaster,
-    CrostonForecaster,
-)
-from ootils_core.mps.engine import AggregateDemandEngine, AggregateDemandRequest, AggregateDemandResult
+from ootils_core.mps.engine import AggregateDemandEngine, AggregateDemandResult
 from ootils_core.mps.models import MPSNode, MPSStatus
 from ootils_core.crp.engine import CRPEngine, CRPResult
-from ootils_core.crp.models import WorkCenter, Routing, Operation
 from ootils_core.atp.engine import ATPEngine
-from ootils_core.atp.models import ATPRequest, ATPResult, ATPConfig
+from ootils_core.atp.models import ATPResult, ATPConfig
 
 from tests.fixtures.forecast_data import (
     ForecastDatasets,
-    BOMDatasets,
-    RoutingDatasets,
-    ForecastFixture,
 )
 
 

--- a/tests/test_phase1_integration.py
+++ b/tests/test_phase1_integration.py
@@ -416,7 +416,7 @@ class TestEndToEndFlow:
     def test_mps_to_crp_flow(self, mock_db_connection):
         """Test flow from MPS approval to CRP check."""
         # Step 1: Create approved MPS node
-        mps_node = MPSNode(
+        MPSNode(
             mps_id=uuid4(),
             item_id=uuid4(),
             location_id=uuid4(),

--- a/tests/test_router_bom.py
+++ b/tests/test_router_bom.py
@@ -11,11 +11,10 @@ from __future__ import annotations
 
 import os
 from datetime import date
-from typing import Any, Generator
+from typing import Any
 from unittest.mock import MagicMock
-from uuid import UUID, uuid4
+from uuid import uuid4
 
-import pytest
 from fastapi.testclient import TestClient
 
 # Must set token BEFORE importing the app

--- a/tests/test_router_calc.py
+++ b/tests/test_router_calc.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 
 import os
 from unittest.mock import MagicMock, patch
-from uuid import UUID, uuid4
+from uuid import uuid4
 
-import pytest
 from fastapi.testclient import TestClient
 
 os.environ.setdefault("OOTILS_API_TOKEN", "test-token")

--- a/tests/test_router_calendars.py
+++ b/tests/test_router_calendars.py
@@ -9,10 +9,9 @@ Covers:
 from __future__ import annotations
 
 import os
-from datetime import date, datetime, timezone
-from decimal import Decimal
+from datetime import date
 from unittest.mock import MagicMock
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient

--- a/tests/test_router_dq.py
+++ b/tests/test_router_dq.py
@@ -9,11 +9,9 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timezone
-from typing import Generator
 from unittest.mock import MagicMock, patch
-from uuid import UUID, uuid4
+from uuid import uuid4
 
-import pytest
 from fastapi.testclient import TestClient
 
 os.environ.setdefault("OOTILS_API_TOKEN", "test-token")

--- a/tests/test_router_events.py
+++ b/tests/test_router_events.py
@@ -8,11 +8,9 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timezone
-from typing import Generator
 from unittest.mock import MagicMock, patch
-from uuid import UUID, uuid4
+from uuid import uuid4
 
-import pytest
 from fastapi.testclient import TestClient
 
 os.environ.setdefault("OOTILS_API_TOKEN", "test-token")

--- a/tests/test_router_ghosts.py
+++ b/tests/test_router_ghosts.py
@@ -13,9 +13,8 @@ import os
 from datetime import date, datetime
 from typing import Any
 from unittest.mock import MagicMock, patch
-from uuid import UUID, uuid4
+from uuid import uuid4
 
-import pytest
 from fastapi.testclient import TestClient
 
 # Must set token BEFORE importing the app

--- a/tests/test_router_graph.py
+++ b/tests/test_router_graph.py
@@ -6,12 +6,11 @@ Covers GET /v1/graph and GET /v1/nodes (the nodes_router).
 from __future__ import annotations
 
 import os
-from datetime import date, datetime, timezone
+from datetime import date
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
-import pytest
 from fastapi.testclient import TestClient
 
 os.environ.setdefault("OOTILS_API_TOKEN", "test-token")

--- a/tests/test_router_planning_params.py
+++ b/tests/test_router_planning_params.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 import os
 from decimal import Decimal
 from unittest.mock import MagicMock
-from uuid import UUID, uuid4
+from uuid import uuid4
 
-import pytest
 from fastapi.testclient import TestClient
 
 os.environ.setdefault("OOTILS_API_TOKEN", "test-token")

--- a/tests/test_router_rccp.py
+++ b/tests/test_router_rccp.py
@@ -10,12 +10,11 @@ output: {column: value}.
 from __future__ import annotations
 
 import os
-from datetime import date, timedelta
+from datetime import date
 from typing import Any
 from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
-import pytest
 from fastapi.testclient import TestClient
 
 # Must set token BEFORE importing the app

--- a/tests/test_router_scenarios.py
+++ b/tests/test_router_scenarios.py
@@ -11,9 +11,8 @@ from __future__ import annotations
 import os
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
-from uuid import UUID, uuid4
+from uuid import uuid4
 
-import pytest
 from fastapi.testclient import TestClient
 
 os.environ.setdefault("OOTILS_API_TOKEN", "test-token")

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -8,18 +8,17 @@ Sections:
 from __future__ import annotations
 
 import os
-import uuid
 from datetime import date, timedelta
 from decimal import Decimal
 from typing import Optional
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
 import pytest
 
 from ootils_core.engine.kernel.calc.projection import ProjectionKernel
 from ootils_core.engine.kernel.graph.dirty import DirtyFlagManager
-from ootils_core.models import CalcRun, Node, Edge, Scenario, PlanningEvent
+from ootils_core.models import Node
 
 
 # ===========================================================================
@@ -369,8 +368,6 @@ def test_po_date_change_propagates_to_pi():
     from ootils_core.engine.kernel.graph.dirty import DirtyFlagManager
     from ootils_core.engine.orchestration.calc_run import CalcRunManager
     from ootils_core.engine.orchestration.propagator import PropagationEngine
-    from ootils_core.models import Node, Edge
-    from datetime import datetime, timezone
 
     today = date.today()
 

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -310,7 +310,7 @@ class TestCalcRunManagerLock:
         def mock_execute(sql, params=None):
             call_count[0] += 1
             mock_result = MagicMock()
-            sql_stripped = sql.strip()
+            sql.strip()
 
             if "pg_try_advisory_lock" in sql:
                 mock_result.fetchone.return_value = {"locked": True}
@@ -372,7 +372,7 @@ def test_po_date_change_propagates_to_pi():
     today = date.today()
 
     with psycopg.connect(DATABASE_URL, row_factory=dict_row) as conn:
-        with conn.cursor() as cur:
+        with conn.cursor():
             # ----------------------------------------------------------------
             # Setup fixtures
             # ----------------------------------------------------------------

--- a/tests/test_sprint2_temporal.py
+++ b/tests/test_sprint2_temporal.py
@@ -13,15 +13,13 @@ import os
 from datetime import date, timedelta
 from decimal import Decimal
 from typing import Optional
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
 import pytest
 
 from ootils_core.engine.kernel.temporal.bridge import (
-    AggregatedBucket,
     TemporalBridge,
-    _bucket_key_for_grain,
     _bucket_end_for_grain,
     _grain_rank,
     _week_start,
@@ -885,7 +883,6 @@ def test_temporal_bridge_aggregate_integration():
     import psycopg
     from psycopg.rows import dict_row
 
-    from ootils_core.engine.kernel.graph.store import GraphStore
 
     item_id = uuid4()
     location_id = uuid4()

--- a/tests/test_temporal_bridge.py
+++ b/tests/test_temporal_bridge.py
@@ -6,7 +6,6 @@ aggregate/disaggregate, and all internal helpers.
 """
 from __future__ import annotations
 
-import logging
 from datetime import date, timedelta
 from decimal import Decimal
 from unittest.mock import MagicMock, patch

--- a/tests/test_zone_transition.py
+++ b/tests/test_zone_transition.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import date, timedelta
 from decimal import Decimal
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest


### PR DESCRIPTION
## Summary

Ten focused cycles of test → analyze → improve on `chore/iterative-quality-pass`. Each cycle = one commit, all green throughout. Lower-risk hygiene, no architectural changes.

## Cycles

| # | Commit | What |
|---|---|---|
| 1 | (baseline) | Measure: 1681 tests pass, 0 lint issues in `src/`, 242 in `tests/`. No commit. |
| 2 | `7a2132d` | `ruff check --fix tests/` — auto-fix 192 unused-imports / redefinitions across 59 files. |
| 3 | `b23fc2d` | `ruff --unsafe-fixes` (E712, F841) + manual fixes (split 5 semicolons in `test_llc_calculator`, rename `l→line`, noqa on availability-probe import). Lint in `tests/`: 242 → 12 issues. |
| 4 | `4b72c25` | Annotate `db: psycopg.Connection` on 9 functions in `engine/orchestration/{propagator,calc_run}.py`. Prepares R2 (batch propagation refactor). |
| 5 | `ead4744` | `tools/agent_tools.py` from **0% → 100% coverage** — 8 unit tests mocking `ShortageDetector` / `ScenarioManager` / propagation engine at their definition sites (lazy imports). |
| 6 | `446ca39` | `docs/INDEX.md` — categorised navigation map for the ~50 docs files. Resolves **R9**. 58 internal links verified. |
| 7 | `f441376` | Mark R1 + R4 **Resolved** (PRs #215 / #216) in REVIEW-2026-05. Add **R11** (CI integration job runs only `test_phase1_e2e.py` — 13 other integration tests un-exercised). |
| 8 | `b0f551d` | Replace bare "copy-on-write" with "deep-copy fork" in README + CLAUDE.md (the code does deep-copy, not CoW). Bump stale migration count 21 → 32. Tighten JSONB rule wording. Resolves **R10** partially. |
| 9 | `6293eea` | `.pre-commit-config.yaml` — ruff (blocking on `src/`, non-blocking on `tests/`), trailing-whitespace, EOF fixer, YAML/TOML validation, merge-conflict guard, 500KB large-file guard, LF line endings. Resolves **R6** partially. |
| 9b | `e08b966` | Drop unused `pytest` import in `test_agent_tools.py` (surfaced by the new pre-commit hook). |

## Net impact on REVIEW-2026-05

Status changes:
- R6 — Open → **Partially resolved** (pre-commit done; Makefile / mypy / coverage threshold still open)
- R9 — Open → **Resolved**
- R10 — Open → **Partially resolved** (vocabulary aligned; lazy materialization remains a future option)
- R1, R4 — already Resolved by #215/#216, status updated with PR refs and merge date
- **New: R11** (CI integration scope) — discovered during cycle 5

Findings still open: R2 (batch propagation, critical, dedicated session), R3 (CORS + security headers), R5 (ROADMAP/SECURITY.md alignment), R6 (rest), R7 (JSONB drift), R8 (onboarding), R10 (rest), R11 (CI scope).

## Test plan

- [x] 1689 unit tests pass (was 1681, +8 from cycle 5)
- [x] `ruff check src/` clean; `ruff check tests/` down to 12 intentional E402 (conditional imports in test setup)
- [x] `pre-commit run ruff --all-files` passes
- [ ] CI green
- [ ] CI runs the 8 new tests in `tests/test_agent_tools.py` (unit, no DB)

## Out of scope (intentionally deferred)

- **R2** (batch propagation) — hot path, needs a dedicated session with a benchmark setup
- **R3** (CORS + security headers) — middleware addition, separate PR
- **R5** (full ROADMAP / SECURITY.md alignment) — bigger doc rewrite
- **R6 remainder** — Makefile, mypy strict, `--cov-fail-under` threshold
- **R7** (JSONB drift on `dq_agent.summary`) — needs DQ domain input
- **R8** (QUICKSTART.md, examples/)
- **R10 remainder** — true lazy CoW for scenarios (vs. current deep-copy)
- **R11** — widening CI's integration scope to `tests/integration/`

## Notes

- Cycle 9 was split into two commits (9 and 9b) because the new pre-commit hook surfaced a dead import that needed a follow-up.
- No behavioral change in `src/` (only added type hints + cosmetic comment in CLAUDE.md). The engine and routers are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)