### PR TITLE
docs: ADR-013 external interfaces (formats + full reload + approval)

### DIFF
--- a/docs/ADR-013-external-interfaces.md
+++ b/docs/ADR-013-external-interfaces.md
@@ -1,0 +1,175 @@
+# ADR-013 : Interfaces externes — formats fichiers, full reload, approval
+
+## Statut
+DRAFT — 2026-05-23
+
+## Contexte
+
+ADR-009 a posé l'architecture du pipeline d'import : staging zone immuable, DQ pipeline 4 niveaux (L1 structurel → L4 croisé), SCD2 sur master data, UOM conversions, calendriers opérationnels. Cette base est en production avec les niveaux L1 et L2 implémentés et testés.
+
+Trois questions sont restées ouvertes parce qu'elles concernent le **contrat externe** (entre Ootils et les outils tiers : SAP IBP, Kinaxis, Oracle, exports Excel ad-hoc), pas l'architecture interne :
+
+1. **Quels formats fichiers** accepte-t-on en entrée ? L'API actuelle ne supporte que JSON, ce qui élimine de facto 90 % des outils qui dumpent en CSV/TSV/XLSX.
+2. **Semantique de refresh** : un import remplace-t-il l'état existant ou le complète-t-il ? ADR-009 reste muet ; en pratique l'upsert par `external_id` actuel implémente un comportement hybride flou.
+3. **Workflow d'approbation** : l'humain-dans-la-boucle est-il obligatoire avant injection en core, ou peut-on auto-approuver les batches DQ-verts ?
+
+Ce besoin émerge maintenant parce qu'on veut commencer à interfacer Ootils avec des outils réels (ERP du client, exports planificateurs, données historiques). Sans décisions tranchées sur ces trois points, chaque intégration réinventerait son propre contrat.
+
+## Décisions
+
+### D1 — Formats fichiers : TSV (principal) + CSV + XLSX + JSON
+
+L'API accepte quatre formats en upload :
+
+- **TSV (`.tab`, `.tsv`)** — séparateur `\t`. **Format recommandé pour les exports ERP** : les valeurs métier contiennent rarement des tabs, contrairement aux virgules/points-virgules/guillemets qui pourrissent les CSV. Encodage UTF-8 sans BOM.
+- **CSV (`.csv`)** — séparateur `,` ou `;` (auto-détection via `csv.Sniffer` sur le header). Quoting `"` standard. UTF-8 sans BOM, fallback CP-1252 si décodage UTF-8 échoue (clients Windows).
+- **XLSX (`.xlsx`)** — première sheet utilisée par défaut, override via header HTTP `X-Sheet-Name`. Cellules vides → NULL côté staging. `openpyxl` en read-only pour les gros fichiers.
+- **JSON (`.json`)** — déjà supporté. Tableau d'objets, un objet = une ligne.
+
+Tous les formats convergent vers le même schéma `ingest_rows` (col_01..col_15 en TEXT). La première ligne du fichier est obligatoire et porte les **noms canoniques de colonnes** définis par entité (voir D5). Le parser fait le mapping `header_name` → `col_N` côté staging.
+
+Détection du format : par extension du fichier si extension présente, sinon par sniff du contenu (start byte `PK` → XLSX, `{` ou `[` → JSON, première ligne contient `\t` → TSV, sinon CSV).
+
+### D2 — Schéma `staging` dédié dans la même DB
+
+Création d'un schéma Postgres `staging` qui regroupe les tables existantes (`ingest_batches`, `ingest_rows`, `data_quality_issues`, `external_id_mapping`) + les nouvelles tables (`staging.uploads`, `staging.transform_runs`). Les tables canoniques (`items`, `nodes`, `edges`, etc.) restent dans `public`.
+
+Bénéfices :
+- Séparation visuelle claire dans DBeaver/psql (`\dn`)
+- Permissions Postgres distinctes : les jobs d'import peuvent avoir `GRANT ALL ON SCHEMA staging` sans accès direct à `public`
+- Backups partitionnables (staging peut avoir une retention courte, public longue)
+
+Anti-décision : pas de DB séparée (`ootils_staging`) — ça forcerait des Foreign Data Wrappers pour les joins L2/L4 et romprait la simplicité des transactions atomiques sur l'approval.
+
+La migration `033_staging_schema.sql` :
+- Crée le schéma `staging`
+- `ALTER TABLE ... SET SCHEMA staging` pour `ingest_batches`, `ingest_rows`, `data_quality_issues`, `external_id_mapping`
+- Crée `staging.uploads` (1 row par fichier uploadé : filename, size, format, sha256, batch_id)
+- Crée `staging.transform_runs` (1 row par exécution d'approval : batch_id, started_at, completed_at, rows_inserted, rows_updated, rows_deleted)
+
+### D3 — Semantique : full reload par `(entity_type, source_system)`
+
+Chaque batch approuvé **remplace intégralement** l'état canonique pour son couple `(entity_type, source_system)`. Concrètement, sur approval :
+
+```
+BEGIN;
+  -- 1. Pour chaque external_id présent dans le batch : UPSERT dans la canonique
+  --    Insert si nouveau, update si existant. Trace dans master_data_audit_log.
+  --    Pour les entités SCD2 (item_planning_params) : ferme la version active
+  --    + crée une nouvelle ligne (ne JAMAIS écraser une version historique).
+
+  -- 2. Pour chaque external_id absent du batch mais présent en canonique
+  --    avec le même source_system : marquer active=FALSE (soft delete).
+  --    Garder l'historique pour audit + rollback.
+
+  -- 3. Recalculer L4 (cross-batch) sur l'état résultant : items orphelins,
+  --    planning_params sans item parent, etc.
+COMMIT;
+```
+
+Pourquoi full reload et pas delta :
+- Un export ERP est par nature un snapshot
+- Le client n'a pas toujours un `modified_at` fiable côté source
+- Les deletes implicites (item retiré du fichier) sont détectés naturellement
+- Idempotent par construction : rejouer le même batch deux fois est un no-op
+
+Multi-source : deux ERPs peuvent alimenter la même entité (ex: items master depuis SAP, lifecycle status depuis MES). Chacun maintient son périmètre via `source_system`. Un item peut avoir des champs alimentés par deux sources : chaque source possède sa colonne — résolu via D5 (colonnes par source).
+
+### D4 — Approval obligatoire, pas d'auto-approve
+
+Même quand DQ pipeline retourne zéro erreur et zéro warning, le batch reste en status `validated` et requiert une action humaine explicite : `POST /v1/staging/batches/{batch_id}/approve`.
+
+Justifications :
+- Un batch peut être DQ-vert et **structurellement délétère** (ex: scope drastique réduit involontairement → 80 % des items disparaissent par soft-delete D3)
+- La traçabilité audit demande un identifiant humain sur chaque injection
+- Évite les boucles d'auto-approbation entre systèmes
+
+Le payload `/approve` accepte un commentaire libre (`notes`) et est tracé dans `staging.transform_runs.approved_by` + `approved_at` + `approval_notes`. Le `approved_by` est extrait du JWT/token de l'appelant (le mécanisme d'authentification reste hors scope de cet ADR).
+
+Endpoint complémentaire : `POST /v1/staging/batches/{batch_id}/reject` avec raison obligatoire (`reason`). Marque le batch `rejected`, les ingest_rows restent stockées (rejeu possible après correction côté source).
+
+Diff pre-approval : un endpoint `GET /v1/staging/batches/{batch_id}/diff` retourne le delta (`{will_insert: N, will_update: M, will_soft_delete: K}`) avec un sample de 10 lignes par catégorie. Permet à l'humain de visualiser l'impact avant d'approuver — c'est le garde-fou principal contre les imports destructeurs.
+
+### D5 — Templates CSV/TSV par entité avec colonnes canoniques
+
+Chaque entité a un schéma de fichier documenté dans `docs/staging-templates/<entity>.md`, avec les colonnes obligatoires, optionnelles, et le mapping vers les tables canoniques. Exemple pour `items` :
+
+```
+external_id     (obligatoire, UNIQUE par source_system)  -> items.external_id
+name            (obligatoire, max 200 chars)             -> items.name
+item_type       (obligatoire ∈ {finished_good, semi_finished, component, raw_material})
+uom             (obligatoire, code UOM connu de uom_conversions)
+status          (optionnel, défaut 'active')             -> items.status
+description     (optionnel)                              -> items.description (à ajouter)
+```
+
+Le header de la première ligne du fichier doit matcher ces noms (case-insensitive, espaces tolérés). Colonnes inconnues → issue DQ L1 `UNKNOWN_COLUMN` (severity warning, pas bloquant). Colonnes obligatoires manquantes → erreur L1 bloquante.
+
+Un fichier exemple `docs/staging-templates/items.tsv` est versionné dans le repo pour servir de référence.
+
+### D6 — Lifecycle d'un batch (state machine)
+
+```
+                   upload                  L1-L2-L3-L4              approve
+   external file ────────> pending ────────────────────> validated ─────────> imported
+                              │                              │                    │
+                              │  L1 fatal (encoding, format) │  reject             │
+                              └──────────────> rejected      └─────> rejected      ▼
+                                                                                public.*
+                                                                              (canonical
+                                                                              tables)
+```
+
+Transitions autorisées et seules ces transitions :
+- `pending → validated` : DQ pipeline complete, aucune issue de niveau `error` (warnings tolérés)
+- `pending → rejected` : DQ pipeline a déclenché un blocage (encoding invalide, format non reconnu, schema header invalide, etc.) OU `POST /reject` appelé
+- `validated → imported` : `POST /approve` réussi (transaction commit)
+- `validated → rejected` : `POST /reject` manuel
+- `imported` : terminal, immutable
+
+Aucun batch ne revient en arrière. Pour rejouer après correction côté ERP : nouvel upload, nouveau batch_id.
+
+## Conséquences
+
+### Positives
+- **Contrat externe lisible** : un fournisseur de données sait exactement quel format pousser, sur quel endpoint, dans quel template
+- **Idempotent par construction** : full reload + soft delete = rejouer N fois donne le même état final
+- **Audit complet** : chaque ligne en `public` est traçable au batch → fichier → utilisateur qui a approuvé
+- **Pas de surprise** : `/diff` montre l'impact avant `/approve`, l'humain garde le contrôle même quand DQ est vert
+- **Multi-source clean** : SAP peut alimenter le master, MES le lifecycle, sans collision
+
+### Négatives
+- **Latence d'import** : l'approval manuel ajoute ~minutes-heures entre upload et disponibilité en planning. Acceptable pour master data (refresh hebdo/quotidien) ; sera douloureux pour les transactions temps réel (POs, customer orders) qui pourraient justifier un fast-path à étudier en v2.
+- **Friction sur les hot-fixes** : corriger un seul item demande de re-pousser le fichier complet (D3 full reload). Mitigé par la possibilité de batches "patch" sur un `source_system` distinct.
+- **Stockage staging** : conserver les `raw_content` indéfiniment fait croître `staging.*`. Politique de retention à définir hors ADR (suggestion : 90 jours, configurable).
+
+### Risques
+- **Soft-delete cascade** : un batch incomplet (export tronqué) pourrait soft-deleter 90 % des items. Mitigation : l'endpoint `/diff` doit refuser l'approval si le ratio `soft_delete / current_active > 20 %` sauf flag `--force` explicite + commentaire obligatoire.
+- **Encoding sur fichiers ERP legacy** : CP-1252, Latin-1, etc. circulent encore. Le parser doit tenter UTF-8 d'abord, log un warning si fallback à CP-1252, refuser au-delà.
+
+## Roadmap d'implémentation
+
+| # | Livrable | Effort | Bloquant pour |
+|---|----------|--------|---------------|
+| 1 | Migration `033_staging_schema.sql` (création schéma + move tables) | 1 j | Tout le reste |
+| 2 | `staging/parser.py` (TSV/CSV/XLSX/JSON unifié, sniffing, encoding) | 2-3 j | Tests de bout en bout |
+| 3 | `staging/loader.py` (upload → ingest_batches + ingest_rows) | 1 j | Endpoint upload |
+| 4 | Endpoint `POST /v1/staging/upload` (multipart + entity_type) | 1 j | Première intégration externe possible |
+| 5 | DQ L3 (règles métier SC, ~15 règles initiales) | 3-4 j | Approval significatif |
+| 6 | DQ L4 (cross-batch dedup + orphan check) | 2 j | Multi-source clean |
+| 7 | Endpoint `GET /diff` (preview impact pre-approval) | 1-2 j | Approval safe |
+| 8 | Endpoint `POST /approve` avec semantics full-reload + soft delete | 2-3 j | Le cœur du flux |
+| 9 | Endpoint `POST /reject` + audit | 0.5 j | Operations |
+| 10 | Templates `docs/staging-templates/*.md` + `*.tsv` exemples | 2 j | Onboarding intégration externe |
+| 11 | Tests integration end-to-end (upload TSV → DQ → diff → approve) | 2 j | Production-ready |
+| 12 | Documentation utilisateur (README staging, exemples curl) | 1 j | Self-service |
+
+**Total** : ~3-4 semaines focus.
+
+## Références
+
+- ADR-009 : Architecture Pipeline d'Import (le socle staging+DQ que cet ADR complète)
+- ADR-005 : Storage Layer (conventions schemas Postgres)
+- `src/ootils_core/api/routers/ingest.py` (l'implémentation actuelle JSON-only à étendre)
+- `src/ootils_core/engine/dq/` (le DQ engine L1+L2 actuel)
+- Migration `007_import_pipeline.sql` (le schéma initial)

--- a/docs/staging-templates/README.md
+++ b/docs/staging-templates/README.md
@@ -1,0 +1,36 @@
+# Staging templates — file format contracts per entity
+
+These templates are the **canonical contract** between Ootils and any external tool that pushes data through the staging pipeline (ADR-013).
+
+Each entity supported by `ingest_batches.entity_type` has:
+
+- A specification document (`<entity>.md`) listing required + optional columns, types, value constraints, and how they map to canonical tables
+- An example file (`<entity>.tsv`) ready to feed into `POST /v1/staging/upload`
+
+## Conventions across all templates
+
+- **First line is the header** — exact column names from the spec (case-insensitive, leading/trailing spaces tolerated)
+- **Encoding** : UTF-8 sans BOM (CP-1252 toléré en fallback avec warning DQ)
+- **Séparateur** : TSV (`\t`) recommandé, CSV (`,` ou `;`) toléré avec auto-détection
+- **Valeurs manquantes** : cellule vide pour optionnel, **jamais "NULL" ou "N/A"** (ces strings seraient stockées telles quelles)
+- **Dates** : ISO 8601 (`YYYY-MM-DD`)
+- **Décimales** : point `.` comme séparateur (jamais virgule), pas de séparateur de milliers
+- **Booléens** : `true` / `false` (lowercase), `1` / `0` toléré
+
+## Catalogue par entité
+
+| Entité | Template | Refresh | Notes |
+|--------|----------|---------|-------|
+| items | [items.md](items.md) — [items.tsv](items.tsv) | full reload | Master, source SAP/ERP typique |
+| locations | locations.md *(TBD)* | full reload | Master, faible volume |
+| suppliers | suppliers.md *(TBD)* | full reload | Master, faible volume |
+| supplier_items | supplier_items.md *(TBD)* | full reload | Master + commercial |
+| item_planning_params | item_planning_params.md *(TBD)* | **SCD2** | Versionné par effective_from/to |
+| on_hand | on_hand.md *(TBD)* | full reload | Snapshot WMS, quotidien |
+| purchase_orders | purchase_orders.md *(TBD)* | full reload | ERP, refresh quotidien |
+| work_orders | work_orders.md *(TBD)* | full reload | MES, refresh quotidien |
+| customer_orders | customer_orders.md *(TBD)* | full reload | ERP commercial |
+| transfers | transfers.md *(TBD)* | full reload | Inter-locations |
+| forecasts | forecasts.md *(TBD)* | full reload | Outil prévision |
+
+Les templates marqués TBD sont rédigés au fil de l'implémentation de la roadmap ADR-013.

--- a/docs/staging-templates/items.md
+++ b/docs/staging-templates/items.md
@@ -1,0 +1,64 @@
+# Template `items` — master article
+
+**Refresh model** : full reload par `(entity_type='items', source_system)`.
+Un fichier remplace intégralement le périmètre items du source_system.
+
+**Target canonique** : table `items` (+ écriture audit dans `master_data_audit_log`).
+
+## Colonnes
+
+| Colonne | Type | Obligatoire | Contraintes | Mappe vers |
+|---------|------|-------------|-------------|------------|
+| `external_id` | TEXT | ✓ | unique par source_system, max 100 chars | `items.external_id` |
+| `name` | TEXT | ✓ | max 200 chars, non vide après trim | `items.name` |
+| `item_type` | ENUM | ✓ | ∈ {`finished_good`, `semi_finished`, `component`, `raw_material`} | `items.item_type` |
+| `uom` | TEXT | ✓ | code UOM connu (∈ `uom_conversions.from_uom` ∪ `uom_conversions.to_uom` ∪ liste blanche `EA`, `KG`, `L`, `M`) | `items.uom` |
+| `status` | ENUM | ✗ | ∈ {`active`, `phase_out`, `obsolete`}, défaut `active` | `items.status` |
+
+## Règles DQ activées
+
+| Niveau | Code | Type | Description |
+|--------|------|------|-------------|
+| L1 | `MISSING_REQUIRED` | error | une colonne obligatoire est vide |
+| L1 | `INVALID_ENUM_VALUE` | error | `item_type` ou `status` hors liste |
+| L1 | `MAX_LENGTH_EXCEEDED` | error | `name` > 200 ou `external_id` > 100 |
+| L1 | `UNKNOWN_COLUMN` | warning | colonne en plus dans le fichier, ignorée |
+| L2 | `UOM_UNKNOWN` | error | `uom` non référencé dans `uom_conversions` ou whitelist |
+| L3 | `DUPLICATE_EXTERNAL_ID` | error | même `external_id` deux fois dans le batch |
+| L3 | `NAME_TOO_GENERIC` | warning | `name` ∈ {`item`, `n/a`, `tbd`, single char} |
+| L4 | `RECONCILE_DELETE_RATIO` | error | si > 20 % des items existants seraient soft-deleted (override possible avec `--force`) |
+
+## Exemple
+
+Voir [items.tsv](items.tsv) pour un fichier prêt à uploader (10 items représentatifs).
+
+## Comportement à l'approval (D3 ADR-013)
+
+Pour chaque ligne du batch :
+- Si `external_id` n'existe pas en `items` (pour ce `source_system`) → **INSERT**
+- Si `external_id` existe et que les valeurs diffèrent → **UPDATE** (champs uniquement, pas l'`item_id` UUID) + audit log
+- Si l'item existe en `items` mais son `external_id` ne figure plus dans le fichier (pour ce `source_system`) → **soft delete** (`status='obsolete'` + `active=FALSE` sur les nodes liés)
+
+Aucun `DELETE` SQL dur n'est jamais effectué — l'historique est immutable.
+
+## Exemple curl
+
+```bash
+curl -X POST "${OOTILS_API_URL}/v1/staging/upload" \
+  -H "Authorization: Bearer ${OOTILS_API_TOKEN}" \
+  -F "file=@items_sap_2026w22.tsv" \
+  -F "entity_type=items" \
+  -F "source_system=SAP-EU"
+# -> 202 Accepted, returns { "batch_id": "uuid", "status": "pending" }
+
+# Poll DQ status
+curl "${OOTILS_API_URL}/v1/staging/batches/${BATCH_ID}" \
+  -H "Authorization: Bearer ${OOTILS_API_TOKEN}"
+# Once status="validated", review diff:
+curl "${OOTILS_API_URL}/v1/staging/batches/${BATCH_ID}/diff" \
+  -H "Authorization: Bearer ${OOTILS_API_TOKEN}"
+# Approve:
+curl -X POST "${OOTILS_API_URL}/v1/staging/batches/${BATCH_ID}/approve" \
+  -H "Authorization: Bearer ${OOTILS_API_TOKEN}" \
+  -d '{"notes": "Weekly SAP master refresh, validated by ops"}'
+```

--- a/docs/staging-templates/items.tsv
+++ b/docs/staging-templates/items.tsv
@@ -1,0 +1,11 @@
+external_id	name	item_type	uom	status
+SAP-FG-00001	Smart Sensor Module 24V	finished_good	EA	active
+SAP-FG-00002	Industrial Gateway Pro	finished_good	EA	active
+SAP-FG-00003	Compact Controller X1	finished_good	EA	phase_out
+SAP-SA-01024	Power Supply Subassembly 24V/5A	semi_finished	EA	active
+SAP-SA-01025	Wireless Radio Module	semi_finished	EA	active
+SAP-CP-04201	PCB Main Board Rev3	component	EA	active
+SAP-PT-08833	Connector M12 5-pin shielded	component	EA	active
+SAP-PT-08834	Cable Cat6 shielded	component	M	active
+SAP-RM-15007	Steel sheet 1.5mm AISI 304	raw_material	KG	active
+SAP-RM-15008	Industrial epoxy resin grade A	raw_material	L	active


### PR DESCRIPTION
## Summary

ADR-013 closes the three contract-level questions left open by ADR-009 (staging+DQ+SCD2 architecture), based on the design discussion in chat: TSV/CSV/XLSX as primary file formats, full-reload semantics, mandatory human approval.

**No code changes** — pure design + first template (items) as proof-of-concept. The 12-step implementation roadmap inside the ADR will be picked up in follow-up PRs.

## Decisions

1. **D1 — File formats**: TSV (recommended for ERP exports), CSV (`,` or `;` auto-detected), XLSX, JSON. Single parser, single staging schema downstream.
2. **D2 — Staging schema**: dedicated `staging.*` schema in the same DB. Migration 033 moves existing ingest tables in.
3. **D3 — Full reload**: each approved batch replaces the canonical state for its `(entity_type, source_system)` pair. UPSERT + soft-delete of items absent from the file.
4. **D4 — Approval mandatory**: no auto-approval. `/diff` endpoint shows impact pre-approval; deletion-ratio > 20% blocks unless `force=true`.
5. **D5 — Canonical column names per entity**: per-entity templates under `docs/staging-templates/`. Ships with `items.md` + `items.tsv` as the first proof.
6. **D6 — Lifecycle state machine**: `pending → validated → imported` (forward only; no transitions backwards).

## What ships in this PR

- `docs/ADR-013-external-interfaces.md` (~250 lines)
- `docs/staging-templates/README.md` — catalogue of upcoming templates
- `docs/staging-templates/items.md` + `items.tsv` — first entity contract, full spec + 10-row example

## What's NOT in this PR

The 12-step implementation roadmap (parser, upload endpoint, DQ L3/L4, /diff, /approve, full reload logic, remaining entity templates, integration tests, docs). ~3-4 weeks of focused work, picked up in follow-up PRs.

## Test plan

- [ ] Read the ADR end-to-end and validate the 6 decisions
- [ ] Review the items.md template — is the column list complete? are the DQ rules right?
- [ ] Approve to merge as DRAFT status (ADR moves to ACCEPTED once we start coding step 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)