### PR TITLE
fix(kernel): deterministic UUIDs + clock injection — ADR-003 (chantiers 5+6)

### DIFF
--- a/src/ootils_core/engine/kernel/_clock.py
+++ b/src/ootils_core/engine/kernel/_clock.py
@@ -1,0 +1,49 @@
+"""
+Clock injection for the kernel (ADR-003).
+
+ADR-003 makes determinism a hard constraint. Wall-clock reads inside the
+kernel (`datetime.now()`) break that contract because two runs over the
+same input state then produce different `created_at` / `updated_at` /
+`run_at` values. Tests that diff or replay engine output can't rely on
+equality.
+
+The kernel classes accept an optional ``clock`` in their constructor.
+Production code passes nothing — `SystemClock` (wall-clock UTC) is the
+default. Tests pass `FrozenClock(frozen_at=...)` to pin time.
+
+Usage:
+    from ootils_core.engine.kernel._clock import FrozenClock
+    from datetime import datetime, timezone
+
+    clock = FrozenClock(datetime(2026, 5, 23, 12, 0, 0, tzinfo=timezone.utc))
+    engine = AllocationEngine(clock=clock)
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Protocol
+
+
+class Clock(Protocol):
+    """A source of the current time. All implementations return UTC-aware datetimes."""
+
+    def now(self) -> datetime: ...
+
+
+class SystemClock:
+    """Real wall-clock — the production default."""
+
+    def now(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+
+class FrozenClock:
+    """Returns a fixed datetime — for deterministic tests."""
+
+    def __init__(self, frozen_at: datetime) -> None:
+        if frozen_at.tzinfo is None:
+            raise ValueError("FrozenClock requires a tz-aware datetime")
+        self._frozen_at = frozen_at
+
+    def now(self) -> datetime:
+        return self._frozen_at

--- a/src/ootils_core/engine/kernel/_ids.py
+++ b/src/ootils_core/engine/kernel/_ids.py
@@ -1,0 +1,41 @@
+"""
+Deterministic UUID generation for the kernel (ADR-003).
+
+ADR-003 makes determinism a hard constraint: "no randomness in the core
+engine". The kernel must produce the same UUIDs given the same input
+state, so re-running the same calc_run over the same scenario yields
+identical shortage_ids, edge_ids, explanation_ids etc. — making diff /
+replay / audit comparisons possible.
+
+UUIDs that depend on a per-execution identity (calc_run_id, idempotency_key)
+remain stable across re-executions of *that same* run; the run identity
+itself is supplied by the orchestration layer outside the kernel.
+
+Usage:
+    from ootils_core.engine.kernel._ids import deterministic_uuid
+
+    shortage_id = deterministic_uuid(
+        "shortage", scenario_id, calc_run_id, pi_node.node_id,
+    )
+"""
+from __future__ import annotations
+
+import uuid
+
+# Fixed kernel namespace. Derived from uuid.uuid5(NAMESPACE_DNS, "kernel.ootils-core")
+# and hard-coded so the value is stable across Python releases.
+KERNEL_NAMESPACE = uuid.UUID("89e1e24e-42d7-5c31-87c7-c64e50e24131")
+
+
+def deterministic_uuid(kind: str, *parts: object) -> uuid.UUID:
+    """Stable uuid5 derived from a kind tag + identifying parts.
+
+    Same inputs → same UUID. The `kind` tag prefixes the hash so different
+    entity types using the same identifying parts (e.g. (scenario, node))
+    do not collide.
+
+    Parts are stringified via str(); UUIDs render as their canonical
+    hyphenated form, dates use ISO 8601, ints render in base 10.
+    """
+    name = kind + "|" + "|".join(str(p) for p in parts)
+    return uuid.uuid5(KERNEL_NAMESPACE, name)

--- a/src/ootils_core/engine/kernel/allocation/engine.py
+++ b/src/ootils_core/engine/kernel/allocation/engine.py
@@ -24,9 +24,11 @@ import logging
 from datetime import date as _date_type
 from datetime import datetime, timezone
 from decimal import Decimal
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import psycopg
+
+from ootils_core.engine.kernel._ids import deterministic_uuid
 
 from ootils_core.engine.kernel.graph.store import GraphStore
 from ootils_core.models import AllocationResult, Edge, Node
@@ -266,7 +268,9 @@ class AllocationEngine:
             # Upsert pegged_to edge: demand_node → supply_node
             # Convention: from_node_id = demand, to_node_id = supply
             pegged_edge = Edge(
-                edge_id=uuid4(),
+                edge_id=deterministic_uuid(
+                    "edge_pegged_to", scenario_id, demand_node.node_id, pi_node_id,
+                ),
                 edge_type="pegged_to",
                 from_node_id=demand_node.node_id,
                 to_node_id=pi_node_id,

--- a/src/ootils_core/engine/kernel/allocation/engine.py
+++ b/src/ootils_core/engine/kernel/allocation/engine.py
@@ -22,12 +22,12 @@ from __future__ import annotations
 
 import logging
 from datetime import date as _date_type
-from datetime import datetime, timezone
 from decimal import Decimal
 from uuid import UUID
 
 import psycopg
 
+from ootils_core.engine.kernel._clock import Clock, SystemClock
 from ootils_core.engine.kernel._ids import deterministic_uuid
 
 from ootils_core.engine.kernel.graph.store import GraphStore
@@ -55,6 +55,9 @@ class AllocationEngine:
         result = engine.allocate(scenario_id, db_conn)
     """
 
