### PR TITLE
feat(staging): POST /v1/staging/upload endpoint (multipart file)

### DIFF
--- a/src/ootils_core/api/app.py
+++ b/src/ootils_core/api/app.py
@@ -31,7 +31,7 @@ except ImportError:
 
 from ootils_core.api.auth import _expected_token
 from ootils_core.api.dependencies import _get_ootils_db, get_db
-from ootils_core.api.routers import bom, calc, calendars, demo, dq, events, explain, forecasting, ghosts, graph, ingest, issues, mrp, mrp_apics, planning_params, projection, rccp, scenarios, simulate
+from ootils_core.api.routers import bom, calc, calendars, demo, dq, events, explain, forecasting, ghosts, graph, ingest, issues, mrp, mrp_apics, planning_params, projection, rccp, scenarios, simulate, staging
 from ootils_core.api.routers.graph import nodes_router
 from ootils_core.mps import router as mps_router
 from ootils_core.atp import atp_router
@@ -338,6 +338,7 @@ def create_app() -> FastAPI:
     application.include_router(graph.router)
     application.include_router(nodes_router)
     application.include_router(ingest.router)
+    application.include_router(staging.router)
     application.include_router(dq.router)
     application.include_router(bom.router)
     application.include_router(calendars.router)

--- a/src/ootils_core/api/routers/staging.py
+++ b/src/ootils_core/api/routers/staging.py
@@ -1,0 +1,208 @@
+"""
+POST /v1/staging/* — file-upload entry point for the staging pipeline.
+
+This router is the HTTP surface of ADR-013. It orchestrates the
+parser (step 2) + the loader (step 3) into a single transactional
+operation, exposed as a multipart file-upload endpoint.
+
+Endpoint:
+    POST /v1/staging/upload
+        multipart form fields:
+            file:           the file content (required)
+            entity_type:    one of the values supported by
+                            ingest_batches.entity_type CHECK constraint
+            source_system:  free-text identifier of the upstream system
+            notes:          optional free-text annotation
+            format_hint:    optional ('tsv','csv','xlsx','json') to
+                            skip auto-detection
+            sheet_name:     optional XLSX sheet override
+            delimiter:      optional CSV delimiter override
+
+        Returns 202 Accepted with the upload_id + batch_id and the
+        parse + load diagnostics. The batch status is 'pending' — the
+        DQ pipeline (L1..L4) runs asynchronously or via a follow-up
+        endpoint (TBD in ADR-013 step 5+).
+
+ADR-013 D4 mandates approval; this endpoint only enqueues the upload —
+batches sit in `pending` until /v1/staging/batches/{id}/approve lands.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Annotated, Optional
+
+import psycopg
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    UploadFile,
+    status,
+)
+
+from ootils_core.api.auth import require_auth
+from ootils_core.api.dependencies import get_db
+from ootils_core.staging.loader import LoaderError, load_to_staging
+from ootils_core.staging.parser import ParseError, ParseOptions, parse
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/v1/staging", tags=["staging"])
+
+
+# Allowed values for entity_type — must stay in sync with the CHECK
+# constraint on ingest_batches.entity_type (see migration 007).
+_VALID_ENTITY_TYPES = frozenset({
+    "items",
+    "locations",
+    "suppliers",
+    "supplier_items",
+    "purchase_orders",
+    "customer_orders",
+    "forecasts",
+    "work_orders",
+    "transfers",
+    "on_hand",
+})
+
+# Allowed format hints (parser SUPPORTED_FORMATS — kept here too to
+# validate early and return a 400 rather than letting the parser raise)
+_VALID_FORMAT_HINTS = frozenset({"tsv", "csv", "xlsx", "json"})
+
+# Reasonable upper bound on upload size — 50 MB covers an ERP item
+# master export (5K items × ~200 bytes = 1MB) with plenty of headroom
+# but blocks accidental dumps of entire DBs.
+_MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+
+
+@router.post(
+    "/upload",
+    status_code=status.HTTP_202_ACCEPTED,
+    dependencies=[Depends(require_auth)],
+)
+def upload_file(
+    file: Annotated[UploadFile, File(description="Source file (TSV/CSV/XLSX/JSON)")],
+    entity_type: Annotated[str, Form(description="Target entity (items, locations, etc.)")],
+    source_system: Annotated[str, Form(description="Upstream system identifier (SAP-EU, KINAXIS, ...)")],
+    notes: Annotated[Optional[str], Form(description="Free-text annotation")] = None,
+    format_hint: Annotated[Optional[str], Form(description="tsv/csv/xlsx/json — skip auto-detect")] = None,
+    sheet_name: Annotated[Optional[str], Form(description="XLSX sheet override")] = None,
+    delimiter: Annotated[Optional[str], Form(description="CSV delimiter override")] = None,
+    db: psycopg.Connection = Depends(get_db),
+) -> dict:
+    """Upload a file into the staging zone (ADR-013 step 1 of the lifecycle)."""
+
+    # ---------- 1. Input validation ----------
+    if entity_type not in _VALID_ENTITY_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"unknown entity_type {entity_type!r}; "
+                f"expected one of {sorted(_VALID_ENTITY_TYPES)}"
+            ),
+        )
+    if format_hint is not None and format_hint not in _VALID_FORMAT_HINTS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"unknown format_hint {format_hint!r}; "
+                f"expected one of {sorted(_VALID_FORMAT_HINTS)}"
+            ),
+        )
+    if not source_system or not source_system.strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="source_system is required and cannot be empty",
+        )
+
+    # ---------- 2. Read bytes ----------
+    raw = file.file.read()
+    if not raw:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="uploaded file is empty",
+        )
+    if len(raw) > _MAX_UPLOAD_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"file exceeds {_MAX_UPLOAD_BYTES} bytes",
+        )
+
+    # ---------- 3. Parse ----------
+    options = ParseOptions(
+        sheet_name=sheet_name,
+        delimiter=delimiter,
+    )
+    try:
+        parse_result = parse(
+            data=raw,
+            filename=file.filename,
+            format_hint=format_hint,
+            options=options,
+        )
+    except ParseError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"parse error: {e}",
+        ) from e
+
+    # ---------- 4. Load into staging tables ----------
+    try:
+        load_result = load_to_staging(
+            db,
+            parse_result=parse_result,
+            entity_type=entity_type,
+            source_system=source_system.strip(),
+            raw_bytes_size=len(raw),
+            filename=file.filename or "upload",
+            content_type=file.content_type,
+            submitted_by=_extract_submitter(),
+            notes=notes,
+        )
+        db.commit()
+    except LoaderError as e:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"load error: {e}",
+        ) from e
+    except Exception as e:
+        db.rollback()
+        logger.exception("staging upload failed unexpectedly: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="internal error while persisting upload",
+        ) from e
+
+    logger.info(
+        "staging.upload OK: batch=%s entity=%s source=%s rows=%d format=%s",
+        load_result.batch_id, entity_type, source_system,
+        load_result.rows_inserted, load_result.format,
+    )
+
+    return {
+        "upload_id": str(load_result.upload_id),
+        "batch_id": str(load_result.batch_id),
+        "status": "pending",
+        "entity_type": entity_type,
+        "source_system": source_system.strip(),
+        "rows_inserted": load_result.rows_inserted,
+        "format": load_result.format,
+        "encoding": load_result.encoding,
+        "delimiter": load_result.delimiter,
+        "headers": load_result.headers,
+        "sha256": load_result.sha256,
+        "file_size_bytes": load_result.file_size_bytes,
+    }
+
+
+def _extract_submitter() -> str | None:
+    """Placeholder for pulling the authenticated identity off the request.
+
+    The current `require_auth` dependency only validates the bearer
+    token (no subject extraction yet). When ADR-013's audit story
+    needs real identities (OIDC subject, API-key owner, etc.) this
+    function is the single place to wire it up.
+    """
+    return None

--- a/tests/integration/test_staging_upload.py
+++ b/tests/integration/test_staging_upload.py
@@ -1,0 +1,212 @@
+"""Integration tests for POST /v1/staging/upload (ADR-013 step 4).
+
+Builds on the test patterns in test_ingest.py — uses a TestClient
+wired to the migrated test DB, with auth via OOTILS_API_TOKEN.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+
+import psycopg
+import pytest
+from psycopg.rows import dict_row
+
+from .conftest import requires_db
+
+
+@pytest.fixture(scope="module")
+def staging_client(migrated_db):
+    """Module-scoped TestClient for /v1/staging/* endpoints."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = "test-token"
+
+    from fastapi.testclient import TestClient
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+
+    app = create_app()
+    db = OotilsDB(migrated_db)
+
+    def override_db():
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="module")
+def auth():
+    return {"Authorization": "Bearer test-token"}
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_upload_tsv_items(staging_client, auth, migrated_db: str) -> None:
+    """Upload a tiny TSV items file, verify 202 + DB state."""
+    data = (
+        b"external_id\tname\titem_type\tuom\tstatus\n"
+        b"SAP-001\tWidget A\tfinished_good\tEA\tactive\n"
+        b"SAP-002\tWidget B\tcomponent\tEA\tphase_out\n"
+    )
+    resp = staging_client.post(
+        "/v1/staging/upload",
+        headers=auth,
+        files={"file": ("items.tsv", io.BytesIO(data), "text/tab-separated-values")},
+        data={
+            "entity_type": "items",
+            "source_system": "SAP-EU",
+            "notes": "weekly refresh",
+        },
+    )
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["status"] == "pending"
+    assert body["entity_type"] == "items"
+    assert body["source_system"] == "SAP-EU"
+    assert body["rows_inserted"] == 2
+    assert body["format"] == "tsv"
+    assert body["delimiter"] == "\t"
+    assert body["encoding"] == "utf-8"
+    assert body["headers"] == ["external_id", "name", "item_type", "uom", "status"]
+    assert len(body["sha256"]) == 64
+    assert body["file_size_bytes"] == len(data)
+
+    # Verify staging.uploads + ingest_batches were written
+    with psycopg.connect(migrated_db, row_factory=dict_row) as c:
+        up = c.execute(
+            "SELECT * FROM staging.uploads WHERE upload_id = %s",
+            (body["upload_id"],),
+        ).fetchone()
+        assert up is not None
+        assert up["batch_id"] == body["batch_id"]
+        assert up["sha256"] == body["sha256"]
+        assert up["filename"] == "items.tsv"
+
+        batch = c.execute(
+            "SELECT * FROM ingest_batches WHERE batch_id = %s",
+            (body["batch_id"],),
+        ).fetchone()
+        assert batch["status"] == "pending"
+        assert batch["entity_type"] == "items"
+        assert batch["total_rows"] == 2
+
+        rows = c.execute(
+            "SELECT row_number, col_01, col_02 FROM ingest_rows "
+            "WHERE batch_id = %s ORDER BY row_number",
+            (body["batch_id"],),
+        ).fetchall()
+        assert len(rows) == 2
+        assert rows[0]["col_01"] == "SAP-001"
+        assert rows[1]["col_02"] == "Widget B"
+
+
+@requires_db
+def test_upload_csv_with_semicolon_sniffed(staging_client, auth) -> None:
+    data = b"external_id;name\nA1;Foo\nA2;Bar\n"
+    resp = staging_client.post(
+        "/v1/staging/upload",
+        headers=auth,
+        files={"file": ("items.csv", io.BytesIO(data), "text/csv")},
+        data={"entity_type": "items", "source_system": "OPS-EU"},
+    )
+    assert resp.status_code == 202, resp.text
+    assert resp.json()["delimiter"] == ";"
+    assert resp.json()["format"] == "csv"
+
+
+@requires_db
+def test_upload_json(staging_client, auth) -> None:
+    payload = json.dumps([
+        {"external_id": "J1", "name": "Foo", "item_type": "component", "uom": "EA"},
+        {"external_id": "J2", "name": "Bar", "item_type": "component", "uom": "EA"},
+    ]).encode("utf-8")
+    resp = staging_client.post(
+        "/v1/staging/upload",
+        headers=auth,
+        files={"file": ("items.json", io.BytesIO(payload), "application/json")},
+        data={"entity_type": "items", "source_system": "API-PUSH"},
+    )
+    assert resp.status_code == 202, resp.text
+    assert resp.json()["format"] == "json"
+    assert resp.json()["rows_inserted"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_upload_rejects_unknown_entity_type(staging_client, auth) -> None:
+    resp = staging_client.post(
+        "/v1/staging/upload",
+        headers=auth,
+        files={"file": ("x.tsv", io.BytesIO(b"a\tb\n1\t2\n"), "text/plain")},
+        data={"entity_type": "nonsense", "source_system": "X"},
+    )
+    assert resp.status_code == 400
+    assert "unknown entity_type" in resp.json()["detail"]
+
+
+@requires_db
+def test_upload_rejects_empty_file(staging_client, auth) -> None:
+    resp = staging_client.post(
+        "/v1/staging/upload",
+        headers=auth,
+        files={"file": ("x.tsv", io.BytesIO(b""), "text/plain")},
+        data={"entity_type": "items", "source_system": "X"},
+    )
+    assert resp.status_code == 400
+    assert "empty" in resp.json()["detail"].lower()
+
+
+@requires_db
+def test_upload_rejects_missing_source_system(staging_client, auth) -> None:
+    resp = staging_client.post(
+        "/v1/staging/upload",
+        headers=auth,
+        files={"file": ("x.tsv", io.BytesIO(b"a\tb\n1\t2\n"), "text/plain")},
+        data={"entity_type": "items", "source_system": "  "},
+    )
+    assert resp.status_code == 400
+    assert "source_system" in resp.json()["detail"]
+
+
+@requires_db
+def test_upload_rejects_malformed_json(staging_client, auth) -> None:
+    """A .json file that can't be parsed surfaces as a 400 parse error."""
+    resp = staging_client.post(
+        "/v1/staging/upload",
+        headers=auth,
+        files={"file": ("bad.json", io.BytesIO(b"{not json"), "application/json")},
+        data={"entity_type": "items", "source_system": "X"},
+    )
+    assert resp.status_code == 400
+    assert "parse error" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_upload_requires_auth(staging_client) -> None:
+    resp = staging_client.post(
+        "/v1/staging/upload",
+        files={"file": ("x.tsv", io.BytesIO(b"a\tb\n1\t2\n"), "text/plain")},
+        data={"entity_type": "items", "source_system": "X"},
+    )
+    # Either 401 or 403 depending on the auth dependency's behaviour
+    assert resp.status_code in (401, 403)

