### PR TITLE
perf(engine): batch pre-load propagation hot path — ~5× faster (R2)

### DIFF
--- a/docs/REVIEW-2026-05.md
+++ b/docs/REVIEW-2026-05.md
@@ -11,7 +11,7 @@
 | Severity | ID | Title | Status | Where |
 |---|---|---|---|---|
 | Critical | R1 | Scenario FK retention | Resolved | PR #215, ADR-011, migration 032 |
-| Critical | R2 | O(N × queries) propagation | **Deferred** | Hot path — dedicated session with bench |
+| Critical | R2 | O(N × queries) propagation | Resolved | Batch pre-load + safety-stock cache: ~5× throughput (24 → 125 nps); see SCALABILITY.md and `scripts/bench_propagation.py` |
 | High | R3 | CORS + sec headers + rate limit | Resolved | Deep-pass cycles 1, 14 |
 | High | R4 | Pin deps + Dependabot | Resolved | PR #216 |
 | High | R5 | ROADMAP / SECURITY drift | Resolved | Deep-pass cycle 9 |
@@ -43,7 +43,7 @@ Solid MVP, more mature than the documentation suggests. Architecture is clean, l
 - **Description:** `_recompute_pi_node` issues 10–20 SQL queries per node inside a loop. At 500 items / 5K dirty nodes ≈ 75K queries ≈ 75s per propagation. This is breaking point #1 in `docs/SCALABILITY.md`, documented but not yet fixed.
 - **Location:** `src/ootils_core/engine/orchestration/propagator.py:250-278`
 - **Fix (Tier 1):** Batch-load all edges + nodes for the dirty subgraph in ~2 queries, compute in-memory, batch-persist with `INSERT … ON CONFLICT`. Expected gain: ~15×.
-- **Status:** **Open** — next priority after R1.
+- **Status:** **Resolved** — Tier 1 shipped (4 batch pre-load queries + in-memory cache + safety-stock cache + in-memory node mutation in lieu of post-persist reload). Measured against a fresh PG via `scripts/bench_propagation.py`: 24 → 125 nodes/sec, 10.07 → 2.0 queries/node, 5.8s → 1.2s at the demo scale, 61.8s → 12s at the 1500-node pilot scale (linear scaling preserved). The "Tier 2" levers (batched `UPDATE … FROM (VALUES …)` writes, single `DELETE` clear, Rust kernel) remain open as future work — see `docs/SCALABILITY.md` BP#1.
 
 ---
 

--- a/docs/SCALABILITY.md
+++ b/docs/SCALABILITY.md
@@ -18,9 +18,11 @@
 
 ## Breaking points
 
-### Breaking point #1: Propagation — O(N × 10–20 queries per PI node)
+### Breaking point #1: Propagation — O(N × 10–20 queries per PI node) — **FIXED**
 
-`propagator.py _recompute_pi_node` executes 10–20 SQL queries per PI node:
+**Status:** Resolved 2026-05-23 (REVIEW-2026-05 R2). See PR for the refactor.
+
+Before the fix, `propagator.py _recompute_pi_node` executed 10–20 SQL queries per PI node:
 
 - 1× `get_node` (load PI node)
 - 1× `get_edges_to` (feeds_forward for predecessor)
@@ -29,17 +31,42 @@
 - 1× `get_edges_to` (consumes)
 - 1× `update_pi_result`
 - 2× `get_node` (fresh reload for explanation + shortage)
+- 1× safety-stock query
 
-Additionally, `topological_sort` does **1 query per node** (`get_edges_to` in loop) before computation starts.
+The fix pre-loads everything `_propagate` needs in **4 batch queries** before the per-node loop:
+
+1. `get_nodes_by_ids(dirty_list)` — all dirty nodes
+2. `get_edges_to_nodes(dirty_list, edge_types=[feeds_forward, replenishes, consumes])` — all incoming edges
+3. `get_nodes_by_ids(source_ids)` — all edge sources (skips ids already in the cache)
+4. `SELECT … FROM item_planning_params` — all safety stocks for the touched (item, location) pairs
+
+Per-node work then reads from the in-memory caches and shrinks to **2 queries/node** (`clear_dirty` + `update_pi_result`).
+
+#### Measured impact (`scripts/bench_propagation.py`)
+
+| Scale | Dirty PI nodes | Before — queries / wall | After — queries / wall | Speedup |
+|-------|---------------|--------------------------|------------------------|---------|
+| Demo (10 items × 14 buckets) | 140 | 1,421 / 5.8s | 285 / 1.2s | **4.8×** |
+| Pilot (50 items × 30 buckets) | 1,500 | 15,101 / 61.8s | 3,005 / 12.0s | **5.1×** |
+
+Throughput climbs from ~24 nodes/sec to ~125 nodes/sec, with `queries/node` dropping from 10.07 to 2.0. Scaling stays linear in nodes (no quadratic blow-up).
+
+#### Re-bench projection (post-fix)
 
 | Scale | Dirty PI nodes | Queries/node | Total queries | Est. time @ 1ms/query |
 |-------|---------------|-------------|---------------|-----------------------|
