### PR TITLE
feat(seed): phase 7 — projection graph + propagation + OH calibration (final)

### DIFF
--- a/scripts/seed_realistic_dataset.py
+++ b/scripts/seed_realistic_dataset.py
@@ -63,6 +63,8 @@ from ootils_core.seed.demand.order_history import (
     generate_order_history,
     insert_order_history,
 )
+from ootils_core.seed.projection.graph import seed_projection_graph
+from ootils_core.seed.projection.calibration import calibrate
 
 
 def _admin_recreate_db(dsn: str, dbname: str) -> None:
@@ -265,6 +267,48 @@ def _phase5_demand(
         "orders_gen_seconds": round(t_co_gen, 3),
         "forecast_insert_seconds": round(t_fc_ins, 3),
         "orders_insert_seconds": round(t_co_ins, 3),
+    }
+
+
+def _phase7_calibrate(conn, profile: Profile, items, locations) -> dict:
+    """Seed projection graph + propagate + iteratively calibrate OH for shortage target."""
+    t0 = time.perf_counter()
+    graph = seed_projection_graph(conn, items, locations, horizon_days=90)
+    t_graph = time.perf_counter() - t0
+
+    result = calibrate(
+        conn,
+        target_pct=profile.target_shortage_pct,
+        tolerance=0.02,
+        max_iterations=10,
+    )
+
+    return {
+        "horizon_days": (graph.horizon_end - graph.horizon_start).days,
+        "series_count": graph.series_count,
+        "pi_node_count": graph.pi_node_count,
+        "edges_total": graph.edges_total,
+        "feeds_forward": graph.feeds_forward_count,
+        "replenishes_oh": graph.replenishes_from_oh_count,
+        "replenishes_transfer": graph.replenishes_from_transfer_count,
+        "consumes_orders": graph.consumes_from_orders_count,
+        "consumes_forecasts": graph.consumes_from_forecasts_count,
+        "graph_seed_seconds": graph.seconds,
+        "calibration_iterations": [
+            {
+                "i": it.iteration,
+                "oh_scale_next": round(it.oh_scale_applied, 3),
+                "pi_total": it.pi_total,
+                "pi_short": it.pi_with_shortage,
+                "shortage_pct": round(it.shortage_pct * 100, 2),
+                "propagation_s": it.propagation_seconds,
+            }
+            for it in result.iterations
+        ],
+        "converged": result.converged,
+        "final_shortage_pct": round(result.final_shortage_pct * 100, 2),
+        "calibration_seconds": result.total_seconds,
+        "phase7_total_seconds": round(t_graph + result.total_seconds, 2),
     }
 
 
@@ -670,6 +714,7 @@ def main() -> int:
         validation_p5 = _validate_demand(conn)
         stats_p6 = _phase6_history(conn, profile, items_ref, locations_ref)
         validation_p6 = _validate_history(conn)
+        stats_p7 = _phase7_calibrate(conn, profile, items_ref, locations_ref)
 
     print()
     print("=" * 60)
@@ -756,6 +801,22 @@ def main() -> int:
     print("=" * 60)
     for k, v in validation_p6.items():
         print(f"  {k:35s}  {v}")
+
+    print()
+    print("=" * 60)
+    print("PHASE 7 — projection graph + propagation + OH calibration")
+    print("=" * 60)
+    for k, v in stats_p7.items():
+        if k == "calibration_iterations":
+            print(f"  {k}:")
+            for it in v:
+                scale_disp = "bootstrap-resize" if it["oh_scale_next"] != it["oh_scale_next"] else f"x{it['oh_scale_next']}"
+                label = "boot" if it["i"] == 0 else f"iter {it['i']}"
+                print(f"    {label}: PIs={it['pi_total']}  short={it['pi_short']}  "
+                      f"pct={it['shortage_pct']}%  prop={it['propagation_s']}s  "
+                      f"next OH {scale_disp}")
+        else:
+            print(f"  {k:30s}  {v}")
     return 0
 
 

--- a/src/ootils_core/seed/projection/__init__.py
+++ b/src/ootils_core/seed/projection/__init__.py
@@ -1,0 +1,1 @@
+"""Projection-graph generators: series + PI nodes + replenishes/consumes/feeds_forward edges."""

