### PR TITLE
test(audit): split test_m6_api.py into pure + real-DB integration

### DIFF
--- a/tests/integration/test_m6_api_integration.py
+++ b/tests/integration/test_m6_api_integration.py
@@ -134,7 +134,7 @@ class TestPostEvents:
         """POST event without trigger_node_id → 202, event row persisted."""
         payload = {
             "event_type": "supply_date_changed",
-            "source": "integration-test",
+            "source": "test",
             "field_changed": "due_date",
             "new_date": "2026-12-01",
         }
@@ -155,14 +155,14 @@ class TestPostEvents:
                 ).fetchone()
                 assert row is not None
                 assert row["event_type"] == "supply_date_changed"
-                assert row["source"] == "integration-test"
+                assert row["source"] == "test"
             finally:
                 c.execute("DELETE FROM events WHERE event_id = %s", (event_id,))
                 c.commit()
 
     def test_post_event_onhand_updated(self, api_client, auth, seeded_db):
         """A different valid event_type — onhand_updated, manual source."""
-        payload = {"event_type": "onhand_updated", "source": "manual"}
+        payload = {"event_type": "onhand_updated", "source": "user"}
         resp = api_client.post("/v1/events", json=payload, headers=auth)
         assert resp.status_code == 202, resp.text
         event_id = resp.json()["event_id"]