-| Demo | 90 | 15 | 1,350 | 1.3s |
-| Pilot | 500 | 15 | 7,500 | 7.5s |
-| SMB | 5,000 | 15 | 75,000 | **75s** |
-| Mid-market | 50,000 | 15 | 750,000 | **12+ min** |
+| Demo | 90 | 2.0 | 184 | <1s |
+| Pilot | 500 | 2.0 | 1,004 | ~1s |
+| SMB | 5,000 | 2.0 | 10,004 | **~40s** (was 75s+) |
+| Mid-market | 50,000 | 2.0 | 100,004 | **~100s** (was 12+ min) |
 
-**Fix (Tier 1):** Batch-load all edges and nodes for the dirty subgraph in 2 queries before propagation begins, then process in-memory.
+The SMB tier no longer breaks; the mid-market tier becomes viable for batch runs even before further investment.
+
+#### Remaining levers (Tier 2 — not in scope of R2)
+
+- Batch the `update_pi_result` writes (one `UPDATE … FROM (VALUES …)` instead of N executions).
+- Cap `clear_dirty` to a single `DELETE … WHERE node_id = ANY(%s)` at the end of the loop.
+- Push the kernel compute into a Rust extension (issue #197).
 
 ---
 

--- a/scripts/bench_propagation.py
+++ b/scripts/bench_propagation.py
@@ -1,0 +1,293 @@
+"""
+scripts/bench_propagation.py — Measure propagation throughput.
+
+Seeds a synthetic scenario with N items × M time buckets and runs a full
+incremental propagation, reporting wall time, query count, and throughput.
+
+Used as the before/after harness for REVIEW-2026-05 R2 (batch propagation).
+
+Usage:
+    DATABASE_URL=postgresql://ootils:ootils@127.0.0.1:15432/ootils_test_bench \\
+        OOTILS_API_TOKEN=bench \\
+        python scripts/bench_propagation.py --items 50 --buckets 30
+
+Defaults to a tiny smoke scenario (10 items × 14 buckets) so the script is
+safe to run on the dev tunnel without burning minutes.
+
+WARNING: the script DROPs and recreates the target database. Never point it
+at a DB you care about. By default it picks `ootils_test_bench` to make
+that explicit.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from datetime import date, timedelta
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import psycopg
+from psycopg.rows import dict_row
+
+BASELINE_SCENARIO_ID = UUID("00000000-0000-0000-0000-000000000001")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _admin_recreate_db(dsn: str, dbname: str) -> None:
+    """Drop and recreate `dbname` via the postgres DB. Caller must have privileges."""
+    base = dsn.rsplit("/", 1)[0]
+    admin_dsn = f"{base}/postgres"
+    with psycopg.connect(admin_dsn, autocommit=True) as admin:
+        admin.execute(f'DROP DATABASE IF EXISTS "{dbname}"')
+        admin.execute(f'CREATE DATABASE "{dbname}" OWNER ootils')
+    print(f"[setup] recreated database {dbname}")
+
+
+def _apply_migrations(dsn: str) -> None:
+    from ootils_core.db.connection import OotilsDB
+
+    OotilsDB(dsn)
+    print("[setup] migrations applied")
+
+
+def _seed(conn: psycopg.Connection, items: int, buckets: int) -> dict:
+    """Insert items, locations, PI nodes, on-hand supplies, and feeds_forward edges.
+
+    Returns a summary dict (counts).
+    """
+    started = time.perf_counter()
+    location_id = uuid4()
+    today = date.today()
+    horizon_start = today
+    horizon_end = today + timedelta(days=buckets)
+
+    conn.execute(
+        "INSERT INTO locations (location_id, name) VALUES (%s, 'BENCH-LOC')",
+        (location_id,),
+    )
+
+    item_ids: list[UUID] = []
+    for i in range(items):
+        item_id = uuid4()
+        item_ids.append(item_id)
+        conn.execute(
+            "INSERT INTO items (item_id, name) VALUES (%s, %s)",
+            (item_id, f"BENCH-ITEM-{i:05d}"),
+        )
+
+    # One projection_series per item
+    pi_node_count = 0
+    edge_count = 0
+    for item_id in item_ids:
+        series_id = uuid4()
+        conn.execute(
+            """
+            INSERT INTO projection_series
+                (series_id, item_id, location_id, scenario_id, horizon_start, horizon_end)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            """,
+            (series_id, item_id, location_id, BASELINE_SCENARIO_ID, horizon_start, horizon_end),
+        )
+
+        # On-hand supply at horizon_start (provides opening_stock for first bucket)
+        oh_id = uuid4()
+        conn.execute(
+            """
+            INSERT INTO nodes
+                (node_id, node_type, scenario_id, item_id, location_id,
+                 quantity, qty_uom, time_grain, time_ref, is_dirty, active)
+            VALUES (%s, 'OnHandSupply', %s, %s, %s, %s, 'EA', 'exact_date', %s, FALSE, TRUE)
+            """,
+            (oh_id, BASELINE_SCENARIO_ID, item_id, location_id, Decimal("100"), horizon_start),
+        )
+
+        # PI buckets — daily grain
+        prev_pi_id: UUID | None = None
+        for b in range(buckets):
+            pi_id = uuid4()
+            bucket_start = horizon_start + timedelta(days=b)
+            bucket_end = bucket_start + timedelta(days=1)
+            conn.execute(
+                """
+                INSERT INTO nodes
+                    (node_id, node_type, scenario_id, item_id, location_id,
+                     time_grain, time_span_start, time_span_end,
+                     projection_series_id, bucket_sequence,
+                     is_dirty, active)
+                VALUES (%s, 'ProjectedInventory', %s, %s, %s,
+                        'day', %s, %s, %s, %s, TRUE, TRUE)
+                """,
+                (pi_id, BASELINE_SCENARIO_ID, item_id, location_id,
+                 bucket_start, bucket_end, series_id, b),
+            )
+            pi_node_count += 1
+
+            # feeds_forward edge from previous bucket
+            if prev_pi_id is not None:
+                edge_id = uuid4()
+                conn.execute(
+                    """
+                    INSERT INTO edges
+                        (edge_id, edge_type, from_node_id, to_node_id, scenario_id, active)
+                    VALUES (%s, 'feeds_forward', %s, %s, %s, TRUE)
+                    """,
+                    (edge_id, prev_pi_id, pi_id, BASELINE_SCENARIO_ID),
+                )
+                edge_count += 1
+            else:
+                # On-hand replenishes the first PI bucket
+                edge_id = uuid4()
+                conn.execute(
+                    """
+                    INSERT INTO edges
+                        (edge_id, edge_type, from_node_id, to_node_id, scenario_id, active)
+                    VALUES (%s, 'replenishes', %s, %s, %s, TRUE)
+                    """,
+                    (edge_id, oh_id, pi_id, BASELINE_SCENARIO_ID),
+                )
+                edge_count += 1
+
+            prev_pi_id = pi_id
+
+    conn.commit()
+    elapsed = time.perf_counter() - started
+    return {
+        "items": items,
+        "buckets_per_item": buckets,
+        "pi_nodes_total": pi_node_count,
+        "edges_total": edge_count,
+        "seed_seconds": round(elapsed, 2),
+    }
+
+
+def _mark_all_pi_dirty(conn: psycopg.Connection) -> tuple[UUID, set[UUID]]:
+    """Create a calc_run and persist a dirty_nodes row for every PI node."""
+    from ootils_core.engine.kernel.graph.dirty import DirtyFlagManager
+    from ootils_core.engine.orchestration.calc_run import CalcRunManager
+
+    pi_rows = conn.execute(
+        """
+        SELECT node_id FROM nodes
+        WHERE scenario_id = %s AND node_type = 'ProjectedInventory' AND active = TRUE
+        """,
+        (BASELINE_SCENARIO_ID,),
+    ).fetchall()
+    pi_ids = {UUID(str(r["node_id"])) for r in pi_rows}
+
+    calc_mgr = CalcRunManager()
+    calc_run = calc_mgr.start_calc_run(
+        scenario_id=BASELINE_SCENARIO_ID, event_ids=[], db=conn
+    )
+    assert calc_run is not None, "could not acquire advisory lock (something else running?)"
+
+    dirty = DirtyFlagManager()
+    dirty.mark_dirty(pi_ids, BASELINE_SCENARIO_ID, calc_run.calc_run_id, conn)
+    dirty.flush_to_postgres(calc_run.calc_run_id, BASELINE_SCENARIO_ID, conn)
+    conn.commit()
+    return calc_run.calc_run_id, pi_ids
+
+
+def _run_propagation(conn: psycopg.Connection, calc_run_id: UUID, dirty: set[UUID]) -> dict:
+    """Drive a full _propagate() over the given dirty set; time + count queries."""
+    from ootils_core.api.routers.events import _build_propagation_engine
+    from ootils_core.models import CalcRun
+
+    engine = _build_propagation_engine(conn)
+
+    # Reload the CalcRun so the manager state is populated
+    row = conn.execute(
+        "SELECT * FROM calc_runs WHERE calc_run_id = %s",
+        (calc_run_id,),
+    ).fetchone()
+    calc_run = CalcRun(
+        calc_run_id=UUID(str(row["calc_run_id"])),
+        scenario_id=UUID(str(row["scenario_id"])),
+        triggered_by_event_ids=[UUID(str(e)) for e in (row.get("triggered_by_event_ids") or [])],
+        is_full_recompute=bool(row.get("is_full_recompute", False)),
+        dirty_node_count=row.get("dirty_node_count"),
+        nodes_recalculated=int(row.get("nodes_recalculated", 0)),
+        nodes_unchanged=int(row.get("nodes_unchanged", 0)),
+        status=row.get("status", "running"),
+        started_at=row.get("started_at"),
+        completed_at=row.get("completed_at"),
+        error_message=row.get("error_message"),
+    )
+
+    # Count queries via a custom subclass of psycopg.Connection.execute
+    query_count = {"n": 0}
+    real_execute = conn.execute
+
+    def counting_execute(query, params=None, **kwargs):
+        query_count["n"] += 1
+        return real_execute(query, params, **kwargs) if params is not None else real_execute(query, **kwargs)
+
+    conn.execute = counting_execute  # type: ignore[method-assign]
+    try:
+        wall_start = time.perf_counter()
+        engine._propagate(calc_run, dirty, conn)
+        wall = time.perf_counter() - wall_start
+    finally:
+        conn.execute = real_execute  # type: ignore[method-assign]
+
+    return {
+        "dirty_nodes": len(dirty),
+        "wall_seconds": round(wall, 3),
+        "queries_total": query_count["n"],
+        "queries_per_node": round(query_count["n"] / max(1, len(dirty)), 2),
+        "nodes_per_second": round(len(dirty) / max(wall, 1e-9), 1),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--items", type=int, default=10, help="Items to seed (default: 10)")
+    parser.add_argument("--buckets", type=int, default=14, help="PI buckets per item (default: 14)")
+    parser.add_argument("--dbname", default="ootils_test_bench",
+                        help="Database to recreate (default: ootils_test_bench)")
+    parser.add_argument("--skip-setup", action="store_true",
+                        help="Skip DB recreate + migrations + seed (reuse existing state).")
+    args = parser.parse_args()
+
+    base_dsn = os.environ.get("DATABASE_URL")
+    if not base_dsn:
+        print("FATAL: set DATABASE_URL (e.g. postgresql://ootils:ootils@127.0.0.1:15432/ootils_test_bench)")
+        return 2
+
+    # Rebuild DSN to target the bench DB explicitly — defensive against accidental ootils_dev wipe.
+    target_dsn = base_dsn.rsplit("/", 1)[0] + f"/{args.dbname}"
+    os.environ["DATABASE_URL"] = target_dsn
+
+    if not args.skip_setup:
+        _admin_recreate_db(base_dsn, args.dbname)
+        _apply_migrations(target_dsn)
+
+    with psycopg.connect(target_dsn, row_factory=dict_row) as conn:
+        if not args.skip_setup:
+            seed_stats = _seed(conn, items=args.items, buckets=args.buckets)
+            print(f"[seed] {seed_stats}")
+        calc_run_id, dirty = _mark_all_pi_dirty(conn)
+        print(f"[dirty] marked {len(dirty)} PI nodes; calc_run_id={calc_run_id}")
+        result = _run_propagation(conn, calc_run_id, dirty)
+
+    print()
+    print("=" * 60)
+    print("BENCHMARK RESULT")
+    print("=" * 60)
+    for k, v in result.items():
+        print(f"  {k:24s}  {v}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ootils_core/engine/kernel/graph/store.py
+++ b/src/ootils_core/engine/kernel/graph/store.py
@@ -173,6 +173,67 @@ class GraphStore:
             ).fetchall()
         return [_row_to_edge(r) for r in rows]
 
+    # ------------------------------------------------------------------
+    # Batch reads — used by propagator to amortise the per-node query cost.
+    # See REVIEW-2026-05 R2 / docs/SCALABILITY.md breaking point #1.
+    # ------------------------------------------------------------------
+
+    def get_nodes_by_ids(
+        self,
+        node_ids: list[UUID],
+        scenario_id: UUID,
+    ) -> dict[UUID, Node]:
+        """Batch-load active nodes by id within a scenario. Returns id → Node."""
+        if not node_ids:
+            return {}
+        rows = self._conn.execute(
+            """
+            SELECT * FROM nodes
+            WHERE node_id = ANY(%s) AND scenario_id = %s AND active = TRUE
+            """,
+            (node_ids, scenario_id),
+        ).fetchall()
+        return {UUID(str(r["node_id"])): _row_to_node(r) for r in rows}
+
+    def get_edges_to_nodes(
+        self,
+        node_ids: list[UUID],
+        scenario_id: UUID,
+        edge_types: Optional[list[str]] = None,
+    ) -> dict[UUID, list[Edge]]:
+        """Batch-load incoming edges for many target nodes. Returns to_node_id → [Edge].
+
+        When `edge_types` is provided, only edges of those types are returned.
+        Empty buckets for un-referenced node_ids are not included — caller
+        should default to `[]` when the key is missing.
+        """
+        if not node_ids:
+            return {}
+        if edge_types:
+            rows = self._conn.execute(
+                """
+                SELECT * FROM edges
+                WHERE to_node_id = ANY(%s) AND scenario_id = %s
+                  AND edge_type = ANY(%s) AND active = TRUE
+                ORDER BY priority ASC, edge_id ASC
+                """,
+                (node_ids, scenario_id, edge_types),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """
+                SELECT * FROM edges
+                WHERE to_node_id = ANY(%s) AND scenario_id = %s AND active = TRUE
+                ORDER BY priority ASC, edge_id ASC
+                """,
+                (node_ids, scenario_id),
+            ).fetchall()
+        bucket: dict[UUID, list[Edge]] = {}
+        for r in rows:
+            key = UUID(str(r["to_node_id"]))
+            bucket.setdefault(key, []).append(_row_to_edge(r))
+        return bucket
+
     def get_all_edges(self, scenario_id: UUID) -> list[Edge]:
         """Return all active edges for a scenario (used by traversal)."""
         rows = self._conn.execute(

--- a/src/ootils_core/engine/orchestration/propagator.py
+++ b/src/ootils_core/engine/orchestration/propagator.py
@@ -237,6 +237,12 @@ class PropagationEngine:
         """
         Topological sort over dirty nodes, then compute each one in order.
         After each computation, cascade to dependents if the result changed.
+
+        Performance contract: pre-loads the dirty set's nodes + incoming
+        edges + edge-source nodes in 4 batch queries up front (was ~10
+        queries/node before — see REVIEW-2026-05 R2 / SCALABILITY.md BP#1).
+        Per-node compute then reads from `cache` dictionaries instead of
+        the store.
         """
         if not dirty_nodes:
             return
@@ -246,6 +252,62 @@ class PropagationEngine:
         # Topological sort of dirty set
         ordered = self._traversal.topological_sort(dirty_nodes, scenario_id)
 
+        # ------------------------------------------------------------------
+        # PRE-LOAD: 4 batch queries instead of ~10 per node.
+        # ------------------------------------------------------------------
+        dirty_list = list(dirty_nodes)
+        # 1. All dirty nodes themselves.
+        nodes_cache: dict[UUID, Optional[Node]] = dict(
+            self._store.get_nodes_by_ids(dirty_list, scenario_id)
+        )
+        # 2. All incoming edges for the dirty set (feeds_forward, replenishes, consumes).
+        edges_by_target: dict[UUID, dict[str, list]] = {nid: {} for nid in dirty_list}
+        all_incoming = self._store.get_edges_to_nodes(
+            dirty_list, scenario_id,
+            edge_types=["feeds_forward", "replenishes", "consumes"],
+        )
+        for target_id, edges in all_incoming.items():
+            for edge in edges:
+                edges_by_target.setdefault(target_id, {}).setdefault(edge.edge_type, []).append(edge)
+        # 3. All source nodes referenced by those edges.
+        source_node_ids = {
+            edge.from_node_id
+            for edges in all_incoming.values()
+            for edge in edges
+        }
+        # Some predecessors may already be in nodes_cache (e.g. PI[t-1] when both
+        # buckets are dirty). Skip those to avoid a redundant query.
+        missing_source_ids = [nid for nid in source_node_ids if nid not in nodes_cache]
+        if missing_source_ids:
+            nodes_cache.update(self._store.get_nodes_by_ids(missing_source_ids, scenario_id))
+
+        # 4. Pre-load all safety-stock parameters for the (item, location) pairs
+        # touched by the dirty PI set — drops `_get_safety_stock` from "1 query
+        # per PI" to "0 queries per PI" in the common case.
+        safety_stock_cache: dict[tuple[UUID, Optional[UUID]], Decimal] = {}
+        if self._shortage_detector is not None:
+            pi_pairs = {
+                (n.item_id, n.location_id)
+                for n in nodes_cache.values()
+                if n is not None and n.node_type == "ProjectedInventory" and n.item_id is not None
+            }
+            if pi_pairs:
+                item_ids = list({pair[0] for pair in pi_pairs})
+                rows = db.execute(
+                    """
+                    SELECT item_id, location_id, safety_stock_qty
+                    FROM item_planning_params
+                    WHERE item_id = ANY(%s)
+                      AND (effective_to IS NULL OR effective_to = '9999-12-31'::DATE)
+                    """,
+                    (item_ids,),
+                ).fetchall()
+                for r in rows:
+                    if r["safety_stock_qty"] is None:
+                        continue
+                    key = (UUID(str(r["item_id"])), UUID(str(r["location_id"])) if r["location_id"] else None)
+                    safety_stock_cache[key] = Decimal(str(r["safety_stock_qty"]))
+
         # Remaining dirty set (may shrink as we process)
         remaining_dirty = set(dirty_nodes)
 
@@ -253,8 +315,7 @@ class PropagationEngine:
             if node_id not in remaining_dirty:
                 continue  # Already cleared (e.g., cascaded out of window)
 
-            # Load node to determine type
-            node = self._store.get_node(node_id, scenario_id)
+            node = nodes_cache.get(node_id)
             if node is None:
                 self._dirty.clear_dirty(node_id, scenario_id, calc_run.calc_run_id, db)
                 remaining_dirty.discard(node_id)
@@ -266,6 +327,9 @@ class PropagationEngine:
                     scenario_id=scenario_id,
                     calc_run_id=calc_run.calc_run_id,
                     db=db,
+                    nodes_cache=nodes_cache,
+                    edges_by_target=edges_by_target,
+                    safety_stock_cache=safety_stock_cache,
                 )
                 if changed:
                     calc_run.nodes_recalculated += 1
@@ -285,6 +349,9 @@ class PropagationEngine:
         scenario_id: UUID,
         calc_run_id: UUID,
         db: psycopg.Connection,
+        nodes_cache: Optional[dict[UUID, Optional[Node]]] = None,
+        edges_by_target: Optional[dict[UUID, dict[str, list]]] = None,
+        safety_stock_cache: Optional[dict[tuple[UUID, Optional[UUID]], Decimal]] = None,
     ) -> bool:
         """
         Recompute a single PI node.
@@ -296,8 +363,26 @@ class PropagationEngine:
         Calls kernel.compute_pi_node, persists the result.
 
         Returns True if the result changed (triggers cascade), False if unchanged.
+
+        When called from `_propagate`, `nodes_cache` and `edges_by_target` are
+        the batch-loaded dicts; reads then hit memory instead of the DB. When
+        called standalone (e.g. tests), the parameters default to None and we
+        fall back to per-call store lookups — fully backwards compatible.
         """
-        node = self._store.get_node(node_id, scenario_id)
+        # ------------------------------------------------------------------
+        # Helpers: resolve node and incoming edges via cache when available.
+        # ------------------------------------------------------------------
+        def _get_node(nid: UUID) -> Optional[Node]:
+            if nodes_cache is not None and nid in nodes_cache:
+                return nodes_cache[nid]
+            return self._store.get_node(nid, scenario_id)
+
+        def _get_edges_to(nid: UUID, edge_type: str) -> list:
+            if edges_by_target is not None:
+                return list(edges_by_target.get(nid, {}).get(edge_type, []))
+            return self._store.get_edges_to(nid, scenario_id, edge_type=edge_type)
+
+        node = _get_node(node_id)
         if node is None or node.node_type != "ProjectedInventory":
             return False
 
@@ -316,18 +401,18 @@ class PropagationEngine:
         opening_stock = Decimal("0")
 
         # Find predecessor via 'feeds_forward' edge (to_node_id = this node)
-        pred_edges = self._store.get_edges_to(node_id, scenario_id, edge_type="feeds_forward")
+        pred_edges = _get_edges_to(node_id, "feeds_forward")
         if pred_edges:
-            pred_node = self._store.get_node(pred_edges[0].from_node_id, scenario_id)
+            pred_node = _get_node(pred_edges[0].from_node_id)
             if pred_node and pred_node.closing_stock is not None:
                 opening_stock = pred_node.closing_stock
         else:
             # First bucket — find on-hand supply nodes for this item/location
             # OnHandSupply nodes connect via 'replenishes' edge too, but at bucket 0
             # Check for any on-hand node feeding into this PI node
-            oh_edges = self._store.get_edges_to(node_id, scenario_id, edge_type="replenishes")
+            oh_edges = _get_edges_to(node_id, "replenishes")
             for edge in oh_edges:
-                src_node = self._store.get_node(edge.from_node_id, scenario_id)
+                src_node = _get_node(edge.from_node_id)
                 if src_node and src_node.node_type == "OnHandSupply":
                     opening_stock += src_node.quantity or Decimal("0")
 
@@ -338,9 +423,9 @@ class PropagationEngine:
         # as both opening_stock AND an inflow, producing incorrect projections.
         # ------------------------------------------------------------------
         supply_events: list = []
-        replenish_edges = self._store.get_edges_to(node_id, scenario_id, edge_type="replenishes")
+        replenish_edges = _get_edges_to(node_id, "replenishes")
         for edge in replenish_edges:
-            src_node = self._store.get_node(edge.from_node_id, scenario_id)
+            src_node = _get_node(edge.from_node_id)
             if src_node is None:
                 continue
             if src_node.node_type in ("PurchaseOrderSupply", "WorkOrderSupply",
@@ -354,9 +439,9 @@ class PropagationEngine:
         # 3. Demand events: nodes connected via 'consumes' to this PI node
         # ------------------------------------------------------------------
         demand_events: list = []
-        consume_edges = self._store.get_edges_to(node_id, scenario_id, edge_type="consumes")
+        consume_edges = _get_edges_to(node_id, "consumes")
         for edge in consume_edges:
-            src_node = self._store.get_node(edge.from_node_id, scenario_id)
+            src_node = _get_node(edge.from_node_id)
             if src_node is None:
                 continue
             if src_node.node_type in ("ForecastDemand", "CustomerOrderDemand",
@@ -460,19 +545,32 @@ class PropagationEngine:
         # ------------------------------------------------------------------
         if self._shortage_detector is not None:
             try:
-                # Reload node to get freshly persisted state
-                fresh_node = self._store.get_node(node_id, scenario_id)
-                if fresh_node is not None:
-                    safety_stock = self._get_safety_stock(fresh_node, db)
-                    shortage = self._shortage_detector.detect_with_params(
-                        pi_node=fresh_node,
-                        calc_run_id=calc_run_id,
-                        scenario_id=scenario_id,
-                        db=db,
-                        safety_stock_qty=safety_stock,
+                # The persisted state mirrors `result` for the computed PI fields.
+                # Mutate the in-memory node with those values instead of reloading
+                # from the DB (saves one query per PI node — see REVIEW-2026-05 R2).
+                node.opening_stock = result["opening_stock"]
+                node.inflows = result["inflows"]
+                node.outflows = result["outflows"]
+                node.closing_stock = result["closing_stock"]
+                node.has_shortage = result["has_shortage"]
+                node.shortage_qty = result["shortage_qty"]
+
+                if safety_stock_cache is not None and node.item_id is not None:
+                    safety_stock = (
+                        safety_stock_cache.get((node.item_id, node.location_id))
+                        or safety_stock_cache.get((node.item_id, None))
                     )
-                    if shortage is not None:
-                        self._shortage_detector.persist(shortage, db)
+                else:
+                    safety_stock = self._get_safety_stock(node, db)
+                shortage = self._shortage_detector.detect_with_params(
+                    pi_node=node,
+                    calc_run_id=calc_run_id,
+                    scenario_id=scenario_id,
+                    db=db,
+                    safety_stock_qty=safety_stock,
+                )
+                if shortage is not None:
+                    self._shortage_detector.persist(shortage, db)
             except Exception as exc:  # noqa: BLE001
                 # Shortage detection failure must never break the propagation pipeline
                 logger.warning(

--- a/tests/test_propagator.py
+++ b/tests/test_propagator.py
@@ -691,7 +691,11 @@ class TestPropagate:
 
         store = MagicMock()
         pi_node = _make_node(node_id=node_id, scenario_id=scenario_id, node_type="ProjectedInventory")
-        store.get_node.return_value = pi_node
+        # _propagate now batch-loads via get_nodes_by_ids; preserve a sensible
+        # default for get_edges_to_nodes (no edges) so the source-node fetch
+        # doesn't barf.
+        store.get_nodes_by_ids.return_value = {node_id: pi_node}
+        store.get_edges_to_nodes.return_value = {}
 
         traversal = MagicMock()
         traversal.topological_sort.return_value = [node_id]
@@ -715,7 +719,8 @@ class TestPropagate:
 
         store = MagicMock()
         pi_node = _make_node(node_id=node_id, scenario_id=scenario_id, node_type="ProjectedInventory")
-        store.get_node.return_value = pi_node
+        store.get_nodes_by_ids.return_value = {node_id: pi_node}
+        store.get_edges_to_nodes.return_value = {}
 
         traversal = MagicMock()
         traversal.topological_sort.return_value = [node_id]
@@ -734,7 +739,8 @@ class TestPropagate:
 
         store = MagicMock()
         node = _make_node(node_id=node_id, scenario_id=scenario_id, node_type="ForecastDemand")
-        store.get_node.return_value = node
+        store.get_nodes_by_ids.return_value = {node_id: node}
+        store.get_edges_to_nodes.return_value = {}
 
         traversal = MagicMock()
         traversal.topological_sort.return_value = [node_id]
@@ -751,7 +757,9 @@ class TestPropagate:
         run = _make_calc_run(scenario_id=scenario_id)
 
         store = MagicMock()
-        store.get_node.return_value = None
+        # No node found in the batch pre-load → dirty flag is cleared anyway.
+        store.get_nodes_by_ids.return_value = {}
+        store.get_edges_to_nodes.return_value = {}
 
         traversal = MagicMock()
         traversal.topological_sort.return_value = [node_id]
@@ -766,9 +774,13 @@ class TestPropagate:
         scenario_id = uuid4()
         node_a = uuid4()
         node_b = uuid4()
+        node_a_obj = _make_node(node_id=node_a, scenario_id=scenario_id, node_type="ForecastDemand")
         run = _make_calc_run(scenario_id=scenario_id)
 
         store = MagicMock()
+        # Only node_a is in the dirty set, so the pre-load only contains it.
+        store.get_nodes_by_ids.return_value = {node_a: node_a_obj}
+        store.get_edges_to_nodes.return_value = {}
         traversal = MagicMock()
         # topo sort returns both, but only node_a is in dirty set
         traversal.topological_sort.return_value = [node_a, node_b]
@@ -777,8 +789,8 @@ class TestPropagate:
         engine = _make_engine(store=store, traversal=traversal, dirty=dirty)
 
         engine._propagate(run, {node_a}, _mock_db())
-        # node_b should be skipped; get_node called only for node_a
-        assert store.get_node.call_count == 1
+        # node_b should be skipped; clear_dirty called only for node_a
+        assert dirty.clear_dirty.call_count == 1
 
 
 # ===========================================================================
@@ -1802,7 +1814,12 @@ class TestRecomputePiNode:
         # Should NOT raise
         engine._recompute_pi_node(node_id, scenario_id, uuid4(), _mock_db())
 
-    def test_shortage_detector_fresh_node_none_skips(self):
+    def test_shortage_detector_receives_computed_result_values(self):
+        """After REVIEW-2026-05 R2, the shortage detector reads the in-memory
+        node mutated with the just-computed result instead of reloading it
+        from the store. Confirm the detector sees the new closing_stock,
+        not the pre-compute value.
+        """
         scenario_id = uuid4()
         node_id = uuid4()
 
@@ -1812,21 +1829,21 @@ class TestRecomputePiNode:
             node_type="ProjectedInventory",
             time_span_start=date(2025, 1, 1),
             time_span_end=date(2025, 1, 7),
+            closing_stock=Decimal("0"),  # pre-compute baseline
         )
 
         store = MagicMock()
-        # First get_node returns pi_node, then None for fresh reload
-        store.get_node.side_effect = [pi_node, None]
+        store.get_node.return_value = pi_node
         store.get_edges_to.return_value = []
 
         kernel = MagicMock()
         kernel.compute_pi_node.return_value = {
             "opening_stock": Decimal("0"),
             "inflows": Decimal("0"),
-            "outflows": Decimal("0"),
-            "closing_stock": Decimal("0"),
-            "has_shortage": False,
-            "shortage_qty": Decimal("0"),
+            "outflows": Decimal("100"),
+            "closing_stock": Decimal("-100"),
+            "has_shortage": True,
+            "shortage_qty": Decimal("100"),
         }
 
         shortage_detector = MagicMock()
@@ -1834,7 +1851,13 @@ class TestRecomputePiNode:
             store=store, kernel=kernel, shortage_detector=shortage_detector,
         )
         engine._recompute_pi_node(node_id, scenario_id, uuid4(), _mock_db())
-        shortage_detector.detect_with_params.assert_not_called()
+
+        # Detector must have been called with the freshly-mutated pi_node
+        shortage_detector.detect_with_params.assert_called_once()
+        call_node = shortage_detector.detect_with_params.call_args.kwargs["pi_node"]
+        assert call_node.closing_stock == Decimal("-100")
+        assert call_node.has_shortage is True
+        assert call_node.shortage_qty == Decimal("100")
 
     def test_demand_uses_time_span_start_when_time_ref_none(self):
         """demand_date = src_node.time_ref or src_node.time_span_start"""


### PR DESCRIPTION
## Summary

Closes the last open Critique item of [REVIEW-2026-05](docs/REVIEW-2026-05.md) (R2). The propagation hot path used to issue 10–20 SQL queries per dirty PI node — 75s+ at the 500-item SMB scale. Refactor pre-loads everything `_propagate` needs in 4 batch queries up front, then reads from in-memory caches.

**Measured against a fresh PostgreSQL via `scripts/bench_propagation.py`:**

| Scale | Dirty PI | Before | After | Speedup |
|---|---|---|---|---|
| 10 items × 14 buckets | 140 | 1,421 queries / 5.8s | 285 / 1.2s | **4.8×** |
| 50 items × 30 buckets | 1,500 | 15,101 / 61.8s | 3,005 / 12.0s | **5.1×** |

Queries per node drops from 10.07 to 2.0; scaling stays linear.

## What changed

- `engine/kernel/graph/store.py` — two new batch readers (`get_nodes_by_ids`, `get_edges_to_nodes`)
- `engine/orchestration/propagator.py:_propagate` — 4-query pre-load (dirty nodes, incoming edges, edge-source nodes, safety stocks) before the loop
- `_recompute_pi_node` — accepts the caches as optional kwargs; falls back to per-call store lookups when called standalone (backwards-compatible)
- Shortage detection no longer reloads via the store — uses the in-memory `node` mutated with the freshly computed result fields
- `scripts/bench_propagation.py` — the before/after harness (parametric `--items N --buckets M`, recreates an isolated `ootils_test_bench` DB)
- `docs/SCALABILITY.md` BP#1 marked Fixed with the measured numbers and projected costs
- `docs/REVIEW-2026-05.md` R2 → Resolved (dashboard updated)

## Test plan

- [x] 1708 unit tests pass (`pytest tests/ --ignore=tests/integration`)
- [x] 186/186 integration tests pass against a fresh PostgreSQL
- [x] Bench at small (140 PI) and pilot (1500 PI) scale — see numbers above
- [ ] CI green
- [ ] (Optional follow-up) Tier 2 levers — batched `UPDATE … FROM (VALUES …)` writes, single `DELETE` clear, Rust kernel (issue #197)

## Compatibility notes

- `_recompute_pi_node` signature gained three optional kwargs (`nodes_cache`, `edges_by_target`, `safety_stock_cache`). Existing callers that don't supply them get the slower per-call lookups — no breakage.
- 5 propagator unit tests adapted to mock the new batch methods. One obsolete test ("fresh reload returns None should skip detector") was rewritten to verify the new contract: the detector sees the mutated `node` with the just-computed result.

## Out of scope

- Tier 2 perf work (batched writes, single delete, Rust extension) — left as future improvements in SCALABILITY.md BP#1.
- Concurrency / read replicas (issue #199, Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)