--- a/src/ootils_core/seed/projection/calibration.py
+++ b/src/ootils_core/seed/projection/calibration.py
@@ -1,0 +1,316 @@
+"""
+calibration.py — propagate + measure shortages + adjust OH iteratively.
+
+After the projection graph is seeded, this module:
+
+1. Marks all PI nodes dirty + starts a calc_run
+2. Runs the SQL propagation engine (the fast one — Tier 3)
+3. Measures the shortage rate over the just-computed PIs
+4. If outside the target band, scales all OnHandSupply quantities and reruns
+5. Stops when the band is hit or after `max_iterations`
+
+The OH scaling is a simple proportional controller — coarse but fast and
+deterministic. A future v2 could do per-(item, loc) calibration based on
+which series are short, but global scaling is enough to land in a 5-9% band.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from decimal import Decimal
+from uuid import UUID
+
+import psycopg
+
+from ootils_core.engine.kernel.graph.dirty import DirtyFlagManager
+from ootils_core.engine.orchestration.calc_run import CalcRunManager
+from ootils_core.engine.orchestration.propagator_sql import SqlPropagationEngine
+from ootils_core.seed.transactional.nodes import BASELINE_SCENARIO_ID
+
+
+@dataclass
+class CalibrationIteration:
+    iteration: int
+    oh_scale_applied: float
+    pi_total: int
+    pi_with_shortage: int
+    shortage_pct: float
+    propagation_seconds: float
+
+
+@dataclass
+class CalibrationResult:
+    iterations: list[CalibrationIteration]
+    converged: bool
+    final_shortage_pct: float
+    total_seconds: float
+
+
+def _measure_shortage_pct(conn: psycopg.Connection) -> tuple[int, int]:
+    """Return (pi_with_shortage, pi_total) for the baseline scenario."""
+    row = conn.execute(
+        """
+        SELECT
+            COUNT(*) FILTER (WHERE has_shortage = TRUE) AS short_n,
+            COUNT(*)                                    AS total_n
+        FROM nodes
+        WHERE node_type = 'ProjectedInventory'
+          AND scenario_id = %s
+          AND active = TRUE
+        """,
+        (BASELINE_SCENARIO_ID,),
+    ).fetchone()
+    return int(row["short_n"]), int(row["total_n"])
+
+
+def _mark_all_pi_dirty_and_start_run(conn: psycopg.Connection) -> tuple[UUID, set[UUID]]:
+    """Create a fresh calc_run, persist all active PIs as dirty under it."""
+    # Complete any prior running calc_run on this scenario so the advisory
+    # lock can be re-acquired.
+    conn.execute(
+        "UPDATE calc_runs SET status = 'completed', completed_at = now() "
+        "WHERE scenario_id = %s AND status = 'running'",
+        (BASELINE_SCENARIO_ID,),
+    )
+    conn.execute("DELETE FROM dirty_nodes WHERE scenario_id = %s", (BASELINE_SCENARIO_ID,))
+
+    pi_rows = conn.execute(
+        """
+        SELECT node_id FROM nodes
+        WHERE node_type = 'ProjectedInventory'
+          AND scenario_id = %s AND active = TRUE
+        """,
+        (BASELINE_SCENARIO_ID,),
+    ).fetchall()
+    pi_ids = {UUID(str(r["node_id"])) for r in pi_rows}
+
+    calc_mgr = CalcRunManager()
+    calc_run = calc_mgr.start_calc_run(
+        scenario_id=BASELINE_SCENARIO_ID, event_ids=[], db=conn,
+    )
+    assert calc_run is not None, "could not acquire advisory lock"
+    dirty = DirtyFlagManager()
+    dirty.mark_dirty(pi_ids, BASELINE_SCENARIO_ID, calc_run.calc_run_id, conn)
+    dirty.flush_to_postgres(calc_run.calc_run_id, BASELINE_SCENARIO_ID, conn)
+    conn.commit()
+    return calc_run.calc_run_id, pi_ids
+
+
+def _scale_on_hand(conn: psycopg.Connection, factor: float) -> int:
+    """Multiply every OnHandSupply.quantity by `factor`. Returns rowcount."""
+    cur = conn.execute(
+        """
+        UPDATE nodes SET quantity = quantity * %s::numeric, updated_at = now()
+        WHERE node_type = 'OnHandSupply'
+          AND scenario_id = %s
+          AND active = TRUE
+        """,
+        (Decimal(str(factor)), BASELINE_SCENARIO_ID),
+    )
+    conn.commit()
+    return cur.rowcount or 0
+
+
+def _build_sql_engine(conn: psycopg.Connection) -> SqlPropagationEngine:
+    from ootils_core.engine.kernel.graph.store import GraphStore
+    from ootils_core.engine.kernel.graph.traversal import GraphTraversal
+    from ootils_core.engine.kernel.calc.projection import ProjectionKernel
+    from ootils_core.engine.kernel.shortage.detector import ShortageDetector
+
+    store = GraphStore(conn)
+    return SqlPropagationEngine(
+        store=store,
+        traversal=GraphTraversal(store),
+        dirty=DirtyFlagManager(),
+        calc_run_mgr=CalcRunManager(),
+        kernel=ProjectionKernel(),
+        shortage_detector=ShortageDetector(),
+    )
+
+
+def _run_propagation(conn: psycopg.Connection) -> float:
+    """One full propagation pass on all dirty PIs. Returns wall_seconds."""
+    from ootils_core.models import CalcRun
+
+    calc_run_id, dirty = _mark_all_pi_dirty_and_start_run(conn)
+    engine = _build_sql_engine(conn)
+    row = conn.execute(
+        "SELECT * FROM calc_runs WHERE calc_run_id = %s",
+        (calc_run_id,),
+    ).fetchone()
+    calc_run = CalcRun(
+        calc_run_id=UUID(str(row["calc_run_id"])),
+        scenario_id=UUID(str(row["scenario_id"])),
+        triggered_by_event_ids=[],
+        is_full_recompute=bool(row.get("is_full_recompute", False)),
+        dirty_node_count=row.get("dirty_node_count"),
+        nodes_recalculated=int(row.get("nodes_recalculated", 0)),
+        nodes_unchanged=int(row.get("nodes_unchanged", 0)),
+        status=row.get("status", "running"),
+        started_at=row.get("started_at"),
+        completed_at=row.get("completed_at"),
+        error_message=row.get("error_message"),
+    )
+    started = time.perf_counter()
+    engine._propagate(calc_run, dirty, conn)
+    if engine._shortage_detector is not None:
+        engine._shortage_detector.resolve_stale(
+            scenario_id=BASELINE_SCENARIO_ID,
+            calc_run_id=calc_run_id,
+            db=conn,
+        )
+    # Close the calc_run cleanly so the next iteration can start a new one
+    conn.execute(
+        "UPDATE calc_runs SET status = 'completed', completed_at = now() "
+        "WHERE calc_run_id = %s",
+        (calc_run_id,),
+    )
+    conn.commit()
+    return time.perf_counter() - started
+
+
+def _bootstrap_oh_from_demand(
+    conn: psycopg.Connection,
+    horizon_days: int,
+    target_cover_days: int = 30,
+) -> int:
+    """One-shot rebalancing of OH based on the demand actually wired into the graph.
+
+    Reads total outflows per (item, location) over the horizon (after one
+    propagation), divides by horizon_days to get the daily average, and
+    sets OH = daily_avg * target_cover_days.
+
+    Returns the number of OH rows updated. Idempotent — calling it twice
+    just overwrites with the same target.
+    """
+    cur = conn.execute(
+        """
+        WITH demand_per_pair AS (
+            SELECT
+                pi.item_id,
+                pi.location_id,
+                COALESCE(SUM(pi.outflows), 0)::numeric / NULLIF(%s, 0) AS daily_demand
+            FROM nodes pi
+            WHERE pi.node_type = 'ProjectedInventory'
+              AND pi.scenario_id = %s
+              AND pi.active = TRUE
+              AND pi.outflows IS NOT NULL
+            GROUP BY pi.item_id, pi.location_id
+        )
+        UPDATE nodes oh
+        SET quantity = GREATEST(
+                COALESCE(dpp.daily_demand, 0) * %s::numeric,
+                oh.quantity
+            ),
+            updated_at = now()
+        FROM demand_per_pair dpp
+        WHERE oh.node_type = 'OnHandSupply'
+          AND oh.scenario_id = %s
+          AND oh.active = TRUE
+          AND oh.item_id = dpp.item_id
+          AND oh.location_id = dpp.location_id
+        """,
+        (horizon_days, BASELINE_SCENARIO_ID, target_cover_days, BASELINE_SCENARIO_ID),
+    )
+    conn.commit()
+    return cur.rowcount or 0
+
+
+def _next_oh_scale(pct: float, target_pct: float, tolerance: float) -> tuple[float, bool]:
+    """Pick the OH multiplier for the next iteration.
+
+    Symmetric log-step controller: scale up or down by similar magnitudes
+    so we don't overshoot massively then crawl back. Cap aggressive cases
+    so a single iteration can't push OH by more than ~2.5x in either
+    direction — keeps the trajectory monotonic-ish near the band.
+
+    Special case: when pct is exactly 0, gap-based reasoning breaks (the
+    signal is "more than enough OH"). Use a fixed aggressive downscale.
+    """
+    if abs(pct - target_pct) <= tolerance:
+        return 1.0, True
+    if pct > target_pct:
+        gap = pct - target_pct
+        if gap >= 0.50:
+            return 2.5, False
+        if gap >= 0.20:
+            return 1.8, False
+        if gap >= 0.10:
+            return 1.4, False
+        if gap >= 0.05:
+            return 1.15, False
+        return 1.05, False
+    # pct < target -> reduce OH
+    if pct < 0.005:
+        # Stuck at zero — system has way too much OH. Big symmetric step down.
+        return 0.4, False
+    gap = target_pct - pct
+    if gap >= 0.10:
+        return 0.5, False
+    if gap >= 0.05:
+        return 0.7, False
+    if gap >= 0.02:
+        return 0.85, False
+    return 0.95, False
+
+
+def calibrate(
+    conn: psycopg.Connection,
+    target_pct: float = 0.07,
+    tolerance: float = 0.02,
+    max_iterations: int = 10,
+    bootstrap_cover_days: int = 30,
+    horizon_days: int = 90,
+) -> CalibrationResult:
+    """Iteratively scale OH until shortage_pct is within [target-tol, target+tol].
+
+    Sequence:
+      1. Run one propagation pass (with the safety-stock-sized initial OH).
+      2. Bootstrap OH from the observed demand (daily_avg * cover_days). This
+         puts us in the right order of magnitude before the iterative phase.
+      3. Iterate: propagate, measure, scale, repeat until within band or
+         max_iterations is exhausted.
+    """
+    started = time.perf_counter()
+    iterations: list[CalibrationIteration] = []
+    converged = False
+
+    # --- bootstrap pass: one propagation just to populate outflows ---
+    bootstrap_seconds = _run_propagation(conn)
+    _bootstrap_oh_from_demand(conn, horizon_days, bootstrap_cover_days)
+    short_n, total_n = _measure_shortage_pct(conn)
+    iterations.append(CalibrationIteration(
+        iteration=0,  # iteration 0 = bootstrap probe + OH resize
+        oh_scale_applied=float("nan"),  # we don't apply a scalar — we resize per-pair
+        pi_total=total_n,
+        pi_with_shortage=short_n,
+        shortage_pct=round((short_n / total_n) if total_n else 0.0, 4),
+        propagation_seconds=round(bootstrap_seconds, 2),
+    ))
+
+    # --- iterative scaling phase ---
+    for i in range(max_iterations):
+        propagation_seconds = _run_propagation(conn)
+        short_n, total_n = _measure_shortage_pct(conn)
+        pct = (short_n / total_n) if total_n else 0.0
+
+        scale, conv = _next_oh_scale(pct, target_pct, tolerance)
+        iterations.append(CalibrationIteration(
+            iteration=i + 1,
+            oh_scale_applied=scale,
+            pi_total=total_n,
+            pi_with_shortage=short_n,
+            shortage_pct=round(pct, 4),
+            propagation_seconds=round(propagation_seconds, 2),
+        ))
+        if conv:
+            converged = True
+            break
+        _scale_on_hand(conn, scale)
+
+    return CalibrationResult(
+        iterations=iterations,
+        converged=converged,
+        final_shortage_pct=iterations[-1].shortage_pct if iterations else 0.0,
+        total_seconds=round(time.perf_counter() - started, 2),
+    )

--- a/src/ootils_core/seed/projection/graph.py
+++ b/src/ootils_core/seed/projection/graph.py
@@ -1,0 +1,377 @@
+"""
+graph.py — seed the projection graph (series + PI nodes + edges).
+
+In production, the projection graph is built reactively by the engine
+when events come in. For a static benchmark dataset we materialise it
+up front for one scope: every (FG, DC) pair gets a 90-day daily PI chain
+plus all the edges that drive propagation:
+
+  feeds_forward  PI[t] -> PI[t+1]                       within each series
+  replenishes    OnHandSupply(FG, DC) -> PI[0]          opening stock
+  replenishes    TransferSupply(FG, DC, ETA) -> PI[i]   in-flight inventory
+  consumes       CustomerOrderDemand -> PI[i]           point-in-time
+  consumes       ForecastDemand (monthly) -> PI[i..i+30] multi-day span
+
+The 90-day horizon is intentional — wider horizons explode the PI count
+(900 K at 365 days) and aren't needed to calibrate shortages or stress
+the propagator. Extend `horizon_days` later if downstream scenarios need it.
+
+Volumes expected on profile M:
+  projection_series   1 500  (active FGs ~ 477 x 3 DCs ~ 1 431)
+  PI nodes          128 790  (1 431 x 90 days)
+  feeds_forward     127 359  (1 431 x 89)
+  replenishes OH      1 431
+  replenishes T-in     ~500
+  consumes orders     ~6 000
+  consumes forecasts ~12 900  (~3 monthly forecasts per series x ~30 daily PIs)
+  ------------------------
+  edges total        ~148 K
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import date, timedelta
+from uuid import UUID, uuid4
+
+import psycopg
+
+from ootils_core.seed.master.items import ItemSet
+from ootils_core.seed.master.locations import LocationSet
+from ootils_core.seed.transactional.nodes import BASELINE_SCENARIO_ID
+
+
+@dataclass
+class SeededGraph:
+    """Counts produced — fed into the validation report."""
+    series_count: int
+    pi_node_count: int
+    feeds_forward_count: int
+    replenishes_from_oh_count: int
+    replenishes_from_transfer_count: int
+    consumes_from_orders_count: int
+    consumes_from_forecasts_count: int
+    horizon_start: date
+    horizon_end: date  # exclusive
+    seconds: float
+
+    @property
+    def edges_total(self) -> int:
+        return (
+            self.feeds_forward_count
+            + self.replenishes_from_oh_count
+            + self.replenishes_from_transfer_count
+            + self.consumes_from_orders_count
+            + self.consumes_from_forecasts_count
+        )
+
+
+def seed_projection_graph(
+    conn: psycopg.Connection,
+    item_set: ItemSet,
+    loc_set: LocationSet,
+    horizon_days: int = 90,
+) -> SeededGraph:
+    """Materialise the FG-at-DC projection graph for the next `horizon_days` days."""
+    started = time.perf_counter()
+    today = date.today()
+    horizon_start = today
+    horizon_end = today + timedelta(days=horizon_days)
+
+    active_fgs = [it for it in item_set.at_level(0) if it.status == "active"]
+    dcs = loc_set.dcs()
+
+    # ------------------------------------------------------------------
+    # 1. projection_series — one per (FG, DC)
+    # ------------------------------------------------------------------
+    series_rows: list[tuple[UUID, UUID, UUID, date, date]] = []
+    # Map for fast lookup when building PIs and edges
+    series_id_by_pair: dict[tuple[UUID, UUID], UUID] = {}
+    for fg in active_fgs:
+        for dc in dcs:
+            sid = uuid4()
+            series_rows.append((sid, fg.item_id, dc.location_id, horizon_start, horizon_end))
+            series_id_by_pair[(fg.item_id, dc.location_id)] = sid
+
+    conn.execute(
+        """
+        INSERT INTO projection_series
+            (series_id, item_id, location_id, scenario_id, horizon_start, horizon_end)
+        SELECT
+            s.id, s.item_id, s.loc_id, %s, s.hs, s.he
+        FROM UNNEST(%s::uuid[], %s::uuid[], %s::uuid[], %s::date[], %s::date[])
+             AS s(id, item_id, loc_id, hs, he)
+        """,
+        (
+            BASELINE_SCENARIO_ID,
+            [r[0] for r in series_rows],
+            [r[1] for r in series_rows],
+            [r[2] for r in series_rows],
+            [r[3] for r in series_rows],
+            [r[4] for r in series_rows],
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # 2. PI nodes — 90 daily buckets per series
+    # ------------------------------------------------------------------
+    pi_ids: list[UUID] = []
+    pi_item_id: list[UUID] = []
+    pi_loc_id: list[UUID] = []
+    pi_bs: list[date] = []
+    pi_be: list[date] = []
+    pi_series_id: list[UUID] = []
+    pi_seq: list[int] = []
+    # Track PI ids per (series_id, bucket_sequence) for edge wiring below
+    pi_by_series_seq: dict[tuple[UUID, int], UUID] = {}
+    for series_id, item_id, loc_id, hs, _he in series_rows:
+        for b in range(horizon_days):
+            pid = uuid4()
+            pi_ids.append(pid)
+            pi_item_id.append(item_id)
+            pi_loc_id.append(loc_id)
+            pi_bs.append(hs + timedelta(days=b))
+            pi_be.append(hs + timedelta(days=b + 1))
+            pi_series_id.append(series_id)
+            pi_seq.append(b)
+            pi_by_series_seq[(series_id, b)] = pid
+
+    conn.execute(
+        """
+        INSERT INTO nodes
+            (node_id, node_type, scenario_id, item_id, location_id,
+             time_grain, time_span_start, time_span_end,
+             projection_series_id, bucket_sequence, is_dirty, active)
+        SELECT
+            p.id, 'ProjectedInventory', %s, p.item_id, p.loc_id,
+            'day', p.bs, p.be, p.sid, p.seq, TRUE, TRUE
+        FROM UNNEST(
+            %s::uuid[], %s::uuid[], %s::uuid[], %s::date[], %s::date[],
+            %s::uuid[], %s::int[]
+        ) AS p(id, item_id, loc_id, bs, be, sid, seq)
+        """,
+        (
+            BASELINE_SCENARIO_ID,
+            pi_ids, pi_item_id, pi_loc_id, pi_bs, pi_be, pi_series_id, pi_seq,
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # 3. feeds_forward edges — within each series, PI[t] -> PI[t+1]
+    # ------------------------------------------------------------------
+    ff_ids: list[UUID] = []
+    ff_from: list[UUID] = []
+    ff_to: list[UUID] = []
+    for series_id, _, _, _, _ in series_rows:
+        for b in range(horizon_days - 1):
+            ff_ids.append(uuid4())
+            ff_from.append(pi_by_series_seq[(series_id, b)])
+            ff_to.append(pi_by_series_seq[(series_id, b + 1)])
+
+    if ff_ids:
+        conn.execute(
+            """
+            INSERT INTO edges
+                (edge_id, edge_type, from_node_id, to_node_id, scenario_id, active)
+            SELECT
+                e.id, 'feeds_forward', e.frm, e.dest, %s, TRUE
+            FROM UNNEST(%s::uuid[], %s::uuid[], %s::uuid[]) AS e(id, frm, dest)
+            """,
+            (BASELINE_SCENARIO_ID, ff_ids, ff_from, ff_to),
+        )
+
+    # ------------------------------------------------------------------
+    # 4. replenishes: OnHandSupply (FG, DC) -> PI[0]
+    # ------------------------------------------------------------------
+    oh_rows = conn.execute(
+        """
+        SELECT n.node_id, n.item_id, n.location_id
+        FROM nodes n
+        JOIN locations l ON l.location_id = n.location_id
+        JOIN items i ON i.item_id = n.item_id
+        WHERE n.node_type = 'OnHandSupply'
+          AND n.active = TRUE
+          AND n.scenario_id = %s
+          AND l.location_type = 'dc'
+          AND i.item_type = 'finished_good'
+        """,
+        (BASELINE_SCENARIO_ID,),
+    ).fetchall()
+    rep_oh_ids: list[UUID] = []
+    rep_oh_from: list[UUID] = []
+    rep_oh_to: list[UUID] = []
+    for r in oh_rows:
+        pair = (UUID(str(r["item_id"])), UUID(str(r["location_id"])))
+        sid = series_id_by_pair.get(pair)
+        if sid is None:
+            continue
+        pi0 = pi_by_series_seq.get((sid, 0))
+        if pi0 is None:
+            continue
+        rep_oh_ids.append(uuid4())
+        rep_oh_from.append(UUID(str(r["node_id"])))
+        rep_oh_to.append(pi0)
+    if rep_oh_ids:
+        conn.execute(
+            """
+            INSERT INTO edges (edge_id, edge_type, from_node_id, to_node_id, scenario_id, active)
+            SELECT e.id, 'replenishes', e.frm, e.dest, %s, TRUE
+            FROM UNNEST(%s::uuid[], %s::uuid[], %s::uuid[]) AS e(id, frm, dest)
+            """,
+            (BASELINE_SCENARIO_ID, rep_oh_ids, rep_oh_from, rep_oh_to),
+        )
+
+    # ------------------------------------------------------------------
+    # 5. replenishes: TransferSupply (FG, DC) with ETA in window -> PI[i]
+    # ------------------------------------------------------------------
+    t_rows = conn.execute(
+        """
+        SELECT n.node_id, n.item_id, n.location_id, n.time_ref
+        FROM nodes n
+        JOIN locations l ON l.location_id = n.location_id
+        WHERE n.node_type = 'TransferSupply'
+          AND n.active = TRUE
+          AND n.scenario_id = %s
+          AND l.location_type = 'dc'
+          AND n.time_ref >= %s AND n.time_ref < %s
+        """,
+        (BASELINE_SCENARIO_ID, horizon_start, horizon_end),
+    ).fetchall()
+    rep_t_ids: list[UUID] = []
+    rep_t_from: list[UUID] = []
+    rep_t_to: list[UUID] = []
+    for r in t_rows:
+        pair = (UUID(str(r["item_id"])), UUID(str(r["location_id"])))
+        sid = series_id_by_pair.get(pair)
+        if sid is None:
+            continue
+        eta: date = r["time_ref"]
+        seq = (eta - horizon_start).days
+        pi = pi_by_series_seq.get((sid, seq))
+        if pi is None:
+            continue
+        rep_t_ids.append(uuid4())
+        rep_t_from.append(UUID(str(r["node_id"])))
+        rep_t_to.append(pi)
+    if rep_t_ids:
+        conn.execute(
+            """
+            INSERT INTO edges (edge_id, edge_type, from_node_id, to_node_id, scenario_id, active)
+            SELECT e.id, 'replenishes', e.frm, e.dest, %s, TRUE
+            FROM UNNEST(%s::uuid[], %s::uuid[], %s::uuid[]) AS e(id, frm, dest)
+            """,
+            (BASELINE_SCENARIO_ID, rep_t_ids, rep_t_from, rep_t_to),
+        )
+
+    # ------------------------------------------------------------------
+    # 6. consumes: open CustomerOrderDemand -> PI[bucket containing time_ref]
+    # ------------------------------------------------------------------
+    co_rows = conn.execute(
+        """
+        SELECT node_id, item_id, location_id, time_ref
+        FROM nodes
+        WHERE node_type = 'CustomerOrderDemand'
+          AND active = TRUE
+          AND scenario_id = %s
+          AND time_ref >= %s AND time_ref < %s
+        """,
+        (BASELINE_SCENARIO_ID, horizon_start, horizon_end),
+    ).fetchall()
+    co_ids: list[UUID] = []
+    co_from: list[UUID] = []
+    co_to: list[UUID] = []
+    for r in co_rows:
+        pair = (UUID(str(r["item_id"])), UUID(str(r["location_id"])))
+        sid = series_id_by_pair.get(pair)
+        if sid is None:
+            continue
+        seq = (r["time_ref"] - horizon_start).days
+        pi = pi_by_series_seq.get((sid, seq))
+        if pi is None:
+            continue
+        co_ids.append(uuid4())
+        co_from.append(UUID(str(r["node_id"])))
+        co_to.append(pi)
+    if co_ids:
+        conn.execute(
+            """
+            INSERT INTO edges (edge_id, edge_type, from_node_id, to_node_id, scenario_id, active)
+            SELECT e.id, 'consumes', e.frm, e.dest, %s, TRUE
+            FROM UNNEST(%s::uuid[], %s::uuid[], %s::uuid[]) AS e(id, frm, dest)
+            """,
+            (BASELINE_SCENARIO_ID, co_ids, co_from, co_to),
+        )
+
+    # ------------------------------------------------------------------
+    # 7. consumes: ForecastDemand (monthly span) -> PI[i] for each overlapping bucket
+    # ------------------------------------------------------------------
+    fc_rows = conn.execute(
+        """
+        SELECT node_id, item_id, location_id, time_span_start, time_span_end
+        FROM nodes
+        WHERE node_type = 'ForecastDemand'
+          AND active = TRUE
+          AND scenario_id = %s
+          AND time_span_start < %s
+          AND time_span_end   > %s
+        """,
+        (BASELINE_SCENARIO_ID, horizon_end, horizon_start),
+    ).fetchall()
+    fc_ids: list[UUID] = []
+    fc_from: list[UUID] = []
+    fc_to: list[UUID] = []
+    for r in fc_rows:
+        pair = (UUID(str(r["item_id"])), UUID(str(r["location_id"])))
+        sid = series_id_by_pair.get(pair)
+        if sid is None:
+            continue
+        # Iterate days the forecast overlaps the horizon
+        ovl_start = max(horizon_start, r["time_span_start"])
+        ovl_end = min(horizon_end, r["time_span_end"])
+        seq = (ovl_start - horizon_start).days
+        days = (ovl_end - ovl_start).days
+        forecast_node_id = UUID(str(r["node_id"]))
+        for k in range(days):
+            pi = pi_by_series_seq.get((sid, seq + k))
+            if pi is None:
+                continue
+            fc_ids.append(uuid4())
+            fc_from.append(forecast_node_id)
+            fc_to.append(pi)
+    if fc_ids:
+        conn.execute(
+            """
+            INSERT INTO edges (edge_id, edge_type, from_node_id, to_node_id, scenario_id, active)
+            SELECT e.id, 'consumes', e.frm, e.dest, %s, TRUE
+            FROM UNNEST(%s::uuid[], %s::uuid[], %s::uuid[]) AS e(id, frm, dest)
+            """,
+            (BASELINE_SCENARIO_ID, fc_ids, fc_from, fc_to),
+        )
+
+    conn.commit()
+
+    # ------------------------------------------------------------------
+    # Update query planner stats — without this the first propagation run
+    # uses stale row-count estimates and picks seq scans where indexes would
+    # be 50x faster. Observed first-iter propagation time on profile S
+    # dropped from 535 s to ~10 s after this.
+    # ------------------------------------------------------------------
+    conn.execute("ANALYZE nodes")
+    conn.execute("ANALYZE edges")
+    conn.execute("ANALYZE projection_series")
+    conn.commit()
+
+    elapsed = time.perf_counter() - started
+
+    return SeededGraph(
+        series_count=len(series_rows),
+        pi_node_count=len(pi_ids),
+        feeds_forward_count=len(ff_ids),
+        replenishes_from_oh_count=len(rep_oh_ids),
+        replenishes_from_transfer_count=len(rep_t_ids),
+        consumes_from_orders_count=len(co_ids),
+        consumes_from_forecasts_count=len(fc_ids),
+        horizon_start=horizon_start,
+        horizon_end=horizon_end,
+        seconds=round(elapsed, 2),
+    )


### PR DESCRIPTION
## Summary

Final phase of the realistic dataset generator. Seeds the propagation graph (series + PIs + edges) over a 90-day horizon for every (FG, DC) pair, then iteratively calibrates `OnHandSupply` quantities until the shortage rate lands in the target band (default 7% ± 2%).

Builds on #228 (phases 1-5) and #229 (phase 6).

## What's new

```
src/ootils_core/seed/projection/
├── graph.py        Materialises projection_series + PI nodes + edges
│                   (feeds_forward / replenishes from OH+Transfer /
│                    consumes from open orders + forecast spans).
│                   Runs ANALYZE on nodes/edges/projection_series at the
│                   end — without this the first propagation hits
│                   pathological seq scans (535s -> 12s on profile S).
└── calibration.py  Bootstrap OH = demand_avg * cover_days, then iterate
                    with a symmetric log-step controller capped at 2.5x
                    per iteration. Special-cases pct=0 to avoid getting
                    stuck "way too much OH" for many iterations.
```

## Measured on profile M

| Step | Time | Shortage % |
|---|---|---|
| Graph seed (1 299 series / 116 910 PIs / 239 805 edges) | 41 s | — |
| Bootstrap probe (safety-stock-sized OH) | 33 s | 84.5% |
| OH resize to demand_avg × 30d cover | — | — |
| iter 1 (×2.5) | 30 s | 58.7% |
| iter 2 (×1.15) | 20 s | 14.4% |
| iter 3 (×0.85) | 17 s | 3.85% |
| iter 4 (×1.15) | 18 s | 16.1% |
| iter 5 (terminal) | 17 s | **5.65% ✅** |
| **TOTAL phase 7** | **4 min 24 s** | **converged in band** |

Final dataset state on profile M: 116 910 PIs computed, 6 604 with shortage, OH calibrated end-to-end. Ready for downstream benchmarks, allocation engine tests, RCCP scenarios.

## Why ANALYZE matters here

After phases 1-6 insert hundreds of thousands of rows, Postgres has stale planner statistics — the first propagation falls back to seq scans on `nodes` / `edges`. Observed: 535 s for the first iter on profile S, dropping to ~12 s after `ANALYZE`. Running `ANALYZE nodes; ANALYZE edges; ANALYZE projection_series` at the end of graph seeding is a 1-second insurance policy.

## Profile S sanity check

Same flow on profile S (528 series / 47K PIs / 100K edges) converges in 86 s total to ~5.4% shortage — proves the calibration logic isn't M-specific.

## Test plan

- [ ] CI green
- [x] `python scripts/seed_realistic_dataset.py --profile S` converges in band
- [x] `python scripts/seed_realistic_dataset.py --profile M` converges in band in 264 s
- [x] Ruff lint passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)