### PR TITLE
feat(staging): unified TSV/CSV/XLSX/JSON parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dependencies = [
     "pydantic ~= 2.12",
     "openai ~= 2.15",
     "slowapi ~= 0.1",
+    # Staging file parsers (ADR-013): TSV/CSV via stdlib csv, XLSX via openpyxl.
+    "openpyxl ~= 3.1",
+    "python-multipart ~= 0.0.20",  # FastAPI file uploads (multipart/form-data)
 ]
 
 [project.optional-dependencies]

--- a/src/ootils_core/staging/__init__.py
+++ b/src/ootils_core/staging/__init__.py
@@ -1,0 +1,9 @@
+"""
+ootils_core.staging — external-data ingestion pipeline (ADR-013).
+
+Submodules:
+    parser    — unified TSV/CSV/XLSX/JSON parser with format + encoding detection
+    loader    — parsed rows -> ingest_batches + ingest_rows (TBD)
+    rules     — DQ L3/L4 business rules (TBD)
+    approve   — full-reload transform + load on /approve (TBD)
+"""

--- a/src/ootils_core/staging/parser.py
+++ b/src/ootils_core/staging/parser.py
@@ -1,0 +1,416 @@
+"""
+parser.py — unified file parser for the staging pipeline (ADR-013 D1).
+
+Accepts file bytes + an optional format hint, returns a `ParseResult`
+with the parsed rows as dicts keyed by the header columns, plus the
+metadata needed by `staging.uploads` (format, encoding, sha256).
+
+Four supported formats:
+
+  TSV   .tab / .tsv         delimiter '\\t'. Recommended for ERP exports
+                            because business values rarely contain tabs.
+  CSV   .csv                delimiter auto-detected via csv.Sniffer
+                            (',' or ';'). Quoting '"' standard.
+  XLSX  .xlsx               first sheet by default; pass sheet_name in
+                            ParseOptions to override. openpyxl read-only.
+  JSON  .json               top-level array of objects, one per row.
+
+All formats converge to the same intermediate shape: a list of
+``dict[str, str]`` where keys are the column headers (case-preserved
+from the file) and values are TEXT (no type coercion happens here —
+that's the DQ engine's job downstream).
+
+Encoding handling for text formats:
+  1. Try UTF-8 (with or without BOM)
+  2. Fall back to CP-1252 (typical for legacy Windows / SAP exports),
+     log a warning
+  3. Anything else: raise ParseError
+
+Format detection (when not given):
+  - by extension if present and recognised
+  - else content-sniffed (PK -> xlsx, { or [ -> json, \\t in header -> tsv)
+  - else CSV by default
+"""
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import json
+import logging
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+SUPPORTED_FORMATS = ("tsv", "csv", "xlsx", "json")
+TEXT_FORMATS = ("tsv", "csv", "json")
+
+
+# Encodings we try in order, in priority. Add to this tuple if a new
+# legacy source needs support; the first one that decodes wins.
+_ENCODINGS_TRY = ("utf-8-sig", "utf-8", "cp1252", "latin-1")
+
+
+class ParseError(ValueError):
+    """Raised when the file cannot be parsed (format, encoding, structure)."""
+
+
+@dataclass(frozen=True)
+class ParseOptions:
+    """Tunables for the parser. Defaults match the most common ERP shape.
+
+    sheet_name: only relevant for XLSX. None -> first sheet.
+    delimiter:  if set, skip csv.Sniffer and use this delimiter directly.
+                Use when the source is known (e.g. always ';' from a
+                French ERP).
+    max_rows:   if set, stop parsing after this many data rows (excluding
+                the header). Useful for dry-run / preview endpoints.
+    """
+    sheet_name: str | None = None
+    delimiter: str | None = None
+    max_rows: int | None = None
+
+
+@dataclass
+class ParseResult:
+    """Outcome of parsing one file. All fields are populated except
+    when a format doesn't have a notion of the metadata (e.g. XLSX
+    has no `encoding`, JSON has no `delimiter`)."""
+    rows: list[dict[str, str]]
+    headers: list[str]
+    format: str               # 'tsv' / 'csv' / 'xlsx' / 'json'
+    encoding: str | None      # text formats only
+    delimiter: str | None     # tsv / csv only
+    sha256: str
+    # Diagnostic counters for the response
+    row_count: int = field(init=False)
+    header_count: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        # Use object.__setattr__ since dataclass is mutable but these
+        # are derived fields — we don't want callers messing with them.
+        object.__setattr__(self, "row_count", len(self.rows))
+        object.__setattr__(self, "header_count", len(self.headers))
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def parse(
+    data: bytes,
+    filename: str | None = None,
+    format_hint: str | None = None,
+    options: ParseOptions | None = None,
+) -> ParseResult:
+    """Parse `data` (the raw file bytes) into a ParseResult.
+
+    Arguments:
+        data:         file bytes, exactly as read from the upload
+        filename:     optional original filename. Used for format
+                      detection by extension. Not stored elsewhere.
+        format_hint:  optional explicit format. If set, skips detection.
+                      Must be one of SUPPORTED_FORMATS.
+        options:      optional ParseOptions for advanced control.
+
+    Returns:
+        ParseResult with rows + metadata.
+
+    Raises:
+        ParseError if the file cannot be decoded, sniffed, or parsed.
+    """
+    if not data:
+        raise ParseError("empty file")
+
+    opts = options or ParseOptions()
+    fmt = (format_hint or _detect_format(data, filename) or "csv").lower()
+    if fmt not in SUPPORTED_FORMATS:
+        raise ParseError(f"unsupported format: {fmt!r}")
+
+    sha = hashlib.sha256(data).hexdigest()
+
+    if fmt == "xlsx":
+        rows, headers = _parse_xlsx(data, opts)
+        return ParseResult(
+            rows=rows, headers=headers, format="xlsx",
+            encoding=None, delimiter=None, sha256=sha,
+        )
+    if fmt == "json":
+        text, enc = _decode_text(data)
+        rows, headers = _parse_json(text)
+        return ParseResult(
+            rows=rows, headers=headers, format="json",
+            encoding=enc, delimiter=None, sha256=sha,
+        )
+    # TSV / CSV
+    text, enc = _decode_text(data)
+    delim = opts.delimiter or _sniff_delimiter(text, fmt)
+    rows, headers = _parse_delimited(text, delim, opts.max_rows)
+    return ParseResult(
+        rows=rows, headers=headers, format=fmt,
+        encoding=enc, delimiter=delim, sha256=sha,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Format detection
+# ---------------------------------------------------------------------------
+
+
+_EXTENSION_MAP = {
+    ".tsv":  "tsv",
+    ".tab":  "tsv",
+    ".csv":  "csv",
+    ".xlsx": "xlsx",
+    ".json": "json",
+}
+
+
+def _detect_format(data: bytes, filename: str | None) -> str | None:
+    """Best-effort format detection. Returns None if undecidable."""
+    if filename:
+        # Find the last dot-extension (lowercase)
+        idx = filename.rfind(".")
+        if idx >= 0:
+            ext = filename[idx:].lower()
+            if ext in _EXTENSION_MAP:
+                return _EXTENSION_MAP[ext]
+
+    # Content sniffing
+    head = data[:64]
+    # XLSX is a ZIP container — starts with "PK"
+    if head.startswith(b"PK\x03\x04") or head.startswith(b"PK\x05\x06"):
+        return "xlsx"
+    # JSON: array or object as outermost (skip whitespace)
+    stripped = head.lstrip()
+    if stripped.startswith(b"[") or stripped.startswith(b"{"):
+        return "json"
+    # Try to decode the first line and check for a tab
+    try:
+        first_nl = data.find(b"\n")
+        first_line_bytes = data[: first_nl if first_nl > 0 else 200]
+        first_line = first_line_bytes.decode("utf-8", errors="replace")
+    except Exception:
+        return None
+    if "\t" in first_line:
+        return "tsv"
+    return "csv"
+
+
+# ---------------------------------------------------------------------------
+# Text decoding (encoding detection)
+# ---------------------------------------------------------------------------
+
+
+def _decode_text(data: bytes) -> tuple[str, str]:
+    """Try the encoding ladder. Returns (text, reported_encoding).
+
+    The codec `utf-8-sig` is used first because it strips the BOM when
+    present and behaves like plain `utf-8` otherwise. We report
+    `utf-8-sig` only when the file actually had a BOM, otherwise we
+    report `utf-8` — the distinction matters for downstream diagnostics
+    (a BOM in an ERP export is a signal worth noting in the response).
+    """
+    had_bom = data.startswith(b"\xef\xbb\xbf")
+    for enc in _ENCODINGS_TRY:
+        try:
+            text = data.decode(enc)
+            if enc in ("utf-8", "utf-8-sig"):
+                reported = "utf-8-sig" if had_bom else "utf-8"
+            else:
+                reported = enc
+                logger.warning(
+                    "staging.parser: file decoded with %s (non-UTF-8). "
+                    "Consider asking the source system to export UTF-8.",
+                    enc,
+                )
+            return text, reported
+        except UnicodeDecodeError:
+            continue
+    raise ParseError(
+        f"could not decode file with any of {list(_ENCODINGS_TRY)}; "
+        "check the source-system export settings"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Delimiter sniffing (TSV / CSV)
+# ---------------------------------------------------------------------------
+
+
+def _sniff_delimiter(text: str, fmt: str) -> str:
+    """For TSV, always '\\t'. For CSV, try csv.Sniffer on the first line."""
+    if fmt == "tsv":
+        return "\t"
+    # CSV — try Sniffer; fall back to ',' if it fails
+    sample = text[:2048]
+    try:
+        dialect = csv.Sniffer().sniff(sample, delimiters=",;\t|")
+        return dialect.delimiter
+    except csv.Error:
+        return ","
+
+
+# ---------------------------------------------------------------------------
+# Per-format parsers
+# ---------------------------------------------------------------------------
+
+
+def _parse_delimited(text: str, delimiter: str, max_rows: int | None) -> tuple[list[dict[str, str]], list[str]]:
+    """Parse a delimited text blob into (rows, headers).
+
+    The first non-empty line is the header. Trailing whitespace on each
+    cell is stripped. Empty cells become "" (not None) — typing happens
+    in the DQ pipeline, not here.
+    """
+    buf = io.StringIO(text)
+    reader = csv.reader(buf, delimiter=delimiter, quotechar='"')
+
+    headers: list[str] = []
+    rows: list[dict[str, str]] = []
+
+    for line_no, raw in enumerate(reader, start=1):
+        if not raw or all(cell.strip() == "" for cell in raw):
+            continue  # skip blank lines
+        if not headers:
+            headers = [c.strip() for c in raw]
+            if not all(headers):
+                raise ParseError(
+                    f"header line contains an empty column at index "
+                    f"{headers.index('')} (line {line_no})"
+                )
+            if len(set(h.lower() for h in headers)) != len(headers):
+                raise ParseError(
+                    f"header line contains duplicate columns "
+                    f"(case-insensitive): {headers}"
+                )
+            continue
+        # Pad / truncate to header length so the dict construction works
+        cells = [c.strip() for c in raw]
+        if len(cells) < len(headers):
+            cells = cells + [""] * (len(headers) - len(cells))
+        elif len(cells) > len(headers):
+            cells = cells[: len(headers)]
+        rows.append(dict(zip(headers, cells)))
+        if max_rows is not None and len(rows) >= max_rows:
+            break
+
+    if not headers:
+        raise ParseError("file contains no header line")
+    return rows, headers
+
+
+def _parse_json(text: str) -> tuple[list[dict[str, str]], list[str]]:
+    """Parse a JSON array of objects. All scalar values stringified."""
+    try:
+        obj = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise ParseError(f"invalid JSON: {e}") from e
+    if not isinstance(obj, list):
+        raise ParseError(
+            f"JSON top-level must be an array of objects, got {type(obj).__name__}"
+        )
+    if not obj:
+        return [], []
+    if not isinstance(obj[0], dict):
+        raise ParseError(
+            f"JSON array elements must be objects, got {type(obj[0]).__name__}"
+        )
+    # Headers = union of all keys in the array, ordered by first appearance.
+    headers: list[str] = []
+    seen: set[str] = set()
+    for item in obj:
+        if not isinstance(item, dict):
+            continue
+        for k in item.keys():
+            if k not in seen:
+                seen.add(k)
+                headers.append(k)
+
+    rows: list[dict[str, str]] = []
+    for item in obj:
+        if not isinstance(item, dict):
+            continue
+        row = {h: _scalar_to_str(item.get(h)) for h in headers}
+        rows.append(row)
+    return rows, headers
+
+
+def _parse_xlsx(data: bytes, options: ParseOptions) -> tuple[list[dict[str, str]], list[str]]:
+    """Parse the chosen sheet. Empty cells become '' (not None)."""
+    try:
+        # Lazy import — openpyxl is a heavy dependency we only load if needed
+        from openpyxl import load_workbook
+    except ImportError as exc:
+        raise ParseError(
+            "openpyxl is required to parse XLSX files but is not installed"
+        ) from exc
+
+    try:
+        wb = load_workbook(filename=io.BytesIO(data), read_only=True, data_only=True)
+    except Exception as e:
+        raise ParseError(f"invalid XLSX: {e}") from e
+
+    if options.sheet_name:
+        if options.sheet_name not in wb.sheetnames:
+            raise ParseError(
+                f"sheet {options.sheet_name!r} not found; "
+                f"available: {wb.sheetnames}"
+            )
+        ws = wb[options.sheet_name]
+    else:
+        ws = wb.active
+
+    rows_iter = ws.iter_rows(values_only=True)
+
+    # First non-empty row = header
+    headers: list[str] = []
+    for raw in rows_iter:
+        if not raw or all(v is None or str(v).strip() == "" for v in raw):
+            continue
+        headers = [str(v).strip() if v is not None else "" for v in raw]
+        if not all(headers):
+            raise ParseError("header row contains an empty column")
+        break
+
+    if not headers:
+        raise ParseError("XLSX contains no header row")
+
+    rows: list[dict[str, str]] = []
+    max_rows = options.max_rows
+    for raw in rows_iter:
+        if not raw or all(v is None or str(v).strip() == "" for v in raw):
+            continue
+        cells: list[str] = []
+        for v in raw[: len(headers)]:
+            cells.append(_scalar_to_str(v))
+        if len(cells) < len(headers):
+            cells = cells + [""] * (len(headers) - len(cells))
+        rows.append(dict(zip(headers, cells)))
+        if max_rows is not None and len(rows) >= max_rows:
+            break
+
+    return rows, headers
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _scalar_to_str(v) -> str:
+    """Convert any scalar (None, str, int, float, bool, date) to a TEXT-safe string.
+
+    The staging layer is type-agnostic by design; coercion + validation
+    happens in the DQ engine. So we just produce a stable text form here.
+    """
+    if v is None:
+        return ""
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, str):
+        return v.strip()
+    # date, datetime, Decimal, int, float — str() gives a canonical form
+    return str(v).strip()

--- a/tests/test_staging_parser.py
+++ b/tests/test_staging_parser.py
@@ -1,0 +1,280 @@
+"""Unit tests for staging.parser — TSV/CSV/XLSX/JSON parsing.
+
+Pure tests, no DB. Cover the format-detection, encoding-fallback, and
+delimiter-sniffing paths plus the edge cases (empty file, no header,
+duplicate headers, mixed sheets in XLSX).
+"""
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from ootils_core.staging.parser import (
+    ParseError,
+    ParseOptions,
+    parse,
+)
+
+
+# ---------------------------------------------------------------------------
+# TSV
+# ---------------------------------------------------------------------------
+
+
+def test_tsv_basic() -> None:
+    data = b"external_id\tname\titem_type\nSAP-001\tWidget A\tfinished_good\nSAP-002\tWidget B\tcomponent\n"
+    r = parse(data, filename="items.tsv")
+    assert r.format == "tsv"
+    assert r.delimiter == "\t"
+    assert r.encoding == "utf-8"
+    assert r.headers == ["external_id", "name", "item_type"]
+    assert r.row_count == 2
+    assert r.rows[0] == {"external_id": "SAP-001", "name": "Widget A", "item_type": "finished_good"}
+
+
+def test_tsv_with_blank_lines_ignored() -> None:
+    data = b"a\tb\n\n1\t2\n\n3\t4\n"
+    r = parse(data, format_hint="tsv")
+    assert r.row_count == 2
+    assert r.rows == [{"a": "1", "b": "2"}, {"a": "3", "b": "4"}]
+
+
+def test_tsv_extension_tab() -> None:
+    data = b"col1\tcol2\nv1\tv2\n"
+    r = parse(data, filename="export.tab")
+    assert r.format == "tsv"
+
+
+# ---------------------------------------------------------------------------
+# CSV
+# ---------------------------------------------------------------------------
+
+
+def test_csv_comma() -> None:
+    data = b"external_id,name\nA1,Foo\nA2,Bar\n"
+    r = parse(data, filename="items.csv")
+    assert r.format == "csv"
+    assert r.delimiter == ","
+    assert r.rows[0]["name"] == "Foo"
+
+
+def test_csv_semicolon_sniffed() -> None:
+    data = b"external_id;name\nA1;Foo\nA2;Bar\n"
+    r = parse(data, filename="items.csv")
+    assert r.delimiter == ";"
+    assert r.row_count == 2
+
+
+def test_csv_with_quoted_comma_in_value() -> None:
+    data = b'external_id,description\nA1,"hello, world"\nA2,plain\n'
+    r = parse(data, filename="items.csv")
+    assert r.rows[0]["description"] == "hello, world"
+
+
+def test_csv_explicit_delimiter_override() -> None:
+    data = b"a|b|c\n1|2|3\n"
+    r = parse(data, format_hint="csv", options=ParseOptions(delimiter="|"))
+    assert r.delimiter == "|"
+    assert r.rows[0] == {"a": "1", "b": "2", "c": "3"}
+
+
+# ---------------------------------------------------------------------------
+# JSON
+# ---------------------------------------------------------------------------
+
+
+def test_json_array_of_objects() -> None:
+    payload = [
+        {"external_id": "A1", "name": "Foo", "qty": 10},
+        {"external_id": "A2", "name": "Bar", "qty": 20},
+    ]
+    data = json.dumps(payload).encode("utf-8")
+    r = parse(data, filename="items.json")
+    assert r.format == "json"
+    assert r.delimiter is None
+    assert r.headers == ["external_id", "name", "qty"]
+    # Scalar coercion to str
+    assert r.rows[0]["qty"] == "10"
+
+
+def test_json_invalid_raises() -> None:
+    with pytest.raises(ParseError, match="invalid JSON"):
+        parse(b"{not json", format_hint="json")
+
+
+def test_json_top_level_object_rejected() -> None:
+    with pytest.raises(ParseError, match="must be an array"):
+        parse(b'{"a": 1}', format_hint="json")
+
+
+def test_json_union_of_keys_as_headers() -> None:
+    payload = [
+        {"a": 1, "b": 2},
+        {"a": 3, "c": 4},
+    ]
+    r = parse(json.dumps(payload).encode("utf-8"), format_hint="json")
+    assert r.headers == ["a", "b", "c"]
+    assert r.rows[0] == {"a": "1", "b": "2", "c": ""}
+    assert r.rows[1] == {"a": "3", "b": "", "c": "4"}
+
+
+# ---------------------------------------------------------------------------
+# Encoding fallback
+# ---------------------------------------------------------------------------
+
+
+def test_cp1252_fallback() -> None:
+    # 'café' encoded in CP-1252 isn't valid UTF-8 because of the 'é' byte 0xE9
+    data = "external_id\tname\nA1\tcafé\n".encode("cp1252")
+    r = parse(data, format_hint="tsv")
+    assert r.encoding == "cp1252"
+    assert r.rows[0]["name"] == "café"
+
+
+def test_utf8_with_bom() -> None:
+    data = "﻿external_id\tname\nA1\tFoo\n".encode("utf-8")
+    r = parse(data, format_hint="tsv")
+    assert r.encoding == "utf-8-sig"
+    # The BOM must not contaminate the first header
+    assert r.headers == ["external_id", "name"]
+
+
+# ---------------------------------------------------------------------------
+# Format detection edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_format_detection_by_content_when_no_extension() -> None:
+    # JSON sniffed by leading '['
+    r = parse(b'[{"a": 1}]')
+    assert r.format == "json"
+
+
+def test_format_detection_tsv_by_tab_in_header() -> None:
+    r = parse(b"col1\tcol2\nv1\tv2\n", filename="unknown")
+    assert r.format == "tsv"
+
+
+def test_format_detection_default_to_csv() -> None:
+    r = parse(b"col1,col2\nv1,v2\n")
+    assert r.format == "csv"
+
+
+# ---------------------------------------------------------------------------
+# Header validation
+# ---------------------------------------------------------------------------
+
+
+def test_empty_file_raises() -> None:
+    with pytest.raises(ParseError, match="empty file"):
+        parse(b"")
+
+
+def test_no_header_raises() -> None:
+    # Only blank lines
+    with pytest.raises(ParseError, match="no header"):
+        parse(b"\n\n\n", format_hint="tsv")
+
+
+def test_empty_column_in_header_raises() -> None:
+    with pytest.raises(ParseError, match="empty column"):
+        parse(b"a\t\tc\n1\t2\t3\n", format_hint="tsv")
+
+
+def test_duplicate_headers_raise() -> None:
+    with pytest.raises(ParseError, match="duplicate"):
+        parse(b"a\tA\nfoo\tbar\n", format_hint="tsv")
+
+
+# ---------------------------------------------------------------------------
+# Row shape robustness
+# ---------------------------------------------------------------------------
+
+
+def test_row_shorter_than_header_pads_with_empty() -> None:
+    data = b"a\tb\tc\n1\t2\n3\t4\t5\n"
+    r = parse(data, format_hint="tsv")
+    assert r.rows[0] == {"a": "1", "b": "2", "c": ""}
+    assert r.rows[1] == {"a": "3", "b": "4", "c": "5"}
+
+
+def test_row_longer_than_header_truncates() -> None:
+    data = b"a\tb\n1\t2\t3\t4\n"
+    r = parse(data, format_hint="tsv")
+    assert r.rows[0] == {"a": "1", "b": "2"}
+
+
+def test_max_rows_limit() -> None:
+    data = b"a\n" + b"\n".join(f"v{i}".encode() for i in range(10)) + b"\n"
+    r = parse(data, format_hint="csv", options=ParseOptions(max_rows=3))
+    assert r.row_count == 3
+
+
+# ---------------------------------------------------------------------------
+# SHA-256
+# ---------------------------------------------------------------------------
+
+
+def test_sha256_is_stable_for_identical_input() -> None:
+    data = b"a\tb\n1\t2\n"
+    a = parse(data, format_hint="tsv")
+    b = parse(data, format_hint="tsv")
+    assert a.sha256 == b.sha256
+
+
+def test_sha256_differs_for_different_input() -> None:
+    a = parse(b"a\tb\n1\t2\n", format_hint="tsv")
+    b = parse(b"a\tb\n1\t3\n", format_hint="tsv")
+    assert a.sha256 != b.sha256
+
+
+# ---------------------------------------------------------------------------
+# XLSX (requires openpyxl runtime)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def xlsx_bytes() -> bytes:
+    """Build a tiny in-memory xlsx with header + 2 rows."""
+    openpyxl = pytest.importorskip("openpyxl")
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws.append(["external_id", "name", "qty"])
+    ws.append(["A1", "Foo", 10])
+    ws.append(["A2", "Bar", 20])
+    # Second sheet to test sheet selection
+    ws2 = wb.create_sheet("Other")
+    ws2.append(["col1"])
+    ws2.append(["x"])
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+def test_xlsx_default_first_sheet(xlsx_bytes: bytes) -> None:
+    r = parse(xlsx_bytes, filename="items.xlsx")
+    assert r.format == "xlsx"
+    assert r.delimiter is None
+    assert r.encoding is None
+    assert r.headers == ["external_id", "name", "qty"]
+    assert r.row_count == 2
+    assert r.rows[0]["qty"] == "10"
+
+
+def test_xlsx_sheet_name_override(xlsx_bytes: bytes) -> None:
+    r = parse(xlsx_bytes, format_hint="xlsx", options=ParseOptions(sheet_name="Other"))
+    assert r.headers == ["col1"]
+    assert r.rows[0] == {"col1": "x"}
+
+
+def test_xlsx_unknown_sheet_raises(xlsx_bytes: bytes) -> None:
+    with pytest.raises(ParseError, match="not found"):
+        parse(xlsx_bytes, format_hint="xlsx", options=ParseOptions(sheet_name="DoesNotExist"))
+
+
+def test_xlsx_format_detected_by_pk_magic_without_extension(xlsx_bytes: bytes) -> None:
+    r = parse(xlsx_bytes)
+    assert r.format == "xlsx"


### PR DESCRIPTION
## Summary

Step 2 of the [ADR-013](docs/ADR-013-external-interfaces.md) roadmap. Pure parser module — no DB. Takes file bytes, returns a typed \`ParseResult\` with rows-as-dicts + metadata.

## API

\`\`\`python
from ootils_core.staging.parser import parse, ParseOptions

result = parse(file_bytes, filename='items.tsv')
# result.format    == 'tsv'
# result.encoding  == 'utf-8' (or 'utf-8-sig' if BOM detected, or 'cp1252' fallback)
# result.delimiter == '\t'
# result.headers   == ['external_id', 'name', 'item_type']
# result.rows      == [{'external_id': 'SAP-001', ...}, ...]
# result.sha256    == '<64 hex chars>' for staging.uploads dedup
\`\`\`

## Coverage (29 unit tests, all pass in 0.4s)

- Format detection by extension AND content sniff (PK magic, [/{, tab-in-header)
- Encoding ladder: utf-8 → utf-8-sig → cp1252 → latin-1 with warning log
- BOM-aware reporting (utf-8 vs utf-8-sig)
- CSV delimiter sniff via csv.Sniffer (',' ';' '\t' '|')
- XLSX via openpyxl read-only, sheet_name override
- JSON top-level array, header = union of keys
- Header validation: empty/duplicate columns raise ParseError
- Row shape robust: pad short rows with '', truncate long rows
- Stable SHA-256 for dedup

## Dependencies

Added to pyproject.toml:
- \`openpyxl ~= 3.1\` (XLSX)
- \`python-multipart ~= 0.0.20\` (will be needed by upload endpoint in step 4)

## Test plan

- [x] 29/29 unit tests pass locally
- [x] Ruff lint passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)