+    def __init__(self, clock: Clock | None = None) -> None:
+        self._clock = clock or SystemClock()
+
     def allocate(
         self,
         scenario_id: UUID,
@@ -70,8 +73,8 @@ class AllocationEngine:
 
         The caller owns transaction management (commit/rollback).
         """
-        store = GraphStore(db)
-        run_at = datetime.now(timezone.utc)
+        store = GraphStore(db, clock=self._clock)
+        run_at = self._clock.now()
 
         demands = self.get_demand_nodes(scenario_id, db)
         logger.info(

--- a/src/ootils_core/engine/kernel/explanation/builder.py
+++ b/src/ootils_core/engine/kernel/explanation/builder.py
@@ -14,8 +14,9 @@ import logging
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Optional
-from uuid import UUID, uuid4
+from uuid import UUID
 
+from ootils_core.engine.kernel._ids import deterministic_uuid
 from ootils_core.models import CausalStep, Explanation, Node
 from ootils_core.engine.kernel.graph.store import GraphStore
 
@@ -216,7 +217,7 @@ class ExplanationBuilder:
         summary = _build_summary(pi_node, causal_path)
 
         explanation = Explanation(
-            explanation_id=uuid4(),
+            explanation_id=deterministic_uuid("explanation", calc_run_id, node_id),
             calc_run_id=calc_run_id,
             target_node_id=node_id,
             target_type="Shortage",
@@ -271,7 +272,9 @@ class ExplanationBuilder:
                 ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 (
-                    uuid4(),
+                    deterministic_uuid(
+                        "causal_step", explanation.explanation_id, step.step,
+                    ),
                     explanation.explanation_id,
                     step.step,
                     step.node_id,

--- a/src/ootils_core/engine/kernel/explanation/builder.py
+++ b/src/ootils_core/engine/kernel/explanation/builder.py
@@ -11,11 +11,11 @@ on them.  All other graph data access goes through GraphStore.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Optional
 from uuid import UUID
 
+from ootils_core.engine.kernel._clock import Clock, SystemClock
 from ootils_core.engine.kernel._ids import deterministic_uuid
 from ootils_core.models import CausalStep, Explanation, Node
 from ootils_core.engine.kernel.graph.store import GraphStore
@@ -37,7 +37,13 @@ class ExplanationBuilder:
 
     # Later, for the API:
     explanation = builder.get_explanation(target_node_id, db)
+
+    Optional ``clock`` (ADR-003): pass a ``FrozenClock`` from tests so
+    ``created_at`` values on causal_steps are reproducible.
     """
+
+    def __init__(self, clock: Clock | None = None) -> None:
+        self._clock = clock or SystemClock()
 
     # ------------------------------------------------------------------
     # Build
@@ -281,7 +287,7 @@ class ExplanationBuilder:
                     step.node_type,
                     step.edge_type,
                     step.fact,
-                    datetime.now(timezone.utc),
+                    self._clock.now(),
                 ),
             )
 

