### PR TITLE
feat(staging): POST /approve — full-reload load (closes ADR-013 hot path)

### DIFF
--- a/src/ootils_core/api/routers/staging.py
+++ b/src/ootils_core/api/routers/staging.py
@@ -43,8 +43,11 @@ from fastapi import (
     status,
 )
 
+from pydantic import BaseModel, Field
+
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db
+from ootils_core.staging.approve import ApprovalError, approve_batch
 from ootils_core.staging.diff import DiffError, compute_diff
 from ootils_core.staging.loader import LoaderError, load_to_staging
 from ootils_core.staging.parser import ParseError, ParseOptions, parse
@@ -266,4 +269,74 @@ def get_batch_diff(
             "threshold": diff.deletion_ratio_threshold,
             "exceeds_threshold": diff.exceeds_deletion_threshold,
         },
+    }
+
+
+class ApproveRequest(BaseModel):
+    """Body of POST /v1/staging/batches/{id}/approve.
+
+    `force` is required (set to True) when the diff's deletion ratio
+    exceeds the 20% threshold — see ADR-013 D4. `notes` is optional but
+    strongly recommended when forcing, as it becomes the audit trail
+    rationale in staging.transform_runs.approval_notes.
+    """
+    notes: Optional[str] = Field(default=None, max_length=2000)
+    force: bool = Field(default=False)
+    # Identity of the approver. The current auth layer doesn't extract
+    # subjects from the bearer token, so callers pass it explicitly for
+    # now. When auth.py grows subject extraction, this becomes optional.
+    approved_by: str = Field(..., min_length=1, max_length=200)
+
+
+@router.post(
+    "/batches/{batch_id}/approve",
+    dependencies=[Depends(require_auth)],
+)
+def approve(
+    batch_id: UUID,
+    body: ApproveRequest,
+    db: psycopg.Connection = Depends(get_db),
+) -> dict:
+    """Apply the validated batch to canonical tables (ADR-013 D3+D4).
+
+    Returns counts (rows_inserted / rows_updated / rows_soft_deleted /
+    rows_noop), the new run_id, and a list of samples per category.
+    The batch transitions from 'validated' to 'imported'; a new
+    `staging.transform_runs` row is created in 'completed' state.
+
+    Failure mode: if the canonical write fails for any reason, the
+    transaction is rolled back and the transform_runs row is marked
+    'failed' with the error message (audit trail preserved). The
+    batch stays in 'validated' state so the operator can retry.
+    """
+    try:
+        result = approve_batch(
+            db,
+            batch_id=batch_id,
+            approved_by=body.approved_by,
+            notes=body.notes,
+            force=body.force,
+        )
+    except ApprovalError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+
+    return {
+        "batch_id": str(result.batch_id),
+        "run_id": str(result.run_id),
+        "entity_type": result.entity_type,
+        "source_system": result.source_system,
+        "approved_by": result.approved_by,
+        "forced_approval": result.forced_approval,
+        "duration_seconds": result.duration_seconds,
+        "counts": {
+            "rows_inserted": result.rows_inserted,
+            "rows_updated": result.rows_updated,
+            "rows_soft_deleted": result.rows_soft_deleted,
+            "rows_noop": result.rows_noop,
+        },
+        "deletion_ratio": result.deletion_ratio,
+        "samples": result.samples,
     }

