### PR TITLE
feat(dq): L4 cross-batch + cross-entity rules

### DIFF
--- a/src/ootils_core/engine/dq/engine.py
+++ b/src/ootils_core/engine/dq/engine.py
@@ -660,6 +660,28 @@ def run_dq(db: psycopg.Connection, batch_id: UUID) -> DQResult:
                    for i in row_issues.get(row_id, [])):
             max_level_reached[row_id] = 3
 
+    # 4c. L4 cross-batch + cross-entity rules — only for rows that passed
+    #     L1+L2+L3 without errors. L4 hits the DB (intra-batch duplicate
+    #     scan + supplier/planning-params lookups). See l4_rules.py.
+    from ootils_core.engine.dq.l4_rules import check_l4
+
+    l4_candidates = [
+        (row_id, row_number, content)
+        for (row_id, row_number, content) in rows_data
+        if not any(i.severity == "error" for i in row_issues.get(row_id, []))
+    ]
+    if l4_candidates:
+        l4_issues = check_l4(l4_candidates, entity_type, batch_id, db)
+        for issue in l4_issues:
+            row_issues.setdefault(issue.row_id, []).append(issue)
+        all_issues.extend(l4_issues)
+
+    # Mark L4 reached for candidates that didn't pick up a new L4 error
+    for row_id, _, _ in l4_candidates:
+        if not any(i.dq_level == 4 and i.severity == "error"
+                   for i in row_issues.get(row_id, [])):
+            max_level_reached[row_id] = 4
+
     # 5. Persist issues
     _persist_issues(db, batch_id, all_issues)
 

