### PR TITLE
feat(staging): loader writes ParseResult to staging.uploads + ingest_*

### DIFF
--- a/src/ootils_core/staging/loader.py
+++ b/src/ootils_core/staging/loader.py
@@ -1,0 +1,222 @@
+"""
+loader.py — persist a parsed file into the staging tables (ADR-013 step 3).
+
+Takes a `ParseResult` (from staging.parser) plus per-batch metadata and
+writes three sets of rows in a single transaction:
+
+  1. staging.uploads      one row per uploaded file (file metadata + sha)
+  2. public.ingest_batches one row per logical batch (1-to-1 with upload
+                          today, but the schema allows N batches per
+                          upload if we ever need re-parsing variants)
+  3. public.ingest_rows    one row per data row from the file, with raw
+                          values in col_01..col_15 + the full row as a
+                          JSON object in raw_content (so the DQ engine
+                          can resolve column names that don't match
+                          col_NN positionally)
+
+The function is intentionally low-level: no HTTP concerns, no auth,
+no DQ. It just persists. The upload endpoint (step 4) is the caller
+that orchestrates parse -> load -> trigger-DQ.
+
+Schema bounds:
+  ingest_rows has col_01..col_15. We require headers <= 15 columns;
+  files with more columns raise LoaderError with a clear message
+  pointing at the schema limit. Future-proofing this would require a
+  migration to add col_16..col_N.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+import psycopg
+
+from ootils_core.staging.parser import ParseResult
+
+
+MAX_COLUMNS_PER_ROW = 15
+"""Hard upper bound — matches ingest_rows.col_01..col_15 in migration 007."""
+
+
+class LoaderError(ValueError):
+    """Raised when the parse result cannot be loaded into staging."""
+
+
+@dataclass(frozen=True)
+class LoadResult:
+    """What the loader actually wrote — returned to the caller for
+    audit logging + response payload."""
+    upload_id: UUID
+    batch_id: UUID
+    rows_inserted: int
+    headers: list[str]
+    format: str
+    encoding: str | None
+    delimiter: str | None
+    sha256: str
+    file_size_bytes: int
+
+
+def load_to_staging(
+    conn: psycopg.Connection,
+    parse_result: ParseResult,
+    entity_type: str,
+    source_system: str,
+    raw_bytes_size: int,
+    filename: str,
+    content_type: str | None = None,
+    submitted_by: str | None = None,
+    notes: str | None = None,
+) -> LoadResult:
+    """Persist a ParseResult into staging.
+
+    Arguments:
+        conn:             open psycopg connection. The function does NOT
+                          commit — the caller decides the transaction
+                          boundary.
+        parse_result:     output of staging.parser.parse()
+        entity_type:      must match ingest_batches.entity_type CHECK
+                          constraint values (items / locations / suppliers / ...)
+        source_system:    free-text identifier of the upstream system
+                          (SAP-EU, KINAXIS, OPS-EXCEL-EXPORT, ...)
+        raw_bytes_size:   size of the original file bytes (for staging.uploads)
+        filename:         original filename (for staging.uploads)
+        content_type:     declared Content-Type header (informational)
+        submitted_by:     who initiated this upload (from auth context)
+        notes:            free-text annotation stored on the batch
+
+    Raises:
+        LoaderError if the parse result violates staging contracts
+        (too many columns, empty rows list, etc.)
+    """
+    if not parse_result.headers:
+        raise LoaderError("parse_result has no headers (empty file)")
+    if len(parse_result.headers) > MAX_COLUMNS_PER_ROW:
+        raise LoaderError(
+            f"file has {len(parse_result.headers)} columns, "
+            f"but ingest_rows supports at most {MAX_COLUMNS_PER_ROW} "
+            f"(col_01..col_{MAX_COLUMNS_PER_ROW:02d}). "
+            "Split the file or extend the schema (migration)."
+        )
+
+    upload_id = uuid4()
+    batch_id = uuid4()
+
+    # ------------------------------------------------------------------
+    # 1. staging.uploads
+    # ------------------------------------------------------------------
+    conn.execute(
+        """
+        INSERT INTO staging.uploads (
+            upload_id, batch_id, filename, file_size_bytes, file_format,
+            sha256, encoding, content_type, uploaded_by
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+        """,
+        (
+            upload_id, batch_id, filename, raw_bytes_size,
+            parse_result.format, parse_result.sha256,
+            parse_result.encoding, content_type, submitted_by,
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # 2. public.ingest_batches
+    # ------------------------------------------------------------------
+    conn.execute(
+        """
+        INSERT INTO ingest_batches (
+            batch_id, entity_type, source_system, status,
+            total_rows, submitted_by, notes
+        ) VALUES (%s, %s, %s, 'pending', %s, %s, %s)
+        """,
+        (
+            batch_id, entity_type, source_system,
+            len(parse_result.rows), submitted_by, notes,
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # 3. public.ingest_rows — bulk INSERT via UNNEST
+    # ------------------------------------------------------------------
+    rows_inserted = 0
+    if parse_result.rows:
+        rows_inserted = _bulk_insert_rows(conn, batch_id, parse_result)
+
+    return LoadResult(
+        upload_id=upload_id,
+        batch_id=batch_id,
+        rows_inserted=rows_inserted,
+        headers=list(parse_result.headers),
+        format=parse_result.format,
+        encoding=parse_result.encoding,
+        delimiter=parse_result.delimiter,
+        sha256=parse_result.sha256,
+        file_size_bytes=raw_bytes_size,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _bulk_insert_rows(
+    conn: psycopg.Connection,
+    batch_id: UUID,
+    parse_result: ParseResult,
+) -> int:
+    """Build 18 parallel arrays (row_id + row_number + raw_content + col_01..col_15)
+    and INSERT via a single UNNEST statement."""
+    n = len(parse_result.rows)
+    headers = parse_result.headers
+    width = len(headers)
+
+    # Pre-allocate the column arrays
+    row_ids: list[UUID] = [uuid4() for _ in range(n)]
+    row_numbers: list[int] = list(range(1, n + 1))
+    raw_contents: list[str] = []
+    cols: list[list[str | None]] = [[None] * n for _ in range(MAX_COLUMNS_PER_ROW)]
+
+    for row_idx, row in enumerate(parse_result.rows):
+        # raw_content = the original row as a JSON dict (header -> value)
+        raw_contents.append(json.dumps(row, ensure_ascii=False))
+        # col_NN = positional value (1-indexed in DB, 0-indexed in array)
+        for c_idx in range(width):
+            cols[c_idx][row_idx] = row.get(headers[c_idx], "")
+
+    # Build the UNNEST query — 18 arrays in, INSERT 18 columns out
+    cur = conn.execute(
+        """
+        INSERT INTO ingest_rows (
+            row_id, batch_id, row_number, raw_content,
+            col_01, col_02, col_03, col_04, col_05,
+            col_06, col_07, col_08, col_09, col_10,
+            col_11, col_12, col_13, col_14, col_15
+        )
+        SELECT
+            r.row_id, %s, r.row_number, r.raw_content,
+            r.c01, r.c02, r.c03, r.c04, r.c05,
+            r.c06, r.c07, r.c08, r.c09, r.c10,
+            r.c11, r.c12, r.c13, r.c14, r.c15
+        FROM UNNEST(
+            %s::uuid[], %s::int[], %s::text[],
+            %s::text[], %s::text[], %s::text[], %s::text[], %s::text[],
+            %s::text[], %s::text[], %s::text[], %s::text[], %s::text[],
+            %s::text[], %s::text[], %s::text[], %s::text[], %s::text[]
+        ) AS r(
+            row_id, row_number, raw_content,
+            c01, c02, c03, c04, c05,
+            c06, c07, c08, c09, c10,
+            c11, c12, c13, c14, c15
+        )
+        """,
+        (
+            batch_id,
+            row_ids, row_numbers, raw_contents,
+            cols[0], cols[1], cols[2], cols[3], cols[4],
+            cols[5], cols[6], cols[7], cols[8], cols[9],
+            cols[10], cols[11], cols[12], cols[13], cols[14],
+        ),
+    )
+    return cur.rowcount or 0

--- a/tests/integration/test_staging_loader.py
+++ b/tests/integration/test_staging_loader.py
@@ -1,0 +1,202 @@
+"""Integration tests for staging.loader — round-trip from ParseResult into Postgres.
+
+Requires a real Postgres with migrations 001..033 applied. Uses the
+existing `migrated_db` fixture in tests/integration/conftest.py.
+"""
+from __future__ import annotations
+
+import json
+
+import psycopg
+import pytest
+from psycopg.rows import dict_row
+
+from ootils_core.staging.loader import (
+    MAX_COLUMNS_PER_ROW,
+    LoaderError,
+    load_to_staging,
+)
+from ootils_core.staging.parser import parse
+
+from .conftest import requires_db
+
+
+@pytest.fixture
+def conn(migrated_db: str):
+    """A clean connection per test, rolled back at teardown to avoid
+    polluting other tests."""
+    with psycopg.connect(migrated_db, row_factory=dict_row) as c:
+        yield c
+        c.rollback()
+
+
+@requires_db
+def test_loader_inserts_upload_batch_and_rows(conn) -> None:
+    """End-to-end: parse TSV bytes, load to staging, verify all three tables."""
+    data = (
+        b"external_id\tname\titem_type\tuom\tstatus\n"
+        b"SAP-001\tWidget A\tfinished_good\tEA\tactive\n"
+        b"SAP-002\tWidget B\tcomponent\tEA\tphase_out\n"
+        b"SAP-003\tWidget C\traw_material\tKG\tactive\n"
+    )
+    pr = parse(data, filename="items_sap.tsv")
+    result = load_to_staging(
+        conn,
+        parse_result=pr,
+        entity_type="items",
+        source_system="SAP-EU",
+        raw_bytes_size=len(data),
+        filename="items_sap.tsv",
+        content_type="text/tab-separated-values",
+        submitted_by="ops@example.com",
+        notes="weekly SAP master refresh",
+    )
+
+    assert result.rows_inserted == 3
+    assert result.format == "tsv"
+    assert result.encoding == "utf-8"
+    assert result.headers == ["external_id", "name", "item_type", "uom", "status"]
+
+    # staging.uploads — exactly 1 row, linked to the batch
+    upload = conn.execute(
+        "SELECT * FROM staging.uploads WHERE upload_id = %s", (result.upload_id,)
+    ).fetchone()
+    assert upload is not None
+    assert upload["batch_id"] == result.batch_id
+    assert upload["filename"] == "items_sap.tsv"
+    assert upload["file_format"] == "tsv"
+    assert upload["file_size_bytes"] == len(data)
+    assert upload["sha256"] == pr.sha256
+    assert upload["uploaded_by"] == "ops@example.com"
+
+    # ingest_batches — exactly 1 row, status=pending, count=3
+    batch = conn.execute(
+        "SELECT * FROM ingest_batches WHERE batch_id = %s", (result.batch_id,)
+    ).fetchone()
+    assert batch is not None
+    assert batch["entity_type"] == "items"
+    assert batch["source_system"] == "SAP-EU"
+    assert batch["status"] == "pending"
+    assert batch["total_rows"] == 3
+    assert batch["submitted_by"] == "ops@example.com"
+    assert batch["notes"] == "weekly SAP master refresh"
+
+    # ingest_rows — 3 rows, row_number 1..3, col_01..col_05 populated
+    rows = conn.execute(
+        """
+        SELECT row_number, raw_content, col_01, col_02, col_03, col_04, col_05, col_06
+        FROM ingest_rows WHERE batch_id = %s ORDER BY row_number
+        """,
+        (result.batch_id,),
+    ).fetchall()
+    assert len(rows) == 3
+    assert [r["row_number"] for r in rows] == [1, 2, 3]
+    assert rows[0]["col_01"] == "SAP-001"
+    assert rows[0]["col_02"] == "Widget A"
+    assert rows[0]["col_03"] == "finished_good"
+    assert rows[0]["col_04"] == "EA"
+    assert rows[0]["col_05"] == "active"
+    # No 6th column in the file -> col_06 stays NULL
+    assert rows[0]["col_06"] is None
+    # raw_content holds the JSON dict so DQ can look up by header name
+    parsed = json.loads(rows[0]["raw_content"])
+    assert parsed["external_id"] == "SAP-001"
+    assert parsed["status"] == "active"
+
+
+@requires_db
+def test_loader_too_many_columns_raises(conn) -> None:
+    headers = "\t".join(f"col{i}" for i in range(MAX_COLUMNS_PER_ROW + 1))
+    values = "\t".join(f"v{i}" for i in range(MAX_COLUMNS_PER_ROW + 1))
+    data = f"{headers}\n{values}\n".encode("utf-8")
+    pr = parse(data, format_hint="tsv")
+    with pytest.raises(LoaderError, match=str(MAX_COLUMNS_PER_ROW)):
+        load_to_staging(
+            conn,
+            parse_result=pr,
+            entity_type="items",
+            source_system="SAP-EU",
+            raw_bytes_size=len(data),
+            filename="too_wide.tsv",
+        )
+
+
+@requires_db
+def test_loader_empty_rows_still_creates_batch(conn) -> None:
+    """A header-only file should still produce a batch + upload row,
+    just with total_rows=0. Useful for catching 'export ran but emitted
+    nothing' situations."""
+    data = b"external_id\tname\n"
+    pr = parse(data, format_hint="tsv")
+    result = load_to_staging(
+        conn,
+        parse_result=pr,
+        entity_type="items",
+        source_system="SAP-EU",
+        raw_bytes_size=len(data),
+        filename="empty_items.tsv",
+    )
+    assert result.rows_inserted == 0
+    batch = conn.execute(
+        "SELECT total_rows FROM ingest_batches WHERE batch_id = %s",
+        (result.batch_id,),
+    ).fetchone()
+    assert batch["total_rows"] == 0
+    # ingest_rows table empty for this batch
+    cnt = conn.execute(
+        "SELECT COUNT(*) AS n FROM ingest_rows WHERE batch_id = %s",
+        (result.batch_id,),
+    ).fetchone()["n"]
+    assert cnt == 0
+
+
+@requires_db
+def test_loader_preserves_non_ascii_values(conn) -> None:
+    """Round-trip with French + accents to confirm UTF-8 survives the
+    JSON serialisation in raw_content."""
+    data = (
+        b"external_id\tname\n"
+        + "RM-001\tAcier inoxydable français\n".encode("utf-8")
+        + "RM-002\tÉpoxy résiné\n".encode("utf-8")
+    )
+    pr = parse(data, format_hint="tsv")
+    result = load_to_staging(
+        conn,
+        parse_result=pr,
+        entity_type="items",
+        source_system="SAP-FR",
+        raw_bytes_size=len(data),
+        filename="raws_fr.tsv",
+    )
+    rows = conn.execute(
+        "SELECT raw_content, col_02 FROM ingest_rows WHERE batch_id = %s ORDER BY row_number",
+        (result.batch_id,),
+    ).fetchall()
+    assert rows[0]["col_02"] == "Acier inoxydable français"
+    parsed = json.loads(rows[0]["raw_content"])
+    assert parsed["name"] == "Acier inoxydable français"
+
+
+@requires_db
+def test_loader_bulk_insert_handles_500_rows(conn) -> None:
+    """Sanity check on bulk insert path — make sure the UNNEST with 18
+    parallel arrays survives a non-trivial row count."""
+    lines = [b"external_id\tname\titem_type\tuom\tstatus"]
+    for i in range(500):
+        lines.append(f"BULK-{i:04d}\tBulk item {i}\tcomponent\tEA\tactive".encode("utf-8"))
+    data = b"\n".join(lines) + b"\n"
+    pr = parse(data, format_hint="tsv")
+    result = load_to_staging(
+        conn,
+        parse_result=pr,
+        entity_type="items",
+        source_system="BULK-TEST",
+        raw_bytes_size=len(data),
+        filename="bulk.tsv",
+    )
+    assert result.rows_inserted == 500
+    cnt = conn.execute(
+        "SELECT COUNT(*) AS n FROM ingest_rows WHERE batch_id = %s",
+        (result.batch_id,),
+    ).fetchone()["n"]
+    assert cnt == 500


### PR DESCRIPTION
## Summary

Step 3 of the [ADR-013](docs/ADR-013-external-interfaces.md) roadmap. The loader bridges the in-memory \`ParseResult\` (from step 2's parser) to the persistent staging zone — one transaction across three tables.

## What lands

\`\`\`python
from ootils_core.staging.parser import parse
from ootils_core.staging.loader import load_to_staging

with psycopg.connect(dsn) as conn:
    pr = parse(file_bytes, filename='items.tsv')
    result = load_to_staging(
        conn,
        parse_result=pr,
        entity_type='items',
        source_system='SAP-EU',
        raw_bytes_size=len(file_bytes),
        filename='items.tsv',
        submitted_by='ops@example.com',
    )
    conn.commit()
# result.upload_id, result.batch_id, result.rows_inserted, ...
\`\`\`

## Three tables written, single transaction

- \`staging.uploads\` — file metadata (sha256, encoding, content_type)
- \`public.ingest_batches\` — \`status='pending'\`, \`entity_type\`, \`source_system\`, \`total_rows\`
- \`public.ingest_rows\` — bulk INSERT via UNNEST. Each row carries \`raw_content\` (full JSON dict by header name) + \`col_01..col_15\` (positional values for SQL filters)

## Design notes

- **No commit inside the loader** — the caller (upload endpoint, step 4) decides the transaction boundary so it can compose with DQ enqueueing.
- **raw_content as JSON** — the DQ engine doesn't need to know which header sits at which positional col_NN. It looks up by header name.
- **> 15 columns raises LoaderError** — that's the schema limit from migration 007. A future migration can widen if a real entity ever needs > 15 columns. All current entities (items, locations, suppliers, supplier_items, planning_params subset, ...) fit comfortably.
- **Header-only file allowed** — total_rows=0, valid batch. Lets ops spot "export ran but produced nothing".

## Integration tests

5 tests in \`tests/integration/test_staging_loader.py\`:
- Full round-trip TSV → 3 tables + content verification
- > 15 columns raises LoaderError
- Empty rows produces empty batch (0 rows but the batch row exists)
- UTF-8 with French accents survives the JSON serialisation
- 500-row bulk insert (UNNEST shape works at scale)

Tests use the existing \`migrated_db\` fixture; rolled back per-test to keep state clean.

## Test plan

- [x] Ruff lint passes locally
- [x] Python imports verified
- [ ] CI integration tests pass (CI Postgres applies migrations 001..033)

🤖 Generated with [Claude Code](https://claude.com/claude-code)