### PR TITLE
docs(migrations): document JSONB carve-outs in 021 and 031 (audit chantier 3)

### DIFF
--- a/src/ootils_core/db/migrations/021_mrp_lot_sizing_params.sql
+++ b/src/ootils_core/db/migrations/021_mrp_lot_sizing_params.sql
@@ -1,5 +1,17 @@
 -- Migration 021: Add Phase 0 MRP lot sizing / consumption params
 -- Compatible with fresh databases and current mrp_* schema used by the engine.
+--
+-- JSONB carve-out (see CLAUDE.md "no JSONB for business data — explicit
+-- carve-outs for diagnostic/staging payloads"):
+--   `mrp_runs.errors` and `mrp_runs.warnings` are unbounded per-run
+--   diagnostic lists emitted by the MRP engine. Each element is a free-form
+--   message string plus an optional context dict; the shape varies by the
+--   originating engine stage and is intended for operator triage rather
+--   than structured querying. Typed normalisation would force a schema
+--   that the engine does not actually produce. This use is one of the
+--   documented carve-outs alongside `dq_agent_runs.summary` (mig 012) and
+--   `demo_runs.artifact` (mig 031). All other engine output is typed
+--   (see `mrp_bucket_records`, `mrp_action_messages` below).
 
 ALTER TYPE lot_size_rule_type ADD VALUE IF NOT EXISTS 'POQ';
 ALTER TYPE lot_size_rule_type ADD VALUE IF NOT EXISTS 'EOQ';

--- a/src/ootils_core/db/migrations/031_demo_runs.sql
+++ b/src/ootils_core/db/migrations/031_demo_runs.sql
@@ -1,4 +1,15 @@
 -- Demo run audit/history
+--
+-- JSONB carve-out (see CLAUDE.md "no JSONB for business data — explicit
+-- carve-outs for diagnostic/staging payloads"):
+--   `demo_runs.artifact` captures the full per-step output payload of a
+--   demo execution (e.g. forecast snapshot, MPS draft, ATP probe). The
+--   shape changes between demo flows and demo evolutions; the table is a
+--   forensic audit trail, never queried as business data. Typed columns
+--   above cover everything that is queried (status, counts, durations).
+--   This is one of the three documented carve-outs alongside
+--   `dq_agent_runs.summary` (mig 012) and `mrp_runs.errors`/`warnings`
+--   (mig 021).
 
 CREATE TABLE IF NOT EXISTS demo_runs (
     demo_run_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
## Summary
Audit 2026-05-23 flagged 4 BLOCK findings against the \"no JSONB\" convention:
- 012_dq_agent.sql:13 — `dq_agent_runs.summary`
- 021_mrp_lot_sizing_params.sql:36-37 + 56-57 — `mrp_runs.errors` / `mrp_runs.warnings`
- 031_demo_runs.sql:24 — `demo_runs.artifact`

**All 4 are exactly the 4 documented carve-outs listed at [CLAUDE.md:60](../blob/main/CLAUDE.md#L60):**
> *Diagnostic / staging payloads are the explicit carve-out: `dq_agent_runs.summary`, `mrp_runs.errors`/`mrp_runs.warnings`, and `demo_runs.artifact` are the **only acceptable cases** — every other column uses typed columns.*

The carve-out was added on 2026-05-22 (commit 2a4690d), one day before the audit ran. The auditor missed it because the rule is split across the headline (\"no JSONB\") and a follow-up paragraph.

## What this PR does
- Adds a top-of-file carve-out comment block to **021** and **031**, mirroring the one already present in **012**. The new comments explain why JSONB is the right shape (unbounded per-run diagnostic / forensic payload, never queried as business data) and cross-reference the other carve-out migrations.
- **No schema change.** No code change. Pure documentation so a code-only auditor sees the rationale in-context without having to read CLAUDE.md.

## Verification
- `grep -r '\bJSONB\b' src/` → every JSONB occurrence is one of the 4 carve-outs or a `-- no JSONB` comment marker. No rogue JSONB exists in the codebase.

## Audit chantiers
- [x] Chantier 1 — print() → logger ([#245](https://github.com/ngoineau/ootils-core/pull/245))
- [x] Chantier 2 — str(exc) sanitization ([#246](https://github.com/ngoineau/ootils-core/pull/246))
- [x] Chantier 3 — JSONB cleanup (this PR — conclusion: no fix needed, doc only)
- [ ] Chantier 4 — Mock-DB tests → integration
- [ ] Chantier 5 — uuid4() → uuid5() deterministic
- [ ] Chantier 6 — Clock injection