### PR TITLE
test(audit): split test_crp_engine.py into pure + real-DB integration

### DIFF
--- a/tests/integration/test_crp_engine_integration.py
+++ b/tests/integration/test_crp_engine_integration.py
@@ -1,0 +1,880 @@
+"""
+Integration tests for ootils_core.crp.engine.CRPEngine against a real
+PostgreSQL database.
+
+Ported from tests/test_crp_engine.py — the mock-heavy test file that
+relied on a ``mock_db_connection`` fixture and scripted ``cursor.fetchall``
+side-effects. The "no mocks" rule (CLAUDE.md) means every fetch_* /
+calculate() branch is exercised by inserting real rows into the
+``items``, ``locations``, ``work_centers``, ``routings``,
+``routing_operations`` and ``planned_supply`` tables and reading back
+the engine's load profiles.
+
+Each test seeds its own rows and tears them down. The function-scoped
+``conn`` fixture rolls back any uncommitted changes; we ``commit()``
+inside tests because CRPEngine opens its own short-lived cursors which
+need the rows persisted.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Optional
+from uuid import UUID, uuid4
+
+import pytest
+
+from ootils_core.crp.engine import CRPEngine, CRPResult
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+def _seed_item(conn) -> UUID:
+    item_id = uuid4()
+    conn.execute(
+        "INSERT INTO items (item_id, name) VALUES (%s, %s)",
+        (item_id, f"CRP Test Item {item_id}"),
+    )
+    return item_id
+
+
+def _seed_location(conn) -> UUID:
+    location_id = uuid4()
+    conn.execute(
+        "INSERT INTO locations (location_id, name) VALUES (%s, %s)",
+        (location_id, f"CRP Test Loc {location_id}"),
+    )
+    return location_id
+
+
+def _seed_work_center(
+    conn,
+    *,
+    code: Optional[str] = None,
+    description: str = "Test Work Center",
+    capacity_per_day: Decimal = Decimal("8.0"),
+    efficiency: Decimal = Decimal("0.9"),
+    active: bool = True,
+) -> UUID:
+    wc_id = uuid4()
+    if code is None:
+        code = f"WC-{wc_id.hex[:8]}"
+    conn.execute(
+        """
+        INSERT INTO work_centers (
+            work_center_id, code, description,
+            capacity_per_day, efficiency, calendar_id, active
+        ) VALUES (%s, %s, %s, %s, %s, NULL, %s)
+        """,
+        (wc_id, code, description, capacity_per_day, efficiency, active),
+    )
+    return wc_id
+
+
+def _seed_routing(
+    conn,
+    *,
+    item_id: UUID,
+    sequence: int = 1,
+    description: str = "Test Routing",
+    active: bool = True,
+) -> UUID:
+    routing_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO routings (routing_id, item_id, sequence, description, active)
+        VALUES (%s, %s, %s, %s, %s)
+        """,
+        (routing_id, item_id, sequence, description, active),
+    )
+    return routing_id
+
+
+def _seed_operation(
+    conn,
+    *,
+    routing_id: UUID,
+    work_center_id: UUID,
+    sequence: int = 10,
+    setup_time: Decimal = Decimal("0"),
+    run_time_per_unit: Decimal = Decimal("0.1"),
+    description: str = "Test Op",
+    active: bool = True,
+) -> UUID:
+    operation_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO routing_operations (
+            operation_id, routing_id, sequence, work_center_id,
+            setup_time, run_time_per_unit, description, active
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        """,
+        (
+            operation_id, routing_id, sequence, work_center_id,
+            setup_time, run_time_per_unit, description, active,
+        ),
+    )
+    return operation_id
+
+
+def _seed_planned_order(
+    conn,
+    *,
+    item_id: UUID,
+    location_id: UUID,
+    quantity: Decimal,
+    due_date: date,
+    status: str = "PLANNED",
+    scenario_id: Optional[UUID] = None,
+) -> UUID:
+    planned_supply_id = uuid4()
+    # Default scenario is the baseline scenario (NOT NULL FK on planned_supply).
+    if scenario_id is None:
+        conn.execute(
+            """
+            INSERT INTO planned_supply (
+                planned_supply_id, item_id, location_id,
+                quantity, due_date, status
+            ) VALUES (%s, %s, %s, %s, %s, %s)
+            """,
+            (planned_supply_id, item_id, location_id, quantity, due_date, status),
+        )
+    else:
+        conn.execute(
+            """
+            INSERT INTO planned_supply (
+                planned_supply_id, item_id, location_id, scenario_id,
+                quantity, due_date, status
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+            """,
+            (planned_supply_id, item_id, location_id, scenario_id,
+             quantity, due_date, status),
+        )
+    return planned_supply_id
+
+
+def _seed_scenario(conn) -> UUID:
+    scenario_id = uuid4()
+    conn.execute(
+        "INSERT INTO scenarios (scenario_id, name) VALUES (%s, %s)",
+        (scenario_id, f"crp-test-{scenario_id}"),
+    )
+    return scenario_id
+
+
+def _teardown(
+    conn,
+    *,
+    planned_orders: Optional[list[UUID]] = None,
+    operations: Optional[list[UUID]] = None,
+    routings: Optional[list[UUID]] = None,
+    work_centers: Optional[list[UUID]] = None,
+    items: Optional[list[UUID]] = None,
+    locations: Optional[list[UUID]] = None,
+    scenarios: Optional[list[UUID]] = None,
+) -> None:
+    """
+    Delete every row written during the test so the DB stays clean.
+    Order matters because of FK chain:
+      planned_supply  → items, locations, scenarios
+      routing_operations → routings, work_centers
+      routings        → items
+    """
+    if planned_orders:
+        conn.execute(
+            "DELETE FROM planned_supply WHERE planned_supply_id = ANY(%s)",
+            (planned_orders,),
+        )
+    if operations:
+        conn.execute(
+            "DELETE FROM routing_operations WHERE operation_id = ANY(%s)",
+            (operations,),
+        )
+    if routings:
+        conn.execute("DELETE FROM routings WHERE routing_id = ANY(%s)", (routings,))
+    if work_centers:
+        conn.execute(
+            "DELETE FROM work_centers WHERE work_center_id = ANY(%s)",
+            (work_centers,),
+        )
+    if locations:
+        conn.execute("DELETE FROM locations WHERE location_id = ANY(%s)", (locations,))
+    if items:
+        conn.execute("DELETE FROM items WHERE item_id = ANY(%s)", (items,))
+    if scenarios:
+        conn.execute(
+            "DELETE FROM scenarios WHERE scenario_id = ANY(%s)",
+            (scenarios,),
+        )
+    conn.commit()
+
+
+# ===========================================================================
+# CRPEngine — calculate() over empty datasets
+# ===========================================================================
+
+class TestCRPEngineEmpty:
+    """Branches where there are no work centers or no planned orders."""
+
+    def test_calculate_no_work_centers(self, conn):
+        """No work centers in DB → CRPResult is empty, no SQL further runs."""
+        # Make sure we don't accidentally see other test rows: we don't insert
+        # any work center. CRPEngine's _fetch_work_centers filters WHERE
+        # active = true, so any leftover inactive rows wouldn't matter — but
+        # if there are residual active work_centers from other tests/modules,
+        # the engine will still return them. To be safe, deactivate all
+        # existing rows for the duration of this test (rolled back at the
+        # end by the conn fixture).
+        conn.execute("UPDATE work_centers SET active = false")
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            result = engine.calculate(horizon_days=30)
+
+            assert isinstance(result, CRPResult)
+            assert result.planned_orders_count == 0
+            assert result.work_centers_count == 0
+            assert len(result.overloads) == 0
+        finally:
+            # Roll back the bulk deactivation
+            conn.rollback()
+
+    def test_calculate_no_planned_orders(self, conn):
+        """Active work center exists, but no planned orders in horizon."""
+        wc_id = _seed_work_center(conn)
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            result = engine.calculate(
+                horizon_days=30,
+                work_centers=[wc_id],
+            )
+            assert result.planned_orders_count == 0
+            # With no orders, no load_buckets are populated and therefore
+            # no LoadProfile is added (work_centers_count == 0).
+            assert result.work_centers_count == 0
+        finally:
+            _teardown(conn, work_centers=[wc_id])
+
+
+# ===========================================================================
+# CRPEngine._fetch_work_centers
+# ===========================================================================
+
+class TestFetchWorkCenters:
+    def test_fetch_active_work_centers(self, conn):
+        wc_id = _seed_work_center(
+            conn,
+            code=f"WC-FETCH-{uuid4().hex[:6]}",
+            capacity_per_day=Decimal("8.0"),
+            efficiency=Decimal("0.9"),
+        )
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            work_centers = engine._fetch_work_centers([wc_id])
+            assert len(work_centers) == 1
+            assert wc_id in work_centers
+            assert work_centers[wc_id].capacity_per_day == Decimal("8.000000")
+        finally:
+            _teardown(conn, work_centers=[wc_id])
+
+    def test_fetch_work_centers_filtered_by_id(self, conn):
+        """
+        Replaces the previous mock-only assertion `assert "WHERE work_center_id
+        IN" in call_args`. The behavioural assertion: passing a list filters
+        the returned work centers to exactly those IDs.
+        """
+        wc_a = _seed_work_center(conn, code=f"WC-A-{uuid4().hex[:6]}")
+        wc_b = _seed_work_center(conn, code=f"WC-B-{uuid4().hex[:6]}")
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            result = engine._fetch_work_centers([wc_a])
+            assert wc_a in result
+            assert wc_b not in result
+            assert len(result) == 1
+        finally:
+            _teardown(conn, work_centers=[wc_a, wc_b])
+
+    def test_inactive_work_center_excluded(self, conn):
+        """The SQL WHERE active = true filter drops inactive rows."""
+        wc_id = _seed_work_center(conn, active=False)
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            result = engine._fetch_work_centers([wc_id])
+            assert len(result) == 0
+        finally:
+            _teardown(conn, work_centers=[wc_id])
+
+
+# ===========================================================================
+# CRPEngine._fetch_planned_orders
+# ===========================================================================
+
+class TestFetchPlannedOrders:
+    def test_fetch_planned_orders(self, conn):
+        item_id = _seed_item(conn)
+        location_id = _seed_location(conn)
+        due_a = date.today() + timedelta(days=10)
+        due_b = date.today() + timedelta(days=15)
+        po_a = _seed_planned_order(
+            conn, item_id=item_id, location_id=location_id,
+            quantity=Decimal("100"), due_date=due_a, status="PLANNED",
+        )
+        po_b = _seed_planned_order(
+            conn, item_id=item_id, location_id=location_id,
+            quantity=Decimal("50"), due_date=due_b, status="RELEASED",
+        )
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            start_date = date.today()
+            end_date = start_date + timedelta(days=90)
+            orders = engine._fetch_planned_orders(start_date, end_date)
+
+            order_ids = {o["planned_supply_id"] for o in orders}
+            assert po_a in order_ids
+            assert po_b in order_ids
+
+            quantities = {o["planned_supply_id"]: o["quantity"] for o in orders
+                          if o["planned_supply_id"] in (po_a, po_b)}
+            assert quantities[po_a] == Decimal("100.000000")
+            assert quantities[po_b] == Decimal("50.000000")
+        finally:
+            _teardown(
+                conn,
+                planned_orders=[po_a, po_b],
+                items=[item_id],
+                locations=[location_id],
+            )
+
+    def test_fetch_planned_orders_with_scenario(self, conn):
+        """
+        Replaces the mock-only `assert call_args[1][2] == scenario_id`.
+        Behavioural assertion: orders tagged with the requested scenario_id
+        are returned; orders tagged with a different scenario are not.
+        """
+        item_id = _seed_item(conn)
+        location_id = _seed_location(conn)
+        scenario_id = _seed_scenario(conn)
+        other_scenario_id = _seed_scenario(conn)
+        due_date = date.today() + timedelta(days=5)
+        po_target = _seed_planned_order(
+            conn, item_id=item_id, location_id=location_id,
+            quantity=Decimal("10"), due_date=due_date,
+            scenario_id=scenario_id,
+        )
+        po_other = _seed_planned_order(
+            conn, item_id=item_id, location_id=location_id,
+            quantity=Decimal("20"), due_date=due_date,
+            scenario_id=other_scenario_id,
+        )
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            start_date = date.today()
+            end_date = start_date + timedelta(days=90)
+            orders = engine._fetch_planned_orders(
+                start_date, end_date, scenario_id=scenario_id,
+            )
+            ids = {o["planned_supply_id"] for o in orders}
+            assert po_target in ids
+            assert po_other not in ids
+        finally:
+            _teardown(
+                conn,
+                planned_orders=[po_target, po_other],
+                items=[item_id],
+                locations=[location_id],
+                scenarios=[scenario_id, other_scenario_id],
+            )
+
+
+# ===========================================================================
+# CRPEngine._fetch_routings
+# ===========================================================================
+
+class TestFetchRoutings:
+    def test_fetch_routings_with_operations(self, conn):
+        item_id = _seed_item(conn)
+        wc1 = _seed_work_center(conn, code=f"WC-FR1-{uuid4().hex[:6]}")
+        wc2 = _seed_work_center(conn, code=f"WC-FR2-{uuid4().hex[:6]}")
+        routing_id = _seed_routing(conn, item_id=item_id)
+        op1 = _seed_operation(
+            conn, routing_id=routing_id, work_center_id=wc1, sequence=10,
+            setup_time=Decimal("1.0"), run_time_per_unit=Decimal("0.5"),
+        )
+        op2 = _seed_operation(
+            conn, routing_id=routing_id, work_center_id=wc2, sequence=20,
+            setup_time=Decimal("0.5"), run_time_per_unit=Decimal("0.25"),
+        )
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            routings = engine._fetch_routings({item_id})
+            assert item_id in routings
+            assert len(routings[item_id].operations) == 2
+            sequences = sorted(op.sequence for op in routings[item_id].operations)
+            assert sequences == [10, 20]
+        finally:
+            _teardown(
+                conn,
+                operations=[op1, op2],
+                routings=[routing_id],
+                work_centers=[wc1, wc2],
+                items=[item_id],
+            )
+
+    def test_fetch_routings_empty(self, conn):
+        """No routings exist for the given item_id → empty dict."""
+        item_id = _seed_item(conn)  # exists but has no routings
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            routings = engine._fetch_routings({item_id})
+            assert len(routings) == 0
+        finally:
+            _teardown(conn, items=[item_id])
+
+
+# ===========================================================================
+# CRPEngine — full calculate() behaviour (load + overloads)
+# ===========================================================================
+
+class TestCRPEngineLoadCalculation:
+    def test_backward_scheduling_single_operation(self, conn):
+        """Single planned order + single-operation routing → load is recorded."""
+        item_id = _seed_item(conn)
+        location_id = _seed_location(conn)
+        wc_id = _seed_work_center(conn, code=f"WC-BS-{uuid4().hex[:6]}")
+        routing_id = _seed_routing(conn, item_id=item_id)
+        op_id = _seed_operation(
+            conn, routing_id=routing_id, work_center_id=wc_id,
+            sequence=10, setup_time=Decimal("0"),
+            run_time_per_unit=Decimal("0.1"),
+        )
+        po_id = _seed_planned_order(
+            conn, item_id=item_id, location_id=location_id,
+            quantity=Decimal("100"),
+            due_date=date.today() + timedelta(days=10),
+        )
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            result = engine.calculate(horizon_days=30, work_centers=[wc_id])
+
+            assert result.planned_orders_count == 1
+            assert result.work_centers_count == 1
+            assert wc_id in result.load_profiles
+        finally:
+            _teardown(
+                conn,
+                planned_orders=[po_id],
+                operations=[op_id],
+                routings=[routing_id],
+                work_centers=[wc_id],
+                items=[item_id],
+                locations=[location_id],
+            )
+
+    def test_load_aggregation_multiple_orders(self, conn):
+        """Two orders for the same item share the work-center load profile."""
+        item_id = _seed_item(conn)
+        location_id = _seed_location(conn)
+        wc_id = _seed_work_center(conn, code=f"WC-LA-{uuid4().hex[:6]}")
+        routing_id = _seed_routing(conn, item_id=item_id)
+        op_id = _seed_operation(
+            conn, routing_id=routing_id, work_center_id=wc_id,
+            sequence=10, setup_time=Decimal("0"),
+            run_time_per_unit=Decimal("0.1"),
+        )
+        due = date.today() + timedelta(days=10)
+        po1 = _seed_planned_order(
+            conn, item_id=item_id, location_id=location_id,
+            quantity=Decimal("100"), due_date=due,
+        )
+        po2 = _seed_planned_order(
+            conn, item_id=item_id, location_id=location_id,
+            quantity=Decimal("100"), due_date=due,
+        )
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            result = engine.calculate(horizon_days=30, work_centers=[wc_id])
+            assert result.planned_orders_count == 2
+            assert wc_id in result.load_profiles
+        finally:
+            _teardown(
+                conn,
+                planned_orders=[po1, po2],
+                operations=[op_id],
+                routings=[routing_id],
+                work_centers=[wc_id],
+                items=[item_id],
+                locations=[location_id],
+            )
+
+
+# ===========================================================================
+# CRPEngine — overload detection
+# ===========================================================================
+
+class TestCRPEngineOverloadDetection:
+    def test_overload_detection_basic(self, conn):
+        """
+        Two planned orders on the same due date routed through the same work
+        center pile up more hours than the daily effective capacity.
+
+        WC effective capacity = 8.0 * 0.9 = 7.2 hours/day.
+        Each order: 50 units * 0.1 run = 5 hours. Two orders, same day → 10h.
+        10 > 7.2 → overload of 2.8 hours.
+        """
+        wc_id = _seed_work_center(
+            conn,
+            code=f"WC-OL-{uuid4().hex[:6]}",
+            capacity_per_day=Decimal("8.0"),
+            efficiency=Decimal("0.9"),
+        )
+        # Two items, two routings, two operations — both at the same wc.
+        item1 = _seed_item(conn)
+        item2 = _seed_item(conn)
+        location_id = _seed_location(conn)
+        r1 = _seed_routing(conn, item_id=item1)
+        r2 = _seed_routing(conn, item_id=item2)
+        op1 = _seed_operation(
+            conn, routing_id=r1, work_center_id=wc_id,
+            sequence=10, run_time_per_unit=Decimal("0.1"),
+        )
+        op2 = _seed_operation(
+            conn, routing_id=r2, work_center_id=wc_id,
+            sequence=10, run_time_per_unit=Decimal("0.1"),
+        )
+        due = date.today() + timedelta(days=5)
+        po1 = _seed_planned_order(
+            conn, item_id=item1, location_id=location_id,
+            quantity=Decimal("50"), due_date=due,
+        )
+        po2 = _seed_planned_order(
+            conn, item_id=item2, location_id=location_id,
+            quantity=Decimal("50"), due_date=due,
+        )
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            result = engine.calculate(horizon_days=30, work_centers=[wc_id])
+            assert len(result.overloads) > 0
+            assert result.overloads[0].excess_hours > Decimal("0")
+        finally:
+            _teardown(
+                conn,
+                planned_orders=[po1, po2],
+                operations=[op1, op2],
+                routings=[r1, r2],
+                work_centers=[wc_id],
+                items=[item1, item2],
+                locations=[location_id],
+            )
+
+    def test_no_overload_when_capacity_sufficient(self, conn):
+        item_id = _seed_item(conn)
+        location_id = _seed_location(conn)
+        wc_id = _seed_work_center(
+            conn,
+            code=f"WC-NOL-{uuid4().hex[:6]}",
+            capacity_per_day=Decimal("8.0"),
+            efficiency=Decimal("0.9"),
+        )
+        routing_id = _seed_routing(conn, item_id=item_id)
+        op_id = _seed_operation(
+            conn, routing_id=routing_id, work_center_id=wc_id,
+            sequence=10, setup_time=Decimal("0"),
+            run_time_per_unit=Decimal("0.01"),
+        )
+        po_id = _seed_planned_order(
+            conn, item_id=item_id, location_id=location_id,
+            quantity=Decimal("10"),
+            due_date=date.today() + timedelta(days=5),
+        )
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            result = engine.calculate(horizon_days=30, work_centers=[wc_id])
+            assert len(result.overloads) == 0
+        finally:
+            _teardown(
+                conn,
+                planned_orders=[po_id],
+                operations=[op_id],
+                routings=[routing_id],
+                work_centers=[wc_id],
+                items=[item_id],
+                locations=[location_id],
+            )
+
+
+# ===========================================================================
+# CRPEngine — top-level helpers get_load_profile / get_overloads
+# ===========================================================================
+
+class TestCRPEngineLoadProfileQueries:
+    def test_get_load_profile(self, conn):
+        item_id = _seed_item(conn)
+        location_id = _seed_location(conn)
+        wc_id = _seed_work_center(
+            conn,
+            code=f"WC-GLP-{uuid4().hex[:6]}",
+            capacity_per_day=Decimal("8.0"),
+            efficiency=Decimal("0.9"),
+        )
+        routing_id = _seed_routing(conn, item_id=item_id)
+        op_id = _seed_operation(
+            conn, routing_id=routing_id, work_center_id=wc_id,
+            sequence=10, setup_time=Decimal("0"),
+            run_time_per_unit=Decimal("0.01"),
+        )
+        po_id = _seed_planned_order(
+            conn, item_id=item_id, location_id=location_id,
+            quantity=Decimal("10"),
+            due_date=date.today() + timedelta(days=5),
+        )
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            profile = engine.get_load_profile(
+                work_center_id=wc_id,
+                horizon_days=30,
+            )
+            assert profile is not None
+            assert profile.work_center_id == wc_id
+            # 30-day horizon spans today..today+30 inclusive → 31 buckets.
+            assert len(profile.buckets) == 31
+        finally:
+            _teardown(
+                conn,
+                planned_orders=[po_id],
+                operations=[op_id],
+                routings=[routing_id],
+                work_centers=[wc_id],
+                items=[item_id],
+                locations=[location_id],
+            )
+
+    def test_get_overloads_no_orders(self, conn):
+        """Active work center, but no planned orders → empty overload list."""
+        wc_id = _seed_work_center(conn, code=f"WC-GOL-{uuid4().hex[:6]}")
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            overloads = engine.get_overloads(horizon_days=30, work_centers=[wc_id])
+            assert isinstance(overloads, list)
+            assert len(overloads) == 0
+        finally:
+            _teardown(conn, work_centers=[wc_id])
+
+
+# ===========================================================================
+# CRPEngine — edge cases
+# ===========================================================================
+
+class TestCRPEdgeCases:
+    def test_inactive_operation_excluded(self, conn):
+        """Routing operation with active=false → contributes no load."""
+        item_id = _seed_item(conn)
+        location_id = _seed_location(conn)
+        wc_id = _seed_work_center(conn, code=f"WC-IO-{uuid4().hex[:6]}")
+        routing_id = _seed_routing(conn, item_id=item_id)
+        op_id = _seed_operation(
+            conn, routing_id=routing_id, work_center_id=wc_id,
+            sequence=10, setup_time=Decimal("1.0"),
+            run_time_per_unit=Decimal("0.5"),
+            active=False,
+        )
+        po_id = _seed_planned_order(
+            conn, item_id=item_id, location_id=location_id,
+            quantity=Decimal("100"),
+            due_date=date.today() + timedelta(days=10),
+        )
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            result = engine.calculate(horizon_days=30, work_centers=[wc_id])
+            # Inactive operations are filtered by _fetch_routings's
+            # WHERE active = true on routing_operations. With no active
+            # operations there is no load → no load profile produced.
+            assert result.planned_orders_count == 1
+            assert result.work_centers_count == 0
+        finally:
+            _teardown(
+                conn,
+                planned_orders=[po_id],
+                operations=[op_id],
+                routings=[routing_id],
+                work_centers=[wc_id],
+                items=[item_id],
+                locations=[location_id],
+            )
+
+    def test_zero_capacity_work_center(self, conn):
+        """A work center with capacity_per_day = 0 is still processed."""
+        wc_id = _seed_work_center(
+            conn,
+            code=f"WC-ZC-{uuid4().hex[:6]}",
+            capacity_per_day=Decimal("0"),
+            efficiency=Decimal("1.0"),
+        )
+        item_id = _seed_item(conn)
+        location_id = _seed_location(conn)
+        routing_id = _seed_routing(conn, item_id=item_id)
+        op_id = _seed_operation(
+            conn, routing_id=routing_id, work_center_id=wc_id,
+            sequence=10, setup_time=Decimal("0"),
+            run_time_per_unit=Decimal("0.1"),
+        )
+        po_id = _seed_planned_order(
+            conn, item_id=item_id, location_id=location_id,
+            quantity=Decimal("10"),
+            due_date=date.today() + timedelta(days=5),
+        )
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            result = engine.calculate(horizon_days=30, work_centers=[wc_id])
+            # Zero-capacity work center: engine falls back to 8h/day default
+            # for days_needed math, then builds a load profile with capacity=0.
+            assert result is not None
+            assert result.work_centers_count == 1
+        finally:
+            _teardown(
+                conn,
+                planned_orders=[po_id],
+                operations=[op_id],
+                routings=[routing_id],
+                work_centers=[wc_id],
+                items=[item_id],
+                locations=[location_id],
+            )
+
+    def test_scenario_filter_applied(self, conn):
+        """
+        Replaces the mock-only `assert cursor.execute.call_count >= 1`.
+        Behavioural assertion: orders tagged with a different scenario
+        are excluded from the calculation result.
+        """
+        scenario_id = _seed_scenario(conn)
+        other_scenario = _seed_scenario(conn)
+        item_id = _seed_item(conn)
+        location_id = _seed_location(conn)
+        wc_id = _seed_work_center(conn, code=f"WC-SF-{uuid4().hex[:6]}")
+        routing_id = _seed_routing(conn, item_id=item_id)
+        op_id = _seed_operation(
+            conn, routing_id=routing_id, work_center_id=wc_id,
+            sequence=10, run_time_per_unit=Decimal("0.1"),
+        )
+        # Order tagged with `other_scenario` — calculate(scenario_id=...)
+        # must ignore it.
+        po_other = _seed_planned_order(
+            conn, item_id=item_id, location_id=location_id,
+            quantity=Decimal("10"),
+            due_date=date.today() + timedelta(days=5),
+            scenario_id=other_scenario,
+        )
+        conn.commit()
+        try:
+            engine = CRPEngine(db_conn=conn)
+            result = engine.calculate(
+                horizon_days=30,
+                work_centers=[wc_id],
+                scenario_id=scenario_id,
+            )
+            assert result.planned_orders_count == 0
+        finally:
+            _teardown(
+                conn,
+                planned_orders=[po_other],
+                operations=[op_id],
+                routings=[routing_id],
+                work_centers=[wc_id],
+                items=[item_id],
+                locations=[location_id],
+                scenarios=[scenario_id, other_scenario],
+            )
+
+
+# ===========================================================================
+# Performance — port with adjusted threshold
+# ===========================================================================
+
+@pytest.mark.slow
+class TestCRPEnginePerformance:
+    """
+    Performance ported from the mocked file. Mocked DB returned scripted
+    rows instantly, so the original threshold was <2s for 1000 orders.
+    Real DB roundtrips dominate now: each INSERT is a network hop, and
+    the engine fetches 1000 rows with item_id IN (...) clauses. We set a
+    generous threshold (<10s for the calculate() call itself, excluding
+    seed time) and mark this test as slow.
+    """
+
+    def test_performance_1000_orders(self, conn):
+        import time
+
+        wc_id = _seed_work_center(
+            conn,
+            code=f"WC-PERF-{uuid4().hex[:6]}",
+            capacity_per_day=Decimal("8.0"),
+            efficiency=Decimal("0.9"),
+        )
+        item_id = _seed_item(conn)
+        location_id = _seed_location(conn)
+        routing_id = _seed_routing(conn, item_id=item_id)
+        op_id = _seed_operation(
+            conn, routing_id=routing_id, work_center_id=wc_id,
+            sequence=10, setup_time=Decimal("0"),
+            run_time_per_unit=Decimal("0.01"),
+        )
+
+        # 1000 planned orders distributed across 90 days, all for the
+        # same item so we only need one routing/operation.
+        planned_order_ids: list[UUID] = []
+        for i in range(1000):
+            po_id = _seed_planned_order(
+                conn, item_id=item_id, location_id=location_id,
+                quantity=Decimal("10"),
+                due_date=date.today() + timedelta(days=i % 90),
+            )
+            planned_order_ids.append(po_id)
+        conn.commit()
+
+        try:
+            engine = CRPEngine(db_conn=conn)
+            start_time = time.perf_counter()
+            result = engine.calculate(
+                horizon_days=90,
+                work_centers=[wc_id],
+            )
+            elapsed = time.perf_counter() - start_time
+
+            assert result.planned_orders_count == 1000
+            # Real-DB threshold: 10s (mocked: 2s). The original engine
+            # target is <500ms but that's only achievable when SQL is
+            # mocked away — real fetch + scheduling on 1000 orders has
+            # network overhead.
+            assert elapsed < 10.0, f"Calculation took {elapsed:.2f}s, expected <10.0s"
+        finally:
+            _teardown(
+                conn,
+                planned_orders=planned_order_ids,
+                operations=[op_id],
+                routings=[routing_id],
+                work_centers=[wc_id],
+                items=[item_id],
+                locations=[location_id],
+            )

--- a/tests/test_crp_engine.py
+++ b/tests/test_crp_engine.py
@@ -1,45 +1,33 @@
 """
-Tests for CRP (Capacity Requirements Planning) Engine.
+Tests for CRP (Capacity Requirements Planning) Engine — pure (no-DB) layer.
 
-Tests cover:
-- Load calculation from planned orders
-- Operation explosion via routings
-- Backward scheduling logic
-- Overload detection
-- Load profile aggregation
-- Performance with 1000+ planned orders
+Mock-heavy DB-driven tests previously in this file were ported to
+``tests/integration/test_crp_engine_integration.py`` per the project rule
+(CLAUDE.md): tests run against real PostgreSQL, no mocks. This slim file
+keeps only tests that exercise the in-memory dataclasses, helper methods,
+and constructor behaviour of CRPEngine itself.
 """
 from __future__ import annotations
 
-import pytest
 from datetime import date, timedelta
 from decimal import Decimal
 from uuid import uuid4
-from unittest.mock import Mock
+
+import pytest
 
 from ootils_core.crp.engine import (
     CRPEngine,
     CRPResult,
+    LoadBucket,
     LoadProfile,
     Overload,
-    LoadBucket,
 )
-from ootils_core.crp.models import WorkCenter, Routing, Operation
+from ootils_core.crp.models import Operation, Routing, WorkCenter
 
 
 # ─────────────────────────────────────────────────────────────
-# Fixtures
+# Fixtures (pure data only — no DB)
 # ─────────────────────────────────────────────────────────────
-
-@pytest.fixture
-def mock_db_connection():
-    """Create a mock database connection."""
-    conn = Mock()
-    cursor = Mock()
-    conn.cursor.return_value.__enter__ = Mock(return_value=cursor)
-    conn.cursor.return_value.__exit__ = Mock(return_value=False)
-    return conn, cursor
-
 
 @pytest.fixture
 def sample_work_center():
@@ -65,8 +53,7 @@ def sample_routing():
         description="Assembly Routing",
         active=True,
     )
-    
-    # Add operations
+
     op1 = Operation(
         operation_id=uuid4(),
         routing_id=routing.routing_id,
@@ -77,7 +64,6 @@ def sample_routing():
         description="Operation 10",
         active=True,
     )
-    
     op2 = Operation(
         operation_id=uuid4(),
         routing_id=routing.routing_id,
@@ -88,35 +74,9 @@ def sample_routing():
         description="Operation 20",
         active=True,
     )
-    
     routing.add_operation(op1)
     routing.add_operation(op2)
-    
     return routing
-
-
-@pytest.fixture
-def sample_planned_orders():
-    """Create sample planned orders."""
-    due_date = date.today() + timedelta(days=10)
-    return [
-        {
-            "planned_supply_id": uuid4(),
-            "item_id": uuid4(),
-            "location_id": uuid4(),
-            "quantity": Decimal("100"),
-            "due_date": due_date,
-            "status": "PLANNED",
-        },
-        {
-            "planned_supply_id": uuid4(),
-            "item_id": uuid4(),
-            "location_id": uuid4(),
-            "quantity": Decimal("50"),
-            "due_date": due_date + timedelta(days=5),
-            "status": "RELEASED",
-        },
-    ]
 
 
 # ─────────────────────────────────────────────────────────────
@@ -125,75 +85,67 @@ def sample_planned_orders():
 
 class TestLoadBucket:
     """Tests for LoadBucket class."""
-    
+
     def test_load_bucket_creation(self, sample_work_center):
-        """Test basic load bucket creation."""
         bucket = LoadBucket(
             work_center_id=sample_work_center.work_center_id,
             bucket_date=date.today(),
             load_hours=Decimal("4.0"),
             capacity_hours=Decimal("8.0"),
         )
-        
+
         assert bucket.work_center_id == sample_work_center.work_center_id
         assert bucket.load_hours == Decimal("4.0")
         assert bucket.capacity_hours == Decimal("8.0")
         assert bucket.is_overloaded is False
         assert bucket.overload_hours == Decimal("0")
-    
+
     def test_load_bucket_overload_detection(self, sample_work_center):
-        """Test overload detection when load exceeds capacity."""
         bucket = LoadBucket(
             work_center_id=sample_work_center.work_center_id,
             bucket_date=date.today(),
             load_hours=Decimal("10.0"),
             capacity_hours=Decimal("8.0"),
         )
-        
+
         assert bucket.is_overloaded is True
         assert bucket.overload_hours == Decimal("2.0")
-    
+
     def test_load_bucket_add_load(self, sample_work_center):
-        """Test adding load to bucket."""
         bucket = LoadBucket(
             work_center_id=sample_work_center.work_center_id,
             bucket_date=date.today(),
             load_hours=Decimal("5.0"),
             capacity_hours=Decimal("8.0"),
         )
-        
         bucket.add_load(Decimal("4.0"))
-        
+
         assert bucket.load_hours == Decimal("9.0")
         assert bucket.is_overloaded is True
         assert bucket.overload_hours == Decimal("1.0")
-    
+
     def test_load_bucket_set_capacity(self, sample_work_center):
-        """Test setting capacity on bucket."""
         bucket = LoadBucket(
             work_center_id=sample_work_center.work_center_id,
             bucket_date=date.today(),
             load_hours=Decimal("6.0"),
             capacity_hours=Decimal("8.0"),
         )
-        
         bucket.set_capacity(Decimal("5.0"))
-        
+
         assert bucket.capacity_hours == Decimal("5.0")
         assert bucket.is_overloaded is True
         assert bucket.overload_hours == Decimal("1.0")
-    
+
     def test_load_bucket_to_dict(self, sample_work_center):
-        """Test conversion to dictionary."""
         bucket = LoadBucket(
             work_center_id=sample_work_center.work_center_id,
             bucket_date=date.today(),
             load_hours=Decimal("10.0"),
             capacity_hours=Decimal("8.0"),
         )
-        
         result = bucket.to_dict()
-        
+
         assert result["work_center_id"] == str(sample_work_center.work_center_id)
         assert result["bucket_date"] == date.today().isoformat()
         assert result["load_hours"] == 10.0
@@ -208,92 +160,76 @@ class TestLoadBucket:
 
 class TestLoadProfile:
     """Tests for LoadProfile class."""
-    
+
     def test_load_profile_creation(self, sample_work_center):
-        """Test basic load profile creation."""
         profile = LoadProfile(
             sample_work_center.work_center_id,
             sample_work_center.code,
         )
-        
+
         assert profile.work_center_id == sample_work_center.work_center_id
         assert profile.work_center_code == sample_work_center.code
         assert len(profile.buckets) == 0
-    
+
     def test_load_profile_add_bucket(self, sample_work_center):
-        """Test adding buckets to profile."""
         profile = LoadProfile(
             sample_work_center.work_center_id,
             sample_work_center.code,
         )
-        
-        bucket1 = LoadBucket(
+        profile.add_bucket(LoadBucket(
             work_center_id=sample_work_center.work_center_id,
             bucket_date=date.today(),
             load_hours=Decimal("8.0"),
             capacity_hours=Decimal("8.0"),
-        )
-        
-        bucket2 = LoadBucket(
+        ))
+        profile.add_bucket(LoadBucket(
             work_center_id=sample_work_center.work_center_id,
             bucket_date=date.today() + timedelta(days=1),
             load_hours=Decimal("10.0"),
             capacity_hours=Decimal("8.0"),
-        )
-        
-        profile.add_bucket(bucket1)
-        profile.add_bucket(bucket2)
-        
+        ))
+
         assert len(profile.buckets) == 2
         assert profile.get_total_load() == Decimal("18.0")
         assert profile.get_total_capacity() == Decimal("16.0")
         assert profile.get_overload_count() == 1
-    
+
     def test_load_profile_get_overloads(self, sample_work_center):
-        """Test getting overloads from profile."""
         profile = LoadProfile(
             sample_work_center.work_center_id,
             sample_work_center.code,
         )
-        
-        # Add normal bucket
         profile.add_bucket(LoadBucket(
             work_center_id=sample_work_center.work_center_id,
             bucket_date=date.today(),
             load_hours=Decimal("6.0"),
             capacity_hours=Decimal("8.0"),
         ))
-        
-        # Add overloaded bucket
         profile.add_bucket(LoadBucket(
             work_center_id=sample_work_center.work_center_id,
             bucket_date=date.today() + timedelta(days=1),
             load_hours=Decimal("12.0"),
             capacity_hours=Decimal("8.0"),
         ))
-        
         overloads = profile.get_overloads()
-        
+
         assert len(overloads) == 1
         assert overloads[0].overload_date == date.today() + timedelta(days=1)
         assert overloads[0].excess_hours == Decimal("4.0")
-    
+
     def test_load_profile_to_dict(self, sample_work_center):
-        """Test conversion to dictionary."""
         profile = LoadProfile(
             sample_work_center.work_center_id,
             sample_work_center.code,
         )
-        
         profile.add_bucket(LoadBucket(
             work_center_id=sample_work_center.work_center_id,
             bucket_date=date.today(),
             load_hours=Decimal("8.0"),
             capacity_hours=Decimal("8.0"),
         ))
-        
         result = profile.to_dict()
-        
+
         assert result["work_center_id"] == str(sample_work_center.work_center_id)
         assert result["work_center_code"] == sample_work_center.code
         assert len(result["buckets"]) == 1
@@ -307,12 +243,10 @@ class TestLoadProfile:
 
 class TestOverload:
     """Tests for Overload class."""
-    
+
     def test_overload_creation(self):
-        """Test basic overload creation."""
         wc_id = uuid4()
         overload_date = date.today()
-        
         overload = Overload(
             work_center_id=wc_id,
             work_center_code="WC-001",
@@ -321,19 +255,17 @@ class TestOverload:
             capacity_hours=Decimal("8.0"),
             excess_hours=Decimal("4.0"),
         )
-        
+
         assert overload.work_center_id == wc_id
         assert overload.work_center_code == "WC-001"
         assert overload.overload_date == overload_date
         assert overload.load_hours == Decimal("12.0")
         assert overload.capacity_hours == Decimal("8.0")
         assert overload.excess_hours == Decimal("4.0")
-    
+
     def test_overload_to_dict(self):
-        """Test conversion to dictionary."""
         wc_id = uuid4()
         overload_date = date.today()
-        
         overload = Overload(
             work_center_id=wc_id,
             work_center_code="WC-001",
@@ -342,9 +274,8 @@ class TestOverload:
             capacity_hours=Decimal("8.0"),
             excess_hours=Decimal("4.0"),
         )
-        
         result = overload.to_dict()
-        
+
         assert result["work_center_id"] == str(wc_id)
         assert result["work_center_code"] == "WC-001"
         assert result["overload_date"] == overload_date.isoformat()
@@ -353,183 +284,41 @@ class TestOverload:
 
 
 # ─────────────────────────────────────────────────────────────
-# Test CRPEngine - Database Mocking
+# Test CRPEngine — constructor / property behaviour (no DB calls)
 # ─────────────────────────────────────────────────────────────
 
 class TestCRPEngine:
-    """Tests for CRPEngine class."""
-    
+    """Tests for CRPEngine class — pure constructor & guard behaviour."""
+
     def test_engine_initialization(self):
-        """Test engine initialization."""
+        """Engine starts with no connection; the connection setter assigns it."""
         engine = CRPEngine()
-        
         assert engine.connection is None
-        
-        mock_conn = Mock()
-        engine.connection = mock_conn
-        
-        assert engine.connection is mock_conn
-    
+
+        # Assign an opaque sentinel — we never touch SQL here, we just
+        # verify the property getter/setter round-trips correctly. Using
+        # `object()` rather than a Mock keeps this test mock-free.
+        sentinel = object()
+        engine.connection = sentinel
+        assert engine.connection is sentinel
+
     def test_engine_requires_connection(self):
-        """Test that engine requires database connection."""
+        """calculate() must raise when no connection has been wired up."""
         engine = CRPEngine()
-        
+
         with pytest.raises(ValueError, match="Database connection not set"):
             engine.calculate(horizon_days=30)
-    
-    def test_engine_calculate_no_work_centers(self, mock_db_connection):
-        """Test calculation when no work centers exist."""
-        conn, cursor = mock_db_connection
-        cursor.fetchall.return_value = []  # No work centers
-        
-        engine = CRPEngine(db_conn=conn)
-        result = engine.calculate(horizon_days=30)
-        
-        assert isinstance(result, CRPResult)
-        assert result.planned_orders_count == 0
-        assert result.work_centers_count == 0
-        assert len(result.overloads) == 0
-    
-    def test_engine_calculate_no_planned_orders(self, mock_db_connection, sample_work_center):
-        """Test calculation when no planned orders exist."""
-        conn, cursor = mock_db_connection
-        
-        # First call: fetch work centers
-        # Second call: fetch planned orders
-        cursor.fetchall.side_effect = [
-            [(sample_work_center.work_center_id, sample_work_center.code, sample_work_center.description,
-              sample_work_center.capacity_per_day, sample_work_center.efficiency, None, True)],
-            [],  # No planned orders
-        ]
-        
-        engine = CRPEngine(db_conn=conn)
-        result = engine.calculate(horizon_days=30)
-        
-        assert result.planned_orders_count == 0
-        assert result.work_centers_count == 0
-    
-    def test_engine_fetch_work_centers(self, mock_db_connection, sample_work_center):
-        """Test fetching work centers from database."""
-        conn, cursor = mock_db_connection
-        cursor.fetchall.return_value = [
-            (sample_work_center.work_center_id, sample_work_center.code, sample_work_center.description,
-             sample_work_center.capacity_per_day, sample_work_center.efficiency, None, True),
-        ]
-        
-        engine = CRPEngine(db_conn=conn)
-        work_centers = engine._fetch_work_centers()
-        
-        assert len(work_centers) == 1
-        assert sample_work_center.work_center_id in work_centers
-        assert work_centers[sample_work_center.work_center_id].code == sample_work_center.code
-    
-    def test_engine_fetch_work_centers_filtered(self, mock_db_connection, sample_work_center):
-        """Test fetching specific work centers by ID."""
-        conn, cursor = mock_db_connection
-        cursor.fetchall.return_value = [
-            (sample_work_center.work_center_id, sample_work_center.code, sample_work_center.description,
-             sample_work_center.capacity_per_day, sample_work_center.efficiency, None, True),
-        ]
-        
-        engine = CRPEngine(db_conn=conn)
-        work_centers = engine._fetch_work_centers([sample_work_center.work_center_id])
-        
-        assert len(work_centers) == 1
-        cursor.execute.assert_called_once()
-        # Verify WHERE clause includes the filter
-        call_args = cursor.execute.call_args[0][0]
-        assert "WHERE work_center_id IN" in call_args
-    
-    def test_engine_fetch_planned_orders(self, mock_db_connection, sample_planned_orders):
-        """Test fetching planned orders from database."""
-        conn, cursor = mock_db_connection
-        
-        # Convert planned orders to row format
-        rows = []
-        for po in sample_planned_orders:
-            rows.append((
-                po["planned_supply_id"],
-                po["item_id"],
-                po["location_id"],
-                po["quantity"],
-                po["due_date"],
-                po["status"],
-            ))
-        
-        cursor.fetchall.return_value = rows
-        
-        engine = CRPEngine(db_conn=conn)
-        start_date = date.today()
-        end_date = start_date + timedelta(days=90)
-        
-        orders = engine._fetch_planned_orders(start_date, end_date)
-        
-        assert len(orders) == 2
-        assert orders[0]["quantity"] == Decimal("100")
-        assert orders[1]["quantity"] == Decimal("50")
-    
-    def test_engine_fetch_planned_orders_with_scenario(self, mock_db_connection):
-        """Test fetching planned orders with scenario filter."""
-        conn, cursor = mock_db_connection
-        cursor.fetchall.return_value = []
-        
-        scenario_id = uuid4()
-        start_date = date.today()
-        end_date = start_date + timedelta(days=90)
-        
-        engine = CRPEngine(db_conn=conn)
-        engine._fetch_planned_orders(start_date, end_date, scenario_id)
-        
-        # Verify scenario filter was applied
-        call_args = cursor.execute.call_args[0]
-        assert call_args[0].count("scenario_id") >= 1
-        assert call_args[1][2] == scenario_id
-    
-    def test_engine_fetch_routings(self, mock_db_connection, sample_routing):
-        """Test fetching routings and operations from database."""
-        conn, cursor = mock_db_connection
-        
-        # First call: fetch routings
-        # Second call: fetch operations
-        cursor.fetchall.side_effect = [
-            [(sample_routing.routing_id, sample_routing.item_id, sample_routing.sequence,
-              sample_routing.description, sample_routing.active)],
-            [(op.operation_id, op.routing_id, op.sequence, op.work_center_id,
-              op.setup_time, op.run_time_per_unit, op.description, op.active)
-             for op in sample_routing.operations],
-        ]
-        
-        engine = CRPEngine(db_conn=conn)
-        item_ids = {sample_routing.item_id}
-        
-        routings = engine._fetch_routings(item_ids)
-        
-        assert len(routings) == 1
-        assert sample_routing.item_id in routings
-        assert len(routings[sample_routing.item_id].operations) == 2
-    
-    def test_engine_fetch_routings_empty(self, mock_db_connection):
-        """Test fetching routings when none exist."""
-        conn, cursor = mock_db_connection
-        cursor.fetchall.return_value = []
-        
-        engine = CRPEngine(db_conn=conn)
-        item_ids = {uuid4()}
-        
-        routings = engine._fetch_routings(item_ids)
-        
-        assert len(routings) == 0
 
 
 # ─────────────────────────────────────────────────────────────
-# Test CRPEngine - Load Calculation
+# Test pure model methods (no DB)
 # ─────────────────────────────────────────────────────────────
 
 class TestCRPEngineLoadCalculation:
-    """Tests for CRP load calculation logic."""
-    
+    """Tests for pure load-related model methods."""
+
     def test_operation_total_time(self):
-        """Test operation total time calculation."""
+        """Operation.total_time = setup + run_time * quantity."""
         op = Operation(
             operation_id=uuid4(),
             routing_id=uuid4(),
@@ -540,339 +329,28 @@ class TestCRPEngineLoadCalculation:
             description="Test Operation",
             active=True,
         )
-        
-        # Total time = setup + (run_time * quantity)
         total = op.total_time(Decimal("100"))
-        
         assert total == Decimal("52.0")  # 2.0 + (0.5 * 100)
-    
+
     def test_work_center_effective_capacity(self, sample_work_center):
-        """Test work center effective capacity calculation."""
-        # Effective capacity = capacity_per_day * efficiency
+        """WorkCenter.effective_capacity_per_day = capacity * efficiency."""
         effective = sample_work_center.effective_capacity_per_day()
-        
         assert effective == Decimal("7.2")  # 8.0 * 0.9
-    
-    def test_backward_scheduling_single_operation(self, mock_db_connection, sample_work_center):
-        """Test backward scheduling for a single operation."""
-        conn, cursor = mock_db_connection
-        
-        # Create routing with one operation
-        routing = Routing(
-            routing_id=uuid4(),
-            item_id=uuid4(),
-            sequence=1,
-            description="Single Op Routing",
-            active=True,
-        )
-        
-        op = Operation(
-            operation_id=uuid4(),
-            routing_id=routing.routing_id,
-            sequence=10,
-            work_center_id=sample_work_center.work_center_id,
-            setup_time=Decimal("0"),
-            run_time_per_unit=Decimal("0.1"),  # 0.1 hours per unit
-            description="Single Operation",
-            active=True,
-        )
-        routing.add_operation(op)
-        
-        # Mock database responses
-        cursor.fetchall.side_effect = [
-            [(sample_work_center.work_center_id, sample_work_center.code, sample_work_center.description,
-              sample_work_center.capacity_per_day, sample_work_center.efficiency, None, True)],
-            [(uuid4(), routing.item_id, uuid4(), Decimal("100"), date.today() + timedelta(days=10), "PLANNED")],
-            [(routing.routing_id, routing.item_id, routing.sequence, routing.description, routing.active)],
-            [(op.operation_id, op.routing_id, op.sequence, op.work_center_id,
-              op.setup_time, op.run_time_per_unit, op.description, op.active)],
-        ]
-        
-        engine = CRPEngine(db_conn=conn)
-        result = engine.calculate(horizon_days=30)
-        
-        assert result.planned_orders_count == 1
-        assert result.work_centers_count == 1
-    
-    def test_load_aggregation_multiple_orders(self, mock_db_connection, sample_work_center):
-        """Test load aggregation from multiple planned orders."""
-        conn, cursor = mock_db_connection
-        
-        # Create routing
-        routing = Routing(
-            routing_id=uuid4(),
-            item_id=uuid4(),
-            sequence=1,
-            description="Test Routing",
-            active=True,
-        )
-        
-        op = Operation(
-            operation_id=uuid4(),
-            routing_id=routing.routing_id,
-            sequence=10,
-            work_center_id=sample_work_center.work_center_id,
-            setup_time=Decimal("0"),
-            run_time_per_unit=Decimal("0.1"),
-            description="Test Operation",
-            active=True,
-        )
-        routing.add_operation(op)
-        
-        item_id = routing.item_id
-        
-        # Mock database responses - two planned orders for same item
-        cursor.fetchall.side_effect = [
-            [(sample_work_center.work_center_id, sample_work_center.code, sample_work_center.description,
-              sample_work_center.capacity_per_day, sample_work_center.efficiency, None, True)],
-            [
-                (uuid4(), item_id, uuid4(), Decimal("100"), date.today() + timedelta(days=10), "PLANNED"),
-                (uuid4(), item_id, uuid4(), Decimal("100"), date.today() + timedelta(days=10), "PLANNED"),
-            ],
-            [(routing.routing_id, routing.item_id, routing.sequence, routing.description, routing.active)],
-            [(op.operation_id, op.routing_id, op.sequence, op.work_center_id,
-              op.setup_time, op.run_time_per_unit, op.description, op.active)],
-        ]
-        
-        engine = CRPEngine(db_conn=conn)
-        result = engine.calculate(horizon_days=30)
-        
-        # Both orders should contribute to load
-        assert result.planned_orders_count == 2
-        
-        # Check load profile
-        profile = result.load_profiles.get(sample_work_center.work_center_id)
-        assert profile is not None
 
 
 # ─────────────────────────────────────────────────────────────
-# Test CRPEngine - Overload Detection
-# ─────────────────────────────────────────────────────────────
-
-class TestCRPEngineOverloadDetection:
-    """Tests for CRP overload detection."""
-    
-    def test_overload_detection_basic(self, mock_db_connection, sample_work_center):
-        """Test basic overload detection."""
-        conn, cursor = mock_db_connection
-        
-        # Create routing with operation that will cause overload
-        # To cause overload, we need load > capacity on at least one day
-        # Sample work center: 8 hours/day * 0.9 efficiency = 7.2 hours/day effective capacity
-        # For a single-day operation to cause overload, we need total_hours > 7.2
-        # Use setup + run_time that exceeds capacity in one day
-        item_id = uuid4()
-        routing = Routing(
-            routing_id=uuid4(),
-            item_id=item_id,
-            sequence=1,
-            description="Overload Test Routing",
-            active=True,
-        )
-        
-        # Setup time alone exceeds daily capacity: 10 hours > 7.2 hours/day
-        # This will be a 1-day operation (10 hours / 7.2 = 1.39, rounded to 2 days)
-        # But we want single-day overload, so use very high setup that stays in 1 day
-        # Actually: 10 hours / 7.2 capacity = 1.39 days -> 2 days -> 5 hours/day (no overload)
-        # Need: load that stays in 1 day and exceeds 7.2
-        # Use 8 hours setup + small run time = 8 hours total, 8/7.2 = 1.11 -> 2 days -> 4 hours/day
-        # Still no overload per day!
-        # 
-        # Solution: Use quantity that creates load > capacity even when spread
-        # If we want 1 day with overload: need total_hours such that total_hours/1_day > 7.2
-        # That means total_hours > 7.2 AND days_needed = 1
-        # days_needed = ceil(total_hours / 7.2) = 1 means total_hours <= 7.2
-        # Contradiction! Can't have 1 day with load > capacity using current logic.
-        #
-        # Alternative: Multiple orders on same day
-        # Create 2 planned orders with same due date, each creating load
-        item_id2 = uuid4()
-        routing2 = Routing(
-            routing_id=uuid4(),
-            item_id=item_id2,
-            sequence=1,
-            description="Overload Test Routing 2",
-            active=True,
-        )
-        op2 = Operation(
-            operation_id=uuid4(),
-            routing_id=routing2.routing_id,
-            sequence=10,
-            work_center_id=sample_work_center.work_center_id,
-            setup_time=Decimal("0"),
-            run_time_per_unit=Decimal("0.1"),
-            description="Load Operation 2",
-            active=True,
-        )
-        routing2.add_operation(op2)
-        
-        op = Operation(
-            operation_id=uuid4(),
-            routing_id=routing.routing_id,
-            sequence=10,
-            work_center_id=sample_work_center.work_center_id,
-            setup_time=Decimal("0"),
-            run_time_per_unit=Decimal("0.1"),
-            description="Load Operation 1",
-            active=True,
-        )
-        routing.add_operation(op)
-        
-        # Two orders, each 50 units * 0.1 hours = 5 hours, same due date
-        # 5 + 5 = 10 hours on same day > 7.2 capacity = overload
-        due_date = date.today() + timedelta(days=5)
-        cursor.fetchall.side_effect = [
-            [(sample_work_center.work_center_id, sample_work_center.code, sample_work_center.description,
-              sample_work_center.capacity_per_day, sample_work_center.efficiency, None, True)],
-            [
-                (uuid4(), item_id, uuid4(), Decimal("50"), due_date, "PLANNED"),
-                (uuid4(), item_id2, uuid4(), Decimal("50"), due_date, "PLANNED"),
-            ],
-            [
-                (routing.routing_id, routing.item_id, routing.sequence, routing.description, routing.active),
-                (routing2.routing_id, routing2.item_id, routing2.sequence, routing2.description, routing2.active),
-            ],
-            [
-                (op.operation_id, op.routing_id, op.sequence, op.work_center_id,
-                 op.setup_time, op.run_time_per_unit, op.description, op.active),
-                (op2.operation_id, op2.routing_id, op2.sequence, op2.work_center_id,
-                 op2.setup_time, op2.run_time_per_unit, op2.description, op2.active),
-            ],
-        ]
-        
-        engine = CRPEngine(db_conn=conn)
-        result = engine.calculate(horizon_days=30)
-        
-        # Should detect overloads (10 hours of work on ~7.2 hours/day capacity)
-        assert len(result.overloads) > 0
-        assert result.overloads[0].excess_hours > Decimal("0")
-    
-    def test_no_overload_when_capacity_sufficient(self, mock_db_connection, sample_work_center):
-        """Test no overload when capacity is sufficient."""
-        conn, cursor = mock_db_connection
-        
-        routing = Routing(
-            routing_id=uuid4(),
-            item_id=uuid4(),
-            sequence=1,
-            description="No Overload Routing",
-            active=True,
-        )
-        
-        # Low run time
-        op = Operation(
-            operation_id=uuid4(),
-            routing_id=routing.routing_id,
-            sequence=10,
-            work_center_id=sample_work_center.work_center_id,
-            setup_time=Decimal("0"),
-            run_time_per_unit=Decimal("0.01"),  # 0.01 hours per unit
-            description="Low Load Operation",
-            active=True,
-        )
-        routing.add_operation(op)
-        
-        item_id = routing.item_id
-        
-        # Small quantity
-        cursor.fetchall.side_effect = [
-            [(sample_work_center.work_center_id, sample_work_center.code, sample_work_center.description,
-              sample_work_center.capacity_per_day, sample_work_center.efficiency, None, True)],
-            [(uuid4(), item_id, uuid4(), Decimal("10"), date.today() + timedelta(days=5), "PLANNED")],
-            [(routing.routing_id, routing.item_id, routing.sequence, routing.description, routing.active)],
-            [(op.operation_id, op.routing_id, op.sequence, op.work_center_id,
-              op.setup_time, op.run_time_per_unit, op.description, op.active)],
-        ]
-        
-        engine = CRPEngine(db_conn=conn)
-        result = engine.calculate(horizon_days=30)
-        
-        # Should have no overloads (0.1 hours of work)
-        assert len(result.overloads) == 0
-
-
-# ─────────────────────────────────────────────────────────────
-# Test CRPEngine - Load Profile Queries
-# ─────────────────────────────────────────────────────────────
-
-class TestCRPEngineLoadProfileQueries:
-    """Tests for load profile query methods."""
-    
-    def test_get_load_profile(self, mock_db_connection, sample_work_center):
-        """Test getting load profile for specific work center."""
-        conn, cursor = mock_db_connection
-        
-        item_id = uuid4()
-        routing = Routing(
-            routing_id=uuid4(),
-            item_id=item_id,
-            sequence=1,
-            description="Test Routing",
-            active=True,
-        )
-        op = Operation(
-            operation_id=uuid4(),
-            routing_id=routing.routing_id,
-            sequence=10,
-            work_center_id=sample_work_center.work_center_id,
-            setup_time=Decimal("0"),
-            run_time_per_unit=Decimal("0.01"),
-            description="Test Op",
-            active=True,
-        )
-        routing.add_operation(op)
-        
-        cursor.fetchall.side_effect = [
-            [(sample_work_center.work_center_id, sample_work_center.code, sample_work_center.description,
-              sample_work_center.capacity_per_day, sample_work_center.efficiency, None, True)],
-            [(uuid4(), item_id, uuid4(), Decimal("10"), date.today() + timedelta(days=5), "PLANNED")],
-            [(routing.routing_id, routing.item_id, routing.sequence, routing.description, routing.active)],
-            [(op.operation_id, op.routing_id, op.sequence, op.work_center_id,
-              op.setup_time, op.run_time_per_unit, op.description, op.active)],
-        ]
-        
-        engine = CRPEngine(db_conn=conn)
-        profile = engine.get_load_profile(
-            work_center_id=sample_work_center.work_center_id,
-            horizon_days=30,
-        )
-        
-        assert profile is not None
-        assert profile.work_center_id == sample_work_center.work_center_id
-        assert len(profile.buckets) == 31  # 30 days horizon = today + 30 days = 31 days total
-    
-    def test_get_overloads(self, mock_db_connection, sample_work_center):
-        """Test getting overloads."""
-        conn, cursor = mock_db_connection
-        
-        cursor.fetchall.side_effect = [
-            [(sample_work_center.work_center_id, sample_work_center.code, sample_work_center.description,
-              sample_work_center.capacity_per_day, sample_work_center.efficiency, None, True)],
-            [],  # No planned orders
-        ]
-        
-        engine = CRPEngine(db_conn=conn)
-        overloads = engine.get_overloads(horizon_days=30)
-        
-        assert isinstance(overloads, list)
-        assert len(overloads) == 0  # No orders = no overloads
-
-
-# ─────────────────────────────────────────────────────────────
-# Test CRPResult
+# Test CRPResult — pure in-memory aggregation
 # ─────────────────────────────────────────────────────────────
 
 class TestCRPResult:
     """Tests for CRPResult class."""
-    
+
     def test_crp_result_creation(self):
-        """Test basic CRP result creation."""
         calc_id = uuid4()
         start = date.today()
         end = start + timedelta(days=90)
-        
         result = CRPResult(calc_id, start, end)
-        
+
         assert result.calculation_id == calc_id
         assert result.horizon_start == start
         assert result.horizon_end == end
@@ -880,30 +358,25 @@ class TestCRPResult:
         assert result.work_centers_count == 0
         assert len(result.load_profiles) == 0
         assert len(result.overloads) == 0
-    
+
     def test_crp_result_add_load_profile(self, sample_work_center):
-        """Test adding load profiles to result."""
         calc_id = uuid4()
         start = date.today()
         end = start + timedelta(days=90)
-        
         result = CRPResult(calc_id, start, end)
-        
+
         profile = LoadProfile(sample_work_center.work_center_id, sample_work_center.code)
         result.add_load_profile(profile)
-        
+
         assert result.work_centers_count == 1
         assert sample_work_center.work_center_id in result.load_profiles
-    
+
     def test_crp_result_collect_overloads(self, sample_work_center):
-        """Test collecting overloads from load profiles."""
         calc_id = uuid4()
         start = date.today()
         end = start + timedelta(days=90)
-        
         result = CRPResult(calc_id, start, end)
-        
-        # Add profile with overloads
+
         profile = LoadProfile(sample_work_center.work_center_id, sample_work_center.code)
         profile.add_bucket(LoadBucket(
             work_center_id=sample_work_center.work_center_id,
@@ -911,235 +384,28 @@ class TestCRPResult:
             load_hours=Decimal("12.0"),
             capacity_hours=Decimal("8.0"),
         ))
-        
         result.add_load_profile(profile)
         result.collect_overloads()
-        
+
         assert len(result.overloads) == 1
         assert result.overloads[0].work_center_id == sample_work_center.work_center_id
-    
+
     def test_crp_result_to_dict(self, sample_work_center):
-        """Test conversion to dictionary."""
         calc_id = uuid4()
         start = date.today()
         end = start + timedelta(days=90)
-        
         result = CRPResult(calc_id, start, end)
         result.planned_orders_count = 10
         result.calculation_time_ms = 150.5
-        
+
         profile = LoadProfile(sample_work_center.work_center_id, sample_work_center.code)
         result.add_load_profile(profile)
         result.collect_overloads()
-        
+
         result_dict = result.to_dict()
-        
         assert result_dict["calculation_id"] == str(calc_id)
         assert result_dict["horizon_start"] == start.isoformat()
         assert result_dict["horizon_end"] == end.isoformat()
         assert result_dict["planned_orders_count"] == 10
         assert result_dict["work_centers_count"] == 1
         assert result_dict["calculation_time_ms"] == 150.5
-
-
-# ─────────────────────────────────────────────────────────────
-# Test Performance
-# ─────────────────────────────────────────────────────────────
-
-class TestCRPEnginePerformance:
-    """Performance tests for CRP engine."""
-    
-    def test_performance_1000_orders(self, mock_db_connection, sample_work_center):
-        """Test performance with 1000+ planned orders."""
-        import time
-        
-        conn, cursor = mock_db_connection
-        
-        # Create routing
-        routing = Routing(
-            routing_id=uuid4(),
-            item_id=uuid4(),
-            sequence=1,
-            description="Performance Test Routing",
-            active=True,
-        )
-        
-        op = Operation(
-            operation_id=uuid4(),
-            routing_id=routing.routing_id,
-            sequence=10,
-            work_center_id=sample_work_center.work_center_id,
-            setup_time=Decimal("0"),
-            run_time_per_unit=Decimal("0.01"),
-            description="Test Operation",
-            active=True,
-        )
-        routing.add_operation(op)
-        
-        item_id = routing.item_id
-        
-        # Generate 1000 planned orders
-        planned_orders_data = []
-        for i in range(1000):
-            planned_orders_data.append((
-                uuid4(),
-                item_id,
-                uuid4(),
-                Decimal("10"),
-                date.today() + timedelta(days=i % 90),
-                "PLANNED",
-            ))
-        
-        cursor.fetchall.side_effect = [
-            [(sample_work_center.work_center_id, sample_work_center.code, sample_work_center.description,
-              sample_work_center.capacity_per_day, sample_work_center.efficiency, None, True)],
-            planned_orders_data,
-            [(routing.routing_id, routing.item_id, routing.sequence, routing.description, routing.active)],
-            [(op.operation_id, op.routing_id, op.sequence, op.work_center_id,
-              op.setup_time, op.run_time_per_unit, op.description, op.active)],
-        ]
-        
-        engine = CRPEngine(db_conn=conn)
-        
-        start_time = time.perf_counter()
-        result = engine.calculate(horizon_days=90)
-        elapsed = time.perf_counter() - start_time
-        
-        assert result.planned_orders_count == 1000
-        
-        # Performance target: <500ms
-        # Note: This is with mocked DB, actual performance may vary
-        assert elapsed < 2.0, f"Calculation took {elapsed:.2f}s, expected <2.0s"
-
-
-# ─────────────────────────────────────────────────────────────
-# Test Edge Cases
-# ─────────────────────────────────────────────────────────────
-
-class TestCRPEdgeCases:
-    """Tests for edge cases and error handling."""
-    
-    def test_inactive_work_center_excluded(self, mock_db_connection, sample_work_center):
-        """Test that inactive work centers are excluded."""
-        conn, cursor = mock_db_connection
-        
-        # Return inactive work center
-        cursor.fetchall.return_value = [
-            (sample_work_center.work_center_id, sample_work_center.code, sample_work_center.description,
-             sample_work_center.capacity_per_day, sample_work_center.efficiency, None, False),  # inactive
-        ]
-        
-        engine = CRPEngine(db_conn=conn)
-        work_centers = engine._fetch_work_centers()
-        
-        # Inactive work centers should be filtered by SQL WHERE clause
-        # but if returned, they won't be used in load calculation
-        assert len(work_centers) == 1
-    
-    def test_inactive_operation_excluded(self, mock_db_connection, sample_work_center):
-        """Test that inactive operations are excluded."""
-        conn, cursor = mock_db_connection
-        
-        routing = Routing(
-            routing_id=uuid4(),
-            item_id=uuid4(),
-            sequence=1,
-            description="Test Routing",
-            active=True,
-        )
-        
-        # Inactive operation
-        op = Operation(
-            operation_id=uuid4(),
-            routing_id=routing.routing_id,
-            sequence=10,
-            work_center_id=sample_work_center.work_center_id,
-            setup_time=Decimal("1.0"),
-            run_time_per_unit=Decimal("0.5"),
-            description="Inactive Operation",
-            active=False,  # inactive
-        )
-        routing.add_operation(op)
-        
-        cursor.fetchall.side_effect = [
-            [(sample_work_center.work_center_id, sample_work_center.code, sample_work_center.description,
-              sample_work_center.capacity_per_day, sample_work_center.efficiency, None, True)],
-            [(uuid4(), routing.item_id, uuid4(), Decimal("100"), date.today() + timedelta(days=10), "PLANNED")],
-            [(routing.routing_id, routing.item_id, routing.sequence, routing.description, routing.active)],
-            [(op.operation_id, op.routing_id, op.sequence, op.work_center_id,
-              op.setup_time, op.run_time_per_unit, op.description, op.active)],
-        ]
-        
-        engine = CRPEngine(db_conn=conn)
-        engine.calculate(horizon_days=30)
-        
-        # Inactive operations should be filtered out during scheduling
-        # The operation won't be added to load buckets
-    
-    def test_zero_capacity_work_center(self, mock_db_connection):
-        """Test handling of work center with zero capacity."""
-        conn, cursor = mock_db_connection
-        
-        wc = WorkCenter(
-            work_center_id=uuid4(),
-            code="WC-ZERO",
-            description="Zero Capacity",
-            capacity_per_day=Decimal("0"),
-            efficiency=Decimal("1.0"),
-            calendar_id=None,
-            active=True,
-        )
-        
-        item_id = uuid4()
-        routing = Routing(
-            routing_id=uuid4(),
-            item_id=item_id,
-            sequence=1,
-            description="Test Routing",
-            active=True,
-        )
-        op = Operation(
-            operation_id=uuid4(),
-            routing_id=routing.routing_id,
-            sequence=10,
-            work_center_id=wc.work_center_id,
-            setup_time=Decimal("0"),
-            run_time_per_unit=Decimal("0.1"),
-            description="Test Op",
-            active=True,
-        )
-        routing.add_operation(op)
-        
-        cursor.fetchall.side_effect = [
-            [(wc.work_center_id, wc.code, wc.description,
-             wc.capacity_per_day, wc.efficiency, None, True)],
-            [(uuid4(), item_id, uuid4(), Decimal("10"), date.today() + timedelta(days=5), "PLANNED")],
-            [(routing.routing_id, routing.item_id, routing.sequence, routing.description, routing.active)],
-            [(op.operation_id, op.routing_id, op.sequence, op.work_center_id,
-              op.setup_time, op.run_time_per_unit, op.description, op.active)],
-        ]
-        
-        engine = CRPEngine(db_conn=conn)
-        result = engine.calculate(horizon_days=30)
-        
-        # Should handle zero capacity gracefully
-        assert result is not None
-        assert result.work_centers_count == 1
-    
-    def test_scenario_filter_applied(self, mock_db_connection):
-        """Test that scenario filter is properly applied."""
-        conn, cursor = mock_db_connection
-        
-        scenario_id = uuid4()
-        
-        cursor.fetchall.side_effect = [
-            [],  # work centers
-        ]
-        
-        engine = CRPEngine(db_conn=conn)
-        engine.calculate(horizon_days=30, scenario_id=scenario_id)
-        
-        # Verify scenario was passed to query (check the call was made)
-        assert cursor.execute.call_count >= 1
-        # The first call should be for work centers (no scenario filter)
-        # Since no work centers, planned orders won't be fetched


### PR DESCRIPTION
## Summary
Eighth mock-cleanup batch. Removes the \`mock_db_connection\` fixture pattern from CRP engine tests. The audit's grep only counted 3 occurrences but the fixture was reused in ~30 test methods.

| File | Before | After | Tests |
|---|---:|---:|---:|
| \`tests/test_crp_engine.py\` | 1145 | 411 | 19 (was 28) |
| \`tests/integration/test_crp_engine_integration.py\` | (new) | 880 | 19 |

Net 28 → 38 tests. Increase from splitting Pydantic vs engine paths and from behavioural assertions replacing SQL-string mock inspections.

## Notable rewrites
- 2 SQL-string assertions (\`"WHERE ... IN"\`, \`call_args\` inspection) → behavioural integration tests with real seeds + filtering.
- \`test_calculate_no_work_centers\` uses \`UPDATE active=false\` (rolled back in teardown) rather than DELETE because \`routing_operations\` FKs would block the delete.

## Performance threshold
\`test_performance_1000_orders\` (@pytest.mark.slow):
- Mocked DB threshold: <2s (engine internal target: <500ms)
- Real DB threshold: <10s (accounts for 1000 seed INSERTs + IN-clause SELECT + scheduling loop)

## Notes flagged for follow-up
1. **Engine source bug** found while reading \`crp/engine.py\`: \`_suggest_resolution_for_overload\` references table \`operations\` (should be \`routing_operations\`). Not exercised by any test in this file. Worth a separate fix PR.
2. **No \`capacity_overrides\` table exists** (migration 028 uses \`work_centers.capacity_per_day + efficiency\`). CRPEngine fetches \`calendar_id\` but doesn't use it in scheduling.

## Verification
- ruff clean
- 19 slim tests pass without \`DATABASE_URL\`
- 19 integration tests collect cleanly under \`requires_db\`
- 0 mocks in integration file (only docstring mention)
- No production code touched

## Mock cleanup progress
| File | State |
|---|---|
| test_db_connection.py | ✓ #252 |
| test_llc_calculator.py | ✓ #252 |
| test_graph_store.py | ✓ #253 |
| test_atp_engine.py | ✓ #254 |
| test_forecasting_api.py | ✓ #255 |
| test_m6_api.py | ✓ #256 |
| test_m4_shortage.py | ✓ #257 |
| test_router_bom/ghosts/rccp.py | ✓ #258 |
| test_crp_engine.py | ✓ (this PR) |
| test_phase1_integration.py | last one pending |