### PR TITLE
perf(engine): batch propagator writes — ~35× further speedup (R2 Tier 2)

### DIFF
--- a/docs/SCALABILITY.md
+++ b/docs/SCALABILITY.md
@@ -62,11 +62,37 @@ Throughput climbs from ~24 nodes/sec to ~125 nodes/sec, with `queries/node` drop
 
 The SMB tier no longer breaks; the mid-market tier becomes viable for batch runs even before further investment.
 
-#### Remaining levers (Tier 2 — not in scope of R2)
+#### Tier 2 — also shipped (2026-05-23)
 
-- Batch the `update_pi_result` writes (one `UPDATE … FROM (VALUES …)` instead of N executions).
-- Cap `clear_dirty` to a single `DELETE … WHERE node_id = ANY(%s)` at the end of the loop.
+After Tier 1, the hot path was bound by per-node round-trips (2 queries × ~4ms tunnel latency = ~8ms/node → ~125 nps ceiling). Tier 2 collapses those into a single round-trip per propagation run:
+
+- `update_pi_result` calls are accumulated and flushed via one
+  `UPDATE … FROM UNNEST(%s::uuid[], %s::numeric[], …)` at the end of
+  `_propagate`.
+- `clear_dirty` calls are batched into one
+  `DELETE FROM dirty_nodes WHERE node_id = ANY(%s)`.
+
+Result: **7 queries total per propagation regardless of dirty count**
+(4 pre-load + 1 safety-stock + 1 batched UPDATE + 1 batched DELETE).
+
+| Scale | Dirty PI | Tier 1 wall | Tier 2 wall | Tier 2 speedup vs Tier 1 |
+|-------|---------|-------------|-------------|--------------------------|
+| 140 nodes | 140 | 1.17 s | **0.12 s** | ~10× |
+| 1.5 K nodes | 1,500 | 11.5 s | **0.39 s** | ~30× |
+| 6 K nodes | 6,000 | 48.7 s | **1.40 s** | ~35× |
+| 15 K nodes | 15,000 | extrap. ≥120 s | **3.66 s** | ≥30× |
+
+Throughput climbs from ~125 nps (Tier 1) to **~4 000 nps** (Tier 2),
+the rate at which PostgreSQL can ingest a single bulk-update statement.
+Cumulative wall-time improvement vs the original pre-R2 implementation:
+**~50× at small scale, ≥150× at mid scale**.
+
+#### Still-open Tier 3 levers (deferred)
+
 - Push the kernel compute into a Rust extension (issue #197).
+- Batch the shortage-detector writes (currently 1 INSERT per shortage —
+  acceptable while shortages stay rare).
+- Streaming / pipelined propagation for very large dirty sets (>100 K).
 
 ---
 

--- a/src/ootils_core/engine/kernel/graph/dirty.py
+++ b/src/ootils_core/engine/kernel/graph/dirty.py
@@ -62,6 +62,32 @@ class DirtyFlagManager:
             (calc_run_id, node_id, scenario_id),
         )
 
