### PR TITLE
fix(api,engine): 3 bonus cleanups from audit follow-up

### DIFF
--- a/src/ootils_core/api/routers/graph.py
+++ b/src/ootils_core/api/routers/graph.py
@@ -64,12 +64,13 @@ async def get_graph(
     scenario_id: UUID = Depends(resolve_scenario_id),
 ) -> GraphResponse:
     """Return nodes and edges for the planning graph at (item, location, scenario)."""
-    # Resolve item UUID
+    # Resolve item UUID — accept UUID, name, or external_id (aligned with projection.py)
     try:
         item_uuid = UUID(item_id)
     except ValueError:
         row = db.execute(
-            "SELECT item_id FROM items WHERE name = %s LIMIT 1", (item_id,)
+            "SELECT item_id FROM items WHERE name = %s OR external_id = %s LIMIT 1",
+            (item_id, item_id),
         ).fetchone()
         if row is None:
             raise HTTPException(
@@ -77,12 +78,13 @@ async def get_graph(
             )
         item_uuid = UUID(str(row["item_id"]))
 
-    # Resolve location UUID
+    # Resolve location UUID — accept UUID, name, or external_id
     try:
         location_uuid = UUID(location_id)
     except ValueError:
         row = db.execute(
-            "SELECT location_id FROM locations WHERE name = %s LIMIT 1", (location_id,)
+            "SELECT location_id FROM locations WHERE name = %s OR external_id = %s LIMIT 1",
+            (location_id, location_id),
         ).fetchone()
         if row is None:
             raise HTTPException(

--- a/src/ootils_core/api/routers/rccp.py
+++ b/src/ootils_core/api/routers/rccp.py
@@ -148,7 +148,9 @@ def _count_working_days(
             """,
             (location_id, start, end),
         ).fetchone()
-        if row and row["cnt"] > 0:
+        # SELECT COUNT(*) always returns one row; cnt == 0 means the calendar
+        # has no working_day entries for this range → fall through to Mon-Fri.
+        if row["cnt"] > 0:
             return int(row["cnt"])
 
     # Fallback: count Mon–Fri in [start, end]

--- a/src/ootils_core/crp/engine.py
+++ b/src/ootils_core/crp/engine.py
@@ -826,7 +826,7 @@ class CRPEngine:
                 FROM planned_supply ps
                 JOIN items i ON ps.item_id = i.item_id
                 JOIN routings r ON i.item_id = r.item_id AND r.active = true
-                JOIN operations op ON r.routing_id = op.routing_id AND op.active = true
+                JOIN routing_operations op ON r.routing_id = op.routing_id AND op.active = true
                 JOIN work_centers wc ON op.work_center_id = wc.work_center_id
                 WHERE ps.due_date >= %s
                   AND ps.due_date <= %s


### PR DESCRIPTION
## Summary
Three small bugs/inconsistencies surfaced by the test-mock cleanup agents while reading the source. Bundled because they're all one-or-two-line fixes.

| # | Site | Fix |
|---|---|---|
| 1 | \`crp/engine.py:829\` | Table name typo \`operations\` → \`routing_operations\` (the real table, created in mig 028). Would have manifested as runtime "relation does not exist" error on overload resolution. |
| 2 | \`api/routers/graph.py:71,84\` | Look up items/locations by \`name OR external_id\` to match \`projection.py\`'s behaviour. Same client identifier should work across endpoints. |
| 3 | \`api/routers/rccp.py:151\` | Drop dead \`row and\` guard (\`SELECT COUNT(*)\` always returns one row). Added a comment clarifying that \`cnt == 0\` deliberately falls through to the Mon-Fri fallback. |

## Verification
- ruff clean on all 3 files
- \`test_router_rccp.py\`: 24/24 pass (no regression on the cleanup)
- The \`crp/engine.py\` bug is not exercised by any current test (no test calls \`_suggest_resolution_for_overload\`) — visual review only. Worth a follow-up integration test in a separate PR.