### PR TITLE
feat(seed): add LINE-ATL-01 + LINE-LAX-01 resources to demo seed

### DIFF
--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -95,6 +95,27 @@ def seed(conn):
     print(f"  ✓ Locations: DC-ATL ({atl_id[:8]}...), DC-LAX ({lax_id[:8]}...)")
 
     # ------------------------------------------------------------------
+    # 2.5. Resources (one per location for RCCP / capacity tests)
+    # ------------------------------------------------------------------
+    res_atl_id = _uid("resource:LINE-ATL-01")
+    res_lax_id = _uid("resource:LINE-LAX-01")
+
+    conn.execute("""
+        INSERT INTO resources (resource_id, external_id, name, resource_type,
+                               location_id, capacity_per_day, capacity_unit)
+        VALUES (%s, 'LINE-ATL-01', 'Atlanta Assembly Line 1', 'line',
+                %s, 480.0, 'minutes'),
+               (%s, 'LINE-LAX-01', 'Los Angeles Assembly Line 1', 'line',
+                %s, 480.0, 'minutes')
+        ON CONFLICT (external_id) DO UPDATE
+            SET name = EXCLUDED.name,
+                location_id = EXCLUDED.location_id,
+                capacity_per_day = EXCLUDED.capacity_per_day,
+                capacity_unit = EXCLUDED.capacity_unit
+    """, (res_atl_id, atl_id, res_lax_id, lax_id))
+    print(f"  ✓ Resources: LINE-ATL-01 ({res_atl_id[:8]}...), LINE-LAX-01 ({res_lax_id[:8]}...)")
+
+    # ------------------------------------------------------------------
     # 3. Projection series  (deterministic IDs)
     # ------------------------------------------------------------------
     series_pump_atl = _uid("series:PUMP-01:DC-ATL")


### PR DESCRIPTION
## Summary
PR #258 (router tests cleanup) flagged that `scripts/seed_demo_data.py` doesn't seed any `resources` rows, so the RCCP integration tests had to inline-seed their own. Same gap in `tests/integration/test_rccp.py`.

Adds 2 `line`-type resources (one per location, deterministic uuid5):

- `LINE-ATL-01` @ `DC-ATL` — 480 min/day capacity
- `LINE-LAX-01` @ `DC-LAX` — 480 min/day capacity

Idempotent via `ON CONFLICT (external_id) DO UPDATE` so re-running the seed picks up name/capacity changes.

## Follow-up scope
Tests that previously inserted resources inline can now rely on these being available in the seeded DB. Migrating those tests to use the centralised resources is a separate cleanup — keeping the inline seeders working for backwards compatibility for now.

## Verification
- Python syntax compile OK
- Pre-existing ruff F541 warnings in this file are unrelated to this PR