+    def clear_dirty_batch(
+        self,
+        node_ids: list[UUID],
+        scenario_id: UUID,
+        calc_run_id: UUID,
+        db,
+    ) -> None:
+        """Clear many dirty flags in one DELETE.
+
+        Used by the propagator's batch write path — replaces N
+        per-node DELETEs with a single round-trip
+        (REVIEW-2026-05 R2 Tier 2 follow-up).
+        """
+        if not node_ids:
+            return
+        key = self._key(scenario_id, calc_run_id)
+        if key in self._dirty:
+            self._dirty[key].difference_update(node_ids)
+        db.execute(
+            """
+            DELETE FROM dirty_nodes
+            WHERE calc_run_id = %s AND scenario_id = %s AND node_id = ANY(%s)
+            """,
+            (calc_run_id, scenario_id, list(node_ids)),
+        )
+
     def get_dirty_nodes(
         self,
         calc_run_id: UUID,

--- a/src/ootils_core/engine/kernel/graph/store.py
+++ b/src/ootils_core/engine/kernel/graph/store.py
@@ -375,6 +375,63 @@ class GraphStore:
                 if neighbour not in visited:
                     stack.append(neighbour)
 
+    def update_pi_results_batch(
+        self,
+        updates: list[tuple],
+    ) -> int:
+        """Batch-persist PI computation results in a single UPDATE…FROM(VALUES…).
+
+        Each tuple in `updates` must be:
+            (node_id, scenario_id, calc_run_id,
+             opening_stock, inflows, outflows, closing_stock,
+             has_shortage, shortage_qty)
+
+        Replaces N round-trips with one. Used by the propagator's batch
+        write path (REVIEW-2026-05 R2 Tier 2 — see ADR-012 follow-up).
+        Returns the number of rows updated.
+        """
+        if not updates:
+            return 0
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc)
+        # Append `updated_at` to every tuple; psycopg renders the list-of-tuples
+        # as a VALUES clause natively when bound to %s.
+        rows = [(*u, now) for u in updates]
+        result = self._conn.execute(
+            """
+            UPDATE nodes AS n SET
+                opening_stock    = v.opening_stock,
+                inflows          = v.inflows,
+                outflows         = v.outflows,
+                closing_stock    = v.closing_stock,
+                has_shortage     = v.has_shortage,
+                shortage_qty     = v.shortage_qty,
+                is_dirty         = FALSE,
+                last_calc_run_id = v.calc_run_id,
+                updated_at       = v.updated_at
+            FROM (
+                SELECT *
+                FROM UNNEST(
+                    %s::uuid[],     %s::uuid[],     %s::uuid[],
+                    %s::numeric[],  %s::numeric[],  %s::numeric[],  %s::numeric[],
+                    %s::boolean[],  %s::numeric[],
+                    %s::timestamptz[]
+                ) AS t(
+                    node_id, scenario_id, calc_run_id,
+                    opening_stock, inflows, outflows, closing_stock,
+                    has_shortage, shortage_qty,
+                    updated_at
+                )
+            ) AS v
+            WHERE n.node_id = v.node_id AND n.scenario_id = v.scenario_id
+            """,
+            tuple(
+                [r[i] for r in rows]
+                for i in range(10)
+            ),
+        )
+        return result.rowcount or 0
+
     def update_pi_result(
         self,
         node_id: UUID,

--- a/src/ootils_core/engine/orchestration/propagator.py
+++ b/src/ootils_core/engine/orchestration/propagator.py
@@ -311,13 +311,18 @@ class PropagationEngine:
         # Remaining dirty set (may shrink as we process)
         remaining_dirty = set(dirty_nodes)
 
+        # Accumulators for batched writes — one round-trip at the end of the
+        # loop instead of two per node. See REVIEW-2026-05 R2 Tier 2.
+        pending_updates: list[tuple] = []
+        cleared_dirty: list[UUID] = []
+
         for node_id in ordered:
             if node_id not in remaining_dirty:
                 continue  # Already cleared (e.g., cascaded out of window)
 
             node = nodes_cache.get(node_id)
             if node is None:
-                self._dirty.clear_dirty(node_id, scenario_id, calc_run.calc_run_id, db)
+                cleared_dirty.append(node_id)
                 remaining_dirty.discard(node_id)
                 continue
 
@@ -330,6 +335,7 @@ class PropagationEngine:
                     nodes_cache=nodes_cache,
                     edges_by_target=edges_by_target,
                     safety_stock_cache=safety_stock_cache,
+                    pending_updates=pending_updates,
                 )
                 if changed:
                     calc_run.nodes_recalculated += 1
@@ -339,9 +345,17 @@ class PropagationEngine:
                 # Non-PI nodes don't need kernel computation — just mark as processed
                 calc_run.nodes_unchanged += 1
 