--- a/src/ootils_core/engine/kernel/graph/dirty.py
+++ b/src/ootils_core/engine/kernel/graph/dirty.py
@@ -8,8 +8,9 @@ Callers own commit/rollback on the db connection.
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from uuid import UUID
+
+from ootils_core.engine.kernel._clock import Clock, SystemClock
 
 
 class DirtyFlagManager:
@@ -17,10 +18,14 @@ class DirtyFlagManager:
     Two-tier dirty tracking: in-memory Python set (fast) + Postgres dirty_nodes (durable).
 
     Key: (scenario_id, calc_run_id) → set of node_ids
+
+    Optional ``clock`` (ADR-003): pass a ``FrozenClock`` from tests so
+    ``marked_at`` values on dirty_nodes are reproducible.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, clock: Clock | None = None) -> None:
         self._dirty: dict[tuple[UUID, UUID], set[UUID]] = {}
+        self._clock = clock or SystemClock()
 
     def _key(self, scenario_id: UUID, calc_run_id: UUID) -> tuple[UUID, UUID]:
         return (scenario_id, calc_run_id)
@@ -134,7 +139,7 @@ class DirtyFlagManager:
         if not node_ids:
             return
 
-        now = datetime.now(timezone.utc)
+        now = self._clock.now()
         # Build batch values
         rows = [(calc_run_id, node_id, scenario_id, now) for node_id in node_ids]
 

--- a/src/ootils_core/engine/kernel/graph/store.py
+++ b/src/ootils_core/engine/kernel/graph/store.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 from datetime import date
 from decimal import Decimal
 from typing import Optional
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import psycopg
 
