### PR TITLE
test(audit): split 3 router test files (bom/ghosts/rccp) into pure + integration

### DIFF
--- a/tests/integration/test_router_bom_integration.py
+++ b/tests/integration/test_router_bom_integration.py
@@ -1,0 +1,575 @@
+"""
+Integration tests for the BOM FastAPI router against a real PostgreSQL
+database (no mocks).
+
+Ported from tests/test_router_bom.py — every test that previously mocked
+``conn.execute`` for _resolve_item_id / _get_active_bom / _get_bom_lines /
+_detect_cycle / _recalculate_llc / _get_on_hand_qty is re-implemented here
+using the seeded test database (PUMP-01 / VALVE-02 items at DC-ATL / DC-LAX
+locations, seeded BOM PUMP-01 → 2× VALVE-02 with 2% scrap).
+
+Tests that need rows beyond the seed (extra items, fresh BOM headers,
+cycle setups) insert per-test rows and clean them up afterwards.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from .conftest import requires_db, TEST_DB_URL
+
+pytestmark = requires_db
+
+SEED_SCRIPT = Path(__file__).parents[2] / "scripts" / "seed_demo_data.py"
+AUTH_HEADERS = {"Authorization": "Bearer integration-test-token"}
+
+
+def _run_seed():
+    env = {**os.environ, "DATABASE_URL": TEST_DB_URL}
+    return subprocess.run(
+        [sys.executable, str(SEED_SCRIPT)],
+        capture_output=True, text=True, env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared module-scoped fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def seeded_db(migrated_db):
+    """Module-scoped: migrated DB with seed data loaded once."""
+    result = _run_seed()
+    if result.returncode != 0:
+        pytest.skip(f"Seed failed: {result.stderr[:500]}")
+    return migrated_db
+
+
+@pytest.fixture(scope="module")
+def api_client(seeded_db):
+    """Module-scoped FastAPI TestClient bound to the real test DB."""
+    os.environ["DATABASE_URL"] = seeded_db
+    os.environ["OOTILS_API_TOKEN"] = "integration-test-token"
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+    from fastapi.testclient import TestClient
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(seeded_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="module")
+def auth():
+    return AUTH_HEADERS
+
+
+# ---------------------------------------------------------------------------
+# Per-test helper utilities
+# ---------------------------------------------------------------------------
+
+
+def _insert_item(conn, external_id: str, name: str = "Test Item") -> str:
+    """Insert an item with the given external_id, returns the item_id (str)."""
+    item_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO items (item_id, external_id, name, item_type, uom, status)
+        VALUES (%s, %s, %s, 'finished_good', 'EA', 'active')
+        """,
+        (item_id, external_id, name),
+    )
+    return str(item_id)
+
+
+def _cleanup_external_ids(conn, external_ids: list[str]):
+    """Remove BOM headers/lines and items matching any of the given external_ids."""
+    if not external_ids:
+        return
+    # Remove BOM rows tied to these items (cascade on bom_headers removes bom_lines)
+    conn.execute(
+        """
+        DELETE FROM bom_headers
+        WHERE parent_item_id IN (
+            SELECT item_id FROM items WHERE external_id = ANY(%s)
+        )
+        """,
+        (external_ids,),
+    )
+    # bom_lines that reference these items as components (in unrelated BOMs)
+    conn.execute(
+        """
+        DELETE FROM bom_lines
+        WHERE component_item_id IN (
+            SELECT item_id FROM items WHERE external_id = ANY(%s)
+        )
+        """,
+        (external_ids,),
+    )
+    conn.execute(
+        "DELETE FROM items WHERE external_id = ANY(%s)",
+        (external_ids,),
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/ingest/bom — DB-backed tests
+# ---------------------------------------------------------------------------
+
+
+class TestIngestBOMEndpoint:
+    """POST /v1/ingest/bom against the real DB."""
+
+    def test_ingest_bom_parent_not_found(self, api_client, auth):
+        resp = api_client.post(
+            "/v1/ingest/bom",
+            json={
+                "parent_external_id": "MISSING-PARENT-XYZ",
+                "components": [
+                    {"component_external_id": "C1", "quantity_per": 1.0},
+                ],
+            },
+            headers=auth,
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert any("MISSING-PARENT-XYZ" in str(d) for d in detail)
+
+    def test_ingest_bom_component_not_found(self, api_client, auth, seeded_db):
+        """Parent exists (PUMP-01 in seed) but component does not."""
+        resp = api_client.post(
+            "/v1/ingest/bom",
+            json={
+                "parent_external_id": "PUMP-01",
+                "components": [
+                    {"component_external_id": "NO-SUCH-COMPONENT-XYZ", "quantity_per": 1.0},
+                ],
+            },
+            headers=auth,
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert any("NO-SUCH-COMPONENT-XYZ" in str(d) for d in detail)
+
+    def test_ingest_bom_cycle_detected(self, api_client, auth, seeded_db):
+        """Construct a cycle: existing BOM has X→Y. New ingest tries Y→X."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        ext_x = f"CYC-X-{uuid4().hex[:6]}"
+        ext_y = f"CYC-Y-{uuid4().hex[:6]}"
+        created = [ext_x, ext_y]
+
+        with psycopg.connect(seeded_db, row_factory=dict_row, autocommit=False) as conn:
+            # Insert two items
+            _insert_item(conn, ext_x)
+            _insert_item(conn, ext_y)
+            # Create existing BOM X → Y
+            x_id = conn.execute(
+                "SELECT item_id FROM items WHERE external_id = %s", (ext_x,)
+            ).fetchone()["item_id"]
+            y_id = conn.execute(
+                "SELECT item_id FROM items WHERE external_id = %s", (ext_y,)
+            ).fetchone()["item_id"]
+            bom_id = uuid4()
+            conn.execute(
+                """
+                INSERT INTO bom_headers (bom_id, parent_item_id, bom_version, effective_from, status)
+                VALUES (%s, %s, '1.0', CURRENT_DATE, 'active')
+                """,
+                (bom_id, x_id),
+            )
+            conn.execute(
+                """
+                INSERT INTO bom_lines (line_id, bom_id, component_item_id, quantity_per, uom, scrap_factor, llc)
+                VALUES (%s, %s, %s, 1.0, 'EA', 0.0, 0)
+                """,
+                (uuid4(), bom_id, y_id),
+            )
+            conn.commit()
+
+        try:
+            # Now try Y → X, which would create a cycle
+            resp = api_client.post(
+                "/v1/ingest/bom",
+                json={
+                    "parent_external_id": ext_y,
+                    "components": [
+                        {"component_external_id": ext_x, "quantity_per": 1.0},
+                    ],
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 422
+            detail = resp.json()["detail"]
+            assert any("cycle" in str(d).lower() for d in detail)
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row, autocommit=False) as conn:
+                _cleanup_external_ids(conn, created)
+                conn.commit()
+
+    def test_ingest_bom_dry_run(self, api_client, auth, seeded_db):
+        """dry_run=True returns 'dry_run' without persisting."""
+        # Use seeded items PUMP-01 (parent) and VALVE-02 (component) so resolution succeeds.
+        # Capture pre-existing BOM count for PUMP-01 to verify no new write.
+        import psycopg
+        from psycopg.rows import dict_row
+
+        resp = api_client.post(
+            "/v1/ingest/bom",
+            json={
+                "parent_external_id": "PUMP-01",
+                "bom_version": "999.0-dry-run-test",  # version that doesn't exist
+                "components": [
+                    {"component_external_id": "VALVE-02", "quantity_per": 3.0},
+                ],
+                "dry_run": True,
+            },
+            headers=auth,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "dry_run"
+        assert body["components_imported"] == 1
+        assert body["llc_updated"] == 0
+
+        # Verify nothing new was written for v999.0
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            post_row = conn.execute(
+                """
+                SELECT COUNT(*) AS n FROM bom_headers bh
+                JOIN items i ON i.item_id = bh.parent_item_id
+                WHERE i.external_id = 'PUMP-01' AND bh.bom_version = '999.0-dry-run-test'
+                """
+            ).fetchone()
+            assert post_row["n"] == 0, "dry_run wrote a header"
+
+    def test_ingest_bom_new_header_success(self, api_client, auth, seeded_db):
+        """Create a fresh BOM on a brand-new parent + component."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        ext_parent = f"INGEST-P-{uuid4().hex[:6]}"
+        ext_comp = f"INGEST-C-{uuid4().hex[:6]}"
+        created = [ext_parent, ext_comp]
+
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            _insert_item(conn, ext_parent)
+            _insert_item(conn, ext_comp)
+            conn.commit()
+
+        try:
+            resp = api_client.post(
+                "/v1/ingest/bom",
+                json={
+                    "parent_external_id": ext_parent,
+                    "bom_version": "1.0",
+                    "effective_from": "2026-01-01",
+                    "components": [
+                        {
+                            "component_external_id": ext_comp,
+                            "quantity_per": 2.0,
+                            "uom": "EA",
+                            "scrap_factor": 0.05,
+                        },
+                    ],
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["status"] == "ok"
+            assert body["components_imported"] == 1
+            assert body["llc_updated"] >= 1
+            assert body["parent_item_id"] is not None
+
+            # Verify DB state
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                row = conn.execute(
+                    """
+                    SELECT bl.quantity_per, bl.uom, bl.scrap_factor
+                    FROM bom_lines bl
+                    JOIN bom_headers bh ON bh.bom_id = bl.bom_id
+                    JOIN items i ON i.item_id = bh.parent_item_id
+                    WHERE i.external_id = %s AND bl.active = TRUE
+                    """,
+                    (ext_parent,),
+                ).fetchone()
+                assert row is not None
+                assert float(row["quantity_per"]) == 2.0
+                assert row["uom"] == "EA"
+                assert float(row["scrap_factor"]) == 0.05
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                _cleanup_external_ids(conn, created)
+                conn.commit()
+
+    def test_ingest_bom_existing_header_update(self, api_client, auth, seeded_db):
+        """Second ingest on same parent + version updates the existing header."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        ext_parent = f"UPD-P-{uuid4().hex[:6]}"
+        ext_comp = f"UPD-C-{uuid4().hex[:6]}"
+        created = [ext_parent, ext_comp]
+
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            _insert_item(conn, ext_parent)
+            _insert_item(conn, ext_comp)
+            conn.commit()
+
+        try:
+            # First ingest
+            r1 = api_client.post(
+                "/v1/ingest/bom",
+                json={
+                    "parent_external_id": ext_parent,
+                    "bom_version": "1.0",
+                    "components": [
+                        {"component_external_id": ext_comp, "quantity_per": 1.0},
+                    ],
+                },
+                headers=auth,
+            )
+            assert r1.status_code == 200, r1.text
+            bom_id_1 = r1.json()["bom_id"]
+
+            # Second ingest same version — should re-use the same bom_id (UPDATE branch)
+            r2 = api_client.post(
+                "/v1/ingest/bom",
+                json={
+                    "parent_external_id": ext_parent,
+                    "bom_version": "1.0",
+                    "components": [
+                        {"component_external_id": ext_comp, "quantity_per": 5.0},
+                    ],
+                },
+                headers=auth,
+            )
+            assert r2.status_code == 200, r2.text
+            assert r2.json()["bom_id"] == bom_id_1
+
+            # Verify quantity was updated
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                row = conn.execute(
+                    """
+                    SELECT bl.quantity_per FROM bom_lines bl
+                    JOIN bom_headers bh ON bh.bom_id = bl.bom_id
+                    JOIN items i ON i.item_id = bh.parent_item_id
+                    WHERE i.external_id = %s AND bl.active = TRUE
+                    """,
+                    (ext_parent,),
+                ).fetchone()
+                assert float(row["quantity_per"]) == 5.0
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                _cleanup_external_ids(conn, created)
+                conn.commit()
+
+    def test_ingest_bom_empty_components_deactivates_all(self, api_client, auth, seeded_db):
+        """Empty components list deactivates all lines of existing BOM."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        ext_parent = f"EMPTY-P-{uuid4().hex[:6]}"
+        ext_comp = f"EMPTY-C-{uuid4().hex[:6]}"
+        created = [ext_parent, ext_comp]
+
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            _insert_item(conn, ext_parent)
+            _insert_item(conn, ext_comp)
+            conn.commit()
+
+        try:
+            # First ingest with a component
+            api_client.post(
+                "/v1/ingest/bom",
+                json={
+                    "parent_external_id": ext_parent,
+                    "components": [
+                        {"component_external_id": ext_comp, "quantity_per": 1.0},
+                    ],
+                },
+                headers=auth,
+            )
+
+            # Second ingest with empty components
+            resp = api_client.post(
+                "/v1/ingest/bom",
+                json={
+                    "parent_external_id": ext_parent,
+                    "components": [],
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["status"] == "ok"
+            assert body["components_imported"] == 0
+
+            # Verify the previously-active line was deactivated
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                row = conn.execute(
+                    """
+                    SELECT COUNT(*) AS n FROM bom_lines bl
+                    JOIN bom_headers bh ON bh.bom_id = bl.bom_id
+                    JOIN items i ON i.item_id = bh.parent_item_id
+                    WHERE i.external_id = %s AND bl.active = TRUE
+                    """,
+                    (ext_parent,),
+                ).fetchone()
+                assert row["n"] == 0
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                _cleanup_external_ids(conn, created)
+                conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/bom/{parent_external_id} — DB-backed tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetBOMEndpoint:
+    def test_get_bom_item_not_found(self, api_client, auth):
+        resp = api_client.get(
+            "/v1/bom/MISSING-XYZ", headers=auth
+        )
+        assert resp.status_code == 404
+        assert "MISSING-XYZ" in resp.json()["detail"]
+
+    def test_get_bom_no_active_header(self, api_client, auth, seeded_db):
+        """Item exists but has no BOM (use VALVE-02 — leaf in seed)."""
+        resp = api_client.get("/v1/bom/VALVE-02", headers=auth)
+        # VALVE-02 has no BOM in the seed (it's a leaf component)
+        assert resp.status_code == 404
+
+    def test_get_bom_success(self, api_client, auth):
+        """PUMP-01 has a seeded BOM: 1 component (VALVE-02), qty=2, scrap=0.02."""
+        resp = api_client.get("/v1/bom/PUMP-01", headers=auth)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["parent_external_id"] == "PUMP-01"
+        assert body["bom_version"] == "1.0"
+        assert len(body["components"]) == 1
+        comp = body["components"][0]
+        assert comp["component_external_id"] == "VALVE-02"
+        assert comp["quantity_per"] == 2.0
+        assert comp["uom"] == "EA"
+        assert abs(comp["scrap_factor"] - 0.02) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/bom/explode — DB-backed tests
+# ---------------------------------------------------------------------------
+
+
+class TestExplodeBOMEndpoint:
+    def test_explode_bom_item_not_found(self, api_client, auth):
+        resp = api_client.post(
+            "/v1/bom/explode",
+            json={"item_external_id": "MISSING-XYZ", "quantity": 10},
+            headers=auth,
+        )
+        assert resp.status_code == 404
+
+    def test_explode_bom_location_not_found(self, api_client, auth):
+        """Item exists, but location doesn't → 422."""
+        resp = api_client.post(
+            "/v1/bom/explode",
+            json={
+                "item_external_id": "PUMP-01",
+                "quantity": 5,
+                "location_external_id": "NOWHERE-XYZ",
+            },
+            headers=auth,
+        )
+        assert resp.status_code == 422
+
+    def test_explode_bom_leaf_item_no_bom(self, api_client, auth):
+        """VALVE-02 is a leaf (no BOM) → explosion empty."""
+        resp = api_client.post(
+            "/v1/bom/explode",
+            json={"item_external_id": "VALVE-02", "quantity": 10},
+            headers=auth,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["total_components"] == 0
+        assert body["components_with_shortage"] == 0
+        assert body["explosion"] == []
+
+    def test_explode_bom_pump_with_seed_data(self, api_client, auth):
+        """
+        Explode PUMP-01 × 100 units.
+        Seed BOM: PUMP-01 → 2× VALVE-02 with scrap 0.02 → gross = 100 * 2 * 1.02 = 204.
+        OnHand VALVE-02 @ DC-LAX = 45 → shortage at DC-LAX = 204 - 45 = 159.
+        Without location filter: SUM of all OnHand VALVE-02 = 45.
+        """
+        resp = api_client.post(
+            "/v1/bom/explode",
+            json={
+                "item_external_id": "PUMP-01",
+                "quantity": 100,
+                "location_external_id": "DC-LAX",
+            },
+            headers=auth,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["total_components"] == 1
+        line = body["explosion"][0]
+        assert line["level"] == 1
+        assert line["component_external_id"] == "VALVE-02"
+        assert abs(line["gross_requirement"] - 204.0) < 1e-3
+        # OnHand VALVE-02 @ DC-LAX = 45 per seed
+        assert line["on_hand_qty"] == 45.0
+        assert abs(line["net_requirement"] - 159.0) < 1e-3
+        assert line["has_shortage"] is True
+        assert body["components_with_shortage"] == 1
+
+    def test_explode_bom_pump_no_location_aggregates_all_onhand(self, api_client, auth):
+        """Without location filter, on_hand sums across all locations.
+
+        Seed: only OnHandSupply VALVE-02 lives @ DC-LAX (qty=45). Sum = 45.
+        """
+        resp = api_client.post(
+            "/v1/bom/explode",
+            json={"item_external_id": "PUMP-01", "quantity": 100},
+            headers=auth,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        line = body["explosion"][0]
+        assert line["on_hand_qty"] == 45.0  # only seed OnHand for VALVE-02
+
+    def test_explode_bom_levels_cap(self, api_client, auth):
+        """levels=1 returns at most level-1 components (PUMP-01 → VALVE-02 only)."""
+        resp = api_client.post(
+            "/v1/bom/explode",
+            json={"item_external_id": "PUMP-01", "quantity": 1, "levels": 1},
+            headers=auth,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # All entries must be at level 1
+        for line in body["explosion"]:
+            assert line["level"] == 1

--- a/tests/integration/test_router_ghosts_integration.py
+++ b/tests/integration/test_router_ghosts_integration.py
@@ -1,0 +1,518 @@
+"""
+Integration tests for the Ghosts FastAPI router against a real PostgreSQL
+database (no mocks).
+
+Ported from tests/test_router_ghosts.py — every test that previously mocked
+``conn.execute()`` for items / resources / ghost_nodes / ghost_members /
+nodes / edges queries, or patched ``run_ghost``, is re-implemented here
+against a real DB.
+
+Uses the seeded PUMP-01 / VALVE-02 items as ghost members.
+
+Note on `run_ghost`: rather than mock the engine entrypoint, we call the
+endpoint with a non-existent ghost_id, which triggers the ValueError →
+sanitised 404 path. The success path needs a fully wired phase_transition
+or capacity_aggregate ghost — out of scope for router integration tests
+(covered by tests/integration/test_ghosts.py and the engine unit tests).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from .conftest import requires_db, TEST_DB_URL
+
+pytestmark = requires_db
+
+SEED_SCRIPT = Path(__file__).parents[2] / "scripts" / "seed_demo_data.py"
+AUTH_HEADERS = {"Authorization": "Bearer integration-test-token"}
+BASELINE_SCENARIO_ID = "00000000-0000-0000-0000-000000000001"
+
+
+def _run_seed():
+    env = {**os.environ, "DATABASE_URL": TEST_DB_URL}
+    return subprocess.run(
+        [sys.executable, str(SEED_SCRIPT)],
+        capture_output=True, text=True, env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared module-scoped fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def seeded_db(migrated_db):
+    result = _run_seed()
+    if result.returncode != 0:
+        pytest.skip(f"Seed failed: {result.stderr[:500]}")
+    return migrated_db
+
+
+@pytest.fixture(scope="module")
+def api_client(seeded_db):
+    os.environ["DATABASE_URL"] = seeded_db
+    os.environ["OOTILS_API_TOKEN"] = "integration-test-token"
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+    from fastapi.testclient import TestClient
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(seeded_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="module")
+def auth():
+    return AUTH_HEADERS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_item_uuids(conn) -> tuple[str, str]:
+    """Return (pump_item_id, valve_item_id) from the seeded items."""
+    pump = conn.execute(
+        "SELECT item_id FROM items WHERE external_id = 'PUMP-01'"
+    ).fetchone()
+    valve = conn.execute(
+        "SELECT item_id FROM items WHERE external_id = 'VALVE-02'"
+    ).fetchone()
+    return str(pump["item_id"]), str(valve["item_id"])
+
+
+def _cleanup_ghost(conn, ghost_name: str):
+    """Best-effort cleanup of a ghost (cascade also removes members)."""
+    # Find ghost(s) by name
+    rows = conn.execute(
+        "SELECT ghost_id, node_id FROM ghost_nodes WHERE name = %s", (ghost_name,)
+    ).fetchall()
+    for row in rows:
+        # Drop edges first
+        if row["node_id"]:
+            conn.execute(
+                "DELETE FROM edges WHERE from_node_id = %s OR to_node_id = %s",
+                (row["node_id"], row["node_id"]),
+            )
+        conn.execute("DELETE FROM ghost_nodes WHERE ghost_id = %s", (row["ghost_id"],))
+        # Then the graph node
+        if row["node_id"]:
+            conn.execute("DELETE FROM nodes WHERE node_id = %s", (row["node_id"],))
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/ingest/ghosts — item / resource validation against DB
+# ---------------------------------------------------------------------------
+
+
+class TestGhostsIngestValidationDB:
+    """DB-backed validation: item not found, resource not found."""
+
+    def test_ingest_ghost_item_not_found(self, api_client, auth):
+        """Unknown item_id → 422."""
+        a = str(uuid4())
+        resp = api_client.post(
+            "/v1/ingest/ghosts",
+            json={
+                "name": f"g_item_not_found_{uuid4().hex[:6]}",
+                "ghost_type": "capacity_aggregate",
+                "members": [
+                    {"item_id": a, "role": "member"},
+                ],
+            },
+            headers=auth,
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert any("not found" in str(d) for d in detail)
+
+    def test_ingest_ghost_resource_not_found(self, api_client, auth, seeded_db):
+        """Resource_id provided but does not exist → 422."""
+        import psycopg
+        from psycopg.rows import dict_row
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            pump_id, _ = _seed_item_uuids(conn)
+        bogus_resource = str(uuid4())
+        resp = api_client.post(
+            "/v1/ingest/ghosts",
+            json={
+                "name": f"g_res_not_found_{uuid4().hex[:6]}",
+                "ghost_type": "capacity_aggregate",
+                "resource_id": bogus_resource,
+                "members": [{"item_id": pump_id, "role": "member"}],
+            },
+            headers=auth,
+        )
+        assert resp.status_code == 422
+        assert any("resource_id not found" in str(d) for d in resp.json()["detail"])
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/ingest/ghosts — insert / update happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestGhostsIngestEndpoint:
+    def test_ingest_ghost_insert_no_members(self, api_client, auth, seeded_db):
+        """Insert with empty members: just creates ghost_node + graph node."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        name = f"g_no_members_{uuid4().hex[:6]}"
+        try:
+            resp = api_client.post(
+                "/v1/ingest/ghosts",
+                json={
+                    "name": name,
+                    "ghost_type": "phase_transition",
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["action"] == "inserted"
+            assert body["member_count"] == 0
+            assert body["node_id"] is not None
+            # Verify DB row
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                row = conn.execute(
+                    "SELECT ghost_id, node_id FROM ghost_nodes WHERE name = %s",
+                    (name,),
+                ).fetchone()
+                assert row is not None
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                _cleanup_ghost(conn, name)
+                conn.commit()
+
+    def test_ingest_ghost_insert_with_members(self, api_client, auth, seeded_db):
+        """Insert phase_transition with both members → creates members + edges."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            pump_id, valve_id = _seed_item_uuids(conn)
+
+        name = f"g_phase_{uuid4().hex[:6]}"
+        try:
+            resp = api_client.post(
+                "/v1/ingest/ghosts",
+                json={
+                    "name": name,
+                    "ghost_type": "phase_transition",
+                    "description": "desc",
+                    "members": [
+                        {"item_id": pump_id, "role": "outgoing"},
+                        {"item_id": valve_id, "role": "incoming"},
+                    ],
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["action"] == "inserted"
+            assert body["member_count"] == 2
+            assert body["node_id"] is not None
+
+            # Verify members in DB
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                rows = conn.execute(
+                    "SELECT role FROM ghost_members WHERE ghost_id = %s::uuid ORDER BY role",
+                    (body["ghost_id"],),
+                ).fetchall()
+                assert {r["role"] for r in rows} == {"outgoing", "incoming"}
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                _cleanup_ghost(conn, name)
+                conn.commit()
+
+    def test_ingest_ghost_update_existing(self, api_client, auth, seeded_db):
+        """Second ingest on same (name, ghost_type, scenario_id) → UPDATE branch."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            pump_id, valve_id = _seed_item_uuids(conn)
+
+        name = f"g_upd_{uuid4().hex[:6]}"
+        try:
+            r1 = api_client.post(
+                "/v1/ingest/ghosts",
+                json={
+                    "name": name,
+                    "ghost_type": "phase_transition",
+                    "description": "v1",
+                    "members": [
+                        {"item_id": pump_id, "role": "outgoing"},
+                        {"item_id": valve_id, "role": "incoming"},
+                    ],
+                },
+                headers=auth,
+            )
+            assert r1.status_code == 201, r1.text
+            ghost_id = r1.json()["ghost_id"]
+
+            # Second ingest — same name + type → update branch
+            r2 = api_client.post(
+                "/v1/ingest/ghosts",
+                json={
+                    "name": name,
+                    "ghost_type": "phase_transition",
+                    "description": "v2-updated",
+                    "members": [
+                        {"item_id": pump_id, "role": "outgoing"},
+                        {"item_id": valve_id, "role": "incoming"},
+                    ],
+                },
+                headers=auth,
+            )
+            assert r2.status_code == 201, r2.text
+            body = r2.json()
+            assert body["action"] == "updated"
+            assert body["ghost_id"] == ghost_id
+            assert body["member_count"] == 2
+
+            # Verify description updated
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                row = conn.execute(
+                    "SELECT description FROM ghost_nodes WHERE ghost_id = %s::uuid",
+                    (ghost_id,),
+                ).fetchone()
+                assert row["description"] == "v2-updated"
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                _cleanup_ghost(conn, name)
+                conn.commit()
+
+    def test_ingest_ghost_capacity_aggregate_happy_path(self, api_client, auth, seeded_db):
+        """capacity_aggregate with two 'member' items."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            pump_id, valve_id = _seed_item_uuids(conn)
+
+        name = f"g_cap_{uuid4().hex[:6]}"
+        try:
+            resp = api_client.post(
+                "/v1/ingest/ghosts",
+                json={
+                    "name": name,
+                    "ghost_type": "capacity_aggregate",
+                    "members": [
+                        {"item_id": pump_id, "role": "member"},
+                        {"item_id": valve_id, "role": "member"},
+                    ],
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["action"] == "inserted"
+            assert body["member_count"] == 2
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                _cleanup_ghost(conn, name)
+                conn.commit()
+
+    def test_ingest_ghost_explicit_valid_status_and_curve(
+        self, api_client, auth, seeded_db
+    ):
+        """Explicit status='active' + transition_curve='step' to hit validator 'return v' branches."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            pump_id, _ = _seed_item_uuids(conn)
+
+        name = f"g_explicit_{uuid4().hex[:6]}"
+        try:
+            resp = api_client.post(
+                "/v1/ingest/ghosts",
+                json={
+                    "name": name,
+                    "ghost_type": "capacity_aggregate",
+                    "status": "active",
+                    "members": [
+                        {
+                            "item_id": pump_id,
+                            "role": "member",
+                            "transition_curve": "step",
+                        }
+                    ],
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                _cleanup_ghost(conn, name)
+                conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/ghosts (list)
+# ---------------------------------------------------------------------------
+
+
+class TestListGhostsEndpoint:
+    def test_list_ghosts_with_filter_no_match(self, api_client, auth):
+        """Filter by a ghost_type + a non-existent scenario_id → empty result."""
+        bogus_scenario = str(uuid4())
+        resp = api_client.get(
+            "/v1/ghosts",
+            params={
+                "ghost_type": "phase_transition",
+                "scenario_id": bogus_scenario,
+            },
+            headers=auth,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 0
+        assert body["ghosts"] == []
+
+    def test_list_ghosts_with_results(self, api_client, auth, seeded_db):
+        """Insert a ghost, list it back, check serialization."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            pump_id, valve_id = _seed_item_uuids(conn)
+
+        name = f"g_list_{uuid4().hex[:6]}"
+        try:
+            r_ins = api_client.post(
+                "/v1/ingest/ghosts",
+                json={
+                    "name": name,
+                    "ghost_type": "phase_transition",
+                    "members": [
+                        {"item_id": pump_id, "role": "outgoing"},
+                        {"item_id": valve_id, "role": "incoming"},
+                    ],
+                },
+                headers=auth,
+            )
+            assert r_ins.status_code == 201, r_ins.text
+            ghost_id = r_ins.json()["ghost_id"]
+
+            resp = api_client.get(
+                "/v1/ghosts",
+                params={"ghost_type": "phase_transition"},
+                headers=auth,
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            found = [g for g in body["ghosts"] if g["ghost_id"] == ghost_id]
+            assert len(found) == 1
+            g = found[0]
+            assert g["name"] == name
+            assert g["ghost_type"] == "phase_transition"
+            assert len(g["members"]) == 2
+            # serialization sanity
+            assert g["created_at"] is not None
+            assert g["updated_at"] is not None
+            for m in g["members"]:
+                assert m["item_id"] in (pump_id, valve_id)
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                _cleanup_ghost(conn, name)
+                conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/ghosts/{ghost_id} (detail)
+# ---------------------------------------------------------------------------
+
+
+class TestGetGhostEndpoint:
+    def test_get_ghost_not_found(self, api_client, auth):
+        gid = str(uuid4())
+        resp = api_client.get(f"/v1/ghosts/{gid}", headers=auth)
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"]
+
+    def test_get_ghost_with_graph_node_and_edges(self, api_client, auth, seeded_db):
+        """Insert a phase_transition ghost, fetch detail, expect graph_node + edges."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            pump_id, valve_id = _seed_item_uuids(conn)
+
+        name = f"g_detail_{uuid4().hex[:6]}"
+        try:
+            r_ins = api_client.post(
+                "/v1/ingest/ghosts",
+                json={
+                    "name": name,
+                    "ghost_type": "phase_transition",
+                    "members": [
+                        {"item_id": pump_id, "role": "outgoing"},
+                        {"item_id": valve_id, "role": "incoming"},
+                    ],
+                },
+                headers=auth,
+            )
+            assert r_ins.status_code == 201, r_ins.text
+            ghost_id = r_ins.json()["ghost_id"]
+
+            resp = api_client.get(f"/v1/ghosts/{ghost_id}", headers=auth)
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["ghost_id"] == ghost_id
+            assert body["graph_node"] is not None
+            assert body["graph_node"]["node_id"] is not None
+            # PUMP-01 and VALVE-02 have Item nodes in the seed (OnHand + others ref them),
+            # so the ingest path may or may not create ghost_member edges depending on
+            # presence of node_type='Item' rows. We only assert the structure.
+            assert isinstance(body["graph_node"]["edges"], list)
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                _cleanup_ghost(conn, name)
+                conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/ghosts/{ghost_id}/run — error path (ValueError → 404 sanitised)
+# ---------------------------------------------------------------------------
+
+
+class TestRunGhostEndpoint:
+    def test_run_ghost_unknown_id_returns_404(self, api_client, auth):
+        """run_ghost raises ValueError on unknown ghost_id → router returns sanitised 404."""
+        gid = str(uuid4())
+        sid = str(uuid4())
+        resp = api_client.post(
+            f"/v1/ghosts/{gid}/run",
+            json={
+                "scenario_id": sid,
+                "from_date": "2026-01-01",
+                "to_date": "2026-01-31",
+            },
+            headers=auth,
+        )
+        assert resp.status_code == 404
+        # Sanitised message (chantier 2)
+        assert resp.json()["detail"] == "Ghost not found or invalid parameters"

--- a/tests/integration/test_router_rccp_integration.py
+++ b/tests/integration/test_router_rccp_integration.py
@@ -1,0 +1,611 @@
+"""
+Integration tests for the RCCP FastAPI router against a real PostgreSQL
+database (no mocks).
+
+Ported from tests/test_router_rccp.py — every test that previously mocked
+``conn.execute()`` for resources / load aggregation / capacity overrides /
+operational_calendars queries is re-implemented here against a real DB.
+
+The seed (scripts/seed_demo_data.py) does NOT include any `resources`
+rows — RCCP work-center data lives outside the demo seed. Each test that
+needs a resource inserts it locally with a unique external_id and cleans
+up afterwards.
+
+The pure-helper tests (`_bucket_start`, `_generate_buckets`, …) remain in
+the slim tests/test_router_rccp.py file — no DB required there.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from .conftest import requires_db, TEST_DB_URL
+
+pytestmark = requires_db
+
+SEED_SCRIPT = Path(__file__).parents[2] / "scripts" / "seed_demo_data.py"
+AUTH_HEADERS = {"Authorization": "Bearer integration-test-token"}
+BASELINE_SCENARIO_ID = "00000000-0000-0000-0000-000000000001"
+
+
+def _run_seed():
+    env = {**os.environ, "DATABASE_URL": TEST_DB_URL}
+    return subprocess.run(
+        [sys.executable, str(SEED_SCRIPT)],
+        capture_output=True, text=True, env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared module-scoped fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def seeded_db(migrated_db):
+    result = _run_seed()
+    if result.returncode != 0:
+        pytest.skip(f"Seed failed: {result.stderr[:500]}")
+    return migrated_db
+
+
+@pytest.fixture(scope="module")
+def api_client(seeded_db):
+    os.environ["DATABASE_URL"] = seeded_db
+    os.environ["OOTILS_API_TOKEN"] = "integration-test-token"
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+    from fastapi.testclient import TestClient
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(seeded_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="module")
+def auth():
+    return AUTH_HEADERS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_resource(
+    conn,
+    *,
+    external_id: str,
+    capacity_per_day: float = 100.0,
+    resource_type: str = "machine",
+    location_id=None,
+) -> dict:
+    """Insert a resource row + corresponding 'Resource' graph node."""
+    resource_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO resources
+            (resource_id, external_id, name, resource_type, capacity_per_day, capacity_unit, location_id)
+        VALUES (%s, %s, 'Test Resource', %s, %s, 'hours', %s)
+        """,
+        (resource_id, external_id, resource_type, capacity_per_day, location_id),
+    )
+    node_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO nodes (node_id, node_type, scenario_id, external_id, active)
+        VALUES (%s, 'Resource', %s::UUID, %s, TRUE)
+        """,
+        (node_id, BASELINE_SCENARIO_ID, external_id),
+    )
+    return {"resource_id": resource_id, "node_id": node_id}
+
+
+def _insert_work_order_supply(
+    conn, *, item_id: str, time_ref: date, quantity: float, resource_node_id
+) -> str:
+    """Insert a WorkOrderSupply node + consumes_resource edge → returns node_id."""
+    node_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO nodes
+            (node_id, node_type, scenario_id, item_id, quantity, time_grain, time_ref, active)
+        VALUES (%s, 'WorkOrderSupply', %s::UUID, %s, %s, 'exact_date', %s, TRUE)
+        """,
+        (node_id, BASELINE_SCENARIO_ID, item_id, quantity, time_ref),
+    )
+    conn.execute(
+        """
+        INSERT INTO edges (edge_id, edge_type, from_node_id, to_node_id, scenario_id, active)
+        VALUES (%s, 'consumes_resource', %s, %s, %s::UUID, TRUE)
+        """,
+        (uuid4(), node_id, resource_node_id, BASELINE_SCENARIO_ID),
+    )
+    return str(node_id)
+
+
+def _cleanup_resource(conn, external_id: str):
+    """Remove the resource + its graph node + capacity overrides + edges + supply nodes."""
+    # Find resource and node
+    res_row = conn.execute(
+        "SELECT resource_id FROM resources WHERE external_id = %s", (external_id,)
+    ).fetchone()
+    node_row = conn.execute(
+        "SELECT node_id FROM nodes WHERE node_type = 'Resource' AND external_id = %s",
+        (external_id,),
+    ).fetchone()
+
+    if res_row:
+        conn.execute(
+            "DELETE FROM resource_capacity_overrides WHERE resource_id = %s",
+            (res_row["resource_id"],),
+        )
+
+    if node_row:
+        node_id = node_row["node_id"]
+        # Edges referencing this resource node
+        # Delete supply nodes that have a consumes_resource edge to this resource
+        rows = conn.execute(
+            """
+            SELECT n.node_id FROM nodes n
+            JOIN edges e ON e.from_node_id = n.node_id
+            WHERE e.edge_type = 'consumes_resource'
+              AND e.to_node_id = %s
+              AND n.node_type IN ('WorkOrderSupply', 'PlannedSupply')
+            """,
+            (node_id,),
+        ).fetchall()
+        for r in rows:
+            conn.execute("DELETE FROM edges WHERE from_node_id = %s", (r["node_id"],))
+            conn.execute("DELETE FROM nodes WHERE node_id = %s", (r["node_id"],))
+        # Delete remaining edges to/from the resource node
+        conn.execute(
+            "DELETE FROM edges WHERE from_node_id = %s OR to_node_id = %s",
+            (node_id, node_id),
+        )
+        conn.execute("DELETE FROM nodes WHERE node_id = %s", (node_id,))
+
+    if res_row:
+        conn.execute(
+            "DELETE FROM resources WHERE resource_id = %s",
+            (res_row["resource_id"],),
+        )
+
+
+def _seed_pump_item_id(conn) -> str:
+    return str(
+        conn.execute("SELECT item_id FROM items WHERE external_id = 'PUMP-01'")
+        .fetchone()["item_id"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoint — error paths
+# ---------------------------------------------------------------------------
+
+
+class TestRCCPEndpointErrors:
+    def test_rccp_resource_not_found(self, api_client, auth):
+        resp = api_client.get(
+            "/v1/rccp/NO-SUCH-RESOURCE-XYZ",
+            params={"from_date": "2026-01-13", "to_date": "2026-01-19"},
+            headers=auth,
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Endpoint — happy paths against real DB
+# ---------------------------------------------------------------------------
+
+
+class TestRCCPEndpointDefaults:
+    def test_default_dates_returns_buckets(self, api_client, auth, seeded_db):
+        """No from_date/to_date → defaults today / +12 weeks. month grain."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        ext = f"RES-DEF-{uuid4().hex[:6]}"
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            _insert_resource(conn, external_id=ext, capacity_per_day=100.0)
+            conn.commit()
+        try:
+            resp = api_client.get(
+                f"/v1/rccp/{ext}",
+                params={"grain": "month"},
+                headers=auth,
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["resource"]["external_id"] == ext
+            assert len(body["buckets"]) >= 1
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                _cleanup_resource(conn, ext)
+                conn.commit()
+
+
+class TestRCCPEndpointWithLoad:
+    def test_load_and_overload_no_location(self, api_client, auth, seeded_db):
+        """One-week bucket, no location. Load > capacity → overloaded.
+
+        capacity_per_day=100, Mon→Fri = 5 weekdays × 100 = 500 capacity.
+        Load = 300 + 400 = 700 → 140% → overloaded.
+        """
+        import psycopg
+        from psycopg.rows import dict_row
+
+        ext = f"RES-LOAD-{uuid4().hex[:6]}"
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            ids = _insert_resource(conn, external_id=ext, capacity_per_day=100.0)
+            pump_id = _seed_pump_item_id(conn)
+            # Add two WorkOrderSupply rows in the window
+            _insert_work_order_supply(
+                conn,
+                item_id=pump_id,
+                time_ref=date(2026, 1, 13),  # Monday
+                quantity=300.0,
+                resource_node_id=ids["node_id"],
+            )
+            _insert_work_order_supply(
+                conn,
+                item_id=pump_id,
+                time_ref=date(2026, 1, 15),  # Wednesday
+                quantity=400.0,
+                resource_node_id=ids["node_id"],
+            )
+            conn.commit()
+
+        try:
+            resp = api_client.get(
+                f"/v1/rccp/{ext}",
+                params={
+                    "from_date": "2026-01-13",
+                    "to_date": "2026-01-17",
+                    "grain": "week",
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert len(body["buckets"]) == 1
+            b = body["buckets"][0]
+            assert b["load"] == 700.0
+            assert b["capacity"] == 500.0
+            assert b["utilization_pct"] == 140.0
+            assert b["overloaded"] is True
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                _cleanup_resource(conn, ext)
+                conn.commit()
+
+    def test_capacity_override_path(self, api_client, auth, seeded_db):
+        """Override day uses override capacity instead of weekday heuristic."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        ext = f"RES-OVR-{uuid4().hex[:6]}"
+        override_date = date(2026, 1, 13)  # Monday
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            ids = _insert_resource(conn, external_id=ext, capacity_per_day=100.0)
+            pump_id = _seed_pump_item_id(conn)
+            _insert_work_order_supply(
+                conn,
+                item_id=pump_id,
+                time_ref=override_date,
+                quantity=50.0,
+                resource_node_id=ids["node_id"],
+            )
+            # Override Monday capacity to 50
+            conn.execute(
+                """
+                INSERT INTO resource_capacity_overrides
+                    (resource_id, override_date, capacity, reason)
+                VALUES (%s, %s, 50.0, 'test-override')
+                """,
+                (ids["resource_id"], override_date),
+            )
+            conn.commit()
+
+        try:
+            resp = api_client.get(
+                f"/v1/rccp/{ext}",
+                params={
+                    "from_date": "2026-01-13",  # Mon
+                    "to_date": "2026-01-14",    # Tue
+                    "grain": "day",
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert len(body["buckets"]) == 2
+            # Monday: load=50, capacity=50 (override) → 100%
+            assert body["buckets"][0]["capacity"] == 50.0
+            assert body["buckets"][0]["load"] == 50.0
+            assert body["buckets"][0]["utilization_pct"] == 100.0
+            assert body["buckets"][0]["overloaded"] is False
+            # Tuesday: load=0, capacity=100 (weekday)
+            assert body["buckets"][1]["capacity"] == 100.0
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                _cleanup_resource(conn, ext)
+                conn.commit()
+
+
+class TestRCCPEndpointWithCalendar:
+    def test_calendar_working_day_with_factor(self, api_client, auth, seeded_db):
+        """location_id present → operational_calendars query.
+        is_working_day=True, capacity_factor=0.5 → capacity_per_day × 0.5 added.
+        """
+        import psycopg
+        from psycopg.rows import dict_row
+
+        ext = f"RES-CAL-{uuid4().hex[:6]}"
+        cal_date = date(2026, 1, 13)  # Monday
+        try:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                # Use seeded DC-ATL location
+                loc_row = conn.execute(
+                    "SELECT location_id FROM locations WHERE external_id = 'DC-ATL'"
+                ).fetchone()
+                loc_id = loc_row["location_id"]
+                _insert_resource(
+                    conn,
+                    external_id=ext,
+                    capacity_per_day=100.0,
+                    location_id=loc_id,
+                )
+                # Insert calendar row (clear conflict first)
+                conn.execute(
+                    """
+                    INSERT INTO operational_calendars
+                        (location_id, calendar_date, is_working_day, capacity_factor)
+                    VALUES (%s, %s, TRUE, 0.5)
+                    ON CONFLICT (location_id, calendar_date) DO UPDATE
+                        SET is_working_day = EXCLUDED.is_working_day,
+                            capacity_factor = EXCLUDED.capacity_factor
+                    """,
+                    (loc_id, cal_date),
+                )
+                conn.commit()
+
+            resp = api_client.get(
+                f"/v1/rccp/{ext}",
+                params={
+                    "from_date": cal_date.isoformat(),
+                    "to_date": cal_date.isoformat(),
+                    "grain": "day",
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["buckets"][0]["capacity"] == 50.0
+            assert body["buckets"][0]["load"] == 0.0
+            assert body["buckets"][0]["utilization_pct"] == 0.0
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                # Clean up the calendar row we created (restore prior state if it was different).
+                # Safe to delete because the date 2026-01-13 isn't a US holiday in the seed.
+                conn.execute(
+                    "DELETE FROM operational_calendars WHERE calendar_date = %s",
+                    (cal_date,),
+                )
+                _cleanup_resource(conn, ext)
+                conn.commit()
+
+    def test_calendar_non_working_day_zero_capacity(self, api_client, auth, seeded_db):
+        """is_working_day=False → no capacity added."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        ext = f"RES-HOL-{uuid4().hex[:6]}"
+        cal_date = date(2026, 1, 13)  # Monday
+        try:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                loc_row = conn.execute(
+                    "SELECT location_id FROM locations WHERE external_id = 'DC-ATL'"
+                ).fetchone()
+                loc_id = loc_row["location_id"]
+                _insert_resource(
+                    conn,
+                    external_id=ext,
+                    capacity_per_day=100.0,
+                    location_id=loc_id,
+                )
+                conn.execute(
+                    """
+                    INSERT INTO operational_calendars
+                        (location_id, calendar_date, is_working_day, capacity_factor)
+                    VALUES (%s, %s, FALSE, 1.0)
+                    ON CONFLICT (location_id, calendar_date) DO UPDATE
+                        SET is_working_day = EXCLUDED.is_working_day,
+                            capacity_factor = EXCLUDED.capacity_factor
+                    """,
+                    (loc_id, cal_date),
+                )
+                conn.commit()
+
+            resp = api_client.get(
+                f"/v1/rccp/{ext}",
+                params={
+                    "from_date": cal_date.isoformat(),
+                    "to_date": cal_date.isoformat(),
+                    "grain": "day",
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["buckets"][0]["capacity"] == 0.0
+            assert body["buckets"][0]["utilization_pct"] == 0.0
+            assert body["buckets"][0]["overloaded"] is False
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                conn.execute(
+                    "DELETE FROM operational_calendars WHERE calendar_date = %s",
+                    (cal_date,),
+                )
+                _cleanup_resource(conn, ext)
+                conn.commit()
+
+
+class TestRCCPEndpointWeekend:
+    def test_saturday_no_capacity(self, api_client, auth, seeded_db):
+        """Saturday → weekday() >= 5 → no calendar query, 0 capacity."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        ext = f"RES-SAT-{uuid4().hex[:6]}"
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            loc_row = conn.execute(
+                "SELECT location_id FROM locations WHERE external_id = 'DC-ATL'"
+            ).fetchone()
+            loc_id = loc_row["location_id"]
+            _insert_resource(
+                conn,
+                external_id=ext,
+                capacity_per_day=100.0,
+                location_id=loc_id,
+            )
+            conn.commit()
+        try:
+            # 2026-01-17 is a Saturday
+            resp = api_client.get(
+                f"/v1/rccp/{ext}",
+                params={
+                    "from_date": "2026-01-17",
+                    "to_date": "2026-01-17",
+                    "grain": "day",
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["buckets"][0]["capacity"] == 0.0
+            assert body["buckets"][0]["utilization_pct"] == 0.0
+            assert body["buckets"][0]["overloaded"] is False
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                _cleanup_resource(conn, ext)
+                conn.commit()
+
+
+class TestRCCPResourceSerialization:
+    def test_resource_with_location_id_serialized(self, api_client, auth, seeded_db):
+        """resource.location_id appears in the response when set."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        ext = f"RES-SER-{uuid4().hex[:6]}"
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            loc_row = conn.execute(
+                "SELECT location_id FROM locations WHERE external_id = 'DC-ATL'"
+            ).fetchone()
+            loc_id = loc_row["location_id"]
+            _insert_resource(
+                conn,
+                external_id=ext,
+                capacity_per_day=100.0,
+                location_id=loc_id,
+            )
+            conn.commit()
+        try:
+            resp = api_client.get(
+                f"/v1/rccp/{ext}",
+                params={
+                    "from_date": "2026-01-13",
+                    "to_date": "2026-01-13",
+                    "grain": "day",
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["resource"]["location_id"] == str(loc_id)
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                _cleanup_resource(conn, ext)
+                conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# _count_working_days against a real DB (location+calendar variants)
+# ---------------------------------------------------------------------------
+
+
+class TestCountWorkingDaysDB:
+    """The location-specific branches of _count_working_days need a real DB."""
+
+    def test_with_location_calendar_hit(self, api_client, auth, seeded_db):
+        import psycopg
+        from psycopg.rows import dict_row
+        from ootils_core.api.routers.rccp import _count_working_days
+
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            loc_row = conn.execute(
+                "SELECT location_id FROM locations WHERE external_id = 'DC-ATL'"
+            ).fetchone()
+            loc_id = str(loc_row["location_id"])
+            # Seed 4 working days inside [2026-03-02, 2026-03-08]
+            dates = [date(2026, 3, 2), date(2026, 3, 3), date(2026, 3, 4), date(2026, 3, 5)]
+            for d in dates:
+                conn.execute(
+                    """
+                    INSERT INTO operational_calendars
+                        (location_id, calendar_date, is_working_day, capacity_factor)
+                    VALUES (%s, %s, TRUE, 1.0)
+                    ON CONFLICT (location_id, calendar_date) DO UPDATE
+                        SET is_working_day = TRUE
+                    """,
+                    (loc_id, d),
+                )
+            conn.commit()
+
+            try:
+                count = _count_working_days(conn, loc_id, date(2026, 3, 2), date(2026, 3, 8))
+                assert count == 4
+            finally:
+                for d in dates:
+                    conn.execute(
+                        "DELETE FROM operational_calendars WHERE location_id = %s AND calendar_date = %s",
+                        (loc_id, d),
+                    )
+                conn.commit()
+
+    def test_with_location_calendar_zero_falls_back(self, seeded_db):
+        """Calendar count == 0 → Mon–Fri fallback (5 over Mon–Sun)."""
+        import psycopg
+        from psycopg.rows import dict_row
+        from ootils_core.api.routers.rccp import _count_working_days
+
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            loc_row = conn.execute(
+                "SELECT location_id FROM locations WHERE external_id = 'DC-ATL'"
+            ).fetchone()
+            loc_id = str(loc_row["location_id"])
+            # No calendar rows in this date window (pick a date range that's
+            # not covered by the seed's holiday list)
+            result = _count_working_days(
+                conn, loc_id, date(2026, 6, 1), date(2026, 6, 7)
+            )
+            # 2026-06-01 is a Monday → Mon..Fri = 5
+            assert result == 5

--- a/tests/test_router_bom.py
+++ b/tests/test_router_bom.py
@@ -1,20 +1,27 @@
 """
-test_router_bom.py — unit tests for src/ootils_core/api/routers/bom.py.
+Slim tests for the BOM FastAPI router (src/ootils_core/api/routers/bom.py).
 
-Target: 100% coverage.
+Keeps ONLY the tests that legitimately do not need a database:
+  - Pydantic-validation 422 boundary tests (quantity_per > 0, levels range,
+    missing required fields). These fire before any DB call.
+  - 401 auth tests (the auth dependency rejects missing tokens before any
+    DB use).
+  - Router-introspection tests (prefix, tags, registered in app).
 
-All DB calls are mocked via FastAPI dependency_overrides.
-The mock builds `execute(...)` responses as dicts matching the real dict_row
-output: {column: value}.
+Every test that used to mock `_resolve_item_id` / `_get_active_bom` /
+`_get_bom_lines` / `_detect_cycle` / `_recalculate_llc` / `_get_on_hand_qty`
+was ported to tests/integration/test_router_bom_integration.py against a
+real PostgreSQL database, per the "no mocks" rule (CLAUDE.md).
+
+The TestClient here overrides ``get_db`` with a sentinel that raises if
+touched — proving validation / auth fires *before* any DB access happens.
 """
 from __future__ import annotations
 
 import os
-from datetime import date
-from typing import Any
-from unittest.mock import MagicMock
-from uuid import uuid4
 
+import pytest
+from fastapi import status
 from fastapi.testclient import TestClient
 
 # Must set token BEFORE importing the app
@@ -25,658 +32,198 @@ from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db
 
 
-# ─────────────────────────────────────────────────────────────
-# Helpers
-# ─────────────────────────────────────────────────────────────
-
 AUTH_HEADERS = {"Authorization": "Bearer test-token"}
 
 
-def _make_execute_mock(responses: list[Any]) -> MagicMock:
-    """
-    Build a MagicMock for conn.execute() where each call pops the next response.
-    Each response is either:
-      - a MagicMock (returned directly),
-      - a list of dict (treated as fetchall result),
-      - a dict (treated as a single fetchone result),
-      - None (treated as fetchone → None).
-    """
-    responses = list(responses)
-
-    def execute_side_effect(*args, **kwargs):
-        if not responses:
-            # Default: empty result object
-            result = MagicMock()
-            result.fetchone.return_value = None
-            result.fetchall.return_value = []
-            result.rowcount = 0
-            return result
-        item = responses.pop(0)
-        if isinstance(item, MagicMock):
-            return item
-        result = MagicMock()
-        if isinstance(item, list):
-            result.fetchall.return_value = item
-            result.fetchone.return_value = item[0] if item else None
-        elif isinstance(item, dict):
-            result.fetchone.return_value = item
-            result.fetchall.return_value = [item]
-        elif item is None:
-            result.fetchone.return_value = None
-            result.fetchall.return_value = []
-        else:
-            raise TypeError(f"Unexpected response type: {type(item)}")
-        result.rowcount = 1
-        return result
-
-    execute = MagicMock(side_effect=execute_side_effect)
-    return execute
+class _DBAccessForbidden(AssertionError):
+    """Raised if a test that should fail validation tries to use the DB."""
 
 
-def _mock_db(responses: list[Any] | None = None) -> MagicMock:
-    """Return a mock psycopg3 connection with scripted execute() responses."""
-    conn = MagicMock()
-    if responses is None:
-        responses = []
-    conn.execute = _make_execute_mock(responses)
-    # cursor() is a context manager used by _recalculate_llc batch updates
-    cursor_ctx = MagicMock()
-    cursor_ctx.__enter__ = MagicMock(return_value=cursor_ctx)
-    cursor_ctx.__exit__ = MagicMock(return_value=False)
-    cursor_ctx.executemany = MagicMock()
-    conn.cursor = MagicMock(return_value=cursor_ctx)
-    return conn
+class _ForbiddenDB:
+    """Sentinel: any attribute access raises. Proves 422 / 401 fires before DB use."""
+
+    def __getattr__(self, name):
+        raise _DBAccessForbidden(
+            f"Validation test reached DB (accessed {name!r}) — 422/401 should have fired first"
+        )
 
 
-def _make_client(mock_conn: MagicMock) -> TestClient:
+def _make_client_no_db() -> TestClient:
+    """TestClient where any DB use crashes the test."""
     app = create_app()
 
     def override_db():
-        yield mock_conn
+        yield _ForbiddenDB()
 
     app.dependency_overrides[get_db] = override_db
     app.dependency_overrides[require_auth] = lambda: "test-token"
     return TestClient(app)
 
 
-# ─────────────────────────────────────────────────────────────
-# Auth tests (no override_auth)
-# ─────────────────────────────────────────────────────────────
-
-
-def test_ingest_bom_requires_auth():
-    """POST /v1/ingest/bom rejects missing auth."""
+def _make_client_no_auth_override() -> TestClient:
+    """TestClient with DB forbidden AND auth NOT overridden (used for 401 tests)."""
     app = create_app()
-    conn = _mock_db([])
-    app.dependency_overrides[get_db] = lambda: conn
-    with TestClient(app) as c:
-        resp = c.post(
+
+    def override_db():
+        yield _ForbiddenDB()
+
+    app.dependency_overrides[get_db] = override_db
+    return TestClient(app)
+
+
+# ─────────────────────────────────────────────────────────────
+# Auth (401) — no token → rejected before DB access
+# ─────────────────────────────────────────────────────────────
+
+
+class TestBOMRouterAuth:
+    """401 tests for each BOM endpoint (require_auth fires before get_db)."""
+
+    def test_ingest_bom_requires_auth(self):
+        client = _make_client_no_auth_override()
+        resp = client.post(
             "/v1/ingest/bom",
             json={"parent_external_id": "P1", "components": []},
         )
-    assert resp.status_code == 401
+        assert resp.status_code == 401
 
+    def test_get_bom_requires_auth(self):
+        client = _make_client_no_auth_override()
+        resp = client.get("/v1/bom/P1")
+        assert resp.status_code == 401
 
-def test_get_bom_requires_auth():
-    app = create_app()
-    conn = _mock_db([])
-    app.dependency_overrides[get_db] = lambda: conn
-    with TestClient(app) as c:
-        resp = c.get("/v1/bom/P1")
-    assert resp.status_code == 401
-
-
-def test_explode_bom_requires_auth():
-    app = create_app()
-    conn = _mock_db([])
-    app.dependency_overrides[get_db] = lambda: conn
-    with TestClient(app) as c:
-        resp = c.post(
+    def test_explode_bom_requires_auth(self):
+        client = _make_client_no_auth_override()
+        resp = client.post(
             "/v1/bom/explode",
             json={"item_external_id": "P1", "quantity": 10},
         )
-    assert resp.status_code == 401
+        assert resp.status_code == 401
 
 
 # ─────────────────────────────────────────────────────────────
-# POST /v1/ingest/bom
+# Pydantic validation (422) — fires before any DB access
 # ─────────────────────────────────────────────────────────────
 
 
-def test_ingest_bom_parent_not_found():
-    """422 when parent external_id does not resolve."""
-    conn = _mock_db([
-        None,  # _resolve_item_id(parent) → None
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/bom",
-        json={
-            "parent_external_id": "MISSING",
-            "components": [
-                {"component_external_id": "C1", "quantity_per": 1.0},
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-    detail = resp.json()["detail"]
-    assert any("MISSING" in str(d) for d in detail)
+class TestBOMIngestValidation:
+    """422 boundary tests for POST /v1/ingest/bom."""
+
+    def test_ingest_bom_validation_empty_body(self):
+        client = _make_client_no_db()
+        resp = client.post("/v1/ingest/bom", json={}, headers=AUTH_HEADERS)
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_ingest_bom_validation_negative_quantity(self):
+        """quantity_per <= 0 → Field(..., gt=0) blocks before DB."""
+        client = _make_client_no_db()
+        resp = client.post(
+            "/v1/ingest/bom",
+            json={
+                "parent_external_id": "P1",
+                "components": [
+                    {"component_external_id": "C1", "quantity_per": -1.0},
+                ],
+            },
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_ingest_bom_validation_zero_quantity(self):
+        client = _make_client_no_db()
+        resp = client.post(
+            "/v1/ingest/bom",
+            json={
+                "parent_external_id": "P1",
+                "components": [
+                    {"component_external_id": "C1", "quantity_per": 0.0},
+                ],
+            },
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_ingest_bom_validation_scrap_factor_out_of_range(self):
+        """scrap_factor must be in [0.0, 1.0)."""
+        client = _make_client_no_db()
+        resp = client.post(
+            "/v1/ingest/bom",
+            json={
+                "parent_external_id": "P1",
+                "components": [
+                    {"component_external_id": "C1", "quantity_per": 1.0, "scrap_factor": 1.5},
+                ],
+            },
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
-def test_ingest_bom_component_not_found():
-    """422 when a component cannot be resolved."""
-    parent_id = uuid4()
-    conn = _mock_db([
-        {"item_id": parent_id},     # parent found
-        None,                       # component 1 missing
-        {"item_id": uuid4()},       # component 2 OK
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/bom",
-        json={
-            "parent_external_id": "P1",
-            "components": [
-                {"component_external_id": "C1", "quantity_per": 1.0},
-                {"component_external_id": "C2", "quantity_per": 2.0},
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-    assert any("C1" in str(d) for d in resp.json()["detail"])
+class TestBOMExplodeValidation:
+    """422 boundary tests for POST /v1/bom/explode."""
 
+    def test_explode_bom_validation_zero_quantity(self):
+        client = _make_client_no_db()
+        resp = client.post(
+            "/v1/bom/explode",
+            json={"item_external_id": "P1", "quantity": 0},
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
-def test_ingest_bom_cycle_detected():
-    """422 when BOM cycle is detected."""
-    parent_id = uuid4()
-    comp_id = uuid4()
-    # Edges: comp → parent (pre-existing). Now adding parent → comp creates cycle.
-    conn = _mock_db([
-        {"item_id": parent_id},   # _resolve_item_id parent
-        {"item_id": comp_id},     # _resolve_item_id component
-        # _detect_cycle edges: the component already points back to parent
-        [{"parent_item_id": comp_id, "component_item_id": parent_id}],
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/bom",
-        json={
-            "parent_external_id": "P1",
-            "components": [
-                {"component_external_id": "C1", "quantity_per": 1.0},
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-    assert any("cycle" in str(d).lower() for d in resp.json()["detail"])
+    def test_explode_bom_validation_negative_quantity(self):
+        client = _make_client_no_db()
+        resp = client.post(
+            "/v1/bom/explode",
+            json={"item_external_id": "P1", "quantity": -5},
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
+    def test_explode_bom_validation_levels_zero(self):
+        """levels must be >= 1."""
+        client = _make_client_no_db()
+        resp = client.post(
+            "/v1/bom/explode",
+            json={"item_external_id": "P1", "quantity": 1, "levels": 0},
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
-def test_ingest_bom_dry_run():
-    """dry_run=True returns without DB upsert."""
-    parent_id = uuid4()
-    comp_id = uuid4()
-    conn = _mock_db([
-        {"item_id": parent_id},          # resolve parent
-        {"item_id": comp_id},            # resolve component
-        [],                              # _detect_cycle edges (empty)
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/bom",
-        json={
-            "parent_external_id": "P1",
-            "components": [
-                {"component_external_id": "C1", "quantity_per": 1.0},
-            ],
-            "dry_run": True,
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["status"] == "dry_run"
-    assert body["components_imported"] == 1
-    assert body["llc_updated"] == 0
-
-
-def test_ingest_bom_new_header_success():
-    """Happy path: new BOM header + lines + LLC recalculation."""
-    parent_id = uuid4()
-    comp_id = uuid4()
-    line_id = uuid4()
-    conn = _mock_db([
-        {"item_id": parent_id},                      # resolve parent
-        {"item_id": comp_id},                        # resolve component
-        [],                                          # _detect_cycle edges
-        None,                                        # existing_header lookup → None (new)
-        MagicMock(),                                 # INSERT bom_headers
-        MagicMock(),                                 # INSERT bom_lines (one line)
-        MagicMock(),                                 # soft-delete removed lines
-        [                                            # _recalculate_llc edges
-            {
-                "parent_item_id": parent_id,
-                "component_item_id": comp_id,
-                "line_id": line_id,
-            }
-        ],
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/bom",
-        json={
-            "parent_external_id": "P1",
-            "bom_version": "1.0",
-            "effective_from": "2026-01-01",
-            "components": [
-                {
-                    "component_external_id": "C1",
-                    "quantity_per": 2.0,
-                    "uom": "EA",
-                    "scrap_factor": 0.05,
-                },
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["status"] == "ok"
-    assert body["components_imported"] == 1
-    assert body["llc_updated"] == 1
-    assert body["parent_item_id"] == str(parent_id)
-
-
-def test_ingest_bom_existing_header_update():
-    """Covers the UPDATE bom_headers branch for an existing version."""
-    parent_id = uuid4()
-    comp_id = uuid4()
-    existing_bom_id = uuid4()
-    line_id = uuid4()
-    conn = _mock_db([
-        {"item_id": parent_id},                                 # resolve parent
-        {"item_id": comp_id},                                   # resolve component
-        [],                                                     # _detect_cycle edges
-        {"bom_id": existing_bom_id},                            # existing header found
-        MagicMock(),                                            # UPDATE bom_headers
-        MagicMock(),                                            # INSERT bom_lines
-        MagicMock(),                                            # soft-delete
-        [                                                       # _recalculate_llc edges
-            {
-                "parent_item_id": parent_id,
-                "component_item_id": comp_id,
-                "line_id": line_id,
-            }
-        ],
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/bom",
-        json={
-            "parent_external_id": "P1",
-            "components": [
-                {"component_external_id": "C1", "quantity_per": 1.0},
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200
-    assert resp.json()["bom_id"] == str(existing_bom_id)
-
-
-def test_ingest_bom_empty_components_deactivates_all():
-    """component_ids=[] → branch that deactivates all lines of the existing BOM."""
-    parent_id = uuid4()
-    conn = _mock_db([
-        {"item_id": parent_id},              # resolve parent
-        [],                                  # _detect_cycle edges (no components to iterate)
-        None,                                # existing_header lookup → None
-        MagicMock(),                         # INSERT bom_headers
-        MagicMock(),                         # deactivate all lines branch (empty components)
-        [],                                  # _recalculate_llc edges (empty)
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/bom",
-        json={
-            "parent_external_id": "P1",
-            "components": [],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["status"] == "ok"
-    assert body["components_imported"] == 0
-    assert body["llc_updated"] == 0
-
-
-def test_ingest_bom_validation_error_422_missing_fields():
-    """422 from pydantic — empty body."""
-    conn = _mock_db([])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/bom",
-        json={},
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-
-
-def test_ingest_bom_validation_error_negative_quantity():
-    """422 when quantity_per <= 0 (Field(..., gt=0))."""
-    conn = _mock_db([])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/bom",
-        json={
-            "parent_external_id": "P1",
-            "components": [
-                {"component_external_id": "C1", "quantity_per": -1.0},
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
+    def test_explode_bom_validation_levels_too_high(self):
+        """levels must be <= 20."""
+        client = _make_client_no_db()
+        resp = client.post(
+            "/v1/bom/explode",
+            json={"item_external_id": "P1", "quantity": 1, "levels": 100},
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 # ─────────────────────────────────────────────────────────────
-# GET /v1/bom/{parent_external_id}
+# Router introspection
 # ─────────────────────────────────────────────────────────────
 
 
-def test_get_bom_item_not_found():
-    conn = _mock_db([None])  # resolve_item_id → None
-    client = _make_client(conn)
-    resp = client.get("/v1/bom/MISSING", headers=AUTH_HEADERS)
-    assert resp.status_code == 404
-    assert "MISSING" in resp.json()["detail"]
+class TestBOMRouterConfiguration:
+    def test_router_prefix(self):
+        from ootils_core.api.routers import bom
+        assert bom.router.prefix == "/v1"
+
+    def test_router_tags(self):
+        from ootils_core.api.routers import bom
+        assert "bom" in bom.router.tags
+
+    def test_router_registered_in_app(self):
+        app = create_app()
+        bom_routes = [r for r in app.routes if hasattr(r, "path") and "/bom" in r.path]
+        ingest_routes = [
+            r for r in app.routes if hasattr(r, "path") and r.path == "/v1/ingest/bom"
+        ]
+        assert len(bom_routes) > 0
+        assert len(ingest_routes) == 1
 
 
-def test_get_bom_no_active_header():
-    parent_id = uuid4()
-    conn = _mock_db([
-        {"item_id": parent_id},   # resolve parent
-        None,                     # _get_active_bom → None
-    ])
-    client = _make_client(conn)
-    resp = client.get("/v1/bom/P1", headers=AUTH_HEADERS)
-    assert resp.status_code == 404
-
-
-def test_get_bom_success():
-    parent_id = uuid4()
-    bom_id = uuid4()
-    comp_id = uuid4()
-    conn = _mock_db([
-        {"item_id": parent_id},
-        {                                              # _get_active_bom header
-            "bom_id": bom_id,
-            "bom_version": "1.0",
-            "effective_from": date(2026, 1, 1),
-        },
-        [                                              # _get_bom_lines
-            {
-                "line_id": uuid4(),
-                "component_item_id": comp_id,
-                "quantity_per": 2.5,
-                "uom": "EA",
-                "scrap_factor": 0.05,
-                "llc": 1,
-                "component_external_id": "C1",
-            }
-        ],
-    ])
-    client = _make_client(conn)
-    resp = client.get("/v1/bom/P1", headers=AUTH_HEADERS)
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["parent_external_id"] == "P1"
-    assert body["bom_version"] == "1.0"
-    assert body["effective_from"] == "2026-01-01"
-    assert len(body["components"]) == 1
-    c = body["components"][0]
-    assert c["component_external_id"] == "C1"
-    assert c["quantity_per"] == 2.5
-    assert c["uom"] == "EA"
-    assert c["scrap_factor"] == 0.05
-    assert c["llc"] == 1
-
-
-# ─────────────────────────────────────────────────────────────
-# POST /v1/bom/explode
-# ─────────────────────────────────────────────────────────────
-
-
-def test_explode_bom_item_not_found():
-    conn = _mock_db([None])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/bom/explode",
-        json={"item_external_id": "MISSING", "quantity": 10},
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 404
-
-
-def test_explode_bom_location_not_found():
-    parent_id = uuid4()
-    conn = _mock_db([
-        {"item_id": parent_id},   # resolve parent
-        None,                      # location lookup → None
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/bom/explode",
-        json={
-            "item_external_id": "P1",
-            "quantity": 5,
-            "location_external_id": "NOWHERE",
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-
-
-def test_explode_bom_leaf_item_no_bom():
-    """Parent has no active BOM → explosion returns empty."""
-    parent_id = uuid4()
-    conn = _mock_db([
-        {"item_id": parent_id},   # resolve parent
-        None,                      # _get_active_bom → None (leaf)
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/bom/explode",
-        json={"item_external_id": "P1", "quantity": 10},
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["total_components"] == 0
-    assert body["components_with_shortage"] == 0
-    assert body["explosion"] == []
-
-
-def test_explode_bom_with_location_and_shortage():
-    """
-    Happy path: single level explosion with location, one component has shortage,
-    sub-component has no BOM. Covers net_req > 0 recurse and leaf termination.
-    """
-    parent_id = uuid4()
-    loc_id = uuid4()
-    comp_id = uuid4()
-    bom_id = uuid4()
-
-    conn = _mock_db([
-        {"item_id": parent_id},              # resolve parent
-        {"location_id": loc_id},             # resolve location
-        {                                    # _get_active_bom (level 1)
-            "bom_id": bom_id,
-            "bom_version": "1.0",
-            "effective_from": date(2026, 1, 1),
-        },
-        [                                    # _get_bom_lines (level 1)
-            {
-                "line_id": uuid4(),
-                "component_item_id": comp_id,
-                "quantity_per": 2.0,
-                "uom": "EA",
-                "scrap_factor": 0.0,
-                "llc": 0,
-                "component_external_id": "C1",
-            }
-        ],
-        {"qty": 5},                          # on-hand (location path) — shortage 20-5 = 15
-        None,                                # sub-component has no BOM → leaf
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/bom/explode",
-        json={
-            "item_external_id": "P1",
-            "quantity": 10,
-            "location_external_id": "WH1",
-            "explosion_date": "2026-01-01",
-            "levels": 5,
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["total_components"] == 1
-    assert body["components_with_shortage"] == 1
-    line = body["explosion"][0]
-    assert line["level"] == 1
-    assert line["gross_requirement"] == 20.0
-    assert line["on_hand_qty"] == 5.0
-    assert line["net_requirement"] == 15.0
-    assert line["has_shortage"] is True
-
-
-def test_explode_bom_no_shortage_recurses_with_gross():
-    """net_req == 0 → recurse with gross_req branch is exercised."""
-    parent_id = uuid4()
-    comp_id = uuid4()
-    bom_id = uuid4()
-    conn = _mock_db([
-        {"item_id": parent_id},              # resolve parent (no location)
-        {                                    # _get_active_bom (level 1)
-            "bom_id": bom_id,
-            "bom_version": "1.0",
-            "effective_from": date(2026, 1, 1),
-        },
-        [                                    # _get_bom_lines (level 1)
-            {
-                "line_id": uuid4(),
-                "component_item_id": comp_id,
-                "quantity_per": 1.0,
-                "uom": "EA",
-                "scrap_factor": 0.0,
-                "llc": 0,
-                "component_external_id": "C1",
-            }
-        ],
-        {"qty": 1000},                       # on-hand no-location path (massive stock)
-        None,                                # sub-component has no BOM
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/bom/explode",
-        json={"item_external_id": "P1", "quantity": 10},
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["components_with_shortage"] == 0
-    assert body["explosion"][0]["has_shortage"] is False
-
-
-def test_explode_bom_levels_cap():
-    """Cover level > levels early return."""
-    parent_id = uuid4()
-    conn = _mock_db([
-        {"item_id": parent_id},
-        None,  # leaf → no BOM
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/bom/explode",
-        json={"item_external_id": "P1", "quantity": 1, "levels": 1},
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200
-
-
-def test_explode_bom_validation_422_zero_quantity():
-    conn = _mock_db([])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/bom/explode",
-        json={"item_external_id": "P1", "quantity": 0},
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-
-
-def test_explode_bom_validation_422_levels_out_of_range():
-    conn = _mock_db([])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/bom/explode",
-        json={"item_external_id": "P1", "quantity": 1, "levels": 0},
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-
-
-# ─────────────────────────────────────────────────────────────
-# Helper coverage — _detect_cycle, _recalculate_llc via ingest
-# ─────────────────────────────────────────────────────────────
-
-
-def test_detect_cycle_deep_graph_no_cycle():
-    """
-    Build a non-cyclic graph for cycle detection, exercising the full DFS.
-
-    parent=P → components=[C1]
-    existing edges: C1 → X, X → Y (no loop to P).
-    """
-    parent_id = uuid4()
-    c1 = uuid4()
-    x = uuid4()
-    y = uuid4()
-    line_id = uuid4()
-
-    conn = _mock_db([
-        {"item_id": parent_id},      # resolve parent
-        {"item_id": c1},             # resolve C1
-        [                            # _detect_cycle: full edge graph
-            {"parent_item_id": c1, "component_item_id": x},
-            {"parent_item_id": x, "component_item_id": y},
-        ],
-        None,                        # existing_header → None
-        MagicMock(),                 # INSERT bom_headers
-        MagicMock(),                 # INSERT bom_lines
-        MagicMock(),                 # soft-delete
-        [                            # _recalculate_llc edges: the full graph now
-            {"parent_item_id": parent_id, "component_item_id": c1, "line_id": line_id},
-            {"parent_item_id": c1, "component_item_id": x, "line_id": uuid4()},
-            {"parent_item_id": x, "component_item_id": y, "line_id": uuid4()},
-        ],
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/bom",
-        json={
-            "parent_external_id": "P",
-            "components": [
-                {"component_external_id": "C1", "quantity_per": 1.0},
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200, resp.text
-    assert resp.json()["llc_updated"] == 3
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_router_ghosts.py
+++ b/tests/test_router_ghosts.py
@@ -1,20 +1,28 @@
 """
-test_router_ghosts.py — unit tests for src/ootils_core/api/routers/ghosts.py.
+Slim tests for the Ghosts FastAPI router (src/ootils_core/api/routers/ghosts.py).
 
-Target: 100% coverage.
+Keeps ONLY the tests that legitimately do not need a database:
+  - Pydantic-validation 422 boundary tests (ghost_type, status, role,
+    transition_curve allowed values + non-empty name + weight ranges).
+  - Membership-constraint 422 tests for _validate_membership — these run
+    on parsed Pydantic input, *before* any DB call.
+  - 401 auth tests.
+  - Router-introspection tests.
 
-All DB calls are mocked via FastAPI dependency_overrides.
-The mock builds `execute(...)` responses as dicts matching the real dict_row
-output: {column: value}.
+Every test that used to mock DB execute() / patch run_ghost was ported to
+tests/integration/test_router_ghosts_integration.py against a real
+PostgreSQL database, per the "no mocks" rule (CLAUDE.md).
+
+The TestClient here overrides ``get_db`` with a sentinel that raises if
+touched — proving validation / auth fires *before* any DB access happens.
 """
 from __future__ import annotations
 
 import os
-from datetime import date, datetime
-from typing import Any
-from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+import pytest
+from fastapi import status
 from fastapi.testclient import TestClient
 
 # Must set token BEFORE importing the app
@@ -25,879 +33,259 @@ from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db
 
 
-# ─────────────────────────────────────────────────────────────
-# Helpers
-# ─────────────────────────────────────────────────────────────
-
 AUTH_HEADERS = {"Authorization": "Bearer test-token"}
 
 
-def _make_execute_mock(responses: list[Any]) -> MagicMock:
-    """
-    Build a MagicMock for conn.execute() where each call pops the next response.
-    Each response is either:
-      - a MagicMock (returned directly),
-      - a list of dict (treated as fetchall result),
-      - a dict (treated as a single fetchone result),
-      - None (treated as fetchone → None / fetchall → []),
-      - "noop" (a generic empty result for write statements).
-    """
-    responses = list(responses)
-
-    def execute_side_effect(*args, **kwargs):
-        if not responses:
-            result = MagicMock()
-            result.fetchone.return_value = None
-            result.fetchall.return_value = []
-            result.rowcount = 0
-            return result
-        item = responses.pop(0)
-        if isinstance(item, MagicMock):
-            return item
-        result = MagicMock()
-        if isinstance(item, list):
-            result.fetchall.return_value = item
-            result.fetchone.return_value = item[0] if item else None
-        elif isinstance(item, dict):
-            result.fetchone.return_value = item
-            result.fetchall.return_value = [item]
-        elif item is None or item == "noop":
-            result.fetchone.return_value = None
-            result.fetchall.return_value = []
-        else:
-            raise TypeError(f"Unexpected response type: {type(item)}")
-        result.rowcount = 1
-        return result
-
-    return MagicMock(side_effect=execute_side_effect)
+class _DBAccessForbidden(AssertionError):
+    """Raised if a test that should fail validation tries to use the DB."""
 
 
-def _mock_db(responses: list[Any] | None = None) -> MagicMock:
-    """Return a mock psycopg3 connection with scripted execute() responses."""
-    conn = MagicMock()
-    if responses is None:
-        responses = []
-    conn.execute = _make_execute_mock(responses)
-    cursor_ctx = MagicMock()
-    cursor_ctx.__enter__ = MagicMock(return_value=cursor_ctx)
-    cursor_ctx.__exit__ = MagicMock(return_value=False)
-    cursor_ctx.executemany = MagicMock()
-    conn.cursor = MagicMock(return_value=cursor_ctx)
-    return conn
+class _ForbiddenDB:
+    """Sentinel: any attribute access raises. Proves 422 / 401 fires before DB use."""
+
+    def __getattr__(self, name):
+        raise _DBAccessForbidden(
+            f"Validation test reached DB (accessed {name!r}) — 422/401 should have fired first"
+        )
 
 
-def _make_client(mock_conn: MagicMock) -> TestClient:
+def _make_client_no_db() -> TestClient:
+    """TestClient where any DB use crashes the test."""
     app = create_app()
 
     def override_db():
-        yield mock_conn
+        yield _ForbiddenDB()
 
     app.dependency_overrides[get_db] = override_db
     app.dependency_overrides[require_auth] = lambda: "test-token"
     return TestClient(app)
 
 
-# ─────────────────────────────────────────────────────────────
-# Auth tests
-# ─────────────────────────────────────────────────────────────
-
-
-def test_ingest_ghost_requires_auth():
-    """POST /v1/ingest/ghosts rejects missing auth."""
+def _make_client_no_auth_override() -> TestClient:
+    """TestClient with DB forbidden AND auth NOT overridden (401 tests)."""
     app = create_app()
-    conn = _mock_db([])
-    app.dependency_overrides[get_db] = lambda: conn
-    with TestClient(app) as c:
-        resp = c.post(
+
+    def override_db():
+        yield _ForbiddenDB()
+
+    app.dependency_overrides[get_db] = override_db
+    return TestClient(app)
+
+
+# ─────────────────────────────────────────────────────────────
+# Auth (401)
+# ─────────────────────────────────────────────────────────────
+
+
+class TestGhostsRouterAuth:
+    def test_ingest_ghost_requires_auth(self):
+        client = _make_client_no_auth_override()
+        resp = client.post(
+            "/v1/ingest/ghosts",
+            json={"name": "g1", "ghost_type": "phase_transition", "members": []},
+        )
+        assert resp.status_code == 401
+
+    def test_list_ghosts_requires_auth(self):
+        client = _make_client_no_auth_override()
+        resp = client.get("/v1/ghosts")
+        assert resp.status_code == 401
+
+    def test_get_ghost_requires_auth(self):
+        client = _make_client_no_auth_override()
+        resp = client.get(f"/v1/ghosts/{uuid4()}")
+        assert resp.status_code == 401
+
+    def test_run_ghost_requires_auth(self):
+        client = _make_client_no_auth_override()
+        resp = client.post(
+            f"/v1/ghosts/{uuid4()}/run",
+            json={
+                "scenario_id": str(uuid4()),
+                "from_date": "2026-01-01",
+                "to_date": "2026-01-31",
+            },
+        )
+        assert resp.status_code == 401
+
+
+# ─────────────────────────────────────────────────────────────
+# Pydantic field validation (422) — fires before DB access
+# ─────────────────────────────────────────────────────────────
+
+
+class TestGhostIngestPydanticValidation:
+    def test_empty_name_rejected(self):
+        client = _make_client_no_db()
+        resp = client.post(
+            "/v1/ingest/ghosts",
+            json={"name": "   ", "ghost_type": "phase_transition", "members": []},
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_invalid_ghost_type(self):
+        client = _make_client_no_db()
+        resp = client.post(
+            "/v1/ingest/ghosts",
+            json={"name": "g1", "ghost_type": "bogus", "members": []},
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_invalid_status(self):
+        client = _make_client_no_db()
+        resp = client.post(
             "/v1/ingest/ghosts",
             json={
                 "name": "g1",
                 "ghost_type": "phase_transition",
+                "status": "bogus",
                 "members": [],
             },
+            headers=AUTH_HEADERS,
         )
-    assert resp.status_code == 401
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
-
-def test_list_ghosts_requires_auth():
-    app = create_app()
-    conn = _mock_db([])
-    app.dependency_overrides[get_db] = lambda: conn
-    with TestClient(app) as c:
-        resp = c.get("/v1/ghosts")
-    assert resp.status_code == 401
-
-
-def test_get_ghost_requires_auth():
-    app = create_app()
-    conn = _mock_db([])
-    app.dependency_overrides[get_db] = lambda: conn
-    with TestClient(app) as c:
-        resp = c.get(f"/v1/ghosts/{uuid4()}")
-    assert resp.status_code == 401
-
-
-def test_run_ghost_requires_auth():
-    app = create_app()
-    conn = _mock_db([])
-    app.dependency_overrides[get_db] = lambda: conn
-    with TestClient(app) as c:
-        resp = c.post(
-            f"/v1/ghosts/{uuid4()}/run",
-            json={
-                "scenario_id": str(uuid4()),
-                "from_date": "2025-01-01",
-                "to_date": "2025-01-31",
-            },
-        )
-    assert resp.status_code == 401
-
-
-# ─────────────────────────────────────────────────────────────
-# Pydantic validation
-# ─────────────────────────────────────────────────────────────
-
-
-def test_ingest_ghost_empty_name_rejected():
-    conn = _mock_db([])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/ghosts",
-        json={"name": "   ", "ghost_type": "phase_transition", "members": []},
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-
-
-def test_ingest_ghost_invalid_ghost_type():
-    conn = _mock_db([])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/ghosts",
-        json={"name": "g1", "ghost_type": "bogus", "members": []},
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-
-
-def test_ingest_ghost_invalid_status():
-    conn = _mock_db([])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/ghosts",
-        json={
-            "name": "g1",
-            "ghost_type": "phase_transition",
-            "status": "bogus",
-            "members": [],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-
-
-def test_ingest_ghost_member_invalid_role():
-    conn = _mock_db([])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/ghosts",
-        json={
-            "name": "g1",
-            "ghost_type": "phase_transition",
-            "members": [
-                {"item_id": str(uuid4()), "role": "bogus"},
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-
-
-def test_ingest_ghost_member_invalid_curve():
-    conn = _mock_db([])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/ghosts",
-        json={
-            "name": "g1",
-            "ghost_type": "phase_transition",
-            "members": [
-                {
-                    "item_id": str(uuid4()),
-                    "role": "incoming",
-                    "transition_curve": "bogus",
-                },
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-
-
-# ─────────────────────────────────────────────────────────────
-# Membership constraint validation
-# ─────────────────────────────────────────────────────────────
-
-
-def test_ingest_ghost_phase_transition_missing_outgoing():
-    item_a = uuid4()
-    conn = _mock_db([])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/ghosts",
-        json={
-            "name": "g1",
-            "ghost_type": "phase_transition",
-            "members": [
-                {"item_id": str(item_a), "role": "incoming"},
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-    detail = resp.json()["detail"]
-    assert any("outgoing" in str(d) for d in detail)
-
-
-def test_ingest_ghost_phase_transition_extra_member_role():
-    """phase_transition cannot have role='member'."""
-    a, b, c = uuid4(), uuid4(), uuid4()
-    conn = _mock_db([])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/ghosts",
-        json={
-            "name": "g1",
-            "ghost_type": "phase_transition",
-            "members": [
-                {"item_id": str(a), "role": "outgoing"},
-                {"item_id": str(b), "role": "incoming"},
-                {"item_id": str(c), "role": "member"},
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-    detail = resp.json()["detail"]
-    assert any("member" in str(d) for d in detail)
-
-
-def test_ingest_ghost_capacity_aggregate_no_members():
-    """capacity_aggregate requires at least 1 member with role='member'."""
-    a = uuid4()
-    conn = _mock_db([])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/ghosts",
-        json={
-            "name": "g1",
-            "ghost_type": "capacity_aggregate",
-            "members": [
-                {"item_id": str(a), "role": "incoming"},
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-    detail = resp.json()["detail"]
-    # both errors should be present (no members + bad role)
-    assert any("at least 1 member" in str(d) for d in detail)
-    assert any("incoming" in str(d) for d in detail)
-
-
-# ─────────────────────────────────────────────────────────────
-# Item validation
-# ─────────────────────────────────────────────────────────────
-
-
-def test_ingest_ghost_item_not_found():
-    a = uuid4()
-    conn = _mock_db([
-        [],  # SELECT items where item_id = ANY → empty
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/ghosts",
-        json={
-            "name": "g1",
-            "ghost_type": "capacity_aggregate",
-            "members": [
-                {"item_id": str(a), "role": "member"},
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-    detail = resp.json()["detail"]
-    assert any("not found" in str(d) for d in detail)
-
-
-def test_ingest_ghost_resource_not_found():
-    """resource_id provided but not in DB → 422."""
-    a = uuid4()
-    rid = uuid4()
-    conn = _mock_db([
-        [{"item_id": a}],  # items found
-        None,              # resources lookup → None
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/ghosts",
-        json={
-            "name": "g1",
-            "ghost_type": "capacity_aggregate",
-            "resource_id": str(rid),
-            "members": [
-                {"item_id": str(a), "role": "member"},
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-    assert any("resource_id not found" in str(d) for d in resp.json()["detail"])
-
-
-# ─────────────────────────────────────────────────────────────
-# Successful insert / update flows
-# ─────────────────────────────────────────────────────────────
-
-
-def test_ingest_ghost_insert_no_members():
-    """Insert path: no members, no scenario_id, no resource_id."""
-    conn = _mock_db([
-        # no member-validation queries (members empty)
-        # no resource lookup
-        None,    # existing_ghost lookup → None
-        "noop",  # INSERT nodes
-        "noop",  # INSERT ghost_nodes
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/ghosts",
-        json={
-            "name": "g_new",
-            "ghost_type": "phase_transition",
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 201
-    body = resp.json()
-    assert body["action"] == "inserted"
-    assert body["member_count"] == 0
-    assert body["node_id"] is not None
-
-
-def test_ingest_ghost_insert_with_members_and_item_node_found():
-    """Insert flow: members, scenario_id, items + item_nodes all found."""
-    item_a = uuid4()
-    item_b = uuid4()
-    item_a_node = uuid4()
-    sid = uuid4()
-    conn = _mock_db([
-        # 1) item validation
-        [{"item_id": item_a}, {"item_id": item_b}],
-        # 2) (no resource_id provided)
-        # 3) existing_ghost lookup → None
-        None,
-        # 4) INSERT nodes
-        "noop",
-        # 5) INSERT ghost_nodes
-        "noop",
-        # 6) DELETE ghost_members
-        "noop",
-        # 7) DELETE edges
-        "noop",
-        # member 1: INSERT ghost_members, then SELECT item node, then INSERT edge
-        "noop",
-        {"node_id": item_a_node},
-        "noop",
-        # member 2: INSERT ghost_members, then SELECT item node → None, no edge
-        "noop",
-        None,
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/ghosts",
-        json={
-            "name": "g_new",
-            "ghost_type": "phase_transition",
-            "scenario_id": str(sid),
-            "description": "desc",
-            "members": [
-                {"item_id": str(item_a), "role": "outgoing"},
-                {"item_id": str(item_b), "role": "incoming"},
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 201
-    body = resp.json()
-    assert body["action"] == "inserted"
-    assert body["member_count"] == 2
-    assert body["node_id"] is not None
-
-
-def test_ingest_ghost_update_existing():
-    """Update flow: existing ghost found, members reset."""
-    existing_gid = uuid4()
-    existing_nid = uuid4()
-    item_a = uuid4()
-    item_b = uuid4()
-    item_a_node = uuid4()
-    item_b_node = uuid4()
-    rid = uuid4()
-    conn = _mock_db([
-        # 1) item validation
-        [{"item_id": item_a}, {"item_id": item_b}],
-        # 2) resource lookup
-        {"resource_id": rid},
-        # 3) existing_ghost lookup → found
-        {"ghost_id": existing_gid, "node_id": existing_nid},
-        # 4) UPDATE ghost_nodes
-        "noop",
-        # 5) DELETE ghost_members
-        "noop",
-        # 6) DELETE edges
-        "noop",
-        # member 1: insert + node lookup + edge insert
-        "noop",
-        {"node_id": item_a_node},
-        "noop",
-        # member 2: insert + node lookup + edge insert
-        "noop",
-        {"node_id": item_b_node},
-        "noop",
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/ghosts",
-        json={
-            "name": "g_existing",
-            "ghost_type": "phase_transition",
-            "resource_id": str(rid),
-            "description": "updated",
-            "members": [
-                {"item_id": str(item_a), "role": "outgoing"},
-                {"item_id": str(item_b), "role": "incoming"},
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 201
-    body = resp.json()
-    assert body["action"] == "updated"
-    assert body["ghost_id"] == str(existing_gid)
-    assert body["node_id"] == str(existing_nid)
-    assert body["member_count"] == 2
-
-
-def test_ingest_ghost_capacity_aggregate_happy_path():
-    item_a = uuid4()
-    item_b = uuid4()
-    conn = _mock_db([
-        [{"item_id": item_a}, {"item_id": item_b}],
-        None,    # existing_ghost lookup → None
-        "noop",  # INSERT nodes
-        "noop",  # INSERT ghost_nodes
-        "noop",  # DELETE ghost_members
-        "noop",  # DELETE edges
-        # member 1
-        "noop",
-        None,    # item node not found
-        # member 2
-        "noop",
-        None,
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/ghosts",
-        json={
-            "name": "g_cap",
-            "ghost_type": "capacity_aggregate",
-            "members": [
-                {"item_id": str(item_a), "role": "member"},
-                {"item_id": str(item_b), "role": "member"},
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 201
-    body = resp.json()
-    assert body["action"] == "inserted"
-    assert body["member_count"] == 2
-
-
-# ─────────────────────────────────────────────────────────────
-# GET /v1/ghosts (list)
-# ─────────────────────────────────────────────────────────────
-
-
-def test_list_ghosts_empty():
-    conn = _mock_db([
-        [],  # ghost_rows
-    ])
-    client = _make_client(conn)
-    resp = client.get("/v1/ghosts", headers=AUTH_HEADERS)
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["total"] == 0
-    assert body["ghosts"] == []
-
-
-def test_list_ghosts_with_filters_and_results():
-    gid = uuid4()
-    sid = uuid4()
-    rid = uuid4()
-    nid = uuid4()
-    member_id = uuid4()
-    item_id = uuid4()
-    created = datetime(2025, 1, 1, 12, 0, 0)
-    updated = datetime(2025, 1, 2, 12, 0, 0)
-    conn = _mock_db([
-        # ghost_rows
-        [{
-            "ghost_id": gid,
-            "name": "g1",
-            "ghost_type": "phase_transition",
-            "scenario_id": sid,
-            "resource_id": rid,
-            "node_id": nid,
-            "status": "active",
-            "description": "desc",
-            "created_at": created,
-            "updated_at": updated,
-        }],
-        # members for that ghost
-        [{
-            "member_id": member_id,
-            "item_id": item_id,
-            "role": "incoming",
-            "transition_start_date": date(2025, 1, 1),
-            "transition_end_date": date(2025, 2, 1),
-            "transition_curve": "linear",
-            "weight_at_start": 1.0,
-            "weight_at_end": 0.0,
-        }],
-    ])
-    client = _make_client(conn)
-    resp = client.get(
-        "/v1/ghosts",
-        params={
-            "ghost_type": "phase_transition",
-            "scenario_id": str(sid),
-            "ghost_status": "active",
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["total"] == 1
-    g = body["ghosts"][0]
-    assert g["ghost_id"] == str(gid)
-    assert g["scenario_id"] == str(sid)
-    assert g["resource_id"] == str(rid)
-    assert g["node_id"] == str(nid)
-    assert g["created_at"].startswith("2025-01-01")
-    assert g["updated_at"].startswith("2025-01-02")
-    assert len(g["members"]) == 1
-    m = g["members"][0]
-    assert m["transition_start_date"] == "2025-01-01"
-    assert m["transition_end_date"] == "2025-02-01"
-
-
-def test_list_ghosts_with_null_optionals():
-    """Cover the None branches in serialization for scenario/resource/node/dates."""
-    gid = uuid4()
-    member_id = uuid4()
-    item_id = uuid4()
-    conn = _mock_db([
-        [{
-            "ghost_id": gid,
-            "name": "g_no_opts",
-            "ghost_type": "capacity_aggregate",
-            "scenario_id": None,
-            "resource_id": None,
-            "node_id": None,
-            "status": "active",
-            "description": None,
-            "created_at": None,
-            "updated_at": None,
-        }],
-        [{
-            "member_id": member_id,
-            "item_id": item_id,
-            "role": "member",
-            "transition_start_date": None,
-            "transition_end_date": None,
-            "transition_curve": "linear",
-            "weight_at_start": 0.5,
-            "weight_at_end": 0.5,
-        }],
-    ])
-    client = _make_client(conn)
-    resp = client.get("/v1/ghosts", headers=AUTH_HEADERS)
-    assert resp.status_code == 200
-    g = resp.json()["ghosts"][0]
-    assert g["scenario_id"] is None
-    assert g["resource_id"] is None
-    assert g["node_id"] is None
-    assert g["created_at"] is None
-    assert g["updated_at"] is None
-    assert g["members"][0]["transition_start_date"] is None
-    assert g["members"][0]["transition_end_date"] is None
-
-
-# ─────────────────────────────────────────────────────────────
-# GET /v1/ghosts/{ghost_id} (detail)
-# ─────────────────────────────────────────────────────────────
-
-
-def test_get_ghost_not_found():
-    conn = _mock_db([
-        None,  # ghost lookup → None
-    ])
-    client = _make_client(conn)
-    gid = uuid4()
-    resp = client.get(f"/v1/ghosts/{gid}", headers=AUTH_HEADERS)
-    assert resp.status_code == 404
-    assert "not found" in resp.json()["detail"]
-
-
-def test_get_ghost_with_graph_node_and_edges():
-    gid = uuid4()
-    nid = uuid4()
-    sid = uuid4()
-    rid = uuid4()
-    member_id = uuid4()
-    item_id = uuid4()
-    edge_id = uuid4()
-    to_node_id = uuid4()
-    created = datetime(2025, 1, 1, 12, 0, 0)
-    updated = datetime(2025, 1, 2, 12, 0, 0)
-    conn = _mock_db([
-        # ghost row
-        {
-            "ghost_id": gid,
-            "name": "g1",
-            "ghost_type": "phase_transition",
-            "scenario_id": sid,
-            "resource_id": rid,
-            "node_id": nid,
-            "status": "active",
-            "description": "desc",
-            "created_at": created,
-            "updated_at": updated,
-        },
-        # members
-        [{
-            "member_id": member_id,
-            "item_id": item_id,
-            "role": "incoming",
-            "transition_start_date": date(2025, 1, 1),
-            "transition_end_date": date(2025, 2, 1),
-            "transition_curve": "linear",
-            "weight_at_start": 1.0,
-            "weight_at_end": 0.0,
-        }],
-        # graph node lookup
-        {
-            "node_id": nid,
-            "node_type": "Ghost",
-            "scenario_id": sid,
-            "active": True,
-        },
-        # edges
-        [
-            {
-                "edge_id": edge_id,
-                "to_node_id": to_node_id,
-                "edge_type": "ghost_member",
-                "weight_ratio": 1.0,
-            },
-            {
-                "edge_id": uuid4(),
-                "to_node_id": uuid4(),
-                "edge_type": "ghost_member",
-                "weight_ratio": None,
-            },
-        ],
-    ])
-    client = _make_client(conn)
-    resp = client.get(f"/v1/ghosts/{gid}", headers=AUTH_HEADERS)
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["ghost_id"] == str(gid)
-    assert body["graph_node"] is not None
-    assert body["graph_node"]["node_id"] == str(nid)
-    assert len(body["graph_node"]["edges"]) == 2
-    assert body["graph_node"]["edges"][0]["weight_ratio"] == 1.0
-    assert body["graph_node"]["edges"][1]["weight_ratio"] is None
-
-
-def test_get_ghost_no_node_id():
-    """Ghost with no node_id → graph_node is None."""
-    gid = uuid4()
-    conn = _mock_db([
-        # ghost row
-        {
-            "ghost_id": gid,
-            "name": "g1",
-            "ghost_type": "capacity_aggregate",
-            "scenario_id": None,
-            "resource_id": None,
-            "node_id": None,
-            "status": "active",
-            "description": None,
-            "created_at": None,
-            "updated_at": None,
-        },
-        # members (none)
-        [],
-    ])
-    client = _make_client(conn)
-    resp = client.get(f"/v1/ghosts/{gid}", headers=AUTH_HEADERS)
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["graph_node"] is None
-
-
-def test_get_ghost_node_id_present_but_node_missing():
-    """node_id is set in ghost row, but the nodes table no longer has it."""
-    gid = uuid4()
-    nid = uuid4()
-    conn = _mock_db([
-        # ghost row
-        {
-            "ghost_id": gid,
-            "name": "g1",
-            "ghost_type": "capacity_aggregate",
-            "scenario_id": None,
-            "resource_id": None,
-            "node_id": nid,
-            "status": "active",
-            "description": None,
-            "created_at": None,
-            "updated_at": None,
-        },
-        # members
-        [],
-        # graph node lookup → missing
-        None,
-    ])
-    client = _make_client(conn)
-    resp = client.get(f"/v1/ghosts/{gid}", headers=AUTH_HEADERS)
-    assert resp.status_code == 200
-    assert resp.json()["graph_node"] is None
-
-
-# ─────────────────────────────────────────────────────────────
-# POST /v1/ghosts/{ghost_id}/run
-# ─────────────────────────────────────────────────────────────
-
-
-def test_run_ghost_endpoint_success():
-    conn = _mock_db([])
-    client = _make_client(conn)
-    gid = uuid4()
-    sid = uuid4()
-    fake_result = {
-        "ghost_id": str(gid),
-        "ghost_type": "phase_transition",
-        "alerts": [],
-        "summary": {"phase_count": 0},
-    }
-    with patch(
-        "ootils_core.api.routers.ghosts.run_ghost",
-        return_value=fake_result,
-    ) as run_mock:
+    def test_member_invalid_role(self):
+        client = _make_client_no_db()
         resp = client.post(
-            f"/v1/ghosts/{gid}/run",
+            "/v1/ingest/ghosts",
             json={
-                "scenario_id": str(sid),
-                "from_date": "2025-01-01",
-                "to_date": "2025-01-31",
+                "name": "g1",
+                "ghost_type": "phase_transition",
+                "members": [{"item_id": str(uuid4()), "role": "bogus"}],
             },
             headers=AUTH_HEADERS,
         )
-    assert resp.status_code == 200
-    assert resp.json() == fake_result
-    run_mock.assert_called_once()
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
-
-def test_ingest_ghost_phase_transition_outgoing_ok_incoming_wrong():
-    """Hit the incoming_count != 1 branch separately from outgoing branch."""
-    a, b = uuid4(), uuid4()
-    conn = _mock_db([])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/ghosts",
-        json={
-            "name": "g1",
-            "ghost_type": "phase_transition",
-            "members": [
-                {"item_id": str(a), "role": "outgoing"},
-                {"item_id": str(b), "role": "outgoing"},
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-    detail = resp.json()["detail"]
-    assert any("incoming" in str(d) for d in detail)
-
-
-def test_ingest_ghost_explicit_valid_status_and_curve():
-    """Explicitly pass status='active' and transition_curve='step' to exercise validator
-    'return v' branches in IngestGhostRequest.validate_status / GhostMemberInput.validate_curve.
-    """
-    item_a = uuid4()
-    conn = _mock_db([
-        [{"item_id": item_a}],
-        None,    # existing_ghost lookup → None
-        "noop",  # INSERT nodes
-        "noop",  # INSERT ghost_nodes
-        "noop",  # DELETE ghost_members
-        "noop",  # DELETE edges
-        "noop",  # INSERT ghost_members
-        None,    # SELECT item node → None
-    ])
-    client = _make_client(conn)
-    resp = client.post(
-        "/v1/ingest/ghosts",
-        json={
-            "name": "g_explicit",
-            "ghost_type": "capacity_aggregate",
-            "status": "active",
-            "members": [
-                {
-                    "item_id": str(item_a),
-                    "role": "member",
-                    "transition_curve": "step",
-                },
-            ],
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 201
-
-
-def test_run_ghost_endpoint_value_error_404():
-    conn = _mock_db([])
-    client = _make_client(conn)
-    gid = uuid4()
-    sid = uuid4()
-    with patch(
-        "ootils_core.api.routers.ghosts.run_ghost",
-        side_effect=ValueError("Ghost xxx not found"),
-    ):
+    def test_member_invalid_curve(self):
+        client = _make_client_no_db()
         resp = client.post(
-            f"/v1/ghosts/{gid}/run",
+            "/v1/ingest/ghosts",
             json={
-                "scenario_id": str(sid),
-                "from_date": "2025-01-01",
-                "to_date": "2025-01-31",
+                "name": "g1",
+                "ghost_type": "phase_transition",
+                "members": [
+                    {
+                        "item_id": str(uuid4()),
+                        "role": "incoming",
+                        "transition_curve": "bogus",
+                    }
+                ],
             },
             headers=AUTH_HEADERS,
         )
-    assert resp.status_code == 404
-    assert "not found" in resp.json()["detail"]
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
+# ─────────────────────────────────────────────────────────────
+# Membership-constraint validation (422) — pure Python on parsed input,
+# fires before DB queries (only if body.members is non-empty).
+# ─────────────────────────────────────────────────────────────
+
+
+class TestGhostMembershipConstraints:
+    def test_phase_transition_missing_outgoing(self):
+        item_a = uuid4()
+        client = _make_client_no_db()
+        resp = client.post(
+            "/v1/ingest/ghosts",
+            json={
+                "name": "g1",
+                "ghost_type": "phase_transition",
+                "members": [{"item_id": str(item_a), "role": "incoming"}],
+            },
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert any("outgoing" in str(d) for d in detail)
+
+    def test_phase_transition_extra_member_role(self):
+        a, b, c = uuid4(), uuid4(), uuid4()
+        client = _make_client_no_db()
+        resp = client.post(
+            "/v1/ingest/ghosts",
+            json={
+                "name": "g1",
+                "ghost_type": "phase_transition",
+                "members": [
+                    {"item_id": str(a), "role": "outgoing"},
+                    {"item_id": str(b), "role": "incoming"},
+                    {"item_id": str(c), "role": "member"},
+                ],
+            },
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert any("member" in str(d) for d in detail)
+
+    def test_phase_transition_two_outgoing(self):
+        """Hit the incoming_count != 1 branch separately from outgoing branch."""
+        a, b = uuid4(), uuid4()
+        client = _make_client_no_db()
+        resp = client.post(
+            "/v1/ingest/ghosts",
+            json={
+                "name": "g1",
+                "ghost_type": "phase_transition",
+                "members": [
+                    {"item_id": str(a), "role": "outgoing"},
+                    {"item_id": str(b), "role": "outgoing"},
+                ],
+            },
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert any("incoming" in str(d) for d in detail)
+
+    def test_capacity_aggregate_no_members_with_wrong_role(self):
+        """capacity_aggregate requires >=1 member with role='member'.
+        A single 'incoming' member triggers both 'at least 1 member' and
+        the 'cannot have incoming/outgoing' branches.
+        """
+        a = uuid4()
+        client = _make_client_no_db()
+        resp = client.post(
+            "/v1/ingest/ghosts",
+            json={
+                "name": "g1",
+                "ghost_type": "capacity_aggregate",
+                "members": [{"item_id": str(a), "role": "incoming"}],
+            },
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert any("at least 1 member" in str(d) for d in detail)
+        assert any("incoming" in str(d) for d in detail)
+
+
+# ─────────────────────────────────────────────────────────────
+# Router introspection
+# ─────────────────────────────────────────────────────────────
+
+
+class TestGhostsRouterConfiguration:
+    def test_router_tags(self):
+        from ootils_core.api.routers import ghosts
+        assert "ghosts" in ghosts.router.tags
+
+    def test_router_registered_in_app(self):
+        app = create_app()
+        ghost_routes = [
+            r for r in app.routes if hasattr(r, "path") and "/ghosts" in r.path
+        ]
+        ingest_routes = [
+            r for r in app.routes if hasattr(r, "path") and r.path == "/v1/ingest/ghosts"
+        ]
+        assert len(ghost_routes) > 0
+        assert len(ingest_routes) == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_router_rccp.py
+++ b/tests/test_router_rccp.py
@@ -1,20 +1,28 @@
 """
-test_router_rccp.py — unit tests for src/ootils_core/api/routers/rccp.py.
+Slim tests for the RCCP FastAPI router (src/ootils_core/api/routers/rccp.py).
 
-Target: 100% coverage.
+Keeps:
+  - Pure helper unit tests for `_bucket_start`, `_bucket_end`,
+    `_next_bucket_start`, `_generate_buckets`, `_count_working_days`
+    (no-location heuristic only — the location/calendar variants need a DB
+    and are ported to the integration file).
+  - 401 auth tests.
+  - 422 validation tests for the get_rccp endpoint (invalid grain, to_date
+    before from_date — both fire before any DB call).
+  - Router-introspection tests.
 
-All DB calls are mocked via FastAPI dependency_overrides.
-The mock builds `execute(...)` responses as dicts matching the real dict_row
-output: {column: value}.
+Every test that mocked DB responses for resource lookups, load aggregation,
+capacity overrides or operational_calendars was ported to
+tests/integration/test_router_rccp_integration.py, per the "no mocks"
+rule (CLAUDE.md).
 """
 from __future__ import annotations
 
 import os
 from datetime import date
-from typing import Any
-from unittest.mock import MagicMock
-from uuid import UUID, uuid4
 
+import pytest
+from fastapi import status
 from fastapi.testclient import TestClient
 
 # Must set token BEFORE importing the app
@@ -32,512 +40,195 @@ from ootils_core.api.routers.rccp import (
 )
 
 
-# ─────────────────────────────────────────────────────────────
-# Helpers
-# ─────────────────────────────────────────────────────────────
-
 AUTH_HEADERS = {"Authorization": "Bearer test-token"}
 
 
-def _make_execute_mock(responses: list[Any]) -> MagicMock:
-    """
-    Build a MagicMock for conn.execute() where each call pops the next response.
-    """
-    responses = list(responses)
-
-    def execute_side_effect(*args, **kwargs):
-        if not responses:
-            result = MagicMock()
-            result.fetchone.return_value = None
-            result.fetchall.return_value = []
-            result.rowcount = 0
-            return result
-        item = responses.pop(0)
-        if isinstance(item, MagicMock):
-            return item
-        result = MagicMock()
-        if isinstance(item, list):
-            result.fetchall.return_value = item
-            result.fetchone.return_value = item[0] if item else None
-        elif isinstance(item, dict):
-            result.fetchone.return_value = item
-            result.fetchall.return_value = [item]
-        elif item is None or item == "noop":
-            result.fetchone.return_value = None
-            result.fetchall.return_value = []
-        else:
-            raise TypeError(f"Unexpected response type: {type(item)}")
-        result.rowcount = 1
-        return result
-
-    return MagicMock(side_effect=execute_side_effect)
+class _DBAccessForbidden(AssertionError):
+    """Raised if a test that should fail validation tries to use the DB."""
 
 
-def _mock_db(responses: list[Any] | None = None) -> MagicMock:
-    conn = MagicMock()
-    if responses is None:
-        responses = []
-    conn.execute = _make_execute_mock(responses)
-    cursor_ctx = MagicMock()
-    cursor_ctx.__enter__ = MagicMock(return_value=cursor_ctx)
-    cursor_ctx.__exit__ = MagicMock(return_value=False)
-    cursor_ctx.executemany = MagicMock()
-    conn.cursor = MagicMock(return_value=cursor_ctx)
-    return conn
+class _ForbiddenDB:
+    """Sentinel: any attribute access raises. Proves 422 / 401 fires before DB use."""
+
+    def __getattr__(self, name):
+        raise _DBAccessForbidden(
+            f"Validation test reached DB (accessed {name!r}) — 422/401 should have fired first"
+        )
 
 
-def _make_client(mock_conn: MagicMock) -> TestClient:
+def _make_client_no_db() -> TestClient:
     app = create_app()
 
     def override_db():
-        yield mock_conn
+        yield _ForbiddenDB()
 
     app.dependency_overrides[get_db] = override_db
     app.dependency_overrides[require_auth] = lambda: "test-token"
     return TestClient(app)
 
 
-def _resource_row(*, location_id: UUID | None = None) -> dict:
-    return {
-        "resource_id": uuid4(),
-        "external_id": "R1",
-        "name": "Resource 1",
-        "resource_type": "machine",
-        "capacity_per_day": 100.0,
-        "capacity_unit": "hours",
-        "location_id": location_id,
-    }
-
-
-# ─────────────────────────────────────────────────────────────
-# Auth
-# ─────────────────────────────────────────────────────────────
-
-
-def test_rccp_requires_auth():
+def _make_client_no_auth_override() -> TestClient:
     app = create_app()
-    conn = _mock_db([])
-    app.dependency_overrides[get_db] = lambda: conn
-    with TestClient(app) as c:
-        resp = c.get("/v1/rccp/R1")
-    assert resp.status_code == 401
+
+    def override_db():
+        yield _ForbiddenDB()
+
+    app.dependency_overrides[get_db] = override_db
+    return TestClient(app)
 
 
 # ─────────────────────────────────────────────────────────────
-# Bucket helpers — direct unit tests
+# Auth (401)
 # ─────────────────────────────────────────────────────────────
 
 
-def test_bucket_start_day():
-    d = date(2025, 1, 15)  # Wednesday
-    assert _bucket_start(d, "day") == d
-
-
-def test_bucket_start_week():
-    d = date(2025, 1, 15)  # Wednesday
-    assert _bucket_start(d, "week") == date(2025, 1, 13)  # Monday
-
-
-def test_bucket_start_month():
-    d = date(2025, 1, 15)
-    assert _bucket_start(d, "month") == date(2025, 1, 1)
-
-
-def test_bucket_end_day():
-    d = date(2025, 1, 15)
-    assert _bucket_end(d, "day") == d
-
-
-def test_bucket_end_week():
-    monday = date(2025, 1, 13)
-    assert _bucket_end(monday, "week") == date(2025, 1, 19)
-
-
-def test_bucket_end_month_january():
-    assert _bucket_end(date(2025, 1, 1), "month") == date(2025, 1, 31)
-
-
-def test_bucket_end_month_december():
-    """December branch: start.month == 12 → start.replace(day=31)."""
-    assert _bucket_end(date(2025, 12, 1), "month") == date(2025, 12, 31)
-
-
-def test_bucket_end_month_february():
-    assert _bucket_end(date(2025, 2, 1), "month") == date(2025, 2, 28)
-
-
-def test_next_bucket_start_day():
-    assert _next_bucket_start(date(2025, 1, 15), "day") == date(2025, 1, 16)
-
-
-def test_next_bucket_start_week():
-    monday = date(2025, 1, 13)
-    assert _next_bucket_start(monday, "week") == date(2025, 1, 20)
-
-
-def test_next_bucket_start_month():
-    assert _next_bucket_start(date(2025, 1, 1), "month") == date(2025, 2, 1)
-
-
-def test_next_bucket_start_month_december_year_rollover():
-    """December branch: start.month == 12 → year+1, month=1."""
-    assert _next_bucket_start(date(2025, 12, 1), "month") == date(2026, 1, 1)
-
-
-def test_generate_buckets_single_day():
-    buckets = _generate_buckets(date(2025, 1, 13), date(2025, 1, 13), "day")
-    assert buckets == [(date(2025, 1, 13), date(2025, 1, 13))]
-
-
-def test_generate_buckets_week_truncated_at_to_date():
-    """end > to_date branch: week extends past to_date and gets clipped."""
-    # Start mid-week, run for 3 days only
-    buckets = _generate_buckets(date(2025, 1, 15), date(2025, 1, 17), "week")
-    # Monday of week is 2025-01-13, end normally 2025-01-19, clipped to 2025-01-17
-    assert buckets[0] == (date(2025, 1, 13), date(2025, 1, 17))
-
-
-def test_generate_buckets_multiple_weeks():
-    buckets = _generate_buckets(date(2025, 1, 13), date(2025, 1, 26), "week")
-    assert len(buckets) == 2
-    assert buckets[0] == (date(2025, 1, 13), date(2025, 1, 19))
-    assert buckets[1] == (date(2025, 1, 20), date(2025, 1, 26))
+class TestRCCPAuth:
+    def test_rccp_requires_auth(self):
+        client = _make_client_no_auth_override()
+        resp = client.get("/v1/rccp/R1")
+        assert resp.status_code == 401
 
 
 # ─────────────────────────────────────────────────────────────
-# _count_working_days direct tests
+# Bucket helpers — direct pure-Python unit tests
 # ─────────────────────────────────────────────────────────────
 
 
-def test_count_working_days_no_location():
-    """Pure Mon–Fri heuristic, no DB query."""
-    conn = _mock_db([])
-    # 2025-01-13 (Mon) … 2025-01-19 (Sun) → 5 working days
-    assert _count_working_days(conn, None, date(2025, 1, 13), date(2025, 1, 19)) == 5
+class TestBucketStart:
+    def test_day(self):
+        d = date(2025, 1, 15)  # Wednesday
+        assert _bucket_start(d, "day") == d
+
+    def test_week(self):
+        d = date(2025, 1, 15)  # Wednesday
+        assert _bucket_start(d, "week") == date(2025, 1, 13)  # Monday
+
+    def test_month(self):
+        d = date(2025, 1, 15)
+        assert _bucket_start(d, "month") == date(2025, 1, 1)
 
 
-def test_count_working_days_with_location_calendar_hit():
-    """Calendar query returns count > 0 → use it."""
-    conn = _mock_db([
-        {"cnt": 4},  # COUNT query
-    ])
-    result = _count_working_days(conn, str(uuid4()), date(2025, 1, 13), date(2025, 1, 19))
-    assert result == 4
+class TestBucketEnd:
+    def test_day(self):
+        d = date(2025, 1, 15)
+        assert _bucket_end(d, "day") == d
+
+    def test_week(self):
+        monday = date(2025, 1, 13)
+        assert _bucket_end(monday, "week") == date(2025, 1, 19)
+
+    def test_month_january(self):
+        assert _bucket_end(date(2025, 1, 1), "month") == date(2025, 1, 31)
+
+    def test_month_december(self):
+        """December branch: start.month == 12 → start.replace(day=31)."""
+        assert _bucket_end(date(2025, 12, 1), "month") == date(2025, 12, 31)
+
+    def test_month_february(self):
+        assert _bucket_end(date(2025, 2, 1), "month") == date(2025, 2, 28)
 
 
-def test_count_working_days_with_location_calendar_zero_falls_back():
-    """Calendar count == 0 → fall through to Mon–Fri."""
-    conn = _mock_db([
-        {"cnt": 0},
-    ])
-    result = _count_working_days(conn, str(uuid4()), date(2025, 1, 13), date(2025, 1, 19))
-    assert result == 5  # Mon..Fri
+class TestNextBucketStart:
+    def test_day(self):
+        assert _next_bucket_start(date(2025, 1, 15), "day") == date(2025, 1, 16)
+
+    def test_week(self):
+        monday = date(2025, 1, 13)
+        assert _next_bucket_start(monday, "week") == date(2025, 1, 20)
+
+    def test_month(self):
+        assert _next_bucket_start(date(2025, 1, 1), "month") == date(2025, 2, 1)
+
+    def test_month_december_year_rollover(self):
+        """December branch: start.month == 12 → year+1, month=1."""
+        assert _next_bucket_start(date(2025, 12, 1), "month") == date(2026, 1, 1)
 
 
-def test_count_working_days_with_location_calendar_none_falls_back():
-    """Calendar query returns None → fall through to Mon–Fri."""
-    conn = _mock_db([
-        None,
-    ])
-    result = _count_working_days(conn, str(uuid4()), date(2025, 1, 13), date(2025, 1, 19))
-    assert result == 5
+class TestGenerateBuckets:
+    def test_single_day(self):
+        buckets = _generate_buckets(date(2025, 1, 13), date(2025, 1, 13), "day")
+        assert buckets == [(date(2025, 1, 13), date(2025, 1, 13))]
+
+    def test_week_truncated_at_to_date(self):
+        """end > to_date branch: week extends past to_date and gets clipped."""
+        buckets = _generate_buckets(date(2025, 1, 15), date(2025, 1, 17), "week")
+        assert buckets[0] == (date(2025, 1, 13), date(2025, 1, 17))
+
+    def test_multiple_weeks(self):
+        buckets = _generate_buckets(date(2025, 1, 13), date(2025, 1, 26), "week")
+        assert len(buckets) == 2
+        assert buckets[0] == (date(2025, 1, 13), date(2025, 1, 19))
+        assert buckets[1] == (date(2025, 1, 20), date(2025, 1, 26))
 
 
-# ─────────────────────────────────────────────────────────────
-# get_rccp endpoint
-# ─────────────────────────────────────────────────────────────
+class TestCountWorkingDaysNoLocation:
+    """Pure Mon–Fri heuristic, no DB query — safe to test against _ForbiddenDB.
 
-
-def test_rccp_invalid_grain():
-    conn = _mock_db([])
-    client = _make_client(conn)
-    resp = client.get(
-        "/v1/rccp/R1",
-        params={"grain": "fortnight"},
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-    assert "grain" in resp.json()["detail"]
-
-
-def test_rccp_to_date_before_from_date():
-    conn = _mock_db([])
-    client = _make_client(conn)
-    resp = client.get(
-        "/v1/rccp/R1",
-        params={
-            "from_date": "2025-02-01",
-            "to_date": "2025-01-01",
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 422
-    assert "to_date" in resp.json()["detail"]
-
-
-def test_rccp_resource_not_found():
-    conn = _mock_db([
-        None,  # resource lookup
-    ])
-    client = _make_client(conn)
-    resp = client.get(
-        "/v1/rccp/MISSING",
-        params={
-            "from_date": "2025-01-13",
-            "to_date": "2025-01-19",
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 404
-
-
-def test_rccp_default_dates_invalid_grain_path_not_taken():
-    """Use default from_date / to_date (None → today / +12w)."""
-    conn = _mock_db([
-        _resource_row(),  # resource
-        [],               # load rows
-        [],               # capacity overrides
-        # default range = 12 weeks ≈ 84 days, mostly weekdays.
-        # No location_id → no calendar queries.
-    ])
-    client = _make_client(conn)
-    resp = client.get(
-        "/v1/rccp/R1",
-        params={"grain": "month"},
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["resource"]["external_id"] == "R1"
-    assert len(body["buckets"]) >= 1
-
-
-def test_rccp_no_location_with_load_and_overload():
-    """One-week bucket, no location. Load > capacity → overloaded."""
-    rrow = _resource_row()  # capacity_per_day=100, no location_id
-    # Mon 2025-01-13 to Fri 2025-01-17 → 5 weekdays × 100 = 500 capacity
-    # Load = 700 → utilization 140% → overloaded
-    conn = _mock_db([
-        rrow,
-        # load rows
-        [
-            {"time_ref": date(2025, 1, 13), "quantity": 300.0},
-            {"time_ref": date(2025, 1, 15), "quantity": 400.0},
-            {"time_ref": None, "quantity": 999.0},  # ignored (None)
-        ],
-        # capacity overrides
-        [],
-    ])
-    client = _make_client(conn)
-    resp = client.get(
-        "/v1/rccp/R1",
-        params={
-            "from_date": "2025-01-13",
-            "to_date": "2025-01-17",
-            "grain": "week",
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200
-    body = resp.json()
-    assert len(body["buckets"]) == 1
-    b = body["buckets"][0]
-    assert b["load"] == 700.0
-    assert b["capacity"] == 500.0
-    assert b["utilization_pct"] == 140.0
-    assert b["overloaded"] is True
-
-
-def test_rccp_capacity_override_path():
-    """Override day uses override capacity instead of calendar/heuristic."""
-    rrow = _resource_row()
-    # Mon..Tue range — Mon overridden to 50, Tue normal weekday → 100. Total 150.
-    conn = _mock_db([
-        rrow,
-        # load
-        [{"time_ref": date(2025, 1, 13), "quantity": 50.0}],
-        # overrides
-        [{"override_date": date(2025, 1, 13), "capacity": 50.0}],
-    ])
-    client = _make_client(conn)
-    resp = client.get(
-        "/v1/rccp/R1",
-        params={
-            "from_date": "2025-01-13",  # Mon
-            "to_date": "2025-01-14",    # Tue
-            "grain": "day",
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200
-    body = resp.json()
-    assert len(body["buckets"]) == 2
-    # Monday: load=50, capacity=50 (override) → 100%
-    assert body["buckets"][0]["capacity"] == 50.0
-    assert body["buckets"][0]["load"] == 50.0
-    assert body["buckets"][0]["utilization_pct"] == 100.0
-    assert body["buckets"][0]["overloaded"] is False
-    # Tuesday: load=0, capacity=100 (weekday)
-    assert body["buckets"][1]["capacity"] == 100.0
-
-
-def test_rccp_with_location_calendar_working_day_with_factor():
-    """location_id present → operational_calendars query.
-    cal_row with is_working_day=True and capacity_factor=0.5 →
-    capacity_per_day * 0.5 added.
+    The location/calendar variants live in the integration test file.
     """
-    loc_id = uuid4()
-    rrow = _resource_row(location_id=loc_id)
-    # 1-day range, Monday. With cal factor 0.5 → capacity 50.
-    conn = _mock_db([
-        rrow,
-        # load
-        [],
-        # overrides
-        [],
-        # calendar query for Monday
-        {"is_working_day": True, "capacity_factor": 0.5},
-    ])
-    client = _make_client(conn)
-    resp = client.get(
-        "/v1/rccp/R1",
-        params={
-            "from_date": "2025-01-13",
-            "to_date": "2025-01-13",
-            "grain": "day",
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["buckets"][0]["capacity"] == 50.0
-    assert body["buckets"][0]["load"] == 0.0
-    assert body["buckets"][0]["utilization_pct"] == 0.0
+
+    def test_full_week(self):
+        # 2025-01-13 (Mon) … 2025-01-19 (Sun) → 5 working days
+        assert _count_working_days(_ForbiddenDB(), None, date(2025, 1, 13), date(2025, 1, 19)) == 5
+
+    def test_weekend_only(self):
+        # 2025-01-18 (Sat), 2025-01-19 (Sun) → 0 working days
+        assert _count_working_days(_ForbiddenDB(), None, date(2025, 1, 18), date(2025, 1, 19)) == 0
+
+    def test_single_weekday(self):
+        # Monday only
+        assert _count_working_days(_ForbiddenDB(), None, date(2025, 1, 13), date(2025, 1, 13)) == 1
 
 
-def test_rccp_with_location_calendar_working_day_factor_none():
-    """capacity_factor=None → defaults to 1.0."""
-    loc_id = uuid4()
-    rrow = _resource_row(location_id=loc_id)
-    conn = _mock_db([
-        rrow,
-        [],
-        [],
-        {"is_working_day": True, "capacity_factor": None},
-    ])
-    client = _make_client(conn)
-    resp = client.get(
-        "/v1/rccp/R1",
-        params={
-            "from_date": "2025-01-13",
-            "to_date": "2025-01-13",
-            "grain": "day",
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200
-    assert resp.json()["buckets"][0]["capacity"] == 100.0
+# ─────────────────────────────────────────────────────────────
+# Endpoint validation (422) — fires before DB access
+# ─────────────────────────────────────────────────────────────
 
 
-def test_rccp_with_location_calendar_non_working_day():
-    """cal_row.is_working_day=False → no capacity added."""
-    loc_id = uuid4()
-    rrow = _resource_row(location_id=loc_id)
-    conn = _mock_db([
-        rrow,
-        [],
-        [],
-        {"is_working_day": False, "capacity_factor": 1.0},
-    ])
-    client = _make_client(conn)
-    resp = client.get(
-        "/v1/rccp/R1",
-        params={
-            "from_date": "2025-01-13",
-            "to_date": "2025-01-13",
-            "grain": "day",
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["buckets"][0]["capacity"] == 0.0
-    assert body["buckets"][0]["utilization_pct"] == 0.0
+class TestRCCPEndpointValidation:
+    def test_invalid_grain(self):
+        client = _make_client_no_db()
+        resp = client.get(
+            "/v1/rccp/R1",
+            params={"grain": "fortnight"},
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        assert "grain" in resp.json()["detail"]
+
+    def test_to_date_before_from_date(self):
+        client = _make_client_no_db()
+        resp = client.get(
+            "/v1/rccp/R1",
+            params={
+                "from_date": "2025-02-01",
+                "to_date": "2025-01-01",
+            },
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        assert "to_date" in resp.json()["detail"]
 
 
-def test_rccp_with_location_calendar_no_entry_falls_back():
-    """cal_row is None → fall back to Mon–Fri heuristic."""
-    loc_id = uuid4()
-    rrow = _resource_row(location_id=loc_id)
-    conn = _mock_db([
-        rrow,
-        [],
-        [],
-        None,  # calendar query → no entry for Monday
-    ])
-    client = _make_client(conn)
-    resp = client.get(
-        "/v1/rccp/R1",
-        params={
-            "from_date": "2025-01-13",
-            "to_date": "2025-01-13",
-            "grain": "day",
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200
-    assert resp.json()["buckets"][0]["capacity"] == 100.0
+# ─────────────────────────────────────────────────────────────
+# Router introspection
+# ─────────────────────────────────────────────────────────────
 
 
-def test_rccp_weekend_no_capacity_no_query():
-    """Saturday → not weekday → no calendar query → 0 capacity."""
-    loc_id = uuid4()
-    rrow = _resource_row(location_id=loc_id)
-    # 2025-01-18 is a Saturday
-    conn = _mock_db([
-        rrow,
-        [],
-        [],
-        # NO calendar query expected
-    ])
-    client = _make_client(conn)
-    resp = client.get(
-        "/v1/rccp/R1",
-        params={
-            "from_date": "2025-01-18",
-            "to_date": "2025-01-18",
-            "grain": "day",
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["buckets"][0]["capacity"] == 0.0
-    # Zero capacity → utilization_pct = 0.0 (the safe-divide branch)
-    assert body["buckets"][0]["utilization_pct"] == 0.0
-    assert body["buckets"][0]["overloaded"] is False
+class TestRCCPRouterConfiguration:
+    def test_router_prefix(self):
+        from ootils_core.api.routers import rccp
+        assert rccp.router.prefix == "/v1/rccp"
+
+    def test_router_tags(self):
+        from ootils_core.api.routers import rccp
+        assert "rccp" in rccp.router.tags
+
+    def test_router_registered_in_app(self):
+        app = create_app()
+        rccp_routes = [r for r in app.routes if hasattr(r, "path") and "/rccp/" in r.path]
+        assert len(rccp_routes) > 0
 
 
-def test_rccp_resource_with_location_id_serialized():
-    """Make sure location_id appears in the response when set."""
-    loc_id = uuid4()
-    rrow = _resource_row(location_id=loc_id)
-    conn = _mock_db([
-        rrow,
-        [],
-        [],
-        # 1 weekday (Monday) → 1 calendar query
-        {"is_working_day": True, "capacity_factor": 1.0},
-    ])
-    client = _make_client(conn)
-    resp = client.get(
-        "/v1/rccp/R1",
-        params={
-            "from_date": "2025-01-13",
-            "to_date": "2025-01-13",
-            "grain": "day",
-        },
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200
-    assert resp.json()["resource"]["location_id"] == str(loc_id)
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
Seventh mock-cleanup batch. Bundles **3 router test files** that share the same \`_mock_db\` helper pattern. 6 output files (3 slim + 3 integration).

| File | Before | Slim | Integration |
|---|---:|---:|---:|
| test_router_bom.py | 682 | 14 tests | 16 tests |
| test_router_ghosts.py | 903 | 15 tests | 11 tests |
| test_router_rccp.py | 543 | 24 tests | 11 tests |
| **Totals** | **2128 LOC** | **53 tests** | **38 tests** |

Net 63 → 91 tests. Increase comes from splitting Pydantic vs DB-validation paths, adding \`_count_working_days\` branch coverage, and splitting upsert paths (insert vs update).

All integration files use module-scoped \`seeded_db\` / \`api_client\` / \`auth\` fixtures (mirror \`test_atp_api_integration.py\`). Per-test cleanup in \`finally\` blocks.

## Notes flagged for follow-up
1. **RCCP seed gap**: \`scripts/seed_demo_data.py\` doesn't seed resources. Integration tests insert their own. Worth adding 1-2 demo resources to the seed.
2. **Ghosts edges** depend on \`node_type='Item'\` rows the seed doesn't create. \`test_get_ghost_with_graph_node_and_edges\` asserts shape, not count.
3. **\`_count_working_days\` has dead "None" branch** (\`SELECT COUNT(*)\` always returns a row). Code-cleanup candidate.
4. **Integration tests use \`psycopg.connect(seeded_db)\` inline** rather than the \`conn\` fixture, because the TestClient runs API requests under a separate connection from the test's verification queries.

## Verification
- ruff clean on all 6 files
- 53 slim tests pass without \`DATABASE_URL\`
- 38 integration tests collect cleanly under \`requires_db\`
- 0 mocks in any of the 3 integration files
- No production code touched

## Mock cleanup progress
| File | State |
|---|---|
| test_db_connection.py | ✓ ([#252](https://github.com/ngoineau/ootils-core/pull/252)) |
| test_llc_calculator.py | ✓ ([#252](https://github.com/ngoineau/ootils-core/pull/252)) |
| test_graph_store.py | ✓ ([#253](https://github.com/ngoineau/ootils-core/pull/253)) |
| test_atp_engine.py | ✓ ([#254](https://github.com/ngoineau/ootils-core/pull/254)) |
| test_forecasting_api.py | ✓ ([#255](https://github.com/ngoineau/ootils-core/pull/255)) |
| test_m6_api.py | ✓ ([#256](https://github.com/ngoineau/ootils-core/pull/256)) |
| test_m4_shortage.py | ✓ ([#257](https://github.com/ngoineau/ootils-core/pull/257)) |
| test_router_bom.py + ghosts + rccp | ✓ (this PR) |
| test_crp_engine.py | pending |
| test_phase1_integration.py | pending |