--- a/tests/integration/test_m6_api_integration.py
+++ b/tests/integration/test_m6_api_integration.py
@@ -1,0 +1,565 @@
+"""
+Integration tests for the Sprint M6 FastAPI routers
+(/v1/events, /v1/projection, /v1/issues, /v1/explain, /v1/simulate, /v1/graph)
+against a real PostgreSQL database (no mocks).
+
+Ported from tests/test_m6_api.py — every test that previously patched
+GraphStore / ShortageDetector / ExplanationBuilder / ScenarioManager /
+_build_propagation_engine is re-implemented here using the seeded
+test database (PUMP-01 / VALVE-02 items at DC-ATL / DC-LAX locations
+with pre-loaded shortages, per scripts/seed_demo_data.py).
+
+Because we use real engines and real seeded data, assertions are
+written against the response *structure* rather than against mock
+return values. Specific numeric outcomes are only asserted when the
+seed data unambiguously produces them.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from .conftest import requires_db, TEST_DB_URL
+
+pytestmark = requires_db
+
+SEED_SCRIPT = Path(__file__).parents[2] / "scripts" / "seed_demo_data.py"
+AUTH_HEADERS = {"Authorization": "Bearer integration-test-token"}
+BASELINE_SCENARIO_ID = UUID("00000000-0000-0000-0000-000000000001")
+
+
+def _run_seed():
+    env = {**os.environ, "DATABASE_URL": TEST_DB_URL}
+    return subprocess.run(
+        [sys.executable, str(SEED_SCRIPT)],
+        capture_output=True, text=True, env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared module-scoped fixtures (mirror tests/integration/test_atp_api_integration.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def seeded_db(migrated_db):
+    """Module-scoped: migrated DB with seed data loaded once."""
+    result = _run_seed()
+    if result.returncode != 0:
+        pytest.skip(f"Seed failed: {result.stderr[:500]}")
+    return migrated_db
+
+
+@pytest.fixture(scope="module")
+def api_client(seeded_db):
+    """Module-scoped FastAPI TestClient bound to the real test DB."""
+    os.environ["DATABASE_URL"] = seeded_db
+    os.environ["OOTILS_API_TOKEN"] = "integration-test-token"
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+    from fastapi.testclient import TestClient
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(seeded_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="module")
+def auth():
+    return AUTH_HEADERS
+
+
+@pytest.fixture(scope="module")
+def seeded_ids(seeded_db):
+    """Resolve seeded PUMP-01 / DC-ATL / VALVE-02 / DC-LAX UUIDs from the DB."""
+    import psycopg
+    from psycopg.rows import dict_row
+
+    with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+        pump = conn.execute(
+            "SELECT item_id FROM items WHERE external_id = 'PUMP-01'"
+        ).fetchone()
+        valve = conn.execute(
+            "SELECT item_id FROM items WHERE external_id = 'VALVE-02'"
+        ).fetchone()
+        atl = conn.execute(
+            "SELECT location_id FROM locations WHERE external_id = 'DC-ATL'"
+        ).fetchone()
+        lax = conn.execute(
+            "SELECT location_id FROM locations WHERE external_id = 'DC-LAX'"
+        ).fetchone()
+
+    assert pump and valve and atl and lax, "Seed missing PUMP-01/VALVE-02/DC-ATL/DC-LAX"
+
+    return {
+        "pump_id": UUID(str(pump["item_id"])),
+        "valve_id": UUID(str(valve["item_id"])),
+        "atl_id": UUID(str(atl["location_id"])),
+        "lax_id": UUID(str(lax["location_id"])),
+    }
+
+
+def _conn(seeded_db):
+    import psycopg
+    from psycopg.rows import dict_row
+    return psycopg.connect(seeded_db, row_factory=dict_row)
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/events — real DB write + propagation
+# ---------------------------------------------------------------------------
+
+
+class TestPostEvents:
+    """POST /v1/events against a real DB."""
+
+    def test_post_event_success(self, api_client, auth, seeded_db):
+        """POST event without trigger_node_id → 202, event row persisted."""
+        payload = {
+            "event_type": "supply_date_changed",
+            "source": "integration-test",
+            "field_changed": "due_date",
+            "new_date": "2026-12-01",
+        }
+        resp = api_client.post("/v1/events", json=payload, headers=auth)
+        assert resp.status_code == 202, resp.text
+        data = resp.json()
+        assert data["status"] == "queued"
+        assert "event_id" in data
+        assert "scenario_id" in data
+
+        # Verify the row exists in events table — and clean up
+        event_id = data["event_id"]
+        with _conn(seeded_db) as c:
+            try:
+                row = c.execute(
+                    "SELECT event_type, source FROM events WHERE event_id = %s",
+                    (event_id,),
+                ).fetchone()
+                assert row is not None
+                assert row["event_type"] == "supply_date_changed"
+                assert row["source"] == "integration-test"
+            finally:
+                c.execute("DELETE FROM events WHERE event_id = %s", (event_id,))
+                c.commit()
+
+    def test_post_event_onhand_updated(self, api_client, auth, seeded_db):
+        """A different valid event_type — onhand_updated, manual source."""
+        payload = {"event_type": "onhand_updated", "source": "manual"}
+        resp = api_client.post("/v1/events", json=payload, headers=auth)
+        assert resp.status_code == 202, resp.text
+        event_id = resp.json()["event_id"]
+
+        # Cleanup
+        with _conn(seeded_db) as c:
+            c.execute("DELETE FROM events WHERE event_id = %s", (event_id,))
+            c.commit()
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/projection — real GraphStore + seeded series
+# ---------------------------------------------------------------------------
+
+
+class TestGetProjection:
+    """GET /v1/projection against a real DB."""
+
+    def test_projection_with_external_ids(self, api_client, auth):
+        """PUMP-01 @ DC-ATL has a seeded projection series with buckets."""
+        resp = api_client.get(
+            "/v1/projection?item_id=PUMP-01&location_id=DC-ATL",
+            headers=auth,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "series_id" in data
+        assert UUID(data["series_id"])  # parseable
+        assert data["item_id"] == "PUMP-01"
+        assert data["location_id"] == "DC-ATL"
+        assert isinstance(data["buckets"], list)
+        assert len(data["buckets"]) > 0
+        # Each bucket has the expected shape
+        b = data["buckets"][0]
+        for key in ("bucket_sequence", "opening_stock", "closing_stock",
+                    "has_shortage", "shortage_qty"):
+            assert key in b
+
+    def test_projection_with_uuids(self, api_client, auth, seeded_ids):
+        """Same query using UUIDs directly."""
+        resp = api_client.get(
+            f"/v1/projection?item_id={seeded_ids['pump_id']}"
+            f"&location_id={seeded_ids['atl_id']}",
+            headers=auth,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert len(data["buckets"]) > 0
+
+    def test_projection_not_found_unknown_item(self, api_client, auth):
+        """Unknown item external_id → 404."""
+        resp = api_client.get(
+            "/v1/projection?item_id=NOT-A-REAL-ITEM&location_id=DC-ATL",
+            headers=auth,
+        )
+        assert resp.status_code == 404
+
+    def test_projection_not_found_unknown_location(self, api_client, auth):
+        """Known item but unknown location → 404."""
+        resp = api_client.get(
+            "/v1/projection?item_id=PUMP-01&location_id=NOT-A-REAL-LOC",
+            headers=auth,
+        )
+        assert resp.status_code == 404
+
+    def test_projection_no_series_for_unmatched_pair(self, api_client, auth):
+        """
+        Valid item+location pair but no projection_series wired between them
+        (PUMP-01 only has series at DC-ATL, not DC-LAX) → 404 on series lookup.
+        """
+        resp = api_client.get(
+            "/v1/projection?item_id=PUMP-01&location_id=DC-LAX",
+            headers=auth,
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/issues — real ShortageDetector + seeded shortages
+# ---------------------------------------------------------------------------
+
+
+class TestGetIssues:
+    """GET /v1/issues against a real DB."""
+
+    def test_issues_all_severities(self, api_client, auth):
+        """Seed has shortages — fetching with severity=all returns ≥1."""
+        resp = api_client.get(
+            "/v1/issues?severity=all&horizon_days=120",
+            headers=auth,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "issues" in data
+        assert "total" in data
+        assert isinstance(data["issues"], list)
+        # Seeded shortages exist within 120 days
+        assert data["total"] >= 1
+        # Shape check on first issue
+        i = data["issues"][0]
+        for key in ("node_id", "shortage_qty", "severity_score", "severity",
+                    "shortage_date"):
+            assert key in i
+
+    def test_issues_severity_filter(self, api_client, auth):
+        """Filtering by a specific severity returns only that severity."""
+        resp = api_client.get(
+            "/v1/issues?severity=all&horizon_days=120",
+            headers=auth,
+        )
+        assert resp.status_code == 200
+        all_data = resp.json()
+        # Pick a severity present in the seed and verify the filter behaves
+        if all_data["total"] == 0:
+            pytest.skip("Seed produced no shortages within horizon")
+        present_severity = all_data["issues"][0]["severity"]
+        filtered = api_client.get(
+            f"/v1/issues?severity={present_severity}&horizon_days=120",
+            headers=auth,
+        )
+        assert filtered.status_code == 200
+        fdata = filtered.json()
+        assert all(i["severity"] == present_severity for i in fdata["issues"])
+
+    def test_issues_horizon_excludes_far_future(self, api_client, auth):
+        """Very small horizon should yield <= number of issues for large horizon."""
+        small = api_client.get(
+            "/v1/issues?severity=all&horizon_days=1",
+            headers=auth,
+        )
+        large = api_client.get(
+            "/v1/issues?severity=all&horizon_days=365",
+            headers=auth,
+        )
+        assert small.status_code == 200 and large.status_code == 200
+        assert small.json()["total"] <= large.json()["total"]
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/explain — real ExplanationBuilder
+# ---------------------------------------------------------------------------
+
+
+class TestGetExplain:
+    """GET /v1/explain against a real DB."""
+
+    def test_explain_not_found_random_node(self, api_client, auth):
+        """A random (unrelated) UUID has no explanation → 404."""
+        resp = api_client.get(
+            f"/v1/explain?node_id={uuid4()}",
+            headers=auth,
+        )
+        assert resp.status_code == 404
+
+    def test_explain_shortage_node_if_explainable(self, api_client, auth, seeded_db):
+        """
+        For a real PI node that has a shortage, the explanation builder either:
+          - returns a real Explanation (200 with causal_path), OR
+          - returns None (404).
+        Both outcomes are valid — assertion is shape-only on success.
+        """
+        with _conn(seeded_db) as c:
+            row = c.execute(
+                """
+                SELECT node_id FROM nodes
+                WHERE node_type = 'ProjectedInventory'
+                  AND has_shortage = TRUE
+                  AND scenario_id = %s
+                  AND active = TRUE
+                LIMIT 1
+                """,
+                (BASELINE_SCENARIO_ID,),
+            ).fetchone()
+
+        if row is None:
+            pytest.skip("Seed produced no shortage PI nodes")
+
+        node_id = row["node_id"]
+        resp = api_client.get(f"/v1/explain?node_id={node_id}", headers=auth)
+        assert resp.status_code in (200, 404), resp.text
+
+        if resp.status_code == 200:
+            data = resp.json()
+            assert "explanation_id" in data
+            assert "summary" in data
+            assert "causal_path" in data
+            assert isinstance(data["causal_path"], list)
+            assert data["target_node_id"] == str(node_id)
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/simulate — real ScenarioManager.create_scenario + apply_override
+# ---------------------------------------------------------------------------
+
+
+def _cleanup_scenario(seeded_db, scenario_id: str | UUID) -> None:
+    """Remove a scenario and its dependent rows (overrides, nodes, events, etc.)."""
+    sid = str(scenario_id)
+    with _conn(seeded_db) as c:
+        # Delete in dependency order
+        c.execute("DELETE FROM scenario_overrides WHERE scenario_id = %s", (sid,))
+        c.execute("DELETE FROM shortages WHERE scenario_id = %s", (sid,))
+        c.execute("DELETE FROM explanations WHERE calc_run_id IN "
+                  "(SELECT calc_run_id FROM calc_runs WHERE scenario_id = %s)", (sid,))
+        c.execute("DELETE FROM calc_runs WHERE scenario_id = %s", (sid,))
+        c.execute("DELETE FROM events WHERE scenario_id = %s", (sid,))
+        c.execute("DELETE FROM edges WHERE scenario_id = %s", (sid,))
+        c.execute("DELETE FROM nodes WHERE scenario_id = %s", (sid,))
+        c.execute("DELETE FROM projection_series WHERE scenario_id = %s", (sid,))
+        c.execute("DELETE FROM scenarios WHERE scenario_id = %s", (sid,))
+        c.commit()
+
+
+class TestPostSimulate:
+    """POST /v1/simulate against a real DB."""
+
+    def test_simulate_no_overrides_creates_scenario(self, api_client, auth, seeded_db):
+        """POST /simulate with no overrides → 201, new scenario deep-copied from baseline."""
+        name = f"int-empty-sim-{uuid4().hex[:8]}"
+        resp = api_client.post(
+            "/v1/simulate",
+            json={"scenario_name": name},
+            headers=auth,
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["status"] == "created"
+        assert data["override_count"] == 0
+        assert data["scenario_name"] == name
+        scenario_id = data["scenario_id"]
+        assert UUID(scenario_id)
+        # base_scenario_id should be the baseline
+        assert data["base_scenario_id"] == str(BASELINE_SCENARIO_ID)
+
+        try:
+            # Verify row exists
+            with _conn(seeded_db) as c:
+                row = c.execute(
+                    "SELECT name, is_baseline FROM scenarios WHERE scenario_id = %s",
+                    (scenario_id,),
+                ).fetchone()
+                assert row is not None
+                assert row["name"] == name
+                assert row["is_baseline"] is False
+        finally:
+            _cleanup_scenario(seeded_db, scenario_id)
+
+    def test_simulate_with_quantity_override(self, api_client, auth, seeded_db, seeded_ids):
+        """
+        Create a scenario then apply an override on a real seeded node
+        (any node with a quantity column, e.g. a SupplyNode in the seed).
+        """
+        # Find a real node we can override quantity on (baseline supply node).
+        with _conn(seeded_db) as c:
+            row = c.execute(
+                """
+                SELECT node_id FROM nodes
+                WHERE scenario_id = %s
+                  AND node_type IN ('PurchaseOrderSupply', 'CustomerOrderDemand',
+                                    'WorkOrderSupply', 'WorkOrderDemand')
+                  AND quantity IS NOT NULL
+                  AND active = TRUE
+                LIMIT 1
+                """,
+                (BASELINE_SCENARIO_ID,),
+            ).fetchone()
+        if row is None:
+            pytest.skip("Seed produced no overridable supply/demand nodes")
+        node_id = str(row["node_id"])
+
+        name = f"int-qty-sim-{uuid4().hex[:8]}"
+        resp = api_client.post(
+            "/v1/simulate",
+            json={
+                "scenario_name": name,
+                "overrides": [
+                    {"node_id": node_id, "field_name": "quantity", "new_value": "999"}
+                ],
+            },
+            headers=auth,
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        scenario_id = data["scenario_id"]
+
+        try:
+            assert data["override_count"] == 1
+            assert data["failed_overrides"] == []
+            # Verify override row landed in scenario_overrides
+            with _conn(seeded_db) as c:
+                ovr = c.execute(
+                    """
+                    SELECT field_name, new_value FROM scenario_overrides
+                    WHERE scenario_id = %s
+                    """,
+                    (scenario_id,),
+                ).fetchall()
+                assert len(ovr) == 1
+                assert ovr[0]["field_name"] == "quantity"
+                assert str(ovr[0]["new_value"]) == "999"
+        finally:
+            _cleanup_scenario(seeded_db, scenario_id)
+
+    def test_simulate_all_overrides_fail_returns_422(self, api_client, auth, seeded_db):
+        """
+        Non-regression #48 (DB-backed half): if every override targets a node
+        that does not exist in the new scenario, apply_override raises and
+        the router returns 422 with the sanitised failed_overrides list.
+
+        Per chantier 2 of audit 2026-05-23, the per-override 'error' field is
+        a generic message (not str(exc)). We assert presence + node_id /
+        field_name echo, NOT error content.
+        """
+        # A clearly nonexistent node_id (random UUID)
+        bogus_node = str(uuid4())
+        name = f"int-bad-sim-{uuid4().hex[:8]}"
+        resp = api_client.post(
+            "/v1/simulate",
+            json={
+                "scenario_name": name,
+                "overrides": [
+                    {
+                        "node_id": bogus_node,
+                        "field_name": "quantity",  # whitelisted, so Pydantic passes
+                        "new_value": "10",
+                    }
+                ],
+            },
+            headers=auth,
+        )
+        assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+        body = resp.json()
+        detail = body.get("detail", {})
+        assert isinstance(detail, dict), f"Expected dict detail, got: {detail}"
+        assert "failed_overrides" in detail
+        failed = detail["failed_overrides"]
+        assert len(failed) == 1
+        # node_id / field_name are echoed (so client can correlate)
+        assert failed[0]["node_id"] == bogus_node
+        assert failed[0]["field_name"] == "quantity"
+        # error field is present + non-empty, but sanitised — no substring check
+        assert failed[0]["error"]
+
+        # Even though the response is 422, the scenario itself was created
+        # before overrides were applied. Find it by name and clean up.
+        with _conn(seeded_db) as c:
+            row = c.execute(
+                "SELECT scenario_id FROM scenarios WHERE name = %s", (name,),
+            ).fetchone()
+        if row is not None:
+            _cleanup_scenario(seeded_db, row["scenario_id"])
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/graph — real GraphStore + seeded nodes/edges
+# ---------------------------------------------------------------------------
+
+
+class TestGetGraph:
+    """GET /v1/graph against a real DB."""
+
+    def test_graph_with_uuids(self, api_client, auth, seeded_ids):
+        """Graph for PUMP-01 @ DC-ATL returns nodes + edges from the seed."""
+        resp = api_client.get(
+            f"/v1/graph?item_id={seeded_ids['pump_id']}"
+            f"&location_id={seeded_ids['atl_id']}",
+            headers=auth,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "nodes" in data
+        assert "edges" in data
+        assert isinstance(data["nodes"], list)
+        assert isinstance(data["edges"], list)
+        assert data["depth"] == 2  # default
+        # PUMP-01 @ DC-ATL has projection buckets seeded → at least 1 node
+        assert len(data["nodes"]) > 0
+
+    def test_graph_with_external_id_item_404_on_unknown_location(self, api_client, auth):
+        """
+        The graph router only resolves item/location by name (not external_id).
+        An external_id that is not also stored as 'name' → 404.
+        Use a clearly bogus value to assert the 404 path.
+        """
+        resp = api_client.get(
+            f"/v1/graph?item_id={uuid4()}&location_id=__not_a_real_location__",
+            headers=auth,
+        )
+        # First the item UUID is parsed OK (random UUID), then location name lookup fails
+        assert resp.status_code == 404
+
+    def test_graph_default_depth(self, api_client, auth, seeded_ids):
+        """Default depth=2 echoed in response."""
+        resp = api_client.get(
+            f"/v1/graph?item_id={seeded_ids['valve_id']}"
+            f"&location_id={seeded_ids['lax_id']}",
+            headers=auth,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["depth"] == 2

--- a/tests/test_m6_api.py
+++ b/tests/test_m6_api.py
@@ -1,86 +1,82 @@
 """
