### PR TITLE
feat(staging): POST /reject — close out batch lifecycle

### DIFF
--- a/src/ootils_core/api/routers/staging.py
+++ b/src/ootils_core/api/routers/staging.py
@@ -51,6 +51,7 @@ from ootils_core.staging.approve import ApprovalError, approve_batch
 from ootils_core.staging.diff import DiffError, compute_diff
 from ootils_core.staging.loader import LoaderError, load_to_staging
 from ootils_core.staging.parser import ParseError, ParseOptions, parse
+from ootils_core.staging.reject import RejectionError, reject_batch
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1/staging", tags=["staging"])
@@ -339,4 +340,56 @@ def approve(
         },
         "deletion_ratio": result.deletion_ratio,
         "samples": result.samples,
+    }
+
+
+class RejectRequest(BaseModel):
+    """Body of POST /v1/staging/batches/{id}/reject.
+
+    A rejection is permanent — the batch transitions to 'rejected' and
+    cannot be revived. The `reason` is stored in
+    `staging.transform_runs.approval_notes` AND appended to
+    `ingest_batches.notes` so operators can see the rationale either
+    way.
+
+    To retry the import after correction, the source must be
+    re-uploaded as a new batch (the rejected batch's ingest_rows stay
+    intact for forensics).
+    """
+    rejected_by: str = Field(..., min_length=1, max_length=200)
+    reason: str = Field(..., min_length=1, max_length=2000)
+
+
+@router.post(
+    "/batches/{batch_id}/reject",
+    dependencies=[Depends(require_auth)],
+)
+def reject(
+    batch_id: UUID,
+    body: RejectRequest,
+    db: psycopg.Connection = Depends(get_db),
+) -> dict:
+    """Close out a batch as rejected without writing to canonical."""
+    try:
+        result = reject_batch(
+            db,
+            batch_id=batch_id,
+            rejected_by=body.rejected_by,
+            reason=body.reason,
+        )
+    except RejectionError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+
+    return {
+        "batch_id": str(result.batch_id),
+        "run_id": str(result.run_id),
+        "entity_type": result.entity_type,
+        "source_system": result.source_system,
+        "rejected_by": result.rejected_by,
+        "rejection_reason": result.rejection_reason,
+        "prior_status": result.prior_status,
+        "new_status": "rejected",
     }