--- a/src/ootils_core/engine/dq/l4_rules.py
+++ b/src/ootils_core/engine/dq/l4_rules.py
@@ -1,0 +1,313 @@
+"""
+l4_rules.py — DQ Level 4 (cross-batch / cross-entity rules).
+
+L4 catches errors that are invisible to L1/L2/L3 because they require
+either looking at the WHOLE batch at once (duplicates) or joining
+against canonical tables (orphans, inactive references).
+
+Examples L4 catches but L1-L3 don't:
+  - same external_id appears twice in the same uploaded file
+  - external_id collides with a still-pending batch from another upload
+  - supplier_items references a supplier whose status is now 'blocked'
+  - items being introduced without any matching item_planning_params
+
+Unlike L3 (pure, DB-free), L4 rules DO touch Postgres. They are still
+restricted to rows that passed L1 + L2 + L3 (no error issues) to avoid
+cascading noise.
+
+Adding a new rule:
+  1. Write a function `_l4_<name>(rows, batch_id, db) -> list[DQIssue]`
+  2. Register it under the relevant entity_type(s) in `_L4_RULES`
+  3. Add a test in tests/test_dq_l4_rules.py
+"""
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable
+from uuid import UUID
+
+import psycopg
+
+from ootils_core.engine.dq.engine import DQIssue
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _issue(
+    row_id: UUID,
+    row_number: int,
+    rule_code: str,
+    severity: str,
+    field_name: str | None,
+    raw_value,
+    message: str,
+) -> DQIssue:
+    return DQIssue(
+        row_id=row_id,
+        row_number=row_number,
+        dq_level=4,
+        rule_code=rule_code,
+        severity=severity,
+        field_name=field_name,
+        raw_value=None if raw_value is None else str(raw_value)[:255],
+        message=message,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule: intra-batch duplicate external_id
+# ---------------------------------------------------------------------------
+
+
+def _l4_duplicate_external_id(
+    rows: list[tuple[UUID, int, dict]],
+    batch_id: UUID,  # noqa: ARG001 (signature uniform across rules)
+    db: psycopg.Connection,  # noqa: ARG001
+    *,
+    field: str = "external_id",
+) -> list[DQIssue]:
+    """Same external_id appears 2+ times in the rows of this batch.
+
+    Severity: error (every row with the dup external_id is flagged).
+    The file must be deduplicated before re-upload.
+    """
+    # Count occurrences of each external_id (ignoring missing/empty,
+    # already caught by L1_MISSING_FIELD)
+    counts: Counter[str] = Counter()
+    for _, _, content in rows:
+        val = content.get(field)
+        if val:
+            counts[val] += 1
+
+    duplicates = {v for v, n in counts.items() if n >= 2}
+    if not duplicates:
+        return []
+
+    out: list[DQIssue] = []
+    for row_id, row_number, content in rows:
+        val = content.get(field)
+        if val and val in duplicates:
+            out.append(_issue(
+                row_id, row_number, "L4_DUPLICATE_EXTERNAL_ID", "error",
+                field, val,
+                f"{field}={val!r} appears multiple times in this batch ({counts[val]} occurrences)",
+            ))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Rule: cross-batch collision (same external_id in another pending batch)
+# ---------------------------------------------------------------------------
+
+
+def _l4_inter_batch_collision(
+    rows: list[tuple[UUID, int, dict]],
+    batch_id: UUID,
+    db: psycopg.Connection,
+    *,
+    field: str = "external_id",
+) -> list[DQIssue]:
+    """An external_id in this batch also appears in another batch
+    that is still pending / validated (i.e. not yet imported or rejected).
+
+    Severity: warning. Approving this batch will supersede the other —
+    the operator should know.
+    """
+    external_ids = {
+        content.get(field)
+        for _, _, content in rows
+        if content.get(field)
+    }
+    if not external_ids:
+        return []
+
+    # Look in ingest_rows of OTHER batches that are not terminal.
+    # We match by col_01 since that's the positional column the staging
+    # loader puts external_id into (it's always the first column per the
+    # template convention).
+    rows_in_db = db.execute(
+        """
+        SELECT DISTINCT r.col_01
+        FROM ingest_rows r
+        JOIN ingest_batches b ON b.batch_id = r.batch_id
+        WHERE r.batch_id != %s
+          AND b.status NOT IN ('imported', 'rejected')
+          AND r.col_01 = ANY(%s)
+        """,
+        (batch_id, list(external_ids)),
+    ).fetchall()
+    colliding = {r["col_01"] if isinstance(r, dict) else r[0] for r in rows_in_db}
+    if not colliding:
+        return []
+
+    out: list[DQIssue] = []
+    for row_id, row_number, content in rows:
+        val = content.get(field)
+        if val and val in colliding:
+            out.append(_issue(
+                row_id, row_number, "L4_INTER_BATCH_COLLISION", "warning",
+                field, val,
+                f"{field}={val!r} also present in another open batch; "
+                "approving this one will supersede the previous",
+            ))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Rule: supplier_items pointing at non-active supplier
+# ---------------------------------------------------------------------------
+
+
+def _l4_supplier_inactive(
+    rows: list[tuple[UUID, int, dict]],
+    batch_id: UUID,  # noqa: ARG001
+    db: psycopg.Connection,
+) -> list[DQIssue]:
+    """A supplier_items row references a supplier whose status is not
+    'active' (i.e. inactive or blocked). Approving would create a link
+    to a supplier that can't be used for planning."""
+    sup_ids = {
+        content.get("supplier_external_id")
+        for _, _, content in rows
+        if content.get("supplier_external_id")
+    }
+    if not sup_ids:
+        return []
+
+    bad_sups = db.execute(
+        """
+        SELECT external_id, status FROM suppliers
+        WHERE external_id = ANY(%s) AND status != 'active'
+        """,
+        (list(sup_ids),),
+    ).fetchall()
+    bad_map = {
+        (r["external_id"] if isinstance(r, dict) else r[0]):
+        (r["status"] if isinstance(r, dict) else r[1])
+        for r in bad_sups
+    }
+    if not bad_map:
+        return []
+
+    out: list[DQIssue] = []
+    for row_id, row_number, content in rows:
+        sup_ext = content.get("supplier_external_id")
+        if sup_ext and sup_ext in bad_map:
+            out.append(_issue(
+                row_id, row_number, "L4_SUPPLIER_INACTIVE", "error",
+                "supplier_external_id", sup_ext,
+                f"supplier_external_id={sup_ext!r} has status={bad_map[sup_ext]!r} "
+                "(only 'active' suppliers can be linked)",
+            ))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Rule: items being introduced without item_planning_params (orphan)
+# ---------------------------------------------------------------------------
+
+
+def _l4_orphan_item_no_planning(
+    rows: list[tuple[UUID, int, dict]],
+    batch_id: UUID,  # noqa: ARG001
+    db: psycopg.Connection,
+) -> list[DQIssue]:
+    """An item in this batch has zero item_planning_params rows in the DB.
+
+    Severity: warning. A brand-new item without planning params is valid
+    (the params often arrive in a follow-up batch) but worth flagging so
+    the operator can verify the planning team has the work scheduled.
+    """
+    ext_ids = {
+        content.get("external_id")
+        for _, _, content in rows
+        if content.get("external_id")
+    }
+    if not ext_ids:
+        return []
+
+    # Items that EXIST in canonical and have zero item_planning_params rows.
+    # A brand-new item (not yet in `items`) is NOT an orphan — it's just
+    # being introduced; its planning rows will arrive in a later batch.
+    rows_db = db.execute(
+        """
+        SELECT i.external_id
+        FROM items i
+        LEFT JOIN item_planning_params ipp ON ipp.item_id = i.item_id
+        WHERE i.external_id = ANY(%s)
+        GROUP BY i.external_id
+        HAVING COUNT(ipp.param_id) = 0
+        """,
+        (list(ext_ids),),
+    ).fetchall()
+    orphans = {
+        (r["external_id"] if isinstance(r, dict) else r[0]) for r in rows_db
+    }
+    if not orphans:
+        return []
+
+    out: list[DQIssue] = []
+    for row_id, row_number, content in rows:
+        val = content.get("external_id")
+        if val and val in orphans:
+            out.append(_issue(
+                row_id, row_number, "L4_ORPHAN_ITEM_NO_PLANNING", "warning",
+                "external_id", val,
+                f"item {val!r} has no item_planning_params yet; planning team "
+                "should follow up with a planning_params batch",
+            ))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Registry — entity_type -> list of rule functions
+# ---------------------------------------------------------------------------
+
+
+L4RuleFn = Callable[[list[tuple[UUID, int, dict]], UUID, psycopg.Connection], list[DQIssue]]
+
+
+# Rules that apply to every entity_type carrying an external_id
+_GENERIC_RULES: list[L4RuleFn] = [
+    _l4_duplicate_external_id,
+    _l4_inter_batch_collision,
+]
+
+# Entity-specific rule extensions
+_L4_RULES: dict[str, list[L4RuleFn]] = {
+    "items":           _GENERIC_RULES + [_l4_orphan_item_no_planning],
+    "locations":       _GENERIC_RULES,
+    "suppliers":       _GENERIC_RULES,
+    "supplier_items":  [_l4_supplier_inactive],  # no external_id at row level
+    "purchase_orders": _GENERIC_RULES,
+    "work_orders":     _GENERIC_RULES,
+    "customer_orders": _GENERIC_RULES,
+    "forecasts":       [],   # forecasts don't have a stable external_id by row
+    "transfers":       _GENERIC_RULES,
+    "on_hand":         [],   # OH snapshots are inherently "current state", no external_id
+}
+
+
+def check_l4(
+    rows: list[tuple[UUID, int, dict]],
+    entity_type: str,
+    batch_id: UUID,
+    db: psycopg.Connection,
+) -> list[DQIssue]:
+    """Run all L4 rules for `entity_type` over the given rows.
+
+    Each rule runs in turn; rules don't depend on each other so order
+    doesn't matter except for diagnostic logging.
+
+    Unknown entity_type returns no issues (same opt-in convention as L3).
+    """
+    rule_fns = _L4_RULES.get(entity_type)
+    if not rule_fns:
+        return []
+    out: list[DQIssue] = []
+    for fn in rule_fns:
+        out.extend(fn(rows, batch_id, db))
+    return out

--- a/tests/integration/test_dq_l4.py
+++ b/tests/integration/test_dq_l4.py
@@ -1,0 +1,205 @@
+"""Integration tests for the DB-touching L4 rules.
+
+These need a real Postgres because the rules query ingest_rows /
+ingest_batches / suppliers / items / item_planning_params.
+"""
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import psycopg
+import pytest
+from psycopg.rows import dict_row
+
+from ootils_core.engine.dq.l4_rules import check_l4
+
+from .conftest import requires_db
+
+
+@pytest.fixture
+def conn(migrated_db: str):
+    """Per-test connection, rolled back at teardown."""
+    with psycopg.connect(migrated_db, row_factory=dict_row) as c:
+        yield c
+        c.rollback()
+
+
+def _codes(issues):
+    return [i.rule_code for i in issues]
+
+
+def _new_batch(conn, entity_type: str, source_system: str, status: str = "pending") -> UUID:
+    """Insert a minimal ingest_batches row and return its id."""
+    batch_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO ingest_batches (batch_id, entity_type, source_system, status, total_rows)
+        VALUES (%s, %s, %s, %s, 0)
+        """,
+        (batch_id, entity_type, source_system, status),
+    )
+    return batch_id
+
+
+def _insert_ingest_row(conn, batch_id: UUID, row_number: int, external_id: str) -> None:
+    """Insert one ingest_rows row with col_01 = external_id."""
+    conn.execute(
+        """
+        INSERT INTO ingest_rows (batch_id, row_number, raw_content, col_01)
+        VALUES (%s, %s, %s, %s)
+        """,
+        (batch_id, row_number, "{}", external_id),
+    )
+
+
+# ---------------------------------------------------------------------------
+# L4_INTER_BATCH_COLLISION
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_inter_batch_collision_fires(conn) -> None:
+    """An item external_id present in both this batch and another
+    still-open batch must produce a warning."""
+    other_batch = _new_batch(conn, "items", "OTHER-SOURCE", status="validated")
+    _insert_ingest_row(conn, other_batch, 1, "SHARED-001")
+
+    this_batch = _new_batch(conn, "items", "THIS-SOURCE")
+    rows = [
+        (uuid4(), 1, {"external_id": "SHARED-001"}),
+        (uuid4(), 2, {"external_id": "UNIQUE-002"}),
+    ]
+    issues = check_l4(rows, "items", this_batch, conn)
+    collisions = [i for i in issues if i.rule_code == "L4_INTER_BATCH_COLLISION"]
+    assert len(collisions) == 1
+    assert collisions[0].row_number == 1
+    assert collisions[0].severity == "warning"
+    assert collisions[0].field_name == "external_id"
+
+
+@requires_db
+def test_inter_batch_collision_ignores_imported_batches(conn) -> None:
+    """A previously-imported batch is canonical now — don't flag against it."""
+    old = _new_batch(conn, "items", "OLD-SOURCE", status="imported")
+    _insert_ingest_row(conn, old, 1, "OLD-001")
+
+    this_batch = _new_batch(conn, "items", "THIS-SOURCE")
+    rows = [(uuid4(), 1, {"external_id": "OLD-001"})]
+    issues = check_l4(rows, "items", this_batch, conn)
+    assert "L4_INTER_BATCH_COLLISION" not in _codes(issues)
+
+
+@requires_db
+def test_inter_batch_collision_ignores_rejected_batches(conn) -> None:
+    """A rejected batch isn't going anywhere — no need to warn against it."""
+    rej = _new_batch(conn, "items", "REJ-SOURCE", status="rejected")
+    _insert_ingest_row(conn, rej, 1, "REJ-001")
+
+    this_batch = _new_batch(conn, "items", "THIS-SOURCE")
+    rows = [(uuid4(), 1, {"external_id": "REJ-001"})]
+    issues = check_l4(rows, "items", this_batch, conn)
+    assert "L4_INTER_BATCH_COLLISION" not in _codes(issues)
+
+
+# ---------------------------------------------------------------------------
+# L4_SUPPLIER_INACTIVE
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_supplier_inactive_fires(conn) -> None:
+    """A supplier_items row pointing at a blocked supplier is rejected."""
+    # Seed a blocked supplier
+    conn.execute(
+        """
+        INSERT INTO suppliers (supplier_id, external_id, name, country, status)
+        VALUES (gen_random_uuid(), 'SUP-BLOCKED', 'Bad Co', 'XX', 'blocked')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO suppliers (supplier_id, external_id, name, country, status)
+        VALUES (gen_random_uuid(), 'SUP-OK', 'Good Co', 'XX', 'active')
+        """
+    )
+
+    batch_id = _new_batch(conn, "supplier_items", "TEST")
+    rows = [
+        (uuid4(), 1, {"supplier_external_id": "SUP-BLOCKED", "item_external_id": "I1"}),
+        (uuid4(), 2, {"supplier_external_id": "SUP-OK", "item_external_id": "I2"}),
+    ]
+    issues = check_l4(rows, "supplier_items", batch_id, conn)
+    inact = [i for i in issues if i.rule_code == "L4_SUPPLIER_INACTIVE"]
+    assert len(inact) == 1
+    assert inact[0].row_number == 1
+    assert inact[0].severity == "error"
+    assert "blocked" in inact[0].message
+
+
+@requires_db
+def test_supplier_inactive_ignores_unknown_supplier(conn) -> None:
+    """An unknown supplier_external_id is L2's job, not L4's.
+    L4 only flags suppliers that EXIST but are non-active."""
+    batch_id = _new_batch(conn, "supplier_items", "TEST")
+    rows = [(uuid4(), 1, {"supplier_external_id": "SUP-DOES-NOT-EXIST"})]
+    issues = check_l4(rows, "supplier_items", batch_id, conn)
+    assert "L4_SUPPLIER_INACTIVE" not in _codes(issues)
+
+
+# ---------------------------------------------------------------------------
+# L4_ORPHAN_ITEM_NO_PLANNING
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_orphan_item_no_planning_fires(conn) -> None:
+    """An item already in the DB without item_planning_params should warn."""
+    conn.execute(
+        """
+        INSERT INTO items (item_id, external_id, name, item_type, uom, status)
+        VALUES (gen_random_uuid(), 'ITEM-ORPHAN', 'Orphan', 'component', 'EA', 'active')
+        """
+    )
+    batch_id = _new_batch(conn, "items", "TEST")
+    rows = [(uuid4(), 1, {"external_id": "ITEM-ORPHAN"})]
+    issues = check_l4(rows, "items", batch_id, conn)
+    orph = [i for i in issues if i.rule_code == "L4_ORPHAN_ITEM_NO_PLANNING"]
+    assert len(orph) == 1
+    assert orph[0].severity == "warning"
+    assert "ITEM-ORPHAN" in orph[0].message
+
+
+@requires_db
+def test_orphan_item_with_planning_is_clean(conn) -> None:
+    """An item with at least one item_planning_params row should NOT
+    trigger the orphan warning."""
+    # Seed item + location + planning row
+    item_id = uuid4()
+    loc_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO items (item_id, external_id, name, item_type, uom, status)
+        VALUES (%s, 'ITEM-PLANNED', 'Planned', 'component', 'EA', 'active')
+        """,
+        (item_id,),
+    )
+    conn.execute(
+        """
+        INSERT INTO locations (location_id, external_id, name, location_type, country, timezone)
+        VALUES (%s, 'LOC-1', 'L1', 'plant', 'DE', 'Europe/Berlin')
+        """,
+        (loc_id,),
+    )
+    conn.execute(
+        """
+        INSERT INTO item_planning_params
+            (item_id, location_id, lot_size_rule, planning_horizon_days)
+        VALUES (%s, %s, 'LOTFORLOT', 90)
+        """,
+        (item_id, loc_id),
+    )
+
+    batch_id = _new_batch(conn, "items", "TEST")
+    rows = [(uuid4(), 1, {"external_id": "ITEM-PLANNED"})]
+    issues = check_l4(rows, "items", batch_id, conn)
+    assert "L4_ORPHAN_ITEM_NO_PLANNING" not in _codes(issues)

--- a/tests/test_dq_engine.py
+++ b/tests/test_dq_engine.py
@@ -541,6 +541,19 @@ def _build_run_dq_db(batch_id, entity_type, ingest_rows, ref_data=None):
 
     def handler(sql, params=None):
         sql_low = sql.lower().strip()
+        # L4 queries hit ingest_rows / suppliers / items+ipp with specific
+        # filters. Match them BEFORE the generic ingest_rows match below,
+        # otherwise L4's "SELECT col_01 FROM ingest_rows JOIN ingest_batches"
+        # would pick up the test's primary ingest_rows payload and crash
+        # on a missing col_01 key.
+        if "from ingest_rows r" in sql_low and "join ingest_batches" in sql_low:
+            return []  # L4 inter-batch collision: no other batch by default
+        if "from suppliers" in sql_low and "status != 'active'" in sql_low:
+            return []  # L4 supplier-inactive: no blocked suppliers by default
+        if "from items i" in sql_low and "join item_planning_params" in sql_low:
+            # L4 orphan-item query returns items WITHOUT planning_params.
+            # Default empty -> no orphans flagged.
+            return [{"external_id": eid} for eid in ref_data.get("orphan_items", [])]
         if "from ingest_batches" in sql_low and "select" in sql_low:
             return {"batch_id": batch_id, "entity_type": entity_type, "status": "uploaded"}
         if "from ingest_rows" in sql_low and "select" in sql_low:

--- a/tests/test_dq_l4_rules.py
+++ b/tests/test_dq_l4_rules.py
@@ -1,0 +1,92 @@
+"""Unit tests for the DB-free L4 rules.
+
+Only `_l4_duplicate_external_id` is unit-testable without DB. The
+remaining L4 rules (inter-batch collision, supplier inactive, orphan
+items) need real Postgres and are covered by
+`tests/integration/test_dq_l4.py`.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from ootils_core.engine.dq.l4_rules import check_l4
+
+
+def _row(ext_id, row_number=None):
+    return (uuid4(), row_number or 1, {"external_id": ext_id})
+
+
+def _codes(issues):
+    return [i.rule_code for i in issues]
+
+
+# ---------------------------------------------------------------------------
+# L4_DUPLICATE_EXTERNAL_ID  (intra-batch, DB-free)
+# ---------------------------------------------------------------------------
+
+
+def test_no_duplicates_no_issues() -> None:
+    rows = [_row("A", 1), _row("B", 2), _row("C", 3)]
+    issues = check_l4(rows, "items", uuid4(), db=MagicMock())
+    # Could fire from other rules but no dup-related issues
+    assert "L4_DUPLICATE_EXTERNAL_ID" not in _codes(issues)
+
+
+def test_duplicate_external_id_in_batch() -> None:
+    rows = [_row("DUP", 1), _row("OTHER", 2), _row("DUP", 5)]
+    # Use a mock db with empty results for the cross-batch + orphan rules
+    db = MagicMock()
+    db.execute.return_value.fetchall.return_value = []
+    issues = check_l4(rows, "items", uuid4(), db=db)
+    dup_issues = [i for i in issues if i.rule_code == "L4_DUPLICATE_EXTERNAL_ID"]
+    # Two issues: one per row that bears the dup external_id
+    assert len(dup_issues) == 2
+    assert {i.row_number for i in dup_issues} == {1, 5}
+    assert all(i.severity == "error" for i in dup_issues)
+    assert all(i.field_name == "external_id" for i in dup_issues)
+    assert all("DUP" in i.raw_value for i in dup_issues)
+
+
+def test_three_way_duplicate() -> None:
+    rows = [_row("X", 1), _row("X", 2), _row("X", 3), _row("Y", 4)]
+    db = MagicMock()
+    db.execute.return_value.fetchall.return_value = []
+    issues = check_l4(rows, "items", uuid4(), db=db)
+    dup_issues = [i for i in issues if i.rule_code == "L4_DUPLICATE_EXTERNAL_ID"]
+    assert len(dup_issues) == 3
+    # Message should mention the count
+    for issue in dup_issues:
+        assert "3 occurrences" in issue.message
+
+
+def test_empty_external_id_not_counted_as_duplicate() -> None:
+    """Rows missing external_id (caught by L1 already) shouldn't be
+    silently grouped together as 'duplicates of nothing'."""
+    rows = [
+        (uuid4(), 1, {"external_id": ""}),
+        (uuid4(), 2, {"external_id": None}),
+        (uuid4(), 3, {}),
+        (uuid4(), 4, {"external_id": "REAL"}),
+    ]
+    db = MagicMock()
+    db.execute.return_value.fetchall.return_value = []
+    issues = check_l4(rows, "items", uuid4(), db=db)
+    assert "L4_DUPLICATE_EXTERNAL_ID" not in _codes(issues)
+
+
+def test_unknown_entity_type_no_issues() -> None:
+    rows = [_row("A", 1), _row("A", 2)]
+    db = MagicMock()
+    issues = check_l4(rows, "weather_data", uuid4(), db=db)
+    assert issues == []
+
+
+def test_entity_with_no_l4_rules_returns_empty() -> None:
+    """forecasts and on_hand have no L4 rules in the registry."""
+    rows = [_row("A", 1), _row("A", 2)]
+    db = MagicMock()
+    issues = check_l4(rows, "forecasts", uuid4(), db=db)
+    assert issues == []
+    issues = check_l4(rows, "on_hand", uuid4(), db=db)
+    assert issues == []


### PR DESCRIPTION
## Summary

Step 6 of [ADR-013](docs/ADR-013-external-interfaces.md) roadmap. Adds the L4 layer to the DQ pipeline — rules that need to look at the WHOLE batch at once (duplicates) or join against canonical / other-batch state.

## Rule families (4)

| Code | Severity | Where it looks |
|---|---|---|
| L4_DUPLICATE_EXTERNAL_ID | error | intra-batch (same id appears 2+ times) |
| L4_INTER_BATCH_COLLISION | warning | another open batch has the same id |
| L4_SUPPLIER_INACTIVE | error | canonical \`suppliers\` table — status != 'active' |
| L4_ORPHAN_ITEM_NO_PLANNING | warning | items existing without item_planning_params |

\`L4_ORPHAN_ITEM_NO_PLANNING\` is careful to NOT flag brand-new items (those that don't exist in \`items\` yet) — only items that already exist but lack planning rows. New introductions are valid; their planning arrives in a follow-up batch.

## Architecture

Same registry pattern as l3_rules.py. Each rule has a uniform signature \`(rows, batch_id, db) -> list[DQIssue]\`. Some rules use \`db\`, some don't. The registry maps each \`entity_type\` to a list of applicable rules.

Wired into \`run_dq()\` between L3 and persistence. Only rows passing L1+L2+L3 (no error issues) advance to L4 — same gating pattern. \`max_level_reached\` now reaches 4, \`dq_status='l4_pass'\` on clean rows.

## Tests (93 unit + 7 integration)

Unit (\`tests/test_dq_l4_rules.py\`, 6 tests):
- Intra-batch duplicate fires + counts correctly
- Three-way duplicate generates 3 issues with right messages
- Empty external_id NOT grouped as 'dup of nothing'
- Unknown entity_type returns empty

Integration (\`tests/integration/test_dq_l4.py\`, 7 tests):
- Inter-batch collision fires + correctly ignores imported and rejected batches
- Supplier inactive fires on blocked, ignores unknown (that's L2's job)
- Orphan item warns on existing-without-planning, silent on items with planning rows

Existing 56 DQ engine tests + 31 L3 tests still pass — extended the mock dispatcher to recognise L4's query shapes so they don't pick up unrelated test data.

## What's next

Step 7: \`GET /diff\` preview impact pre-approval
Step 8: \`POST /approve\` (full-reload + soft-delete — the actual transform-and-load)

## Test plan

- [x] Ruff lint passes
- [x] 93/93 unit DQ tests pass locally
- [ ] CI integration tests pass (7 new L4 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)