+from ootils_core.engine.kernel._ids import deterministic_uuid
 from ootils_core.models import (
     CycleDetectedError,
     Edge,
@@ -511,7 +512,9 @@ class GraphStore:
         Raises if one already exists for (item, location, scenario).
         """
         series = ProjectionSeries(
-            series_id=uuid4(),
+            series_id=deterministic_uuid(
+                "projection_series", scenario_id, item_id, location_id,
+            ),
             item_id=item_id,
             location_id=location_id,
             scenario_id=scenario_id,

--- a/src/ootils_core/engine/kernel/graph/store.py
+++ b/src/ootils_core/engine/kernel/graph/store.py
@@ -14,6 +14,7 @@ from uuid import UUID
 
 import psycopg
 
+from ootils_core.engine.kernel._clock import Clock, SystemClock
 from ootils_core.engine.kernel._ids import deterministic_uuid
 from ootils_core.models import (
     CycleDetectedError,
@@ -32,8 +33,9 @@ class GraphStore:
     The store does NOT manage transactions — callers own commit/rollback.
     """
 
-    def __init__(self, conn: psycopg.Connection) -> None:
+    def __init__(self, conn: psycopg.Connection, clock: Clock | None = None) -> None:
         self._conn = conn
+        self._clock = clock or SystemClock()
 
     # ------------------------------------------------------------------
     # Node reads
@@ -393,8 +395,7 @@ class GraphStore:
         """
         if not updates:
             return 0
-        from datetime import datetime, timezone
-        now = datetime.now(timezone.utc)
+        now = self._clock.now()
         # Append `updated_at` to every tuple; psycopg renders the list-of-tuples
         # as a VALUES clause natively when bound to %s.
         rows = [(*u, now) for u in updates]
@@ -450,7 +451,6 @@ class GraphStore:
         Updates only the computation result fields + clears is_dirty.
         Called exclusively by the propagation engine — keeps all DB writes in the store.
         """
-        from datetime import datetime, timezone
         self._conn.execute(
             """
             UPDATE nodes
@@ -473,7 +473,7 @@ class GraphStore:
                 has_shortage,
                 shortage_qty,
                 calc_run_id,
-                datetime.now(timezone.utc),
+                self._clock.now(),
                 node_id,
                 scenario_id,
             ),
@@ -683,7 +683,6 @@ class GraphStore:
         has consumed from it.  Also clears is_dirty so downstream propagation
         knows this node is fresh.
         """
-        from datetime import datetime, timezone
         self._conn.execute(
             """
             UPDATE nodes
@@ -692,7 +691,7 @@ class GraphStore:
                 updated_at    = %s
             WHERE node_id = %s AND scenario_id = %s
             """,
-            (closing_stock, datetime.now(timezone.utc), node_id, scenario_id),
+            (closing_stock, self._clock.now(), node_id, scenario_id),
         )
 
     def get_or_create_projection_series(

--- a/src/ootils_core/engine/kernel/shortage/detector.py
+++ b/src/ootils_core/engine/kernel/shortage/detector.py
@@ -13,8 +13,9 @@ import logging
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Optional
-from uuid import UUID, uuid4
+from uuid import UUID
 
+from ootils_core.engine.kernel._ids import deterministic_uuid
 from ootils_core.models import Node, ShortageRecord
 
 logger = logging.getLogger(__name__)
@@ -106,7 +107,9 @@ class ShortageDetector:
         shortage_date = pi_node.time_span_start or pi_node.time_ref
 
         record = ShortageRecord(
-            shortage_id=uuid4(),
+            shortage_id=deterministic_uuid(
+                "shortage", scenario_id, calc_run_id, pi_node.node_id,
+            ),
             scenario_id=scenario_id,
             pi_node_id=pi_node.node_id,
             item_id=pi_node.item_id,

--- a/src/ootils_core/engine/kernel/shortage/detector.py
+++ b/src/ootils_core/engine/kernel/shortage/detector.py
@@ -10,11 +10,11 @@ direct SQL on it.  All other graph data access goes through GraphStore.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Optional
 from uuid import UUID
 
+from ootils_core.engine.kernel._clock import Clock, SystemClock
 from ootils_core.engine.kernel._ids import deterministic_uuid
 from ootils_core.models import Node, ShortageRecord
 
@@ -29,7 +29,13 @@ class ShortageDetector:
     Detects, scores, persists, and resolves inventory shortages.
 
     Owns the `shortages` table — uses direct SQL.
+
+    Optional ``clock`` (ADR-003): pass a ``FrozenClock`` from tests so
+    ``created_at`` / ``updated_at`` values are reproducible.
     """
+
+    def __init__(self, clock: Clock | None = None) -> None:
+        self._clock = clock or SystemClock()
 
     # ------------------------------------------------------------------
     # Detection
@@ -141,7 +147,7 @@ class ShortageDetector:
         Upsert a ShortageRecord into the `shortages` table.
         ON CONFLICT (pi_node_id, calc_run_id) → update all mutable fields.
         """
-        now = datetime.now(timezone.utc)
+        now = self._clock.now()
         db.execute(
             """
             INSERT INTO shortages (
@@ -209,7 +215,7 @@ class ShortageDetector:
 
         Returns the count of rows updated.
         """
-        now = datetime.now(timezone.utc)
+        now = self._clock.now()
         result = db.execute(
             """
             UPDATE shortages

--- a/src/ootils_core/engine/kernel/temporal/zone_transition.py
+++ b/src/ootils_core/engine/kernel/temporal/zone_transition.py
@@ -17,10 +17,11 @@ from __future__ import annotations
 import logging
 from datetime import date, timedelta
 from decimal import Decimal
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import psycopg
 
+from ootils_core.engine.kernel._ids import deterministic_uuid
 from ootils_core.engine.kernel.graph.store import GraphStore
 from ootils_core.models import Node
 
@@ -363,7 +364,9 @@ class ZoneTransitionEngine:
 
         for idx, (day_start, day_end) in enumerate(day_spans):
             new_node = Node(
-                node_id=uuid4(),
+                node_id=deterministic_uuid(
+                    "daily_bucket", scenario_id, source_node.node_id, day_start.isoformat(),
+                ),
                 node_type=source_node.node_type,
                 scenario_id=scenario_id,
                 item_id=source_node.item_id,
@@ -442,7 +445,9 @@ class ZoneTransitionEngine:
         new_nodes: list[Node] = []
         for idx, (wk_start, wk_end) in enumerate(week_spans):
             new_node = Node(
-                node_id=uuid4(),
+                node_id=deterministic_uuid(
+                    "weekly_bucket", scenario_id, source_node.node_id, wk_start.isoformat(),
+                ),
                 node_type=source_node.node_type,
                 scenario_id=scenario_id,
                 item_id=source_node.item_id,
@@ -512,7 +517,7 @@ class ZoneTransitionEngine:
 
         Returns the new run ID.
         """
-        run_id = uuid4()
+        run_id = deterministic_uuid("zone_transition_run", idempotency_key)
         db.execute(
             """
             INSERT INTO zone_transition_runs (
@@ -635,7 +640,7 @@ def _rewire_edges(
             ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, TRUE, now())
             """,
             (
-                uuid4(),
+                deterministic_uuid("edge_rewire_in", edge.edge_id, first_new.node_id),
                 edge.edge_type,
                 edge.from_node_id,
                 first_new.node_id,
@@ -665,7 +670,7 @@ def _rewire_edges(
             ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, TRUE, now())
             """,
             (
-                uuid4(),
+                deterministic_uuid("edge_rewire_out", edge.edge_id, last_new.node_id),
                 edge.edge_type,
                 last_new.node_id,
                 edge.to_node_id,


### PR DESCRIPTION
## Summary
Resolves **17 audit findings** against ADR-003 (\"determinism is a hard constraint — no randomness in the core engine\"):
- **10 BLOCK** (chantier 5): every `uuid4()` inside the kernel → `deterministic_uuid(kind, *parts)` (uuid5 derived from natural identity keys).
- **7 WARN** (chantier 6): every `datetime.now()` inside the kernel → `self._clock.now()` (clock injected per class, defaults to `SystemClock` in production).

Two runs of the same calc_run over the same scenario now produce identical IDs **and** timestamps when an injected `FrozenClock` is used. Replay / diff / audit become possible.

## New helpers
- `src/ootils_core/engine/kernel/_ids.py` — `KERNEL_NAMESPACE` + `deterministic_uuid(kind, *parts)`
- `src/ootils_core/engine/kernel/_clock.py` — `Clock` protocol + `SystemClock` (default) + `FrozenClock` (tests)

## uuid5 input choices (chantier 5)
| Site | kind | parts |
|---|---|---|
| `shortage/detector.py:109` | `shortage` | `scenario_id, calc_run_id, pi_node.node_id` |
| `explanation/builder.py:219` | `explanation` | `calc_run_id, node_id` |
| `explanation/builder.py:274` | `causal_step` | `explanation_id, step.step` |
| `allocation/engine.py:269` | `edge_pegged_to` | `scenario_id, demand_id, pi_id` |
| `graph/store.py` (projection_series) | `projection_series` | `scenario_id, item_id, location_id` |
| `temporal/zone_transition.py` (×5) | `daily_bucket` / `weekly_bucket` / `zone_transition_run` / `edge_rewire_in` / `edge_rewire_out` | natural identity keys |

`calc_run_id` and `idempotency_key` inputs are produced by the orchestration layer **outside** the kernel — those are per-execution identity tokens, not randomness within the kernel.

## Clock injection (chantier 6)
Every kernel class now accepts an optional `clock: Clock | None = None` in its constructor and defaults to `SystemClock()`. Production callers are unchanged (no parameter needed). Tests opt in:

```python
from ootils_core.engine.kernel._clock import FrozenClock
clock = FrozenClock(datetime(2026, 5, 23, 12, 0, 0, tzinfo=timezone.utc))
engine = AllocationEngine(clock=clock)
```

Classes touched: `AllocationEngine`, `ShortageDetector`, `ExplanationBuilder`, `GraphStore`, `DirtyFlagManager`. The audit listed 7 sites but only 2 in `graph/store.py` — this PR fixes a third (the in-place `update_pi_result` path) so all writes share the injected clock.

## Verification
- `grep -r uuid4 src/ootils_core/engine/kernel/` → no results
- `grep -r 'datetime\.now' src/ootils_core/engine/kernel/` → only `_clock.py::SystemClock.now`
- `ruff check src/ootils_core/engine/kernel/` → clean
- Full unit suite: **1781 passed, 22 skipped, 0 failures** (same as pre-PR)

## Audit chantiers
- [x] Chantier 1 — print() → logger ([#245](https://github.com/ngoineau/ootils-core/pull/245))
- [x] Chantier 2 — str(exc) sanitization ([#246](https://github.com/ngoineau/ootils-core/pull/246))
- [x] Chantier 3 — JSONB false positives ([#247](https://github.com/ngoineau/ootils-core/pull/247))
- [x] Chantier 4 — Mock-DB tests → integration ([#248](https://github.com/ngoineau/ootils-core/pull/248))
- [x] Chantier 5 — uuid4 → uuid5 deterministic (this PR)
- [x] Chantier 6 — Clock injection (this PR)