### PR TITLE
feat(staging): GET /v1/staging/batches/{id}/diff (ADR-013 D4 guard)

### DIFF
--- a/src/ootils_core/api/routers/staging.py
+++ b/src/ootils_core/api/routers/staging.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import logging
 from typing import Annotated, Optional
+from uuid import UUID
 
 import psycopg
 from fastapi import (
@@ -44,6 +45,7 @@ from fastapi import (
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db
+from ootils_core.staging.diff import DiffError, compute_diff
 from ootils_core.staging.loader import LoaderError, load_to_staging
 from ootils_core.staging.parser import ParseError, ParseOptions, parse
 
@@ -206,3 +208,62 @@ def _extract_submitter() -> str | None:
     function is the single place to wire it up.
     """
     return None
+
+
+@router.get(
+    "/batches/{batch_id}/diff",
+    dependencies=[Depends(require_auth)],
+)
+def get_batch_diff(
+    batch_id: UUID,
+    db: psycopg.Connection = Depends(get_db),
+) -> dict:
+    """Preview the impact of approving this batch (ADR-013 D4).
+
+    Returns counts + samples of what `POST /approve` would do:
+      - will_insert     external_ids new to canonical
+      - will_update     external_ids in both; canonical values differ
+      - will_noop       external_ids in both; identical
+      - will_soft_delete external_ids in canonical for this
+                         (entity_type, source_system) but absent from
+                         the batch
+
+    The `deletion_ratio` is a fraction of soft-deletes over the current
+    canonical footprint. When > 20%, `exceeds_deletion_threshold=true` —
+    approval must be called with `force=true` (validated by /approve
+    in step 8). This is the principal protection against destructive
+    imports (truncated ERP exports, scope-reduction accidents, etc.).
+    """
+    try:
+        diff = compute_diff(db, batch_id)
+    except DiffError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+
+    return {
+        "batch_id": str(diff.batch_id),
+        "entity_type": diff.entity_type,
+        "source_system": diff.source_system,
+        "supported": diff.supported,
+        "unsupported_reason": diff.unsupported_reason,
+        "counts": {
+            "in_batch": diff.total_in_batch,
+            "in_canonical_for_source": diff.total_in_canonical_for_source,
+            "will_insert": diff.will_insert_count,
+            "will_update": diff.will_update_count,
+            "will_noop": diff.will_noop_count,
+            "will_soft_delete": diff.will_soft_delete_count,
+        },
+        "samples": {
+            "will_insert": diff.will_insert_sample,
+            "will_update": diff.will_update_sample,
+            "will_soft_delete": diff.will_soft_delete_sample,
+        },
+        "deletion_guard": {
+            "ratio": diff.deletion_ratio,
+            "threshold": diff.deletion_ratio_threshold,
+            "exceeds_threshold": diff.exceeds_deletion_threshold,
+        },
+    }

--- a/src/ootils_core/staging/diff.py
+++ b/src/ootils_core/staging/diff.py
@@ -1,0 +1,302 @@
+"""
+diff.py — compute the impact of approving a validated batch (ADR-013 D4).
+
+Returns a `DiffResult` summarising what `POST /approve` would change in
+the canonical tables if it ran right now:
+
+  will_insert     external_ids in the batch with no canonical row yet
+  will_update     external_ids in both, where one or more fields differ
+  will_noop       external_ids in both, fields identical (batch reproduces
+                  what's already there)
+  will_soft_delete external_ids present in canonical for this
+                  (entity_type, source_system) but absent from the batch
+
+Plus a `deletion_ratio` (= soft_delete / current_active) with a 20%
+threshold flag — ADR-013 D4 mandates that an approval crossing this
+threshold requires an explicit `force=true` from the operator, so the
+endpoint surfaces the warning here.
+
+The endpoint is purely READ — no DB writes — and lives in
+`api/routers/staging.py` as `GET /v1/staging/batches/{id}/diff`.
+
+Currently supports the three master-data entity types (items,
+locations, suppliers). Transactional entities (PO/WO/CO/transfers/etc)
+use timestamps + status transitions and don't have stable upsert
+semantics by external_id — they'll get their own diff logic when the
+/approve step lands for them.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from uuid import UUID
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+# Above this fraction of soft-deletes the approval needs `force=true`.
+# Mirrors the threshold called out in ADR-013 D4.
+DELETION_RATIO_THRESHOLD = 0.20
+
+# Maximum sample rows per category in the response. Keeps the diff
+# response payload manageable even for large batches.
+MAX_SAMPLE_PER_CATEGORY = 10
+
+
+class DiffError(ValueError):
+    """Raised when the diff cannot be computed (bad batch state, etc.)."""
+
+
+@dataclass
+class DiffResult:
+    """One diff response. All counts are non-negative; sample lists are
+    truncated to MAX_SAMPLE_PER_CATEGORY external_ids."""
+    batch_id: UUID
+    entity_type: str
+    source_system: str
+    supported: bool
+    # Counts
+    total_in_batch: int = 0
+    total_in_canonical_for_source: int = 0
+    will_insert_count: int = 0
+    will_update_count: int = 0
+    will_noop_count: int = 0
+    will_soft_delete_count: int = 0
+    # Samples (external_id strings)
+    will_insert_sample: list[str] = field(default_factory=list)
+    will_update_sample: list[str] = field(default_factory=list)
+    will_soft_delete_sample: list[str] = field(default_factory=list)
+    # Deletion ratio guard
+    deletion_ratio: float = 0.0
+    deletion_ratio_threshold: float = DELETION_RATIO_THRESHOLD
+    exceeds_deletion_threshold: bool = False
+    # Diagnostic for unsupported entity_types
+    unsupported_reason: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Per-entity field-comparison specs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _EntitySpec:
+    """How to load + compare canonical rows for one entity_type."""
+    canonical_table: str
+    # SQL fields to SELECT (used both for loading + comparison)
+    fields: tuple[str, ...]
+    # The canonical PK column name (used by external_id_mapping.internal_id)
+    pk_column: str
+
+
+_SPECS: dict[str, _EntitySpec] = {
+    "items": _EntitySpec(
+        canonical_table="items",
+        fields=("external_id", "name", "item_type", "uom", "status"),
+        pk_column="item_id",
+    ),
+    "locations": _EntitySpec(
+        canonical_table="locations",
+        fields=("external_id", "name", "location_type", "country", "timezone"),
+        pk_column="location_id",
+    ),
+    "suppliers": _EntitySpec(
+        canonical_table="suppliers",
+        # lead_time_days + reliability_score may be NULL — comparison
+        # normalises them via str() so '14' == 14 etc.
+        fields=("external_id", "name", "country", "lead_time_days",
+                "reliability_score", "status"),
+        pk_column="supplier_id",
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def compute_diff(conn: psycopg.Connection, batch_id: UUID) -> DiffResult:
+    """Compute insert/update/soft-delete impact of approving this batch.
+
+    Raises:
+        DiffError if the batch doesn't exist or isn't in a status where
+        a diff makes sense (must be 'validated' or 'pending' — anything
+        else is past the decision point).
+    """
+    # ---------- 1. Load batch metadata ----------
+    batch = conn.execute(
+        "SELECT entity_type, source_system, status, dq_status "
+        "FROM ingest_batches WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+    if batch is None:
+        raise DiffError(f"batch {batch_id} not found")
+
+    entity_type = batch["entity_type"] if isinstance(batch, dict) else batch[0]
+    source_system = batch["source_system"] if isinstance(batch, dict) else batch[1]
+    status = batch["status"] if isinstance(batch, dict) else batch[2]
+
+    # Diff only meaningful before approval/rejection
+    if status in ("imported", "rejected"):
+        raise DiffError(
+            f"batch is in terminal status {status!r}; /diff is only meaningful "
+            "for batches in 'pending' or 'validated' state"
+        )
+
+    spec = _SPECS.get(entity_type)
+    if spec is None:
+        return DiffResult(
+            batch_id=batch_id,
+            entity_type=entity_type,
+            source_system=source_system,
+            supported=False,
+            unsupported_reason=(
+                f"entity_type {entity_type!r} does not yet have diff support — "
+                "currently implemented for items / locations / suppliers"
+            ),
+        )
+
+    # ---------- 2. Load batch rows ----------
+    batch_records = _load_batch_records(conn, batch_id, spec)
+
+    # ---------- 3. Load canonical rows scoped to (entity_type, source_system) ----------
+    canonical_records = _load_canonical_records(conn, entity_type, source_system, spec)
+
+    # ---------- 4. Compute deltas ----------
+    return _compute_deltas(batch_id, entity_type, source_system, spec,
+                           batch_records, canonical_records)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_batch_records(
+    conn: psycopg.Connection,
+    batch_id: UUID,
+    spec: _EntitySpec,
+) -> dict[str, dict]:
+    """Parse `raw_content` JSON of every ingest_rows row in the batch,
+    keyed by `external_id`. Rows missing an external_id are skipped (L1
+    flagged them already). Duplicates resolve to the LAST occurrence."""
+    rows = conn.execute(
+        "SELECT row_number, raw_content FROM ingest_rows "
+        "WHERE batch_id = %s ORDER BY row_number",
+        (batch_id,),
+    ).fetchall()
+    out: dict[str, dict] = {}
+    for row in rows:
+        raw = row["raw_content"] if isinstance(row, dict) else row[1]
+        try:
+            content = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(content, dict):
+            continue
+        ext_id = content.get("external_id")
+        if not ext_id:
+            continue
+        # Keep only the fields the canonical comparison cares about,
+        # normalised to strings for the equality check below.
+        normalised = {f: _norm(content.get(f)) for f in spec.fields}
+        out[ext_id] = normalised
+    return out
+
+
+def _load_canonical_records(
+    conn: psycopg.Connection,
+    entity_type: str,
+    source_system: str,
+    spec: _EntitySpec,
+) -> dict[str, dict]:
+    """Load rows from the canonical table that were imported from this
+    (entity_type, source_system) — joined through external_id_mapping
+    so each source's footprint is isolated."""
+    fields_sql = ", ".join(f"c.{f}" for f in spec.fields)
+    rows = conn.execute(
+        f"""
+        SELECT {fields_sql}
+        FROM {spec.canonical_table} c
+        JOIN external_id_mapping m
+          ON m.internal_id = c.{spec.pk_column}
+        WHERE m.entity_type = %s
+          AND m.source_system = %s
+        """,
+        (entity_type, source_system),
+    ).fetchall()
+    out: dict[str, dict] = {}
+    for r in rows:
+        if isinstance(r, dict):
+            row_dict = r
+        else:
+            row_dict = dict(zip(spec.fields, r))
+        ext_id = row_dict.get("external_id")
+        if not ext_id:
+            continue
+        out[ext_id] = {f: _norm(row_dict.get(f)) for f in spec.fields}
+    return out
+
+
+def _compute_deltas(
+    batch_id: UUID,
+    entity_type: str,
+    source_system: str,
+    spec: _EntitySpec,
+    batch_records: dict[str, dict],
+    canonical_records: dict[str, dict],
+) -> DiffResult:
+    """Pure set-arithmetic on the two record dicts. No DB."""
+    batch_ids = set(batch_records.keys())
+    canonical_ids = set(canonical_records.keys())
+
+    inserts = sorted(batch_ids - canonical_ids)
+    deletes = sorted(canonical_ids - batch_ids)
+
+    updates: list[str] = []
+    noops: list[str] = []
+    for ext_id in sorted(batch_ids & canonical_ids):
+        if batch_records[ext_id] != canonical_records[ext_id]:
+            updates.append(ext_id)
+        else:
+            noops.append(ext_id)
+
+    n_canonical = len(canonical_ids)
+    deletion_ratio = (len(deletes) / n_canonical) if n_canonical else 0.0
+    exceeds = deletion_ratio > DELETION_RATIO_THRESHOLD
+
+    return DiffResult(
+        batch_id=batch_id,
+        entity_type=entity_type,
+        source_system=source_system,
+        supported=True,
+        total_in_batch=len(batch_ids),
+        total_in_canonical_for_source=n_canonical,
+        will_insert_count=len(inserts),
+        will_update_count=len(updates),
+        will_noop_count=len(noops),
+        will_soft_delete_count=len(deletes),
+        will_insert_sample=inserts[:MAX_SAMPLE_PER_CATEGORY],
+        will_update_sample=updates[:MAX_SAMPLE_PER_CATEGORY],
+        will_soft_delete_sample=deletes[:MAX_SAMPLE_PER_CATEGORY],
+        deletion_ratio=round(deletion_ratio, 4),
+        deletion_ratio_threshold=DELETION_RATIO_THRESHOLD,
+        exceeds_deletion_threshold=exceeds,
+    )
+
+
+def _norm(v) -> str:
+    """Normalise a scalar value to a string for equality comparison.
+
+    Both sides of the diff pass through this so '14' (TSV) == 14 (DB int)
+    == Decimal('14') (DB numeric). NULLs become '' so an empty TSV cell
+    matches a NULL canonical column.
+    """
+    if v is None:
+        return ""
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    return str(v).strip()

--- a/src/ootils_core/staging/diff.py
+++ b/src/ootils_core/staging/diff.py
@@ -87,8 +87,12 @@ class _EntitySpec:
     canonical_table: str
     # SQL fields to SELECT (used both for loading + comparison)
     fields: tuple[str, ...]
-    # The canonical PK column name (used by external_id_mapping.internal_id)
+    # The canonical PK column name (used by external_references.internal_id)
     pk_column: str
+    # `external_references.entity_type` uses SINGULAR ('item', 'location', ...)
+    # while `ingest_batches.entity_type` uses PLURAL ('items', 'locations').
+    # This is the singular form for the join.
+    ref_entity_type: str
 
 
 _SPECS: dict[str, _EntitySpec] = {
@@ -96,11 +100,13 @@ _SPECS: dict[str, _EntitySpec] = {
         canonical_table="items",
         fields=("external_id", "name", "item_type", "uom", "status"),
         pk_column="item_id",
+        ref_entity_type="item",
     ),
     "locations": _EntitySpec(
         canonical_table="locations",
         fields=("external_id", "name", "location_type", "country", "timezone"),
         pk_column="location_id",
+        ref_entity_type="location",
     ),
     "suppliers": _EntitySpec(
         canonical_table="suppliers",
@@ -109,6 +115,7 @@ _SPECS: dict[str, _EntitySpec] = {
         fields=("external_id", "name", "country", "lead_time_days",
                 "reliability_score", "status"),
         pk_column="supplier_id",
+        ref_entity_type="supplier",
     ),
 }
 
@@ -163,7 +170,7 @@ def compute_diff(conn: psycopg.Connection, batch_id: UUID) -> DiffResult:
     batch_records = _load_batch_records(conn, batch_id, spec)
 
     # ---------- 3. Load canonical rows scoped to (entity_type, source_system) ----------
-    canonical_records = _load_canonical_records(conn, entity_type, source_system, spec)
+    canonical_records = _load_canonical_records(conn, source_system, spec)
 
     # ---------- 4. Compute deltas ----------
     return _compute_deltas(batch_id, entity_type, source_system, spec,
@@ -209,24 +216,23 @@ def _load_batch_records(
 
 def _load_canonical_records(
     conn: psycopg.Connection,
-    entity_type: str,
     source_system: str,
     spec: _EntitySpec,
 ) -> dict[str, dict]:
     """Load rows from the canonical table that were imported from this
-    (entity_type, source_system) — joined through external_id_mapping
-    so each source's footprint is isolated."""
+    source_system — joined through `external_references` so each source's
+    footprint stays isolated."""
     fields_sql = ", ".join(f"c.{f}" for f in spec.fields)
     rows = conn.execute(
         f"""
         SELECT {fields_sql}
         FROM {spec.canonical_table} c
-        JOIN external_id_mapping m
-          ON m.internal_id = c.{spec.pk_column}
-        WHERE m.entity_type = %s
-          AND m.source_system = %s
+        JOIN external_references r
+          ON r.internal_id = c.{spec.pk_column}
+        WHERE r.entity_type = %s
+          AND r.source_system = %s
         """,
-        (entity_type, source_system),
+        (spec.ref_entity_type, source_system),
     ).fetchall()
     out: dict[str, dict] = {}
     for r in rows:

--- a/tests/integration/test_staging_diff.py
+++ b/tests/integration/test_staging_diff.py
@@ -1,0 +1,356 @@
+"""Integration tests for GET /v1/staging/batches/{id}/diff (ADR-013 step 7).
+
+The diff endpoint joins ingest_rows + external_id_mapping + canonical
+tables so it inherently needs a real DB. Tests cover:
+  - happy paths for the 3 supported entity types (items, locations,
+    suppliers): pure insert, pure update, pure soft-delete, mixed
+  - the 20% deletion-ratio guard
+  - unsupported entity_type returns supported=false with a reason
+  - non-existent batch / batch in terminal state returns 400
+"""
+from __future__ import annotations
+
+import io
+import os
+from uuid import UUID, uuid4
+
+import psycopg
+import pytest
+from psycopg.rows import dict_row
+
+from .conftest import requires_db
+
+
+@pytest.fixture(scope="module")
+def diff_client(migrated_db):
+    """Module-scoped TestClient sharing the migrated DB connection."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = "test-token"
+
+    from fastapi.testclient import TestClient
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+
+    app = create_app()
+    db = OotilsDB(migrated_db)
+
+    def override_db():
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def auth():
+    return {"Authorization": "Bearer test-token"}
+
+
+@pytest.fixture
+def conn(migrated_db: str):
+    with psycopg.connect(migrated_db, row_factory=dict_row) as c:
+        yield c
+        c.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Helpers — seed canonical state + upload a TSV batch via the existing endpoint
+# ---------------------------------------------------------------------------
+
+
+def _seed_canonical_item(
+    conn,
+    external_id: str,
+    name: str,
+    item_type: str = "component",
+    uom: str = "EA",
+    status: str = "active",
+    source_system: str = "TEST-SOURCE",
+) -> UUID:
+    """Insert one item + its external_id_mapping entry. Returns item_id."""
+    item_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO items (item_id, external_id, name, item_type, uom, status)
+        VALUES (%s, %s, %s, %s, %s, %s)
+        """,
+        (item_id, external_id, name, item_type, uom, status),
+    )
+    conn.execute(
+        """
+        INSERT INTO external_id_mapping
+            (entity_type, external_id, internal_id, source_system)
+        VALUES ('items', %s, %s, %s)
+        """,
+        (external_id, item_id, source_system),
+    )
+    conn.commit()
+    return item_id
+
+
+def _upload_items_tsv(
+    diff_client, auth, rows: list[tuple[str, str, str, str, str]],
+    source_system: str = "TEST-SOURCE",
+) -> UUID:
+    """Upload a TSV through POST /v1/staging/upload, return the batch_id."""
+    lines = ["external_id\tname\titem_type\tuom\tstatus"]
+    for r in rows:
+        lines.append("\t".join(r))
+    data = ("\n".join(lines) + "\n").encode("utf-8")
+    resp = diff_client.post(
+        "/v1/staging/upload",
+        headers=auth,
+        files={"file": ("items.tsv", io.BytesIO(data), "text/tab-separated-values")},
+        data={"entity_type": "items", "source_system": source_system},
+    )
+    assert resp.status_code == 202, resp.text
+    return UUID(resp.json()["batch_id"])
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_diff_pure_insert(diff_client, auth) -> None:
+    """No canonical rows for this source -> every batch row is INSERT."""
+    batch_id = _upload_items_tsv(
+        diff_client, auth,
+        [
+            ("DIFF-INS-001", "Foo", "component", "EA", "active"),
+            ("DIFF-INS-002", "Bar", "component", "EA", "active"),
+        ],
+        source_system="DIFF-INSERT-ONLY",
+    )
+
+    resp = diff_client.get(f"/v1/staging/batches/{batch_id}/diff", headers=auth)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["supported"] is True
+    assert body["counts"]["will_insert"] == 2
+    assert body["counts"]["will_update"] == 0
+    assert body["counts"]["will_soft_delete"] == 0
+    assert body["counts"]["in_canonical_for_source"] == 0
+    assert set(body["samples"]["will_insert"]) == {"DIFF-INS-001", "DIFF-INS-002"}
+    assert body["deletion_guard"]["ratio"] == 0.0
+    assert body["deletion_guard"]["exceeds_threshold"] is False
+
+
+@requires_db
+def test_diff_pure_update(diff_client, auth, conn) -> None:
+    """Same external_ids in canonical, batch changes one field per row -> UPDATE."""
+    src = "DIFF-UPDATE-ONLY"
+    _seed_canonical_item(conn, "DIFF-UPD-001", "OldName1", source_system=src)
+    _seed_canonical_item(conn, "DIFF-UPD-002", "OldName2", source_system=src)
+
+    batch_id = _upload_items_tsv(
+        diff_client, auth,
+        [
+            ("DIFF-UPD-001", "NewName1", "component", "EA", "active"),
+            ("DIFF-UPD-002", "NewName2", "component", "EA", "active"),
+        ],
+        source_system=src,
+    )
+
+    resp = diff_client.get(f"/v1/staging/batches/{batch_id}/diff", headers=auth)
+    body = resp.json()
+    assert body["counts"]["will_insert"] == 0
+    assert body["counts"]["will_update"] == 2
+    assert body["counts"]["will_soft_delete"] == 0
+    assert body["counts"]["will_noop"] == 0
+
+
+@requires_db
+def test_diff_pure_noop(diff_client, auth, conn) -> None:
+    """Canonical = batch values exactly -> all NO-OP, nothing to change."""
+    src = "DIFF-NOOP-ONLY"
+    _seed_canonical_item(conn, "DIFF-NOP-001", "Same",
+                         item_type="component", uom="EA", status="active",
+                         source_system=src)
+
+    batch_id = _upload_items_tsv(
+        diff_client, auth,
+        [("DIFF-NOP-001", "Same", "component", "EA", "active")],
+        source_system=src,
+    )
+
+    resp = diff_client.get(f"/v1/staging/batches/{batch_id}/diff", headers=auth)
+    body = resp.json()
+    assert body["counts"]["will_noop"] == 1
+    assert body["counts"]["will_update"] == 0
+    assert body["counts"]["will_insert"] == 0
+    assert body["counts"]["will_soft_delete"] == 0
+
+
+@requires_db
+def test_diff_pure_soft_delete(diff_client, auth, conn) -> None:
+    """Canonical has 3 rows, batch has 1 (same as one canonical) -> 2 SOFT-DELETE."""
+    src = "DIFF-DEL-ONLY"
+    _seed_canonical_item(conn, "KEEP-001", "Keep", source_system=src)
+    _seed_canonical_item(conn, "DEL-001", "DropMe1", source_system=src)
+    _seed_canonical_item(conn, "DEL-002", "DropMe2", source_system=src)
+
+    batch_id = _upload_items_tsv(
+        diff_client, auth,
+        [("KEEP-001", "Keep", "component", "EA", "active")],
+        source_system=src,
+    )
+
+    resp = diff_client.get(f"/v1/staging/batches/{batch_id}/diff", headers=auth)
+    body = resp.json()
+    assert body["counts"]["will_soft_delete"] == 2
+    assert set(body["samples"]["will_soft_delete"]) == {"DEL-001", "DEL-002"}
+    assert body["counts"]["will_noop"] == 1
+
+
+@requires_db
+def test_diff_mixed(diff_client, auth, conn) -> None:
+    """Realistic mix: 1 insert + 1 update + 1 noop + 1 soft-delete."""
+    src = "DIFF-MIXED"
+    _seed_canonical_item(conn, "MIX-UPD", "OldName", source_system=src)
+    _seed_canonical_item(conn, "MIX-NOP", "SameName", source_system=src)
+    _seed_canonical_item(conn, "MIX-DEL", "Doomed", source_system=src)
+
+    batch_id = _upload_items_tsv(
+        diff_client, auth,
+        [
+            ("MIX-INS", "NewItem", "component", "EA", "active"),
+            ("MIX-UPD", "NewName", "component", "EA", "active"),
+            ("MIX-NOP", "SameName", "component", "EA", "active"),
+        ],
+        source_system=src,
+    )
+
+    body = diff_client.get(f"/v1/staging/batches/{batch_id}/diff", headers=auth).json()
+    counts = body["counts"]
+    assert counts["will_insert"] == 1
+    assert counts["will_update"] == 1
+    assert counts["will_noop"] == 1
+    assert counts["will_soft_delete"] == 1
+    assert counts["in_batch"] == 3
+    assert counts["in_canonical_for_source"] == 3
+
+
+# ---------------------------------------------------------------------------
+# 20% deletion ratio guard
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_diff_deletion_threshold_not_exceeded(diff_client, auth, conn) -> None:
+    """10 canonical + batch keeps 9 -> 10% deletion, under the 20% guard."""
+    src = "DIFF-GUARD-OK"
+    for i in range(10):
+        _seed_canonical_item(conn, f"GRD-OK-{i:03d}", f"Item{i}", source_system=src)
+
+    rows = [(f"GRD-OK-{i:03d}", f"Item{i}", "component", "EA", "active") for i in range(9)]
+    batch_id = _upload_items_tsv(diff_client, auth, rows, source_system=src)
+
+    body = diff_client.get(f"/v1/staging/batches/{batch_id}/diff", headers=auth).json()
+    guard = body["deletion_guard"]
+    assert body["counts"]["will_soft_delete"] == 1
+    assert guard["ratio"] == 0.1
+    assert guard["exceeds_threshold"] is False
+
+
+@requires_db
+def test_diff_deletion_threshold_exceeded(diff_client, auth, conn) -> None:
+    """10 canonical + batch keeps 5 -> 50% deletion, far above 20% guard."""
+    src = "DIFF-GUARD-EXCEED"
+    for i in range(10):
+        _seed_canonical_item(conn, f"GRD-XS-{i:03d}", f"Item{i}", source_system=src)
+
+    rows = [(f"GRD-XS-{i:03d}", f"Item{i}", "component", "EA", "active") for i in range(5)]
+    batch_id = _upload_items_tsv(diff_client, auth, rows, source_system=src)
+
+    body = diff_client.get(f"/v1/staging/batches/{batch_id}/diff", headers=auth).json()
+    guard = body["deletion_guard"]
+    assert body["counts"]["will_soft_delete"] == 5
+    assert guard["ratio"] == 0.5
+    assert guard["exceeds_threshold"] is True
+
+
+# ---------------------------------------------------------------------------
+# Source isolation: another source's items must NOT appear as soft-delete
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_diff_other_source_unaffected(diff_client, auth, conn) -> None:
+    """Items imported from another source_system must NOT show up as
+    soft-delete candidates when this batch's source is different."""
+    _seed_canonical_item(conn, "OTHER-001", "From other source",
+                         source_system="OTHER-SOURCE")
+
+    batch_id = _upload_items_tsv(
+        diff_client, auth,
+        [("THIS-001", "Mine", "component", "EA", "active")],
+        source_system="THIS-SOURCE",
+    )
+
+    body = diff_client.get(f"/v1/staging/batches/{batch_id}/diff", headers=auth).json()
+    assert body["counts"]["will_soft_delete"] == 0
+    assert body["counts"]["in_canonical_for_source"] == 0
+    assert body["counts"]["will_insert"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_diff_unknown_batch_returns_400(diff_client, auth) -> None:
+    bogus = uuid4()
+    resp = diff_client.get(f"/v1/staging/batches/{bogus}/diff", headers=auth)
+    assert resp.status_code == 400
+    assert "not found" in resp.json()["detail"]
+
+
+@requires_db
+def test_diff_unsupported_entity_type_returns_supported_false(
+    diff_client, auth, conn,
+) -> None:
+    """on_hand isn't in the diff registry yet; the endpoint replies 200
+    with supported=False + a reason rather than crashing."""
+    # Inject a batch directly with on_hand entity_type to avoid running
+    # the upload endpoint with an unsupported flow.
+    batch_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO ingest_batches
+            (batch_id, entity_type, source_system, status, total_rows)
+        VALUES (%s, 'on_hand', 'TEST', 'validated', 0)
+        """,
+        (batch_id,),
+    )
+    conn.commit()
+
+    resp = diff_client.get(f"/v1/staging/batches/{batch_id}/diff", headers=auth)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["supported"] is False
+    assert "on_hand" in body["unsupported_reason"]
+
+
+@requires_db
+def test_diff_imported_batch_returns_400(diff_client, auth, conn) -> None:
+    batch_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO ingest_batches
+            (batch_id, entity_type, source_system, status, total_rows)
+        VALUES (%s, 'items', 'TEST', 'imported', 0)
+        """,
+        (batch_id,),
+    )
+    conn.commit()
+    resp = diff_client.get(f"/v1/staging/batches/{batch_id}/diff", headers=auth)
+    assert resp.status_code == 400
+    assert "terminal status" in resp.json()["detail"]

--- a/tests/integration/test_staging_diff.py
+++ b/tests/integration/test_staging_diff.py
@@ -83,9 +83,9 @@ def _seed_canonical_item(
     )
     conn.execute(
         """
-        INSERT INTO external_id_mapping
+        INSERT INTO external_references
             (entity_type, external_id, internal_id, source_system)
-        VALUES ('items', %s, %s, %s)
+        VALUES ('item', %s, %s, %s)
         """,
         (external_id, item_id, source_system),
     )


### PR DESCRIPTION
## Summary

Step 7 of [ADR-013](docs/ADR-013-external-interfaces.md) roadmap. The pre-approval safety net — read-only endpoint that previews what \`POST /approve\` would change in canonical tables. **Principal protection against destructive imports** (truncated ERP exports, scope-reduction accidents).

## API

\`\`\`bash
curl "\${OOTILS_API_URL}/v1/staging/batches/\${BATCH_ID}/diff" \
  -H "Authorization: Bearer \${OOTILS_API_TOKEN}"

# Response 200:
# {
#   "batch_id": "uuid",
#   "entity_type": "items",
#   "source_system": "SAP-EU",
#   "supported": true,
#   "counts": {
#     "in_batch": 4827,
#     "in_canonical_for_source": 4901,
#     "will_insert": 23,
#     "will_update": 156,
#     "will_noop": 4648,
#     "will_soft_delete": 74    <-- 74 items missing from the batch
#   },
#   "samples": {
#     "will_insert": ["SAP-001", ..., up to 10],
#     "will_update": ["SAP-042", ..., up to 10],
#     "will_soft_delete": ["SAP-OBS-001", ..., up to 10]
#   },
#   "deletion_guard": {
#     "ratio": 0.0151,        // 1.5%
#     "threshold": 0.20,      // 20%
#     "exceeds_threshold": false
#   }
# }
\`\`\`

## Set-arithmetic logic

For (entity_type, source_system) of the batch:

| Where the external_id lives | Outcome |
|---|---|
| Batch only | WILL_INSERT |
| Canonical only (same source_system) | WILL_SOFT_DELETE |
| Both, fields differ | WILL_UPDATE |
| Both, fields identical | WILL_NOOP |

Field comparison normalises NULL / numeric / bool to string so a TSV \`"14"\` matches a DB \`int 14\` matches a \`Decimal('14')\`.

## Supported entity types (v1)

- \`items\` — external_id, name, item_type, uom, status
- \`locations\` — external_id, name, location_type, country, timezone
- \`suppliers\` — external_id, name, country, lead_time_days, reliability_score, status

Unknown / unsupported entity_types return \`supported=false\` with a reason rather than crashing. Transactional entities (PO/WO/CO/transfers) will get their own diff specs when \`/approve\` extends to them.

## Deletion guard (ADR-013 D4)

\`deletion_ratio = soft_delete / canonical_count\`. When > 20%, \`exceeds_threshold=true\`. The /approve endpoint (step 8) will refuse the approval past this threshold unless \`force=true\` is set.

## Tests

11 integration tests in \`tests/integration/test_staging_diff.py\`:
- 5 happy paths: pure-insert / pure-update / pure-noop / pure-soft-delete / realistic mixed
- 2 threshold tests: under 20% (not exceeded), over 20% (exceeded)
- 1 source-isolation test: another source's items don't appear as soft-delete
- 3 error paths: unknown batch / unsupported entity_type / terminal status

## Test plan

- [x] Ruff lint passes
- [x] Module imports cleanly
- [ ] CI integration tests pass (11 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)