--- a/src/ootils_core/staging/approve.py
+++ b/src/ootils_core/staging/approve.py
@@ -1,0 +1,454 @@
+"""
+approve.py — execute the full-reload transform + load (ADR-013 D3 + D4).
+
+Implements `POST /v1/staging/batches/{id}/approve`. Given a batch in
+status='validated' (i.e. DQ-clean) plus an optional `force=true` flag
+for crossing the 20% deletion threshold, applies the entire batch to
+the canonical tables in a single atomic transaction:
+
+  1. UPSERT each batch row into the canonical table (insert if the
+     external_id is new, update if it exists; the row carries the
+     full new state).
+  2. Insert/update the corresponding `external_references` mapping so
+     subsequent diffs / approvals stay source-scoped.
+  3. Soft-delete: for each canonical row that belongs to this
+     (entity_type, source_system) but is absent from the batch, mark
+     it inactive in the canonical table (status='obsolete' on items,
+     'inactive' on suppliers) AND remove the mapping. Locations have
+     no status field — only the mapping is removed; the canonical
+     row stays in case another source references it.
+  4. Bookkeeping: ingest_batches.status='imported', staging.transform_runs
+     gets a row with counters + approver identity + outcome.
+
+If any step fails, the whole transaction rolls back. The batch stays
+in status='validated' and the operator can retry after fixing the
+underlying issue.
+
+Currently supports items / locations / suppliers (the same 3 master-data
+entity_types as the diff endpoint). Transactional entities follow when
+they have their canonical-table writers in place.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
+
+import psycopg
+
+from ootils_core.staging.diff import (
+    DELETION_RATIO_THRESHOLD,
+    DiffError,
+    DiffResult,
+    compute_diff,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ApprovalError(ValueError):
+    """Raised when the approval is rejected (bad state, threshold guard, etc.)."""
+
+
+@dataclass
+class ApprovalResult:
+    """Outcome of /approve. Counts are populated only on success."""
+    batch_id: UUID
+    run_id: UUID
+    entity_type: str
+    source_system: str
+    approved_by: str
+    rows_inserted: int = 0
+    rows_updated: int = 0
+    rows_soft_deleted: int = 0
+    rows_noop: int = 0
+    forced_approval: bool = False
+    duration_seconds: float = 0.0
+    deletion_ratio: float = 0.0
+    samples: dict[str, list[str]] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Per-entity approval specs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ApprovalSpec:
+    """How to UPSERT + soft-delete this entity_type's canonical rows."""
+    canonical_table: str
+    pk_column: str
+    ref_entity_type: str          # singular for external_references
+    fields: tuple[str, ...]       # columns to write (external_id always first)
+    soft_delete_column: str | None  # e.g., 'status' for items
+    soft_delete_value: str | None   # e.g., 'obsolete' for items
+
+
+_SPECS: dict[str, _ApprovalSpec] = {
+    "items": _ApprovalSpec(
+        canonical_table="items",
+        pk_column="item_id",
+        ref_entity_type="item",
+        fields=("external_id", "name", "item_type", "uom", "status"),
+        soft_delete_column="status",
+        soft_delete_value="obsolete",
+    ),
+    "locations": _ApprovalSpec(
+        canonical_table="locations",
+        pk_column="location_id",
+        ref_entity_type="location",
+        fields=("external_id", "name", "location_type", "country", "timezone"),
+        # locations has no status/active column — soft-delete only via
+        # removing the external_references row.
+        soft_delete_column=None,
+        soft_delete_value=None,
+    ),
+    "suppliers": _ApprovalSpec(
+        canonical_table="suppliers",
+        pk_column="supplier_id",
+        ref_entity_type="supplier",
+        fields=("external_id", "name", "country", "lead_time_days",
+                "reliability_score", "status"),
+        soft_delete_column="status",
+        soft_delete_value="inactive",
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def approve_batch(
+    conn: psycopg.Connection,
+    batch_id: UUID,
+    approved_by: str,
+    notes: str | None = None,
+    force: bool = False,
+) -> ApprovalResult:
+    """Apply the batch to canonical tables. All-or-nothing transaction.
+
+    Raises:
+        ApprovalError if the batch isn't in 'validated' status, the
+        entity_type isn't supported, or the deletion threshold is
+        crossed without force=true.
+    """
+    import time as _time
+    started = _time.perf_counter()
+
+    # ---------- 1. Load batch + validate state ----------
+    batch_row = conn.execute(
+        "SELECT entity_type, source_system, status, dq_status "
+        "FROM ingest_batches WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+    if batch_row is None:
+        raise ApprovalError(f"batch {batch_id} not found")
+
+    entity_type = batch_row["entity_type"]
+    source_system = batch_row["source_system"]
+    status = batch_row["status"]
+    dq_status = batch_row.get("dq_status")
+
+    if status != "validated":
+        raise ApprovalError(
+            f"batch is in status {status!r}; only batches in 'validated' state can be approved"
+        )
+    if dq_status not in (None, "validated", "warning"):
+        # 'rejected' means DQ found errors — must not be approvable
+        raise ApprovalError(
+            f"batch dq_status is {dq_status!r}; only DQ-validated batches can be approved"
+        )
+
+    spec = _SPECS.get(entity_type)
+    if spec is None:
+        raise ApprovalError(
+            f"entity_type {entity_type!r} does not yet have approval support — "
+            "currently implemented for items / locations / suppliers"
+        )
+
+    # ---------- 2. Compute the diff ----------
+    try:
+        diff = compute_diff(conn, batch_id)
+    except DiffError as e:
+        raise ApprovalError(f"could not compute diff: {e}") from e
+
+    if not diff.supported:
+        raise ApprovalError(diff.unsupported_reason or "diff not supported")
+
+    # ---------- 3. Deletion guard ----------
+    if diff.exceeds_deletion_threshold and not force:
+        raise ApprovalError(
+            f"deletion ratio {diff.deletion_ratio:.1%} exceeds "
+            f"threshold {DELETION_RATIO_THRESHOLD:.0%}; "
+            f"would soft-delete {diff.will_soft_delete_count} of "
+            f"{diff.total_in_canonical_for_source} canonical rows. "
+            f"Pass force=true to override (and include a justification in notes)."
+        )
+
+    # ---------- 4. Open transform_run + perform the load ----------
+    run_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO staging.transform_runs
+            (run_id, batch_id, status, approved_by, approval_notes, forced_approval)
+        VALUES (%s, %s, 'running', %s, %s, %s)
+        """,
+        (run_id, batch_id, approved_by, notes,
+         force and diff.exceeds_deletion_threshold),
+    )
+    conn.commit()
+
+    try:
+        # All canonical-write steps run within a savepoint so a failure
+        # rolls them back without losing the transform_run audit row.
+        conn.execute("SAVEPOINT staging_approve")
+
+        # 4a. Load batch rows (parsed from raw_content)
+        batch_records = _load_batch_records(conn, batch_id, spec)
+
+        # 4b. Upsert canonical + external_references
+        n_inserted, n_updated = _upsert_canonical_rows(
+            conn, spec, source_system, batch_records, diff,
+        )
+
+        # 4c. Soft-delete the rows not in the batch (for this source)
+        n_soft_deleted = _soft_delete_missing(
+            conn, spec, source_system, diff.will_soft_delete_sample
+            if diff.will_soft_delete_count <= 10
+            else _all_soft_delete_targets(conn, spec, source_system,
+                                          set(batch_records.keys())),
+        )
+
+        # 4d. Mark batch as imported
+        conn.execute(
+            """
+            UPDATE ingest_batches
+            SET status = 'imported', imported_at = now()
+            WHERE batch_id = %s
+            """,
+            (batch_id,),
+        )
+
+        # 4e. Close out the transform_run record with counters
+        duration = _time.perf_counter() - started
+        conn.execute(
+            """
+            UPDATE staging.transform_runs
+            SET status = 'completed',
+                completed_at = now(),
+                rows_inserted = %s,
+                rows_updated = %s,
+                rows_soft_deleted = %s,
+                rows_skipped = %s
+            WHERE run_id = %s
+            """,
+            (n_inserted, n_updated, n_soft_deleted,
+             diff.will_noop_count, run_id),
+        )
+
+        conn.execute("RELEASE SAVEPOINT staging_approve")
+        conn.commit()
+
+    except Exception as exc:
+        # On failure, rollback the canonical writes but PRESERVE the
+        # transform_run row with status='failed' for audit.
+        conn.execute("ROLLBACK TO SAVEPOINT staging_approve")
+        conn.execute(
+            """
+            UPDATE staging.transform_runs
+            SET status = 'failed',
+                completed_at = now(),
+                error_message = %s
+            WHERE run_id = %s
+            """,
+            (str(exc)[:2000], run_id),
+        )
+        conn.commit()
+        logger.exception(
+            "staging.approve failed: batch=%s run=%s entity=%s err=%s",
+            batch_id, run_id, entity_type, exc,
+        )
+        raise ApprovalError(f"approval failed during write: {exc}") from exc
+
+    duration = _time.perf_counter() - started
+    logger.info(
+        "staging.approve OK: batch=%s entity=%s source=%s "
+        "ins=%d upd=%d soft_del=%d noop=%d duration=%.2fs",
+        batch_id, entity_type, source_system,
+        n_inserted, n_updated, n_soft_deleted, diff.will_noop_count, duration,
+    )
+
+    return ApprovalResult(
+        batch_id=batch_id,
+        run_id=run_id,
+        entity_type=entity_type,
+        source_system=source_system,
+        approved_by=approved_by,
+        rows_inserted=n_inserted,
+        rows_updated=n_updated,
+        rows_soft_deleted=n_soft_deleted,
+        rows_noop=diff.will_noop_count,
+        forced_approval=force and diff.exceeds_deletion_threshold,
+        duration_seconds=round(duration, 3),
+        deletion_ratio=diff.deletion_ratio,
+        samples={
+            "inserted": diff.will_insert_sample,
+            "updated": diff.will_update_sample,
+            "soft_deleted": diff.will_soft_delete_sample,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_batch_records(
+    conn: psycopg.Connection,
+    batch_id: UUID,
+    spec: _ApprovalSpec,
+) -> dict[str, dict]:
+    """Parse raw_content JSON keyed by external_id (last-wins on dups —
+    L4 caught those already, but defensively the writer wins)."""
+    rows = conn.execute(
+        "SELECT row_number, raw_content FROM ingest_rows "
+        "WHERE batch_id = %s ORDER BY row_number",
+        (batch_id,),
+    ).fetchall()
+    out: dict[str, dict] = {}
+    for row in rows:
+        raw = row["raw_content"]
+        try:
+            content = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(content, dict):
+            continue
+        ext_id = content.get("external_id")
+        if not ext_id:
+            continue
+        # Coerce to the field set the spec expects; missing fields become None
+        normalised = {f: content.get(f) for f in spec.fields}
+        out[ext_id] = normalised
+    return out
+
+
+def _upsert_canonical_rows(
+    conn: psycopg.Connection,
+    spec: _ApprovalSpec,
+    source_system: str,
+    batch_records: dict[str, dict],
+    diff: DiffResult,
+) -> tuple[int, int]:
+    """UPSERT every batch record into the canonical table + register the
+    external_references mapping. Returns (inserted, updated).
+
+    Counts come from `diff` (computed in the same approval transaction,
+    so the numbers reflect this batch's intent). We don't try to derive
+    insert-vs-update from each RETURNING — the SQL plan is the same
+    either way, the diff already classified.
+    """
+    if not batch_records:
+        return 0, 0
+
+    fields = spec.fields
+    table = spec.canonical_table
+    cols_csv = ", ".join(fields)
+    placeholders = ", ".join("%s" for _ in fields)
+    update_set = ", ".join(f"{f} = EXCLUDED.{f}" for f in fields if f != "external_id")
+    upsert_sql = (
+        f"INSERT INTO {table} ({spec.pk_column}, {cols_csv}) "
+        f"VALUES (gen_random_uuid(), {placeholders}) "
+        f"ON CONFLICT (external_id) DO UPDATE SET {update_set} "
+        f"RETURNING {spec.pk_column}"
+    )
+
+    for ext_id, record in batch_records.items():
+        params = tuple(record.get(f) for f in fields)
+        row = conn.execute(upsert_sql, params).fetchone()
+        internal_id = (
+            row[spec.pk_column] if isinstance(row, dict) else row[0]
+        )
+        conn.execute(
+            """
+            INSERT INTO external_references
+                (entity_type, external_id, source_system, internal_id)
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT (entity_type, external_id, source_system) DO UPDATE
+                SET internal_id = EXCLUDED.internal_id, updated_at = now()
+            """,
+            (spec.ref_entity_type, ext_id, source_system, internal_id),
+        )
+
+    return diff.will_insert_count, diff.will_update_count
+
+
+def _all_soft_delete_targets(
+    conn: psycopg.Connection,
+    spec: _ApprovalSpec,
+    source_system: str,
+    batch_external_ids: set[str],
+) -> list[str]:
+    """Fallback path when the diff sample was truncated. Recomputes the
+    full set of external_ids that need soft-delete from canonical state."""
+    rows = conn.execute(
+        f"""
+        SELECT c.external_id
+        FROM {spec.canonical_table} c
+        JOIN external_references r
+          ON r.internal_id = c.{spec.pk_column}
+        WHERE r.entity_type = %s
+          AND r.source_system = %s
+        """,
+        (spec.ref_entity_type, source_system),
+    ).fetchall()
+    canonical_ids = {r["external_id"] for r in rows}
+    return sorted(canonical_ids - batch_external_ids)
+
+
+def _soft_delete_missing(
+    conn: psycopg.Connection,
+    spec: _ApprovalSpec,
+    source_system: str,
+    soft_delete_ids: list[str],
+) -> int:
+    """For each external_id in `soft_delete_ids`:
+      - if the spec has a soft_delete_column, set it on the canonical row
+      - always remove the external_references mapping for this (source, id)
+    Returns the count of distinct external_ids processed (may differ
+    from rows_updated if the canonical column was already at the target value).
+    """
+    if not soft_delete_ids:
+        return 0
+
+    if spec.soft_delete_column and spec.soft_delete_value:
+        conn.execute(
+            f"""
+            UPDATE {spec.canonical_table} c
+            SET {spec.soft_delete_column} = %s
+            FROM external_references r
+            WHERE r.internal_id = c.{spec.pk_column}
+              AND r.entity_type = %s
+              AND r.source_system = %s
+              AND c.external_id = ANY(%s)
+            """,
+            (spec.soft_delete_value, spec.ref_entity_type, source_system,
+             soft_delete_ids),
+        )
+
+    # Always remove the source's claim on the row (other sources may still
+    # reference it via their own external_references entries)
+    conn.execute(
+        """
+        DELETE FROM external_references
+        WHERE entity_type = %s
+          AND source_system = %s
+          AND external_id = ANY(%s)
+        """,
+        (spec.ref_entity_type, source_system, soft_delete_ids),
+    )
+    return len(soft_delete_ids)

--- a/tests/integration/test_staging_approve.py
+++ b/tests/integration/test_staging_approve.py
@@ -153,7 +153,7 @@ def test_approve_pure_insert_creates_canonical_rows(
 
     # Verify canonical tables now hold the rows
     rows = conn.execute(
-        "SELECT external_id, name FROM items WHERE external_id LIKE 'APP-INS-%' "
+        "SELECT external_id, name FROM items WHERE external_id LIKE 'APP-INS-%%' "
         "ORDER BY external_id"
     ).fetchall()
     assert len(rows) == 2
@@ -255,7 +255,7 @@ def test_approve_soft_deletes_missing_rows(staging_client, auth, conn) -> None:
     # external_references entries removed for this source
     refs = conn.execute(
         "SELECT external_id FROM external_references "
-        "WHERE source_system = %s AND external_id LIKE 'APP-DEL-%'",
+        "WHERE source_system = %s AND external_id LIKE 'APP-DEL-%%'",
         (src,),
     ).fetchall()
     assert len(refs) == 0

--- a/tests/integration/test_staging_approve.py
+++ b/tests/integration/test_staging_approve.py
@@ -1,0 +1,400 @@
+"""Integration tests for POST /v1/staging/batches/{id}/approve.
+
+End-to-end pipeline: upload TSV -> validate -> approve -> verify the
+canonical tables changed as the diff predicted.
+
+These tests exercise the full ADR-013 flow that this PR completes:
+the user-visible workflow (upload, validate, approve) plus the
+invariant that after approval the canonical state matches what the
+batch dictated, scoped to the source_system.
+"""
+from __future__ import annotations
+
+import io
+import os
+from uuid import UUID, uuid4
+
+import psycopg
+import pytest
+from psycopg.rows import dict_row
+
+from .conftest import requires_db
+
+
+@pytest.fixture(scope="module")
+def staging_client(migrated_db):
+    """Module-scoped TestClient sharing the migrated DB."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = "test-token"
+
+    from fastapi.testclient import TestClient
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+
+    app = create_app()
+    db = OotilsDB(migrated_db)
+
+    def override_db():
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def auth():
+    return {"Authorization": "Bearer test-token"}
+
+
+@pytest.fixture
+def conn(migrated_db: str):
+    with psycopg.connect(migrated_db, row_factory=dict_row) as c:
+        yield c
+        c.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _upload_and_validate(
+    staging_client, auth, conn, rows, source_system,
+) -> UUID:
+    """Upload a TSV + force the batch into 'validated' state.
+
+    The /upload endpoint leaves the batch at status='pending'. In real
+    operation the DQ runner moves it to 'validated' (or 'rejected').
+    For these tests we skip the DQ run and set the status directly so
+    the approval path is the test target.
+    """
+    lines = ["external_id\tname\titem_type\tuom\tstatus"]
+    for r in rows:
+        lines.append("\t".join(r))
+    data = ("\n".join(lines) + "\n").encode("utf-8")
+    resp = staging_client.post(
+        "/v1/staging/upload",
+        headers=auth,
+        files={"file": ("items.tsv", io.BytesIO(data), "text/plain")},
+        data={"entity_type": "items", "source_system": source_system},
+    )
+    assert resp.status_code == 202, resp.text
+    batch_id = UUID(resp.json()["batch_id"])
+    conn.execute(
+        "UPDATE ingest_batches SET status = 'validated', dq_status = 'validated' "
+        "WHERE batch_id = %s",
+        (batch_id,),
+    )
+    conn.commit()
+    return batch_id
+
+
+def _seed_canonical_item(
+    conn, external_id: str, name: str, source_system: str,
+    item_type: str = "component", uom: str = "EA", status: str = "active",
+) -> UUID:
+    item_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO items (item_id, external_id, name, item_type, uom, status)
+        VALUES (%s, %s, %s, %s, %s, %s)
+        ON CONFLICT (external_id) DO NOTHING
+        """,
+        (item_id, external_id, name, item_type, uom, status),
+    )
+    conn.execute(
+        """
+        INSERT INTO external_references
+            (entity_type, external_id, internal_id, source_system)
+        VALUES ('item', %s, %s, %s)
+        ON CONFLICT (entity_type, external_id, source_system) DO NOTHING
+        """,
+        (external_id, item_id, source_system),
+    )
+    conn.commit()
+    return item_id
+
+
+# ---------------------------------------------------------------------------
+# Pure insert
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_approve_pure_insert_creates_canonical_rows(
+    staging_client, auth, conn,
+) -> None:
+    src = "APPROVE-INS-" + uuid4().hex[:6]
+    batch_id = _upload_and_validate(
+        staging_client, auth, conn,
+        [
+            ("APP-INS-001", "New One", "component", "EA", "active"),
+            ("APP-INS-002", "New Two", "component", "EA", "active"),
+        ],
+        source_system=src,
+    )
+
+    resp = staging_client.post(
+        f"/v1/staging/batches/{batch_id}/approve",
+        headers=auth,
+        json={"approved_by": "test@example.com", "notes": "first import"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["counts"]["rows_inserted"] == 2
+    assert body["counts"]["rows_updated"] == 0
+    assert body["counts"]["rows_soft_deleted"] == 0
+    assert body["forced_approval"] is False
+
+    # Verify canonical tables now hold the rows
+    rows = conn.execute(
+        "SELECT external_id, name FROM items WHERE external_id LIKE 'APP-INS-%' "
+        "ORDER BY external_id"
+    ).fetchall()
+    assert len(rows) == 2
+    assert rows[0]["name"] == "New One"
+
+    # Verify external_references rows exist for this source
+    refs = conn.execute(
+        "SELECT external_id FROM external_references "
+        "WHERE source_system = %s ORDER BY external_id",
+        (src,),
+    ).fetchall()
+    assert {r["external_id"] for r in refs} == {"APP-INS-001", "APP-INS-002"}
+
+    # Batch transitioned to 'imported'
+    batch = conn.execute(
+        "SELECT status, imported_at FROM ingest_batches WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+    assert batch["status"] == "imported"
+    assert batch["imported_at"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Update flow
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_approve_updates_existing_row(staging_client, auth, conn) -> None:
+    src = "APPROVE-UPD-" + uuid4().hex[:6]
+    _seed_canonical_item(conn, "APP-UPD-001", "Old Name", src)
+
+    batch_id = _upload_and_validate(
+        staging_client, auth, conn,
+        [("APP-UPD-001", "New Name", "component", "EA", "active")],
+        source_system=src,
+    )
+
+    resp = staging_client.post(
+        f"/v1/staging/batches/{batch_id}/approve",
+        headers=auth,
+        json={"approved_by": "test@example.com"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["counts"]["rows_inserted"] == 0
+    assert body["counts"]["rows_updated"] == 1
+
+    # The canonical row reflects the new name
+    item = conn.execute(
+        "SELECT name FROM items WHERE external_id = 'APP-UPD-001'"
+    ).fetchone()
+    assert item["name"] == "New Name"
+
+
+# ---------------------------------------------------------------------------
+# Soft-delete
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_approve_soft_deletes_missing_rows(staging_client, auth, conn) -> None:
+    """An item present in canonical for this source but absent from the
+    batch must end up status='obsolete' AND its external_references
+    mapping must be removed for this source."""
+    src = "APPROVE-DEL-" + uuid4().hex[:6]
+    _seed_canonical_item(conn, "APP-KEEP-001", "Keep", src)
+    _seed_canonical_item(conn, "APP-DEL-001", "WillBeRemoved", src)
+    _seed_canonical_item(conn, "APP-DEL-002", "AlsoRemoved", src)
+
+    batch_id = _upload_and_validate(
+        staging_client, auth, conn,
+        [("APP-KEEP-001", "Keep", "component", "EA", "active")],
+        source_system=src,
+    )
+
+    resp = staging_client.post(
+        f"/v1/staging/batches/{batch_id}/approve",
+        headers=auth,
+        json={"approved_by": "test@example.com"},
+    )
+    body = resp.json()
+    assert body["counts"]["rows_soft_deleted"] == 2
+
+    # Canonical items got status='obsolete'
+    obsolete = conn.execute(
+        "SELECT external_id, status FROM items "
+        "WHERE external_id IN ('APP-DEL-001', 'APP-DEL-002') ORDER BY external_id"
+    ).fetchall()
+    assert all(r["status"] == "obsolete" for r in obsolete)
+
+    # external_references entries removed for this source
+    refs = conn.execute(
+        "SELECT external_id FROM external_references "
+        "WHERE source_system = %s AND external_id LIKE 'APP-DEL-%'",
+        (src,),
+    ).fetchall()
+    assert len(refs) == 0
+
+
+# ---------------------------------------------------------------------------
+# 20% deletion ratio guard
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_approve_blocks_excessive_deletion_without_force(
+    staging_client, auth, conn,
+) -> None:
+    """5 canonical, batch keeps 2 -> 60% deletion. Refuses without force."""
+    src = "APPROVE-GRD-" + uuid4().hex[:6]
+    for i in range(5):
+        _seed_canonical_item(conn, f"APP-GRD-{i:03d}", f"Row{i}", src)
+
+    batch_id = _upload_and_validate(
+        staging_client, auth, conn,
+        [
+            ("APP-GRD-000", "Row0", "component", "EA", "active"),
+            ("APP-GRD-001", "Row1", "component", "EA", "active"),
+        ],
+        source_system=src,
+    )
+
+    # Without force=true: 400
+    resp = staging_client.post(
+        f"/v1/staging/batches/{batch_id}/approve",
+        headers=auth,
+        json={"approved_by": "test@example.com"},
+    )
+    assert resp.status_code == 400
+    assert "deletion ratio" in resp.json()["detail"]
+    # Batch must STAY validated — nothing got written
+    batch = conn.execute(
+        "SELECT status FROM ingest_batches WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+    assert batch["status"] == "validated"
+
+
+@requires_db
+def test_approve_proceeds_with_force_true(staging_client, auth, conn) -> None:
+    """Same setup, but force=true -> approval succeeds, audit flag set."""
+    src = "APPROVE-GRD2-" + uuid4().hex[:6]
+    for i in range(5):
+        _seed_canonical_item(conn, f"APP-FRC-{i:03d}", f"Row{i}", src)
+
+    batch_id = _upload_and_validate(
+        staging_client, auth, conn,
+        [
+            ("APP-FRC-000", "Row0", "component", "EA", "active"),
+            ("APP-FRC-001", "Row1", "component", "EA", "active"),
+        ],
+        source_system=src,
+    )
+
+    resp = staging_client.post(
+        f"/v1/staging/batches/{batch_id}/approve",
+        headers=auth,
+        json={
+            "approved_by": "test@example.com",
+            "notes": "Intentional scope reduction — confirmed with planning",
+            "force": True,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["forced_approval"] is True
+    assert body["counts"]["rows_soft_deleted"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_approve_rejects_pending_batch(staging_client, auth, conn) -> None:
+    """A batch still in 'pending' (no DQ yet) can't be approved."""
+    src = "APPROVE-PEND-" + uuid4().hex[:6]
+    # Upload but DO NOT mark as validated
+    lines = ["external_id\tname\titem_type\tuom\tstatus",
+             "APP-PEND-001\tFoo\tcomponent\tEA\tactive"]
+    data = ("\n".join(lines) + "\n").encode("utf-8")
+    resp = staging_client.post(
+        "/v1/staging/upload",
+        headers=auth,
+        files={"file": ("items.tsv", io.BytesIO(data), "text/plain")},
+        data={"entity_type": "items", "source_system": src},
+    )
+    batch_id = resp.json()["batch_id"]
+
+    resp = staging_client.post(
+        f"/v1/staging/batches/{batch_id}/approve",
+        headers=auth,
+        json={"approved_by": "test@example.com"},
+    )
+    assert resp.status_code == 400
+    assert "validated" in resp.json()["detail"]
+
+
+@requires_db
+def test_approve_rejects_unknown_batch(staging_client, auth) -> None:
+    bogus = uuid4()
+    resp = staging_client.post(
+        f"/v1/staging/batches/{bogus}/approve",
+        headers=auth,
+        json={"approved_by": "test@example.com"},
+    )
+    assert resp.status_code == 400
+    assert "not found" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# transform_runs audit
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_approve_writes_transform_runs_audit(staging_client, auth, conn) -> None:
+    """staging.transform_runs must hold a 'completed' row with the
+    counters + approver after a successful approval."""
+    src = "APPROVE-AUD-" + uuid4().hex[:6]
+    batch_id = _upload_and_validate(
+        staging_client, auth, conn,
+        [("APP-AUD-001", "Audited", "component", "EA", "active")],
+        source_system=src,
+    )
+    body = staging_client.post(
+        f"/v1/staging/batches/{batch_id}/approve",
+        headers=auth,
+        json={"approved_by": "auditor@example.com", "notes": "for the record"},
+    ).json()
+
+    run_row = conn.execute(
+        "SELECT * FROM staging.transform_runs WHERE run_id = %s",
+        (body["run_id"],),
+    ).fetchone()
+    assert run_row is not None
+    assert run_row["status"] == "completed"
+    assert run_row["approved_by"] == "auditor@example.com"
+    assert run_row["approval_notes"] == "for the record"
+    assert run_row["rows_inserted"] == 1
+    assert run_row["rows_soft_deleted"] == 0
+    assert run_row["completed_at"] is not None

--- a/tests/integration/test_staging_approve.py
+++ b/tests/integration/test_staging_approve.py
@@ -230,11 +230,18 @@ def test_approve_soft_deletes_missing_rows(staging_client, auth, conn) -> None:
         source_system=src,
     )
 
+    # 3 canonical, batch keeps 1 -> 67% deletion ratio > 20% guard.
+    # Test exercises soft-delete WITH force=true.
     resp = staging_client.post(
         f"/v1/staging/batches/{batch_id}/approve",
         headers=auth,
-        json={"approved_by": "test@example.com"},
+        json={
+            "approved_by": "test@example.com",
+            "force": True,
+            "notes": "test: exercising soft-delete with force=true",
+        },
     )
+    assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["counts"]["rows_soft_deleted"] == 2
 


### PR DESCRIPTION
## Summary

Step 8 of [ADR-013](docs/ADR-013-external-interfaces.md) roadmap. **The cornerstone of the staging pipeline.** Applies a validated batch to canonical tables in a single atomic transaction — insert new, update existing, soft-delete missing — scoped to the batch's (entity_type, source_system).

After this PR, the **end-to-end pipeline is closed**: external file → staging zone → DQ L1-L4 → diff preview → human-approved write to canonical.

## API

\`\`\`bash
# After /upload returned batch_id and the DQ pipeline marked it 'validated'
# (and after operator reviewed /diff and is happy):

curl -X POST "\${OOTILS_API_URL}/v1/staging/batches/\${BATCH_ID}/approve" \
  -H "Authorization: Bearer \${OOTILS_API_TOKEN}" \
  -H "Content-Type: application/json" \
  -d '{
    "approved_by": "ops@example.com",
    "notes": "Weekly SAP master refresh — validated with planning team",
    "force": false
  }'

# Response 200:
# {
#   "batch_id": "uuid",
#   "run_id": "uuid",                          // staging.transform_runs
#   "entity_type": "items",
#   "source_system": "SAP-EU",
#   "approved_by": "ops@example.com",
#   "forced_approval": false,
#   "duration_seconds": 0.124,
#   "counts": {
#     "rows_inserted": 23,
#     "rows_updated": 156,
#     "rows_soft_deleted": 4,
#     "rows_noop": 4644
#   },
#   "deletion_ratio": 0.0008,
#   "samples": {
#     "inserted": ["SAP-001", ..., 10],
#     "updated":  ["SAP-042", ..., 10],
#     "soft_deleted": ["SAP-OBS-001", ..., 4]
#   }
# }
\`\`\`

## Atomicity contract (ADR-013 D3)

Everything happens inside a SAVEPOINT. If ANY canonical write fails:
- the canonical state rolls back to pre-approval
- the batch stays in \`'validated'\` so the operator can retry
- the \`staging.transform_runs\` row gets \`status='failed'\` + \`error_message\` — audit trail preserved

## Deletion guard (ADR-013 D4)

If \`deletion_ratio > 20%\` (more than a fifth of canonical rows would be soft-deleted), approval is refused with **400 Bad Request**. Operator must explicitly pass \`force=true\` and ideally a \`notes\` explaining why — that string is persisted in \`staging.transform_runs.approval_notes\` for audit.

## Soft-delete semantics per entity

| Entity | What happens to canonical row | What happens to external_references |
|---|---|---|
| items     | \`status = 'obsolete'\`  | row deleted for this source |
| suppliers | \`status = 'inactive'\`  | row deleted for this source |
| locations | unchanged (no status column) | row deleted for this source |

This is asymmetric but matches the schema. \`locations\` without a status column can't be marked inactive — removing the mapping is the closest equivalent. Other sources still referencing the same location keep it canonical.

## Tests (9 integration)

- Pure insert -> canonical rows + external_references created
- Update flow -> canonical row reflects new field values
- Soft-delete -> canonical status='obsolete' + mapping removed
- 20% threshold guard refuses without force=true; batch stays 'validated'
- force=true overrides; forced_approval=true returned
- Pending batch (no DQ yet) refused
- Unknown batch_id -> 400
- staging.transform_runs audit row populated with all counters + approver + notes

## What's next

- Step 9: \`POST /reject\` + audit (~0.5 j)
- Steps 10-12: remaining entity templates + e2e tests + docs

## Test plan

- [x] Ruff lint passes
- [x] Imports verified
- [ ] CI integration tests pass (9 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)