-test_m6_api.py — Sprint M6 REST API tests.
+Slim tests for the Sprint M6 FastAPI routers
+(/v1/events, /v1/projection, /v1/issues, /v1/explain, /v1/simulate, /v1/graph).
 
-All DB calls are mocked via dependency overrides.
-Tests cover: auth, events, projection, issues, explain, simulate, graph.
+Keeps ONLY the tests that legitimately do not need a database:
+  - Pydantic-validation 422 boundary tests (unknown event_type, invalid
+    UUID query params, disallowed override field_name, non-regression #48).
+  - Auth boundary tests (401 without / with wrong token — these short-circuit
+    before any DB call via the auth dependency).
+  - OpenAPI / docs gating (no DB use).
+  - Router introspection sanity checks.
+
+Every test that previously patched GraphStore / ShortageDetector /
+ExplanationBuilder / ScenarioManager / _build_propagation_engine was
+ported to tests/integration/test_m6_api_integration.py against a real
+PostgreSQL database, per the "no mocks" rule (CLAUDE.md).
+
+The TestClient here overrides ``get_db`` with a sentinel that raises if
+touched — proving the 422 / 401 fires *before* any DB access happens.
+
+Non-regression #48 (test_post_simulate_invalid_node_returns_422):
+  Override field_name 'shortage_qty' is not in the allowed override
+  whitelist (_ALLOWED_FIELDS). The OverrideIn field_validator rejects it
+  during Pydantic validation, before the DB is touched — so this still
+  belongs in the slim file. Assertions check status 422 + sanitised
+  error structure only, no str(exc) content checks (per chantier 2 of
+  audit 2026-05-23).
 """
 from __future__ import annotations
 
 import os
-from datetime import date
-from decimal import Decimal
-from typing import Generator
-from unittest.mock import MagicMock, patch
-from uuid import UUID, uuid4
 
 import pytest
+from fastapi import status
 from fastapi.testclient import TestClient
 
 # Set env token before importing app
-os.environ["OOTILS_API_TOKEN"] = "test-token"
+os.environ.setdefault("OOTILS_API_TOKEN", "test-token")
 
 from ootils_core.api.app import create_app
 from ootils_core.api.dependencies import get_db
-from ootils_core.models import (
-    CausalStep,
-    Explanation,
-    Node,
-    Scenario,
-    ScenarioOverride,
-    ShortageRecord,
-    ProjectionSeries,
-)
 
-# ─────────────────────────── Fixtures ───────────────────────────
-
-BASELINE_ID = UUID("00000000-0000-0000-0000-000000000001")
-SCENARIO_ID = uuid4()
-ITEM_ID = uuid4()
-LOCATION_ID = uuid4()
-SERIES_ID = uuid4()
-NODE_ID = uuid4()
-EXPLANATION_ID = uuid4()
-CALC_RUN_ID = uuid4()
-SHORTAGE_ID = uuid4()
+AUTH_HEADERS = {"Authorization": "Bearer test-token"}
 
 
-def _mock_db() -> MagicMock:
-    """Return a mock psycopg3 Connection."""
-    conn = MagicMock()
-    conn.execute.return_value = MagicMock(rowcount=1)
-    return conn
+class _DBAccessForbidden(AssertionError):
+    """Raised if a test that should fail validation/auth tries to use the DB."""
 
 
-@pytest.fixture
-def app():
-    application = create_app()
-    return application
+class _ForbiddenDB:
+    """Sentinel: any attribute access raises. Proves 422/401 fires before DB use."""
+
+    def __getattr__(self, name):
+        raise _DBAccessForbidden(
+            f"Validation test reached DB (accessed {name!r}) — 422/401 should have fired first"
+        )
 
 
-@pytest.fixture
-def client(app) -> Generator:
-    """TestClient with mocked DB."""
-    mock_conn = _mock_db()
+def _make_client_no_db() -> TestClient:
+    """TestClient where any DB use crashes the test."""
+    app = create_app()
 
     def override_db():
-        yield mock_conn
+        yield _ForbiddenDB()
 
     app.dependency_overrides[get_db] = override_db
-    with TestClient(app) as c:
-        yield c
-    app.dependency_overrides.clear()
+    return TestClient(app)
 
 
 @pytest.fixture
-def auth_headers():
-    return {"Authorization": "Bearer test-token"}
+def client() -> TestClient:
+    return _make_client_no_db()
 
 
-# ─────────────────────────── Auth Tests ───────────────────────────
+# ─────────────────────────── Health (no auth, no DB) ───────────────────────────
 
 
 def test_health_no_auth(client):
-    """Health endpoint requires no auth."""
+    """Health endpoint requires no auth and never hits the DB."""
     resp = client.get("/health")
     assert resp.status_code == 200
     data = resp.json()
@@ -88,8 +84,11 @@ def test_health_no_auth(client):
     assert data["version"] == "1.0.0"
 
 
+# ─────────────────────────── Auth boundary ───────────────────────────
+
+
 def test_events_401_without_token(client):
-    """All protected endpoints return 401 without token."""
+    """Protected endpoint returns 401 without token, before DB access."""
     resp = client.post("/v1/events", json={"event_type": "supply_date_changed"})
     assert resp.status_code == 401
 
@@ -113,524 +112,112 @@ def test_issues_401_without_token(client):
     assert resp.status_code == 401
 
 
-# ─────────────────────────── POST /events ───────────────────────────
+def test_explain_401_without_token(client):
+    resp = client.get("/v1/explain?node_id=abc")
+    assert resp.status_code == 401
 
 
-def test_post_event_success(app, auth_headers):
-    mock_conn = _mock_db()
-    mock_conn.execute.return_value = MagicMock(rowcount=1)
-
-    def override_db():
-        yield mock_conn
-
-    app.dependency_overrides[get_db] = override_db
-
-    with TestClient(app) as c:
-        resp = c.post(
-            "/v1/events",
-            json={
-                "event_type": "supply_date_changed",
-                "trigger_node_id": str(NODE_ID),
-                "source": "erp-sync",
-                "field_changed": "due_date",
-                "new_date": "2026-04-18",
-            },
-            headers=auth_headers,
-        )
-
-    app.dependency_overrides.clear()
-    assert resp.status_code == 202, resp.text
-    data = resp.json()
-    assert data["status"] == "queued"
-    assert "event_id" in data
-    assert "scenario_id" in data
+def test_simulate_401_without_token(client):
+    resp = client.post("/v1/simulate", json={"scenario_name": "x"})
+    assert resp.status_code == 401
 
 
-def test_post_event_invalid_type(app, auth_headers):
-    mock_conn = _mock_db()
-
-    def override_db():
-        yield mock_conn
-
-    app.dependency_overrides[get_db] = override_db
-
-    with TestClient(app) as c:
-        resp = c.post(
-            "/v1/events",
-            json={"event_type": "invalid_type_xyz"},
-            headers=auth_headers,
-        )
-
-    app.dependency_overrides.clear()
-    assert resp.status_code == 422
+def test_graph_401_without_token(client):
+    resp = client.get("/v1/graph?item_id=a&location_id=b")
+    assert resp.status_code == 401
 
 
-def test_post_event_inserts_to_db(app, auth_headers):
-    """Verify that execute() is called (DB insert happens)."""
-    mock_conn = _mock_db()
-
-    def override_db():
-        yield mock_conn
-
-    app.dependency_overrides[get_db] = override_db
-
-    with TestClient(app) as c:
-        c.post(
-            "/v1/events",
-            json={"event_type": "onhand_updated", "source": "manual"},
-            headers=auth_headers,
-        )
-
-    app.dependency_overrides.clear()
-    assert mock_conn.execute.called
+# ─────────────────────────── POST /v1/events — Pydantic validation ───────────────────────────
 
 
-# ─────────────────────────── GET /projection ───────────────────────────
-
-
-def _make_pi_node(seq: int) -> Node:
-    return Node(
-        node_id=uuid4(),
-        node_type="ProjectedInventory",
-        scenario_id=BASELINE_ID,
-        item_id=ITEM_ID,
-        location_id=LOCATION_ID,
-        projection_series_id=SERIES_ID,
-        bucket_sequence=seq,
-        time_span_start=date(2026, 4, seq),
-        time_span_end=date(2026, 4, seq + 1),
-        time_grain="day",
-        opening_stock=Decimal("100"),
-        inflows=Decimal("0"),
-        outflows=Decimal("20"),
-        closing_stock=Decimal("80"),
-        has_shortage=False,
-        shortage_qty=Decimal("0"),
+def test_post_event_invalid_type_returns_422(client):
+    """Unknown event_type → 422 before any DB write."""
+    resp = client.post(
+        "/v1/events",
+        json={"event_type": "invalid_type_xyz"},
+        headers=AUTH_HEADERS,
     )
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
-def test_get_projection_success(app, auth_headers):
-    mock_conn = _mock_db()
-    series = ProjectionSeries(
-        series_id=SERIES_ID,
-        item_id=ITEM_ID,
-        location_id=LOCATION_ID,
-        scenario_id=BASELINE_ID,
-        horizon_start=date(2026, 4, 1),
-        horizon_end=date(2026, 4, 30),
+# ─────────────────────────── GET /v1/explain — UUID parse ───────────────────────────
+
+
+def test_get_explain_invalid_uuid_returns_422(client):
+    """Non-UUID node_id → 422 (raised explicitly before builder is called)."""
+    resp = client.get("/v1/explain?node_id=not-a-uuid", headers=AUTH_HEADERS)
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
+# ─────────────────────────── POST /v1/simulate — non-regression #48 ───────────────────────────
+
+
+def test_post_simulate_disallowed_field_name_returns_422(client):
+    """
+    POST /simulate with a field_name outside the OverrideIn whitelist must
+    fail Pydantic validation with 422, before any DB / ScenarioManager call.
+    Uses a clearly bogus field name ('totally_not_a_field') — never present
+    in ScenarioManager._ALLOWED_FIELDS, so the field_validator rejects it
+    at body-parse time.
+    """
+    resp = client.post(
+        "/v1/simulate",
+        json={
+            "scenario_name": "bad-field-sim",
+            "overrides": [
+                {
+                    "node_id": "00000000-0000-0000-0000-000000000000",
+                    "field_name": "totally_not_a_field",  # not whitelisted
+                    "new_value": "0",
+                }
+            ],
+        },
+        headers=AUTH_HEADERS,
     )
-    nodes = [_make_pi_node(i) for i in range(1, 4)]
-
-    # Simulate UUID parse succeeding (item_id is a UUID)
-    from ootils_core.engine.kernel.graph.store import GraphStore
-
-    with patch.object(GraphStore, "get_projection_series", return_value=series), \
-         patch.object(GraphStore, "get_nodes_by_series", return_value=nodes):
-
-        def override_db():
-            yield mock_conn
-
-        app.dependency_overrides[get_db] = override_db
-
-        with TestClient(app) as c:
-            resp = c.get(
-                f"/v1/projection?item_id={ITEM_ID}&location_id={LOCATION_ID}",
-                headers=auth_headers,
-            )
-
-    app.dependency_overrides.clear()
-    assert resp.status_code == 200, resp.text
-    data = resp.json()
-    assert data["series_id"] == str(SERIES_ID)
-    assert len(data["buckets"]) == 3
-    assert data["buckets"][0]["bucket_sequence"] == 1
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT, resp.text
+    # FastAPI's default 422 envelope: {"detail": [{"loc": [...], "msg": ..., ...}]}
+    body = resp.json()
+    assert "detail" in body
+    detail = body["detail"]
+    assert isinstance(detail, list) and len(detail) >= 1
+    # The offending field path should be echoed (loc tuple includes "field_name")
+    assert any("field_name" in str(d.get("loc", [])) for d in detail)
 
 
-def test_get_projection_not_found(app, auth_headers):
-    mock_conn = _mock_db()
-
-    from ootils_core.engine.kernel.graph.store import GraphStore
-
-    with patch.object(GraphStore, "get_projection_series", return_value=None):
-
-        def override_db():
-            yield mock_conn
-
-        app.dependency_overrides[get_db] = override_db
-
-        with TestClient(app) as c:
-            resp = c.get(
-                f"/v1/projection?item_id={ITEM_ID}&location_id={LOCATION_ID}",
-                headers=auth_headers,
-            )
-
-    app.dependency_overrides.clear()
-    assert resp.status_code == 404
-
-
-# ─────────────────────────── GET /issues ───────────────────────────
-
-
-def _make_shortage(score: Decimal) -> ShortageRecord:
-    return ShortageRecord(
-        shortage_id=uuid4(),
-        scenario_id=BASELINE_ID,
-        pi_node_id=uuid4(),
-        item_id=ITEM_ID,
-        location_id=LOCATION_ID,
-        shortage_date=date(2026, 4, 8),
-        shortage_qty=Decimal("130"),
-        severity_score=score,
-        explanation_id=None,
-        calc_run_id=CALC_RUN_ID,
-        status="active",
+def test_post_simulate_invalid_node_uuid_returns_422(client):
+    """An override with a non-UUID node_id → 422 before DB."""
+    resp = client.post(
+        "/v1/simulate",
+        json={
+            "scenario_name": "bad-node-uuid",
+            "overrides": [
+                {
+                    "node_id": "not-a-uuid",
+                    "field_name": "quantity",
+                    "new_value": "10",
+                }
+            ],
+        },
+        headers=AUTH_HEADERS,
     )
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
-def test_get_issues_all(app, auth_headers):
-    mock_conn = _mock_db()
-    shortages = [
-        _make_shortage(Decimal("50")),   # low
-        _make_shortage(Decimal("500")),  # medium
-        _make_shortage(Decimal("2000")), # high
-    ]
+# ─────────────────────────── OpenAPI / docs gating ───────────────────────────
 
-    from ootils_core.engine.kernel.shortage.detector import ShortageDetector
 
-    with patch.object(ShortageDetector, "get_active_shortages", return_value=shortages):
-
-        def override_db():
-            yield mock_conn
-
-        app.dependency_overrides[get_db] = override_db
-
-        with TestClient(app) as c:
-            resp = c.get("/v1/issues?severity=all&horizon_days=90", headers=auth_headers)
-
-    app.dependency_overrides.clear()
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["total"] == 3
-
-
-def test_get_issues_filter_high(app, auth_headers):
-    mock_conn = _mock_db()
-    shortages = [
-        _make_shortage(Decimal("50")),
-        _make_shortage(Decimal("2000")),
-    ]
-
-    from ootils_core.engine.kernel.shortage.detector import ShortageDetector
-
-    with patch.object(ShortageDetector, "get_active_shortages", return_value=shortages):
-
-        def override_db():
-            yield mock_conn
-
-        app.dependency_overrides[get_db] = override_db
-
-        with TestClient(app) as c:
-            resp = c.get("/v1/issues?severity=high&horizon_days=90", headers=auth_headers)
-
-    app.dependency_overrides.clear()
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["total"] == 1
-    assert data["issues"][0]["severity"] == "high"
-
-
-def test_get_issues_horizon_filter(app, auth_headers):
-    """Shortages beyond horizon should be excluded."""
-    mock_conn = _mock_db()
-    # shortage date far in the future
-    far_shortage = ShortageRecord(
-        shortage_id=uuid4(),
-        scenario_id=BASELINE_ID,
-        pi_node_id=uuid4(),
-        item_id=ITEM_ID,
-        location_id=LOCATION_ID,
-        shortage_date=date(2030, 1, 1),  # far future
-        shortage_qty=Decimal("130"),
-        severity_score=Decimal("2000"),
-        explanation_id=None,
-        calc_run_id=CALC_RUN_ID,
-        status="active",
-    )
-    near_shortage = _make_shortage(Decimal("2000"))
-
-    from ootils_core.engine.kernel.shortage.detector import ShortageDetector
-
-    with patch.object(
-        ShortageDetector, "get_active_shortages", return_value=[far_shortage, near_shortage]
-    ):
-
-        def override_db():
-            yield mock_conn
-
-        app.dependency_overrides[get_db] = override_db
-
-        with TestClient(app) as c:
-            resp = c.get("/v1/issues?severity=all&horizon_days=90", headers=auth_headers)
-
-    app.dependency_overrides.clear()
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["total"] == 1  # only the near one
-
-
-# ─────────────────────────── GET /explain ───────────────────────────
-
-
-def _make_explanation() -> Explanation:
-    return Explanation(
-        explanation_id=EXPLANATION_ID,
-        calc_run_id=CALC_RUN_ID,
-        target_node_id=NODE_ID,
-        target_type="Shortage",
-        root_cause_node_id=uuid4(),
-        causal_path=[
-            CausalStep(
-                step=1,
-                node_id=uuid4(),
-                node_type="CustomerOrderDemand",
-                edge_type="consumes",
-                fact="Order CO-778 requires 150u due April 8",
-            ),
-            CausalStep(
-                step=2,
-                node_id=uuid4(),
-                node_type="PurchaseOrderSupply",
-                edge_type="replenishes",
-                fact="PO-991 provides 200u due April 18",
-            ),
-        ],
-        summary="Shortage: demand exceeds supply by 130 units.",
-    )
-
-
-def test_get_explain_success(app, auth_headers):
-    mock_conn = _mock_db()
-    explanation = _make_explanation()
-
-    from ootils_core.engine.kernel.explanation.builder import ExplanationBuilder
-
-    with patch.object(ExplanationBuilder, "get_explanation", return_value=explanation):
-
-        def override_db():
-            yield mock_conn
-
-        app.dependency_overrides[get_db] = override_db
-
-        with TestClient(app) as c:
-            resp = c.get(f"/v1/explain?node_id={NODE_ID}", headers=auth_headers)
-
-    app.dependency_overrides.clear()
-    assert resp.status_code == 200, resp.text
-    data = resp.json()
-    assert data["explanation_id"] == str(EXPLANATION_ID)
-    assert data["summary"] == explanation.summary
-    assert len(data["causal_path"]) == 2
-    assert data["causal_path"][0]["step"] == 1
-    assert data["causal_path"][0]["node_type"] == "CustomerOrderDemand"
-
-
-def test_get_explain_not_found(app, auth_headers):
-    mock_conn = _mock_db()
-
-    from ootils_core.engine.kernel.explanation.builder import ExplanationBuilder
-
-    with patch.object(ExplanationBuilder, "get_explanation", return_value=None):
-
-        def override_db():
-            yield mock_conn
-
-        app.dependency_overrides[get_db] = override_db
-
-        with TestClient(app) as c:
-            resp = c.get(f"/v1/explain?node_id={NODE_ID}", headers=auth_headers)
-
-    app.dependency_overrides.clear()
-    assert resp.status_code == 404
-
-
-def test_get_explain_invalid_uuid(app, auth_headers):
-    mock_conn = _mock_db()
-
-    def override_db():
-        yield mock_conn
-
-    app.dependency_overrides[get_db] = override_db
-
-    with TestClient(app) as c:
-        resp = c.get("/v1/explain?node_id=not-a-uuid", headers=auth_headers)
-
-    app.dependency_overrides.clear()
-    assert resp.status_code == 422
-
-
-# ─────────────────────────── POST /simulate ───────────────────────────
-
-
-def test_post_simulate_success(app, auth_headers):
-    mock_conn = _mock_db()
-    new_scenario = Scenario(
-        scenario_id=uuid4(),
-        name="sim-test",
-        parent_scenario_id=BASELINE_ID,
-        is_baseline=False,
-        status="active",
-    )
-    override_result = ScenarioOverride(
-        override_id=uuid4(),
-        scenario_id=new_scenario.scenario_id,
-        node_id=NODE_ID,
-        field_name="quantity",
-        old_value="100",
-        new_value="200",
-    )
-
-    from ootils_core.engine.scenario.manager import ScenarioManager
-
-    with patch.object(ScenarioManager, "create_scenario", return_value=new_scenario), \
-         patch.object(ScenarioManager, "apply_override", return_value=override_result):
-
-        def override_db():
-            yield mock_conn
-
-        app.dependency_overrides[get_db] = override_db
-
-        with TestClient(app) as c:
-            resp = c.post(
-                "/v1/simulate",
-                json={
-                    "scenario_name": "sim-test",
-                    "base_scenario_id": "baseline",
-                    "overrides": [
-                        {"node_id": str(NODE_ID), "field_name": "quantity", "new_value": "200"}
-                    ],
-                },
-                headers=auth_headers,
-            )
-
-    app.dependency_overrides.clear()
-    assert resp.status_code == 201, resp.text
-    data = resp.json()
-    assert data["status"] == "created"
-    assert data["override_count"] == 1
-    assert data["scenario_id"] == str(new_scenario.scenario_id)
-
-
-def test_post_simulate_no_overrides(app, auth_headers):
-    mock_conn = _mock_db()
-    new_scenario = Scenario(
-        scenario_id=uuid4(),
-        name="empty-sim",
-        parent_scenario_id=BASELINE_ID,
-        is_baseline=False,
-        status="active",
-    )
-
-    from ootils_core.engine.scenario.manager import ScenarioManager
-
-    with patch.object(ScenarioManager, "create_scenario", return_value=new_scenario):
-
-        def override_db():
-            yield mock_conn
-
-        app.dependency_overrides[get_db] = override_db
-
-        with TestClient(app) as c:
-            resp = c.post(
-                "/v1/simulate",
-                json={"scenario_name": "empty-sim"},
-                headers=auth_headers,
-            )
-
-    app.dependency_overrides.clear()
-    assert resp.status_code == 201
-    data = resp.json()
-    assert data["override_count"] == 0
-
-
-# ─────────────────────────── GET /graph ───────────────────────────
-
-
-def test_get_graph_success(app, auth_headers):
-    mock_conn = _mock_db()
-
-    nodes_result = [
-        {
-            "node_id": str(NODE_ID),
-            "node_type": "ProjectedInventory",
-            "scenario_id": str(BASELINE_ID),
-            "item_id": str(ITEM_ID),
-            "location_id": str(LOCATION_ID),
-            "quantity": None,
-            "qty_uom": None,
-            "time_grain": "day",
-            "time_ref": None,
-            "time_span_start": "2026-04-01",
-            "time_span_end": "2026-04-02",
-            "is_dirty": False,
-            "last_calc_run_id": None,
-            "active": True,
-            "projection_series_id": str(SERIES_ID),
-            "bucket_sequence": 1,
-            "opening_stock": "100",
-            "inflows": "0",
-            "outflows": "20",
-            "closing_stock": "80",
-            "has_shortage": False,
-            "shortage_qty": "0",
-            "has_exact_date_inputs": False,
-            "has_week_inputs": False,
-            "has_month_inputs": False,
-            "created_at": None,
-            "updated_at": None,
-        }
-    ]
-    mock_conn.execute.return_value.fetchall.return_value = nodes_result
-
-    from ootils_core.engine.kernel.graph.store import GraphStore
-
-    with patch.object(GraphStore, "get_all_edges", return_value=[]):
-
-        def override_db():
-            yield mock_conn
-
-        app.dependency_overrides[get_db] = override_db
-
-        with TestClient(app) as c:
-            resp = c.get(
-                f"/v1/graph?item_id={ITEM_ID}&location_id={LOCATION_ID}",
-                headers=auth_headers,
-            )
-
-    app.dependency_overrides.clear()
-    assert resp.status_code == 200, resp.text
-    data = resp.json()
-    assert "nodes" in data
-    assert "edges" in data
-    assert data["depth"] == 2  # default
-
-
-# ─────────────────────────── OpenAPI schema ───────────────────────────
-
-
-def test_openapi_schema_accessible(client, auth_headers):
-    """OpenAPI schema is disabled by default unless explicitly enabled."""
+def test_openapi_disabled_by_default(client):
+    """OpenAPI schema is disabled unless OOTILS_ENABLE_API_DOCS is set."""
     resp = client.get("/openapi.json")
     assert resp.status_code == 404
 
 
-def test_openapi_schema_accessible_when_docs_enabled(monkeypatch, app, auth_headers):
+def test_openapi_enabled_when_docs_flag_set(monkeypatch):
     monkeypatch.setenv("OOTILS_ENABLE_API_DOCS", "1")
     application = create_app()
 
-    mock_conn = _mock_db()
-
     def override_db():
-        yield mock_conn
+        yield _ForbiddenDB()
 
     application.dependency_overrides[get_db] = override_db
 
@@ -648,60 +235,62 @@ def test_openapi_schema_accessible_when_docs_enabled(monkeypatch, app, auth_head
     application.dependency_overrides.clear()
 
 
-def test_post_simulate_invalid_node_returns_422(app, auth_headers):
-    """
-    Non-regression #48: POST /v1/simulate with an invalid node_id must return 422,
-    not 500. All overrides fail → 422 with failed_overrides detail.
-    """
-    mock_conn = _mock_db()
-    new_scenario = Scenario(
-        scenario_id=uuid4(),
-        name="bad-node-sim",
-        parent_scenario_id=BASELINE_ID,
-        is_baseline=False,
-        status="active",
-    )
+# ─────────────────────────── Router introspection ───────────────────────────
 
-    from ootils_core.engine.scenario.manager import ScenarioManager
 
-    with patch.object(ScenarioManager, "create_scenario", return_value=new_scenario), \
-         patch.object(
-             ScenarioManager,
-             "apply_override",
-             side_effect=ValueError("Node 00000000-0000-0000-0000-000000000000 not found in scenario"),
-         ):
+class TestRouterConfiguration:
+    """Sanity: M6 routers are registered and use require_auth."""
 
-        def override_db():
-            yield mock_conn
+    def test_events_router_registered(self):
+        app = create_app()
+        events_routes = [
+            r for r in app.routes if hasattr(r, "path") and r.path == "/v1/events"
+        ]
+        assert len(events_routes) > 0
 
-        app.dependency_overrides[get_db] = override_db
+    def test_projection_router_registered(self):
+        app = create_app()
+        proj_routes = [
+            r for r in app.routes if hasattr(r, "path") and r.path.startswith("/v1/projection")
+        ]
+        assert len(proj_routes) > 0
 
-        with TestClient(app) as c:
-            resp = c.post(
-                "/v1/simulate",
-                json={
-                    "scenario_name": "bad-node-sim",
-                    "overrides": [
-                        {
-                            "node_id": "00000000-0000-0000-0000-000000000000",
-                            "field_name": "shortage_qty",
-                            "new_value": "0",
-                        }
-                    ],
-                },
-                headers=auth_headers,
-            )
+    def test_issues_router_registered(self):
+        app = create_app()
+        issues_routes = [
+            r for r in app.routes if hasattr(r, "path") and r.path == "/v1/issues"
+        ]
+        assert len(issues_routes) > 0
 
-    app.dependency_overrides.clear()
-    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
-    data = resp.json()
-    detail = data.get("detail", {})
-    assert "failed_overrides" in detail, f"Expected failed_overrides in detail: {detail}"
-    assert len(detail["failed_overrides"]) == 1
-    # Per-override error is sanitized (str(exc) is no longer leaked to the
-    # client — chantier 2 of audit 2026-05-23). The node_id is still
-    # echoed so the client can correlate the failure with the input.
-    failed = detail["failed_overrides"][0]
-    assert failed["node_id"] == "00000000-0000-0000-0000-000000000000"
-    assert failed["field_name"] == "shortage_qty"
-    assert failed["error"]  # generic, non-empty
+    def test_explain_router_registered(self):
+        app = create_app()
+        explain_routes = [
+            r for r in app.routes if hasattr(r, "path") and r.path == "/v1/explain"
+        ]
+        assert len(explain_routes) > 0
+
+    def test_simulate_router_registered(self):
+        app = create_app()
+        sim_routes = [
+            r for r in app.routes if hasattr(r, "path") and r.path == "/v1/simulate"
+        ]
+        assert len(sim_routes) > 0
+
+    def test_graph_router_registered(self):
+        app = create_app()
+        graph_routes = [
+            r for r in app.routes if hasattr(r, "path") and r.path == "/v1/graph"
+        ]
+        assert len(graph_routes) > 0
+
+    def test_simulate_router_uses_auth(self):
+        from ootils_core.api.routers import simulate
+        assert hasattr(simulate, "require_auth")
+
+    def test_events_router_uses_auth(self):
+        from ootils_core.api.routers import events
+        assert hasattr(events, "require_auth")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
Fifth mock-cleanup batch. Removes ~37 MagicMock usages from the M6 (scenarios / simulate / projection / issues / explain / graph / events) router tests.

| File | Before | After | Tests |
|---|---:|---:|---:|
| \`tests/test_m6_api.py\` | 708 | 296 | 22 (was 19) |
| \`tests/integration/test_m6_api_integration.py\` | (new) | 565 | 18 |

Net 19 → 40 tests because the slim file adds auth/404 boundary coverage that the original mocked tests didn't have.

## Notable change
The #48 non-regression test (\`test_post_simulate_invalid_node_returns_422\`) **had to move to integration**. The original used \`field_name="shortage_qty"\` which IS in \`_ALLOWED_FIELDS\`, so Pydantic accepts it and the request reaches \`ScenarioManager.create_scenario\` — requires a real DB. Slim retains a stricter Pydantic boundary using an out-of-whitelist field name. #48 semantics (status 422 + \`failed_overrides\` shape + node_id/field_name echo + non-empty sanitised \`error\` without substring check, per chantier 2) preserved in the integration test.

## Notes flagged for review
1. simulate router's propagation block (\`simulate.py:153-244\`) is wrapped in try/except as best-effort. Integration test doesn't assert on \`calc_run_id\` / \`nodes_recalculated\` for that reason — the override row write itself is verified directly.
2. \`graph.py\` looks up items/locations by \`name\`, \`projection.py\` by \`external_id\`. Divergence flagged as follow-up (out of scope).

## Verification
- ruff clean
- 22 slim tests pass without \`DATABASE_URL\`
- 18 integration tests collect cleanly under \`requires_db\`
- No production code touched

## Mock cleanup progress
| File | State |
|---|---|
| test_db_connection.py | ✓ ([#252](https://github.com/ngoineau/ootils-core/pull/252)) |
| test_llc_calculator.py | ✓ ([#252](https://github.com/ngoineau/ootils-core/pull/252)) |
| test_graph_store.py | ✓ ([#253](https://github.com/ngoineau/ootils-core/pull/253)) |
| test_atp_engine.py | ✓ ([#254](https://github.com/ngoineau/ootils-core/pull/254)) |
| test_forecasting_api.py | ✓ ([#255](https://github.com/ngoineau/ootils-core/pull/255)) |
| test_m6_api.py | ✓ (this PR) |
| test_m4_shortage.py | pending |
| test_crp_engine.py | pending |
| test_phase1_integration.py | pending |
| test_router_{bom,ghosts,rccp}.py | pending |