### PR TITLE
refactor(mrp): rename CycleDetectedError → BomCycleDetectedError (audit cleanup)

### DIFF
--- a/src/ootils_core/engine/mrp/llc_calculator.py
+++ b/src/ootils_core/engine/mrp/llc_calculator.py
@@ -11,7 +11,7 @@ gets the *maximum* depth — this ensures its gross requirements include
 all possible dependent-demand paths.
 
 Cycle detection: any BOM cycle (A → B → … → A) is detected and
-reported as a ``CycleDetectedError`` with the cycle path.
+reported as a ``BomCycleDetectedError`` with the cycle path.
 
 Performance target: 10 000 items in < 50 ms (pure Python).
 """
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 # Exceptions
 # ─────────────────────────────────────────────────────────────
 
-class CycleDetectedError(Exception):
+class BomCycleDetectedError(Exception):
     """Raised when a cycle is found in the BOM graph.
 
     Attributes:
@@ -90,7 +90,7 @@ def compute_llc_pure(
         LLCResult with the full mapping.
 
     Raises:
-        CycleDetectedError: if a cycle is found in the BOM.
+        BomCycleDetectedError: if a cycle is found in the BOM.
 
     Performance: O(V + E) BFS + O(V + E) cycle check.
     """
@@ -143,7 +143,7 @@ def compute_llc_pure(
                         cur = parent_of.get(cur)
                     cycle.append(child)
                     cycle.reverse()
-                    raise CycleDetectedError(cycle)
+                    raise BomCycleDetectedError(cycle)
 
                 if colour.get(child, WHITE) == WHITE:
                     parent_of[child] = node
@@ -243,7 +243,7 @@ class LLCCalculator:
             LLCResult with full mapping and timing.
 
         Raises:
-            CycleDetectedError: if a cycle exists in the BOM.
+            BomCycleDetectedError: if a cycle exists in the BOM.
         """
         # 1. Load all active BOM edges
         rows = self.db.execute("""

--- a/tests/test_llc_calculator.py
+++ b/tests/test_llc_calculator.py
@@ -29,7 +29,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from ootils_core.engine.mrp.llc_calculator import (
     LLCCalculator,
-    CycleDetectedError,
+    BomCycleDetectedError,
     compute_llc_pure,
 )
 
@@ -140,14 +140,14 @@ class TestDiamondBOM:
 # ─────────────────────────────────────────────────────────────
 
 class TestCycleDetection:
-    """Cycle detection must raise CycleDetectedError with the cycle path."""
+    """Cycle detection must raise BomCycleDetectedError with the cycle path."""
 
     def test_simple_cycle(self):
         """A → B → A forms a cycle."""
         a, b = _uuids(2)
         edges = [(a, b), (b, a)]
 
-        with pytest.raises(CycleDetectedError) as exc_info:
+        with pytest.raises(BomCycleDetectedError) as exc_info:
             compute_llc_pure(edges)
 
         assert len(exc_info.value.cycle) >= 2
@@ -158,7 +158,7 @@ class TestCycleDetection:
         a, b, c = _uuids(3)
         edges = [(a, b), (b, c), (c, a)]
 
-        with pytest.raises(CycleDetectedError) as exc_info:
+        with pytest.raises(BomCycleDetectedError) as exc_info:
             compute_llc_pure(edges)
 
         assert a in exc_info.value.cycle
@@ -170,7 +170,7 @@ class TestCycleDetection:
         a = UUID(int=1)
         edges = [(a, a)]
 
-        with pytest.raises(CycleDetectedError):
+        with pytest.raises(BomCycleDetectedError):
             compute_llc_pure(edges)
 
     def test_cycle_with_legs(self):
@@ -186,7 +186,7 @@ class TestCycleDetection:
             (c, a),     # cycle back to A
         ]
 
-        with pytest.raises(CycleDetectedError) as exc_info:
+        with pytest.raises(BomCycleDetectedError) as exc_info:
             compute_llc_pure(edges)
 
         # The cycle path should include A, B, C
@@ -194,7 +194,7 @@ class TestCycleDetection:
         assert a in cycle_set or b in cycle_set or c in cycle_set
 
     def test_no_cycle_linear(self):
-        """Linear chain should NOT raise CycleDetectedError."""
+        """Linear chain should NOT raise BomCycleDetectedError."""
         fg, sa, rm = _uuids(3)
         edges = [(fg, sa), (sa, rm)]
 
@@ -202,7 +202,7 @@ class TestCycleDetection:
         assert result.item_count == 3
 
     def test_no_cycle_diamond(self):
-        """Diamond BOM should NOT raise CycleDetectedError."""
+        """Diamond BOM should NOT raise BomCycleDetectedError."""
         fg, sa1, sa2, rm = _uuids(4)
         edges = [(fg, sa1), (fg, sa2), (sa1, rm), (sa2, rm)]
 
@@ -210,11 +210,11 @@ class TestCycleDetection:
         assert result.item_count == 4
 
     def test_cycle_error_message(self):
-        """CycleDetectedError message should contain the cycle path."""
+        """BomCycleDetectedError message should contain the cycle path."""
         a, b = _uuids(2)
         edges = [(a, b), (b, a)]
 
-        with pytest.raises(CycleDetectedError) as exc_info:
+        with pytest.raises(BomCycleDetectedError) as exc_info:
             compute_llc_pure(edges)
 
         msg = str(exc_info.value)
@@ -717,11 +717,11 @@ class TestEdgeCases:
         assert result.edge_count == 1
 
     def test_cycle_error_has_cycle_attribute(self):
-        """CycleDetectedError should have a .cycle attribute."""
+        """BomCycleDetectedError should have a .cycle attribute."""
         a, b = UUID(int=1), UUID(int=2)
         edges = [(a, b), (b, a)]
 
-        with pytest.raises(CycleDetectedError) as exc_info:
+        with pytest.raises(BomCycleDetectedError) as exc_info:
             compute_llc_pure(edges)
 
         assert hasattr(exc_info.value, 'cycle')


### PR DESCRIPTION
## Summary
Resolves the [WARN] §6 finding from audit 2026-05-23 (deep): two classes both named \`CycleDetectedError\` with incompatible constructors:
- \`models/__init__.py:441\` — \`(from_id, to_id, scenario_id)\` for graph edge cycles
- \`engine/mrp/llc_calculator.py:36\` — \`(cycle: List[UUID])\` for BOM cycles

Consolidation (the auditor's suggested fix) is impossible because the signatures don't match. Instead, rename the BOM-specific one to \`BomCycleDetectedError\` — distinct domains, distinct names. \`except CycleDetectedError\` now unambiguously refers to graph-edge cycles.

## Files
- \`src/ootils_core/engine/mrp/llc_calculator.py\` — class + 1 raise + 3 docstring refs
- \`tests/test_llc_calculator.py\` — 1 import + 10 test references

## Verification
- ruff clean
- 84/84 tests pass (\`tests/test_llc_calculator.py\` + \`tests/test_graph_store.py\`)