### PR TITLE
fix(kernel): drive ShortageRecord timestamps from injected clock (chantier 6 follow-up)

### DIFF
--- a/src/ootils_core/engine/kernel/shortage/detector.py
+++ b/src/ootils_core/engine/kernel/shortage/detector.py
@@ -112,6 +112,10 @@ class ShortageDetector:
 
         shortage_date = pi_node.time_span_start or pi_node.time_ref
 
+        # Drive timestamps from the injected clock so the record is fully
+        # deterministic (ADR-003). The dataclass defaults to wall-clock
+        # datetime.now() — overridden here.
+        now = self._clock.now()
         record = ShortageRecord(
             shortage_id=deterministic_uuid(
                 "shortage", scenario_id, calc_run_id, pi_node.node_id,
@@ -127,6 +131,8 @@ class ShortageDetector:
             calc_run_id=calc_run_id,
             status="active",
             severity_class=severity_class,
+            created_at=now,
+            updated_at=now,
         )
 
         logger.debug(


### PR DESCRIPTION
## Summary
`ShortageRecord.created_at` / `updated_at` use `field(default_factory=lambda: datetime.now(timezone.utc))` (in `models/__init__.py`). The detector previously didn't pass these explicitly, so the dataclass defaults fired immediately with wall-clock time, bypassing the `Clock` injection from chantier 6.

The `persist()` SQL already used `self._clock.now()` correctly, but the dataclass values were already populated before the INSERT, so the row landed with the wall-clock value via the `shortage.created_at` parameter binding.

## Fix
Explicitly compute `now = self._clock.now()` in `detect_with_params` and pass `created_at=now, updated_at=now` to the dataclass constructor.

## Scope note
This fully fixes the INSERT path. The UPDATE path on `shortages.updated_at` is still overridden by the DB trigger `trg_shortages_updated_at` (migration 016) — see the xfailed `test_uses_clock_for_updated_at` in #257. That's a separate trigger-vs-app-clock architectural issue, not addressed here.

## Verification
- ruff clean
- 20 unit tests pass