--- a/src/ootils_core/staging/reject.py
+++ b/src/ootils_core/staging/reject.py
@@ -1,0 +1,118 @@
+"""
+reject.py — close out a batch as 'rejected' without writing to canonical.
+
+POST /v1/staging/batches/{id}/reject is the operator's way to decline
+a batch (typo'd CSV, wrong source_system, scope error spotted in /diff,
+DQ-warning batch deemed too risky to approve, etc.).
+
+Outcome:
+  - ingest_batches.status -> 'rejected'
+  - a staging.transform_runs row is created with status='rolled_back'
+    holding the rejector identity + reason for audit
+  - ingest_rows are NOT deleted; the raw upload stays in the staging
+    zone so the operator can investigate later, and the file's sha256
+    in staging.uploads remains queryable.
+
+A rejected batch is TERMINAL — the lifecycle does not allow moving
+back to 'validated' or 'imported' from here. To re-attempt the import
+the source must be re-uploaded as a new batch.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+
+class RejectionError(ValueError):
+    """Raised when the rejection cannot be applied (bad batch state)."""
+
+
+@dataclass
+class RejectionResult:
+    """Outcome of /reject."""
+    batch_id: UUID
+    run_id: UUID
+    entity_type: str
+    source_system: str
+    rejected_by: str
+    rejection_reason: str
+    prior_status: str  # the status the batch was in before this call
+
+
+def reject_batch(
+    conn: psycopg.Connection,
+    batch_id: UUID,
+    rejected_by: str,
+    reason: str,
+) -> RejectionResult:
+    """Mark a batch as rejected with a free-text reason.
+
+    Raises:
+        RejectionError if the batch doesn't exist or is already in a
+        terminal state ('imported' or 'rejected'). Re-rejecting an
+        already-rejected batch is a no-op semantically but we surface
+        it as an error so the caller knows the rejection didn't take
+        effect this time (and to avoid duplicate audit rows).
+    """
+    if not reason or not reason.strip():
+        raise RejectionError("reason is required and cannot be empty")
+
+    row = conn.execute(
+        "SELECT entity_type, source_system, status FROM ingest_batches "
+        "WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+    if row is None:
+        raise RejectionError(f"batch {batch_id} not found")
+
+    entity_type = row["entity_type"]
+    source_system = row["source_system"]
+    prior_status = row["status"]
+
+    if prior_status in ("imported", "rejected"):
+        raise RejectionError(
+            f"batch is in terminal status {prior_status!r}; rejection refused"
+        )
+
+    run_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO staging.transform_runs
+            (run_id, batch_id, status, approved_by, approval_notes,
+             started_at, completed_at)
+        VALUES (%s, %s, 'rolled_back', %s, %s, now(), now())
+        """,
+        (run_id, batch_id, rejected_by, reason.strip()),
+    )
+    conn.execute(
+        """
+        UPDATE ingest_batches
+        SET status = 'rejected',
+            processed_at = now(),
+            notes = COALESCE(notes || E'\n', '') || %s
+        WHERE batch_id = %s
+        """,
+        (f"[REJECTED by {rejected_by}] {reason.strip()}", batch_id),
+    )
+    conn.commit()
+
+    logger.info(
+        "staging.reject OK: batch=%s entity=%s source=%s rejected_by=%s "
+        "prior_status=%s",
+        batch_id, entity_type, source_system, rejected_by, prior_status,
+    )
+
+    return RejectionResult(
+        batch_id=batch_id,
+        run_id=run_id,
+        entity_type=entity_type,
+        source_system=source_system,
+        rejected_by=rejected_by,
+        rejection_reason=reason.strip(),
+        prior_status=prior_status,
+    )

