### PR TITLE
fix(audit): print() -> logger in connection.py

### DIFF
--- a/src/ootils_core/db/connection.py
+++ b/src/ootils_core/db/connection.py
@@ -16,8 +16,8 @@ Environment:
 """
 from __future__ import annotations
 
+import logging
 import os
-import sys
 import uuid
 from contextlib import contextmanager
 from pathlib import Path
@@ -25,6 +25,8 @@ from typing import Generator
 
 import psycopg
 from psycopg.rows import dict_row
+
+logger = logging.getLogger(__name__)
 
 # Migrations are applied in filename order.
 MIGRATIONS_DIR = Path(__file__).parent / "migrations"
@@ -186,9 +188,9 @@ class OotilsDB:
                     except Exception as e:
                         sqlstate = _sqlstate_of(e)
                         sqlstate_suffix = f" [sqlstate={sqlstate}]" if sqlstate else ""
-                        print(
-                            f"[MIGRATION ERROR] {migration_path.name}{sqlstate_suffix}: {e}",
-                            file=sys.stderr,
+                        logger.error(
+                            "Migration failed: %s%s — %s",
+                            migration_path.name, sqlstate_suffix, e,
                         )
                         raise
             finally:

--- a/tests/test_db_connection.py
+++ b/tests/test_db_connection.py
@@ -254,14 +254,14 @@ def test_apply_migrations_runs_pending_files(fake_migrations_dir):
         (pg_errors.DuplicateObject("constraint already exists"), "42710"),
     ],
 )
-def test_apply_migrations_raises_on_duplicate_sqlstate(fake_migrations_dir, exc, sqlstate, capsys):
+def test_apply_migrations_raises_on_duplicate_sqlstate(fake_migrations_dir, exc, sqlstate, caplog):
     fake_conn, _ = _make_fake_connection(execute_side_effect=exc)
-    with patch("ootils_core.db.connection.psycopg.connect", return_value=fake_conn):
-        with pytest.raises(type(exc)):
-            OotilsDB("postgresql:///x")
+    with caplog.at_level("ERROR", logger="ootils_core.db.connection"):
+        with patch("ootils_core.db.connection.psycopg.connect", return_value=fake_conn):
+            with pytest.raises(type(exc)):
+                OotilsDB("postgresql:///x")
 
-    captured = capsys.readouterr()
-    assert f"[sqlstate={sqlstate}]" in captured.err
+    assert any(f"[sqlstate={sqlstate}]" in rec.getMessage() for rec in caplog.records)
     schema_migration_inserts = [
         call for call in fake_conn.execute.call_args_list
         if "INSERT INTO schema_migrations" in call.args[0]
@@ -269,17 +269,18 @@ def test_apply_migrations_raises_on_duplicate_sqlstate(fake_migrations_dir, exc,
     assert schema_migration_inserts == []
 
 
-def test_apply_migrations_raises_on_real_error(fake_migrations_dir, capsys):
-    """A non-idempotent error should propagate and be logged to stderr."""
+def test_apply_migrations_raises_on_real_error(fake_migrations_dir, caplog):
+    """A non-idempotent error should propagate and be logged."""
     fake_conn, _ = _make_fake_connection(
         execute_side_effect=Exception("syntax error at or near FOO")
     )
-    with patch("ootils_core.db.connection.psycopg.connect", return_value=fake_conn):
-        with pytest.raises(Exception, match="syntax error"):
-            OotilsDB("postgresql:///x")
-    captured = capsys.readouterr()
-    assert "[MIGRATION ERROR]" in captured.err
-    assert "001_init.sql" in captured.err
+    with caplog.at_level("ERROR", logger="ootils_core.db.connection"):
+        with patch("ootils_core.db.connection.psycopg.connect", return_value=fake_conn):
+            with pytest.raises(Exception, match="syntax error"):
+                OotilsDB("postgresql:///x")
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert any("Migration failed" in msg for msg in messages)
+    assert any("001_init.sql" in msg for msg in messages)
 
 
 def test_apply_migrations_runs_files_in_sorted_order(tmp_path, monkeypatch):


### PR DESCRIPTION
Audit chantier 1/6. Converts the migration-failure stderr print() to logger.error. forecasting/engine.py prints flagged in audit are in a docstring example — left alone.