### PR TITLE
fix(api): sanitize str(exc) leaks in router error responses

### DIFF
--- a/src/ootils_core/api/routers/forecasting.py
+++ b/src/ootils_core/api/routers/forecasting.py
@@ -351,7 +351,7 @@ async def generate_forecast(
         logger.exception("forecast.generate failed item=%s location=%s: %s", body.item_id, body.location_id, e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Forecast generation failed: {str(e)}",
+            detail="Forecast generation failed",
         )
 
     # 5. Create forecast header

--- a/src/ootils_core/api/routers/ghosts.py
+++ b/src/ootils_core/api/routers/ghosts.py
@@ -496,9 +496,10 @@ async def run_ghost_endpoint(
             to_date=body.to_date,
         )
     except ValueError as exc:
+        logger.warning("ghost.run failed ghost_id=%s scenario_id=%s: %s", ghost_id, body.scenario_id, exc)
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=str(exc),
+            detail="Ghost not found or invalid parameters",
         )
 
     return result

--- a/src/ootils_core/api/routers/mrp.py
+++ b/src/ootils_core/api/routers/mrp.py
@@ -524,5 +524,5 @@ async def _run_apics_mrp(
             nodes_created=0,
             edges_created=0,
             elapsed_ms=elapsed_ms,
-            errors=[str(e)],
+            errors=["MRP APICS run failed"],
         )

--- a/src/ootils_core/api/routers/mrp_apics.py
+++ b/src/ootils_core/api/routers/mrp_apics.py
@@ -216,7 +216,7 @@ async def run_mrp_apics(
     except Exception as e:
         db.rollback()
         logger.exception("MRP APICS run failed: %s", e)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="MRP APICS run failed")
 
 
 @router.post("/consumption", response_model=ConsumptionResponse)
@@ -323,7 +323,7 @@ async def run_consumption(
     except Exception as e:
         db.rollback()
         logger.exception("Forecast consumption failed: %s", e)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Forecast consumption failed")
 
 
 @router.post("/lot-sizing", response_model=LotSizingResponse)
@@ -367,7 +367,7 @@ async def calculate_lot_sizing(
 
     except Exception as e:
         logger.exception("Lot sizing calculation failed: %s", e)
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail="Lot sizing calculation failed: invalid parameters")
 
 
 @router.get("/apics/llc", response_model=LlcResponse)
@@ -395,4 +395,4 @@ async def get_llc(
     except Exception as e:
         db.rollback()
         logger.exception("LLC calculation failed: %s", e)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="LLC calculation failed")

--- a/src/ootils_core/api/routers/simulate.py
+++ b/src/ootils_core/api/routers/simulate.py
@@ -122,7 +122,7 @@ async def create_simulation(
             failed_overrides.append({
                 "node_id": str(override.node_id),
                 "field_name": override.field_name,
-                "error": str(exc),
+                "error": "Override failed validation",
             })
 
     # If all overrides failed, return 422 with details instead of 500

--- a/src/ootils_core/staging/approve.py
+++ b/src/ootils_core/staging/approve.py
@@ -271,7 +271,7 @@ def approve_batch(
             "staging.approve failed: batch=%s run=%s entity=%s err=%s",
             batch_id, run_id, entity_type, exc,
         )
-        raise ApprovalError(f"approval failed during write: {exc}") from exc
+        raise ApprovalError("approval failed during write") from exc
 
     duration = _time.perf_counter() - started
     logger.info(

--- a/tests/test_m6_api.py
+++ b/tests/test_m6_api.py
@@ -698,4 +698,10 @@ def test_post_simulate_invalid_node_returns_422(app, auth_headers):
     detail = data.get("detail", {})
     assert "failed_overrides" in detail, f"Expected failed_overrides in detail: {detail}"
     assert len(detail["failed_overrides"]) == 1
-    assert "not found" in detail["failed_overrides"][0]["error"].lower()
+    # Per-override error is sanitized (str(exc) is no longer leaked to the
+    # client — chantier 2 of audit 2026-05-23). The node_id is still
+    # echoed so the client can correlate the failure with the input.
+    failed = detail["failed_overrides"][0]
+    assert failed["node_id"] == "00000000-0000-0000-0000-000000000000"
+    assert failed["field_name"] == "shortage_qty"
+    assert failed["error"]  # generic, non-empty


### PR DESCRIPTION
## Summary
- Replaces `detail=str(e)` / `detail=f\"...{str(e)}\"` with generic messages in 9 router/staging sites (8 from audit 2026-05-23 WARN, +1 same-pattern site found during sweep).
- `logger.exception` is preserved on every site so server-side triage is unaffected.
- Staging endpoints that re-raise typed domain errors (`DiffError`, `ApprovalError`, `RejectionError`) are intentionally left alone — those messages are authored API-contract surface.

## Sites fixed
- `api/routers/forecasting.py:354` — 500 generic Exception
- `api/routers/ghosts.py:497` — 404 ValueError (+ warn log)
- `api/routers/mrp.py:527` — response.errors list
- `api/routers/mrp_apics.py:219,326,370,398` — 500/400 generic Exception
- `api/routers/simulate.py:125` — per-override 422 detail
- `staging/approve.py:274` — `ApprovalError` wrapping psycopg write exception

## Test plan
- [ ] CI: ruff + pytest unit + pytest integration green
- [ ] Manual smoke: trigger a 500 in /v1/forecasts/generate, confirm `detail` is generic and full traceback shows in server logs

## Audit chantiers
- [x] Chantier 1 — print() → logger ([#245](https://github.com/ngoineau/ootils-core/pull/245))
- [x] Chantier 2 — str(exc) sanitization (this PR)
- [ ] Chantier 3 — JSONB cleanup
- [ ] Chantier 4 — Mock-DB tests → integration
- [ ] Chantier 5 — uuid4() → uuid5() deterministic
- [ ] Chantier 6 — Clock injection