--- a/tests/integration/test_staging_reject.py
+++ b/tests/integration/test_staging_reject.py
@@ -1,0 +1,246 @@
+"""Integration tests for POST /v1/staging/batches/{id}/reject.
+
+Closes out a batch as 'rejected' (terminal), records the rejection
+in staging.transform_runs + ingest_batches.notes for audit.
+"""
+from __future__ import annotations
+
+import io
+import os
+from uuid import UUID, uuid4
+
+import psycopg
+import pytest
+from psycopg.rows import dict_row
+
+from .conftest import requires_db
+
+
+@pytest.fixture(scope="module")
+def staging_client(migrated_db):
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = "test-token"
+
+    from fastapi.testclient import TestClient
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+
+    app = create_app()
+    db = OotilsDB(migrated_db)
+
+    def override_db():
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def auth():
+    return {"Authorization": "Bearer test-token"}
+
+
+@pytest.fixture
+def conn(migrated_db: str):
+    with psycopg.connect(migrated_db, row_factory=dict_row) as c:
+        yield c
+        c.rollback()
+
+
+def _upload_basic_batch(staging_client, auth, source_system="REJ-TEST") -> UUID:
+    """Upload a tiny valid TSV; batch lands in 'pending'."""
+    data = b"external_id\tname\titem_type\tuom\tstatus\nREJ-001\tFoo\tcomponent\tEA\tactive\n"
+    resp = staging_client.post(
+        "/v1/staging/upload",
+        headers=auth,
+        files={"file": ("items.tsv", io.BytesIO(data), "text/plain")},
+        data={"entity_type": "items", "source_system": source_system},
+    )
+    assert resp.status_code == 202, resp.text
+    return UUID(resp.json()["batch_id"])
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_reject_pending_batch(staging_client, auth, conn) -> None:
+    batch_id = _upload_basic_batch(staging_client, auth, source_system="REJ-PEND")
+
+    resp = staging_client.post(
+        f"/v1/staging/batches/{batch_id}/reject",
+        headers=auth,
+        json={"rejected_by": "ops@example.com",
+              "reason": "wrong source_system spelling"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["new_status"] == "rejected"
+    assert body["prior_status"] == "pending"
+    assert body["rejected_by"] == "ops@example.com"
+    assert body["rejection_reason"] == "wrong source_system spelling"
+
+    # Batch transitioned to rejected; reason appended to notes
+    batch = conn.execute(
+        "SELECT status, notes FROM ingest_batches WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+    assert batch["status"] == "rejected"
+    assert "wrong source_system spelling" in batch["notes"]
+    assert "ops@example.com" in batch["notes"]
+
+    # transform_runs got a rolled_back audit row
+    run = conn.execute(
+        "SELECT * FROM staging.transform_runs WHERE run_id = %s",
+        (body["run_id"],),
+    ).fetchone()
+    assert run["status"] == "rolled_back"
+    assert run["approved_by"] == "ops@example.com"
+    assert run["approval_notes"] == "wrong source_system spelling"
+
+
+@requires_db
+def test_reject_validated_batch(staging_client, auth, conn) -> None:
+    """A batch already marked 'validated' (DQ-clean) can still be rejected
+    — e.g. operator sees in /diff that the batch would soft-delete too
+    much, and refuses to approve."""
+    batch_id = _upload_basic_batch(staging_client, auth, source_system="REJ-VAL")
+    conn.execute(
+        "UPDATE ingest_batches SET status = 'validated' WHERE batch_id = %s",
+        (batch_id,),
+    )
+    conn.commit()
+
+    resp = staging_client.post(
+        f"/v1/staging/batches/{batch_id}/reject",
+        headers=auth,
+        json={"rejected_by": "ops@example.com",
+              "reason": "/diff showed 60% deletion ratio — not approving"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["prior_status"] == "validated"
+    assert body["new_status"] == "rejected"
+
+
+# ---------------------------------------------------------------------------
+# ingest_rows preserved (rejected batch keeps its raw rows for forensics)
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_reject_preserves_ingest_rows(staging_client, auth, conn) -> None:
+    batch_id = _upload_basic_batch(staging_client, auth, source_system="REJ-KEEP")
+    rows_before = conn.execute(
+        "SELECT COUNT(*) AS n FROM ingest_rows WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+    assert rows_before["n"] == 1
+
+    staging_client.post(
+        f"/v1/staging/batches/{batch_id}/reject",
+        headers=auth,
+        json={"rejected_by": "x@y", "reason": "keep me"},
+    )
+
+    rows_after = conn.execute(
+        "SELECT COUNT(*) AS n FROM ingest_rows WHERE batch_id = %s",
+        (batch_id,),
+    ).fetchone()
+    assert rows_after["n"] == 1  # raw rows stay for audit
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+@requires_db
+def test_reject_unknown_batch_returns_400(staging_client, auth) -> None:
+    bogus = uuid4()
+    resp = staging_client.post(
+        f"/v1/staging/batches/{bogus}/reject",
+        headers=auth,
+        json={"rejected_by": "x@y", "reason": "x"},
+    )
+    assert resp.status_code == 400
+    assert "not found" in resp.json()["detail"]
+
+
+@requires_db
+def test_reject_already_rejected_refused(staging_client, auth, conn) -> None:
+    batch_id = _upload_basic_batch(staging_client, auth, source_system="REJ-TWICE")
+    staging_client.post(
+        f"/v1/staging/batches/{batch_id}/reject",
+        headers=auth,
+        json={"rejected_by": "x@y", "reason": "first"},
+    )
+
+    # Second rejection attempt -> 400
+    resp = staging_client.post(
+        f"/v1/staging/batches/{batch_id}/reject",
+        headers=auth,
+        json={"rejected_by": "x@y", "reason": "second"},
+    )
+    assert resp.status_code == 400
+    assert "terminal status" in resp.json()["detail"]
+
+
+@requires_db
+def test_reject_imported_batch_refused(staging_client, auth, conn) -> None:
+    """A batch already imported into canonical can't be rejected — that
+    ship has sailed; you'd need a compensating batch instead."""
+    batch_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO ingest_batches
+            (batch_id, entity_type, source_system, status, total_rows)
+        VALUES (%s, 'items', 'X', 'imported', 0)
+        """,
+        (batch_id,),
+    )
+    conn.commit()
+
+    resp = staging_client.post(
+        f"/v1/staging/batches/{batch_id}/reject",
+        headers=auth,
+        json={"rejected_by": "x@y", "reason": "too late"},
+    )
+    assert resp.status_code == 400
+    assert "terminal status" in resp.json()["detail"]
+
+
+@requires_db
+def test_reject_requires_non_empty_reason(staging_client, auth, conn) -> None:
+    """Pydantic's min_length=1 enforces this at the body schema level
+    (returns 422), backstopped by RejectionError if the body validation
+    is bypassed somehow."""
+    batch_id = _upload_basic_batch(staging_client, auth, source_system="REJ-NOREAS")
+
+    resp = staging_client.post(
+        f"/v1/staging/batches/{batch_id}/reject",
+        headers=auth,
+        json={"rejected_by": "x@y", "reason": ""},
+    )
+    assert resp.status_code == 422  # FastAPI/pydantic validation
+
+
+@requires_db
+def test_reject_blank_reason_refused(staging_client, auth, conn) -> None:
+    """A reason containing only whitespace passes pydantic length but
+    fails our explicit strip-check inside RejectionError."""
+    batch_id = _upload_basic_batch(staging_client, auth, source_system="REJ-BLANK")
+    resp = staging_client.post(
+        f"/v1/staging/batches/{batch_id}/reject",
+        headers=auth,
+        json={"rejected_by": "x@y", "reason": "    "},
+    )
+    assert resp.status_code == 400
+    assert "reason" in resp.json()["detail"].lower()


### PR DESCRIPTION
## Summary

Step 9 of [ADR-013](docs/ADR-013-external-interfaces.md) roadmap. The operator's path to decline a batch without writing to canonical. Closes the lifecycle state machine — every batch can now reach a terminal status (\`imported\` or \`rejected\`).

## API

\`\`\`bash
curl -X POST "\${OOTILS_API_URL}/v1/staging/batches/\${BATCH_ID}/reject" \
  -H "Authorization: Bearer \${OOTILS_API_TOKEN}" \
  -H "Content-Type: application/json" \
  -d '{
    "rejected_by": "ops@example.com",
    "reason": "/diff showed 60% deletion ratio — too aggressive"
  }'

# 200:
# {
#   "batch_id": "uuid",
#   "run_id": "uuid",
#   "rejected_by": "ops@example.com",
#   "rejection_reason": "...",
#   "prior_status": "validated",
#   "new_status": "rejected"
# }
\`\`\`

## What happens server-side

1. Verifies batch isn't already terminal (\`imported\` or \`rejected\`)
2. Inserts staging.transform_runs row with \`status='rolled_back'\` + rejector + reason (audit)
3. Marks \`ingest_batches.status='rejected'\` + appends the reason to the \`notes\` column

\`ingest_rows\` are NOT deleted — raw upload stays for forensics. To retry, re-upload as a new batch.

## Lifecycle state machine — now closed

\`\`\`
                upload                  L1-L2-L3-L4              approve
external file ─────────> pending ────────────────────> validated ─────────> imported
                            │                              │                    │
                            │  L1 fatal                   │  reject              │
                            └──────────────> rejected     └─────> rejected      ▼
                                                                              public.*
\`\`\`

## Tests (8 integration)

- Reject pending batch -> rejected + audit + notes appended
- Reject validated batch -> rejected (post-diff review path)
- ingest_rows preserved after rejection
- Unknown batch -> 400
- Already-rejected batch -> 400 (no duplicate audit)
- Imported batch can't be rejected -> 400 (use compensating batch)
- Empty reason -> 422 (pydantic)
- Whitespace-only reason -> 400 (RejectionError backstop)

## What's next

Step 9 was the last of the **core** ADR-013 steps. Remaining (steps 10-12):
- Templates for remaining 7 entity types (locations.md, suppliers.md, supplier_items.md, ...)
- End-to-end integration tests (full upload → DQ → diff → approve in one test)
- User-facing documentation (README staging, curl walkthrough)

## Test plan

- [x] Ruff lint passes
- [x] Imports verified
- [ ] CI integration tests pass (8 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)