-            # Clear dirty flag
-            self._dirty.clear_dirty(node_id, scenario_id, calc_run.calc_run_id, db)
+            cleared_dirty.append(node_id)
             remaining_dirty.discard(node_id)
+
+        # ------------------------------------------------------------------
+        # FLUSH: one UPDATE…FROM(VALUES…) for results, one DELETE…ANY(…) for
+        # dirty-flag cleanup. Replaces N round-trips with 2.
+        # ------------------------------------------------------------------
+        if pending_updates:
+            self._store.update_pi_results_batch(pending_updates)
+        if cleared_dirty:
+            self._dirty.clear_dirty_batch(cleared_dirty, scenario_id, calc_run.calc_run_id, db)
 
     def _recompute_pi_node(
         self,
@@ -352,6 +366,7 @@ class PropagationEngine:
         nodes_cache: Optional[dict[UUID, Optional[Node]]] = None,
         edges_by_target: Optional[dict[UUID, dict[str, list]]] = None,
         safety_stock_cache: Optional[dict[tuple[UUID, Optional[UUID]], Decimal]] = None,
+        pending_updates: Optional[list[tuple]] = None,
     ) -> bool:
         """
         Recompute a single PI node.
@@ -504,18 +519,29 @@ class PropagationEngine:
 
         # ------------------------------------------------------------------
         # 6. Persist via GraphStore (all DB writes go through the store layer)
+        # When called from the batched _propagate loop, pending_updates is a
+        # list — accumulate and let the caller flush in one UPDATE…FROM(VALUES).
+        # When called standalone (tests, legacy paths), pending_updates is None
+        # → write immediately to preserve the original contract.
         # ------------------------------------------------------------------
-        self._store.update_pi_result(
-            node_id=node_id,
-            scenario_id=scenario_id,
-            calc_run_id=calc_run_id,
-            opening_stock=result["opening_stock"],
-            inflows=result["inflows"],
-            outflows=result["outflows"],
-            closing_stock=result["closing_stock"],
-            has_shortage=result["has_shortage"],
-            shortage_qty=result["shortage_qty"],
-        )
+        if pending_updates is not None:
+            pending_updates.append((
+                node_id, scenario_id, calc_run_id,
+                result["opening_stock"], result["inflows"], result["outflows"],
+                result["closing_stock"], result["has_shortage"], result["shortage_qty"],
+            ))
+        else:
+            self._store.update_pi_result(
+                node_id=node_id,
+                scenario_id=scenario_id,
+                calc_run_id=calc_run_id,
+                opening_stock=result["opening_stock"],
+                inflows=result["inflows"],
+                outflows=result["outflows"],
+                closing_stock=result["closing_stock"],
+                has_shortage=result["has_shortage"],
+                shortage_qty=result["shortage_qty"],
+            )
 
         # ------------------------------------------------------------------
         # 7. Explainability (Sprint M3) — inline causal chain generation

--- a/tests/test_propagator.py
+++ b/tests/test_propagator.py
@@ -710,7 +710,9 @@ class TestPropagate:
         engine._propagate(run, {node_id}, _mock_db())
 
         assert run.nodes_recalculated == 1
-        dirty.clear_dirty.assert_called_once()
+        # Batched flush: one DELETE…ANY(…) at the end of _propagate replaces
+        # the per-node clear_dirty round-trips.
+        dirty.clear_dirty_batch.assert_called_once()
 
     def test_pi_node_unchanged_increments_unchanged(self):
         scenario_id = uuid4()
@@ -768,7 +770,11 @@ class TestPropagate:
         engine = _make_engine(store=store, traversal=traversal, dirty=dirty)
 
         engine._propagate(run, {node_id}, _mock_db())
-        dirty.clear_dirty.assert_called_once()
+        # Even when the node isn't found in the cache, its dirty flag is
+        # cleared via the batched flush at the end of _propagate.
+        dirty.clear_dirty_batch.assert_called_once()
+        node_ids_arg = dirty.clear_dirty_batch.call_args.args[0]
+        assert node_id in node_ids_arg
 
     def test_node_not_in_remaining_dirty_skipped(self):
         scenario_id = uuid4()
@@ -789,8 +795,10 @@ class TestPropagate:
         engine = _make_engine(store=store, traversal=traversal, dirty=dirty)
 
         engine._propagate(run, {node_a}, _mock_db())
-        # node_b should be skipped; clear_dirty called only for node_a
-        assert dirty.clear_dirty.call_count == 1
+        # node_b should be skipped; the batched DELETE includes only node_a.
+        dirty.clear_dirty_batch.assert_called_once()
+        node_ids_arg = dirty.clear_dirty_batch.call_args.args[0]
+        assert list(node_ids_arg) == [node_a]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

After [#222](https://github.com/ngoineau/ootils-core/pull/222) (R2 Tier 1) cut per-node queries from ~10 to 2, the propagation hot path became **bound by network round-trip latency**: 2 queries × ~4ms tunnel × N nodes = a hard ~125 nps ceiling regardless of CPU. This PR collapses the two remaining per-node writes (`update_pi_result`, `clear_dirty`) into one batched flush at the end of `_propagate`.

**Result: ~4000 nps throughput, 7 queries constant** regardless of dirty-node count.

## Measured (`scripts/bench_propagation.py`)

| Scale | Dirty PI | Pre-Tier-2 wall | Tier 2 wall | Speedup vs Tier 1 |
|---|---|---|---|---|
| 140 nodes | 140 | 1.17 s | **0.12 s** | ~10× |
| 1.5 K nodes | 1,500 | 11.5 s | **0.39 s** | ~30× |
| 6 K nodes | 6,000 | 48.7 s | **1.40 s** | ~35× |
| 15 K nodes | 15,000 | extrap. ≥120 s | **3.66 s** | ≥30× |

**Cumulative gain vs pre-R2 main**: ~50× at small scale, ≥150× at mid scale.

## What's in this PR

- **`engine/kernel/graph/store.py`** — new `update_pi_results_batch(updates: list[tuple])`. One `UPDATE … FROM UNNEST(%s::uuid[], %s::numeric[], …) AS v` covering every modified PI node.
- **`engine/kernel/graph/dirty.py`** — new `clear_dirty_batch(node_ids: list[UUID], …)`. One `DELETE … WHERE node_id = ANY(%s)`.
- **`engine/orchestration/propagator.py:_propagate`** — accumulates `pending_updates: list[tuple]` and `cleared_dirty: list[UUID]` during the per-node loop, then invokes the two batch methods once at the end.
- **`_recompute_pi_node`** — takes an optional `pending_updates` kwarg. When provided (the batched path), it appends instead of writing; otherwise it falls back to the original single-row `store.update_pi_result` — keeps the standalone test signature working.

Per-propagation query budget: **7 queries**, constant in N (4 pre-load + 1 safety-stock + 1 batched UPDATE + 1 batched DELETE).

## Test plan

- [x] 1708 unit tests pass (3 propagator tests updated: assert `clear_dirty_batch` instead of `clear_dirty`)
- [x] 185/185 integration tests pass against fresh PostgreSQL (excluding `test_phase1_forecast_mps_crp_atp_rest_e2e` — pre-existing forecast-min-history flake that reproduces on `main`)
- [x] Bench: 4 scales (140, 1.5K, 6K, 15K nodes) all green
- [ ] CI

## Out of scope (Tier 3 — future)

- Rust kernel extension (issue #197)
- Batch the shortage-detector writes (1 INSERT per shortage today — acceptable while shortages stay rare)
- Streaming / pipelined propagation for >100K dirty sets

## Notes

- Within a single transaction, the in-memory `node` mutation (cycle 14 of #221) is already what the shortage detector reads — no observable order change.
- The orphan-edge integrity check that runs at the end of `_copy_nodes` (from #223) is unaffected; this PR doesn't touch scenario forking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)