### PR TITLE
chore(bench): bulk seed in bench_propagation + Tier 3 perf landscape

### DIFF
--- a/docs/SCALABILITY.md
+++ b/docs/SCALABILITY.md
@@ -89,10 +89,40 @@ Cumulative wall-time improvement vs the original pre-R2 implementation:
 
 #### Still-open Tier 3 levers (deferred)
 
-- Push the kernel compute into a Rust extension (issue #197).
+After Tier 2, the propagation hot path is no longer network-bound — it sits
+at ~3 200 nps because the per-node Python loop (`kernel.compute_pi_node` +
+`shortage_detector.detect_with_params` + cache lookups + list appends) takes
+~0.3 ms per PI node and runs N times. The remaining levers are
+**compute-bound**, not query-bound:
+
+- **Pure SQL projection** — rewrite `compute_pi_node` as a `WITH RECURSIVE`
+  / window-function pipeline in PostgreSQL. All compute server-side in one
+  statement, zero Python round-trips per node. Largest expected gain (~50×)
+  but a serious refactor: requires bit-exact parity tests between the SQL
+  and the Python kernel, and pulls explainability into SQL too.
+- **NumPy vectorisation per series** — each projection series is internally
+  sequential (every bucket reads the predecessor's `closing_stock`) but
+  series are mutually independent. Process series in a vectorised NumPy
+  loop using prefix sums for the running stock. ~10× expected, medium refactor.
+- **Rust kernel via PyO3** — issue #197. Same algorithm, native code.
+  ~30× expected, heavier build/CI lift.
 - Batch the shortage-detector writes (currently 1 INSERT per shortage —
   acceptable while shortages stay rare).
-- Streaming / pipelined propagation for very large dirty sets (>100 K).
+- Streaming / pipelined propagation for very large dirty sets (>1 M).
+
+#### Measured perf landscape (2026-05-23, post-Tier-2)
+
+| Horizon × Items | PI nodes | Propagation wall | Throughput |
+|---|---|---|---|
+| 90 d × 50 | 1.5 K | 0.39 s | 3 800 nps |
+| 90 d × 500 | 15 K | 3.7 s | 4 090 nps |
+| 365 d × 100 | 36.5 K | 8.9 s | 4 094 nps |
+| 365 d × 500 (SMB) | 182.5 K | 53 s | 3 420 nps |
+| 365 d × 2 000 (mid-market) | 730 K | 3.8 min | 3 187 nps |
+
+Extrapolated 2-year × 5 K items (~3.6 M nodes) ≈ 19 min. The Tier 3 levers
+target this range — anything beyond ~1 M PI nodes is where Python compute
+becomes the dominant cost.
 
 ---
 

--- a/scripts/bench_propagation.py
+++ b/scripts/bench_propagation.py
@@ -59,6 +59,10 @@ def _apply_migrations(dsn: str) -> None:
 def _seed(conn: psycopg.Connection, items: int, buckets: int) -> dict:
     """Insert items, locations, PI nodes, on-hand supplies, and feeds_forward edges.
 
+    Uses bulk INSERT…SELECT against `UNNEST` arrays so the seed itself
+    does not become the bottleneck at large scale. Without this, seeding
+    100×365 (~73K rows) took ~280s; with bulk it takes <10s.
+
     Returns a summary dict (counts).
     """
     started = time.perf_counter()
@@ -72,88 +76,130 @@ def _seed(conn: psycopg.Connection, items: int, buckets: int) -> dict:
         (location_id,),
     )
 
-    item_ids: list[UUID] = []
+    # 1. Items — single bulk INSERT
+    item_ids: list[UUID] = [uuid4() for _ in range(items)]
+    item_names: list[str] = [f"BENCH-ITEM-{i:05d}" for i in range(items)]
+    conn.execute(
+        "INSERT INTO items (item_id, name) SELECT * FROM UNNEST(%s::uuid[], %s::text[])",
+        (item_ids, item_names),
+    )
+
+    # 2. projection_series — one per item, bulk
+    series_ids: list[UUID] = [uuid4() for _ in range(items)]
+    conn.execute(
+        """
+        INSERT INTO projection_series
+            (series_id, item_id, location_id, scenario_id, horizon_start, horizon_end)
+        SELECT *
+        FROM UNNEST(
+            %s::uuid[], %s::uuid[],
+            ARRAY_FILL(%s::uuid, ARRAY[%s]),
+            ARRAY_FILL(%s::uuid, ARRAY[%s]),
+            ARRAY_FILL(%s::date, ARRAY[%s]),
+            ARRAY_FILL(%s::date, ARRAY[%s])
+        )
+        """,
+        (
+            series_ids, item_ids,
+            location_id, items,
+            BASELINE_SCENARIO_ID, items,
+            horizon_start, items,
+            horizon_end, items,
+        ),
+    )
+
+    # 3. OnHandSupply nodes — one per item, bulk
+    oh_ids: list[UUID] = [uuid4() for _ in range(items)]
+    conn.execute(
+        """
+        INSERT INTO nodes
+            (node_id, node_type, scenario_id, item_id, location_id,
+             quantity, qty_uom, time_grain, time_ref, is_dirty, active)
+        SELECT
+            oh.id, 'OnHandSupply', %s, oh.item_id, %s,
+            100, 'EA', 'exact_date', %s, FALSE, TRUE
+        FROM UNNEST(%s::uuid[], %s::uuid[]) AS oh(id, item_id)
+        """,
+        (
+            BASELINE_SCENARIO_ID, location_id, horizon_start,
+            oh_ids, item_ids,
+        ),
+    )
+
+    # 4. PI nodes — items × buckets bulk INSERT via cross join in SQL
+    # We pre-generate UUIDs in Python (gen_random_uuid would also work,
+    # but explicit ids let us also bulk-insert the matching edges below).
+    pi_node_count = items * buckets
+    pi_ids: list[UUID] = [uuid4() for _ in range(pi_node_count)]
+    # Build flat arrays: row i = item_index * buckets + bucket_index
+    item_id_per_pi: list[UUID] = []
+    series_id_per_pi: list[UUID] = []
+    bucket_start_per_pi: list = []
+    bucket_end_per_pi: list = []
+    bucket_seq_per_pi: list[int] = []
     for i in range(items):
-        item_id = uuid4()
-        item_ids.append(item_id)
-        conn.execute(
-            "INSERT INTO items (item_id, name) VALUES (%s, %s)",
-            (item_id, f"BENCH-ITEM-{i:05d}"),
-        )
-
-    # One projection_series per item
-    pi_node_count = 0
-    edge_count = 0
-    for item_id in item_ids:
-        series_id = uuid4()
-        conn.execute(
-            """
-            INSERT INTO projection_series
-                (series_id, item_id, location_id, scenario_id, horizon_start, horizon_end)
-            VALUES (%s, %s, %s, %s, %s, %s)
-            """,
-            (series_id, item_id, location_id, BASELINE_SCENARIO_ID, horizon_start, horizon_end),
-        )
-
-        # On-hand supply at horizon_start (provides opening_stock for first bucket)
-        oh_id = uuid4()
-        conn.execute(
-            """
-            INSERT INTO nodes
-                (node_id, node_type, scenario_id, item_id, location_id,
-                 quantity, qty_uom, time_grain, time_ref, is_dirty, active)
-            VALUES (%s, 'OnHandSupply', %s, %s, %s, %s, 'EA', 'exact_date', %s, FALSE, TRUE)
-            """,
-            (oh_id, BASELINE_SCENARIO_ID, item_id, location_id, Decimal("100"), horizon_start),
-        )
-
-        # PI buckets — daily grain
-        prev_pi_id: UUID | None = None
         for b in range(buckets):
-            pi_id = uuid4()
-            bucket_start = horizon_start + timedelta(days=b)
-            bucket_end = bucket_start + timedelta(days=1)
-            conn.execute(
-                """
-                INSERT INTO nodes
-                    (node_id, node_type, scenario_id, item_id, location_id,
-                     time_grain, time_span_start, time_span_end,
-                     projection_series_id, bucket_sequence,
-                     is_dirty, active)
-                VALUES (%s, 'ProjectedInventory', %s, %s, %s,
-                        'day', %s, %s, %s, %s, TRUE, TRUE)
-                """,
-                (pi_id, BASELINE_SCENARIO_ID, item_id, location_id,
-                 bucket_start, bucket_end, series_id, b),
-            )
-            pi_node_count += 1
+            item_id_per_pi.append(item_ids[i])
+            series_id_per_pi.append(series_ids[i])
+            bucket_start_per_pi.append(horizon_start + timedelta(days=b))
+            bucket_end_per_pi.append(horizon_start + timedelta(days=b + 1))
+            bucket_seq_per_pi.append(b)
 
-            # feeds_forward edge from previous bucket
-            if prev_pi_id is not None:
-                edge_id = uuid4()
-                conn.execute(
-                    """
-                    INSERT INTO edges
-                        (edge_id, edge_type, from_node_id, to_node_id, scenario_id, active)
-                    VALUES (%s, 'feeds_forward', %s, %s, %s, TRUE)
-                    """,
-                    (edge_id, prev_pi_id, pi_id, BASELINE_SCENARIO_ID),
-                )
-                edge_count += 1
-            else:
-                # On-hand replenishes the first PI bucket
-                edge_id = uuid4()
-                conn.execute(
-                    """
-                    INSERT INTO edges
-                        (edge_id, edge_type, from_node_id, to_node_id, scenario_id, active)
-                    VALUES (%s, 'replenishes', %s, %s, %s, TRUE)
-                    """,
-                    (edge_id, oh_id, pi_id, BASELINE_SCENARIO_ID),
-                )
-                edge_count += 1
+    conn.execute(
+        """
+        INSERT INTO nodes
+            (node_id, node_type, scenario_id, item_id, location_id,
+             time_grain, time_span_start, time_span_end,
+             projection_series_id, bucket_sequence,
+             is_dirty, active)
+        SELECT
+            pi.id, 'ProjectedInventory', %s, pi.item_id, %s,
+            'day', pi.bs, pi.be, pi.series_id, pi.seq,
+            TRUE, TRUE
+        FROM UNNEST(
+            %s::uuid[], %s::uuid[], %s::date[], %s::date[],
+            %s::uuid[], %s::int[]
+        ) AS pi(id, item_id, bs, be, series_id, seq)
+        """,
+        (
+            BASELINE_SCENARIO_ID, location_id,
+            pi_ids, item_id_per_pi, bucket_start_per_pi, bucket_end_per_pi,
+            series_id_per_pi, bucket_seq_per_pi,
+        ),
+    )
 
-            prev_pi_id = pi_id
+    # 5. Edges — 'replenishes' from OnHand to first PI bucket + 'feeds_forward'
+    # between consecutive PI buckets within each series.
+    edge_count = pi_node_count  # 1 'replenishes' per item + (buckets-1) 'feeds_forward' per item = items*buckets total
+    edge_ids: list[UUID] = [uuid4() for _ in range(edge_count)]
+    edge_types: list[str] = []
+    edge_from: list[UUID] = []
+    edge_to: list[UUID] = []
+    for i in range(items):
+        base = i * buckets
+        # First edge: OnHand → first PI bucket
+        edge_types.append("replenishes")
+        edge_from.append(oh_ids[i])
+        edge_to.append(pi_ids[base])
+        # Next: feeds_forward between consecutive PI buckets
+        for b in range(1, buckets):
+            edge_types.append("feeds_forward")
+            edge_from.append(pi_ids[base + b - 1])
+            edge_to.append(pi_ids[base + b])
+
+    conn.execute(
+        """
+        INSERT INTO edges
+            (edge_id, edge_type, from_node_id, to_node_id, scenario_id, active)
+        SELECT
+            e.id, e.type, e.frm, e.dest, %s, TRUE
+        FROM UNNEST(%s::uuid[], %s::text[], %s::uuid[], %s::uuid[]) AS e(id, type, frm, dest)
+        """,
+        (
+            BASELINE_SCENARIO_ID,
+            edge_ids, edge_types, edge_from, edge_to,
+        ),
+    )
 
     conn.commit()
     elapsed = time.perf_counter() - started


### PR DESCRIPTION
## Summary

Two improvements out of the perf-re-test session:

1. **Bulk seed in `scripts/bench_propagation.py`** — the seed itself was a per-row-INSERT loop, taking ~280 s to build the 100×365 fixture (bigger than the propagation under test). Rewrite as 5 bulk INSERTs over UNNEST arrays. Same fixture now seeds in <10 s.

2. **`docs/SCALABILITY.md` BP#1 updated** with the measured perf landscape post-Tier-2 + a "still-open Tier 3 levers" section.

## Measured perf table (added to SCALABILITY.md)

| Horizon × Items | PI nodes | Propagation wall | Throughput |
|---|---|---|---|
| 90 d × 50 | 1.5 K | 0.39 s | 3 800 nps |
| 90 d × 500 | 15 K | 3.7 s | 4 090 nps |
| 365 d × 100 | 36.5 K | 8.9 s | 4 094 nps |
| 365 d × 500 (SMB) | 182.5 K | 53 s | 3 420 nps |
| 365 d × 2 000 (mid-market) | 730 K | 3.8 min | 3 187 nps |

Linear in node count. ~3 200–4 000 nps holds from 1.5 K to 730 K nodes. **7 queries constant** regardless of size.

## Tier 3 — open levers

After Tier 2 ([#224](https://github.com/ngoineau/ootils-core/pull/224)), the hot path is no longer network-bound. The next ~10–50× would have to come from compute, not queries:

- **Pure-SQL projection** — rewrite `compute_pi_node` as a `WITH RECURSIVE` / window-function pipeline. Largest expected gain (~50×), serious refactor + parity tests.
- **NumPy vectorisation per series** — series are independent; process them in a vectorised loop using prefix sums for running stock. ~10× expected.
- **Rust kernel via PyO3** — issue #197. ~30× expected.

No engine code path changes in this PR — only the bench script and the SCALABILITY doc.

## Test plan

- [x] Sanity bench (`--items 10 --buckets 14`) passes: 0.07 s, 7 queries
- [x] Larger benches reproduce the table above
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)