--- a/tests/integration/test_staging_upload.py
+++ b/tests/integration/test_staging_upload.py
@@ -89,7 +89,7 @@ def test_upload_tsv_items(staging_client, auth, migrated_db: str) -> None:
             (body["upload_id"],),
         ).fetchone()
         assert up is not None
-        assert up["batch_id"] == body["batch_id"]
+        assert str(up["batch_id"]) == body["batch_id"]
         assert up["sha256"] == body["sha256"]
         assert up["filename"] == "items.tsv"
 


### PR DESCRIPTION
## Summary

Step 4 of the [ADR-013](docs/ADR-013-external-interfaces.md) roadmap. The HTTP surface that orchestrates parse + load into a single transactional upload. **First external-tool entry point** for the staging pipeline.

## Usage

\`\`\`bash
curl -X POST "\${OOTILS_API_URL}/v1/staging/upload" \
  -H "Authorization: Bearer \${OOTILS_API_TOKEN}" \
  -F "file=@items_sap_2026w22.tsv" \
  -F "entity_type=items" \
  -F "source_system=SAP-EU" \
  -F "notes=weekly master refresh"

# Response 202:
# {
#   "upload_id": "uuid",
#   "batch_id": "uuid",
#   "status": "pending",
#   "rows_inserted": 4827,
#   "format": "tsv",
#   "encoding": "utf-8",
#   "headers": ["external_id", "name", "item_type", "uom", "status"],
#   "sha256": "...",
#   "file_size_bytes": 312456
# }
\`\`\`

## Error mapping

| Code | Cause |
|---|---|
| 400 | unknown entity_type / format_hint, missing source_system, empty file, parse error (encoding, structure, header), loader error (>15 columns) |
| 401/403 | missing/invalid bearer token (existing \`require_auth\`) |
| 413 | file > 50 MB |
| 500 | unexpected exception (rolled back, logged) |

## Coverage

7 integration tests in \`tests/integration/test_staging_upload.py\`:
- TSV happy path with DB verification (3 tables written)
- CSV with \`;\` auto-sniffed
- JSON top-level array
- Unknown entity_type rejected
- Empty file rejected
- Missing source_system rejected
- Malformed JSON surfaces as parse error
- Missing auth returns 401/403

## What's next

This closes the **upload half** of ADR-013. The remaining pipeline:
- Step 5: DQ L3 (business SC rules)
- Step 6: DQ L4 (cross-batch)
- Step 7: \`GET /diff\` pre-approval preview
- Step 8: \`POST /approve\` (full-reload + soft-delete)

The batch sits in \`status='pending'\` until the approve workflow lands.

## Test plan

- [x] Ruff lint passes
- [x] Endpoint registered (verified via \`app.routes\`)
- [ ] CI integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)