### PR TITLE
feat(db): migration 034 — fusion work_centers → resources (ADR-014 D1+D2)

### DIFF
--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -104,9 +104,9 @@ def seed(conn):
         INSERT INTO resources (resource_id, external_id, name, resource_type,
                                location_id, capacity_per_day, capacity_unit)
         VALUES (%s, 'LINE-ATL-01', 'Atlanta Assembly Line 1', 'line',
-                %s, 480.0, 'minutes'),
+                %s, 480.0, 'minute'),
                (%s, 'LINE-LAX-01', 'Los Angeles Assembly Line 1', 'line',
-                %s, 480.0, 'minutes')
+                %s, 480.0, 'minute')
         ON CONFLICT (external_id) DO UPDATE
             SET name = EXCLUDED.name,
                 location_id = EXCLUDED.location_id,

--- a/src/ootils_core/crp/engine.py
+++ b/src/ootils_core/crp/engine.py
@@ -492,41 +492,46 @@ class CRPEngine:
             Dictionary mapping work_center_id to WorkCenter
         """
         work_centers: Dict[UUID, WorkCenter] = {}
-        
+
         with self._conn.cursor() as cur:
+            # Migration 034 (ADR-014 D1): work_centers merged into resources.
+            # The engine does not discriminate by resource_type — every active
+            # row in `resources` is schedulable. We map DB columns to the
+            # internal WorkCenter dataclass: resource_id → work_center_id,
+            # external_id → code, name → description.
             if work_center_ids:
                 placeholders = ",".join("%s" for _ in work_center_ids)
                 cur.execute(f"""
-                    SELECT 
-                        work_center_id,
-                        code,
-                        description,
+                    SELECT
+                        resource_id,
+                        external_id,
+                        name,
                         capacity_per_day,
                         efficiency,
                         calendar_id,
                         active
-                    FROM work_centers
-                    WHERE work_center_id IN ({placeholders})
+                    FROM resources wc
+                    WHERE wc.resource_id IN ({placeholders})
                       AND active = true
                 """, work_center_ids)
             else:
                 cur.execute("""
-                    SELECT 
-                        work_center_id,
-                        code,
-                        description,
+                    SELECT
+                        resource_id,
+                        external_id,
+                        name,
                         capacity_per_day,
                         efficiency,
                         calendar_id,
                         active
-                    FROM work_centers
+                    FROM resources wc
                     WHERE active = true
                 """)
-            
+
             for row in cur.fetchall():
                 wc_id, code, desc, cap, eff, cal_id, active = _row_values(
                     row,
-                    ["work_center_id", "code", "description", "capacity_per_day", "efficiency", "calendar_id", "active"],
+                    ["resource_id", "external_id", "name", "capacity_per_day", "efficiency", "calendar_id", "active"],
                 )
                 work_centers[wc_id] = WorkCenter(
                     work_center_id=wc_id,
@@ -537,7 +542,7 @@ class CRPEngine:
                     calendar_id=cal_id,
                     active=active,
                 )
-        
+
         return work_centers
     
     def _fetch_planned_orders(
@@ -665,11 +670,11 @@ class CRPEngine:
                 routing_ids = list(routing_map.keys())
                 placeholders = ",".join("%s" for _ in routing_ids)
                 cur.execute(f"""
-                    SELECT 
+                    SELECT
                         operation_id,
                         routing_id,
                         sequence,
-                        work_center_id,
+                        resource_id,
                         setup_time,
                         run_time_per_unit,
                         description,
@@ -679,11 +684,16 @@ class CRPEngine:
                       AND active = true
                     ORDER BY routing_id, sequence
                 """, routing_ids)
-                
+
+                # Migration 034: routing_operations.work_center_id renamed
+                # to resource_id. We keep the internal Python attribute
+                # `Operation.work_center_id` so the rest of the engine
+                # (load aggregation, suggest_resolutions, etc.) doesn't
+                # need to change.
                 for row in cur.fetchall():
                     op_id, r_id, seq, wc_id, setup, run, desc, active = _row_values(
                         row,
-                        ["operation_id", "routing_id", "sequence", "work_center_id", "setup_time", "run_time_per_unit", "description", "active"],
+                        ["operation_id", "routing_id", "sequence", "resource_id", "setup_time", "run_time_per_unit", "description", "active"],
                     )
                     op = Operation(
                         operation_id=op_id,
@@ -810,8 +820,15 @@ class CRPEngine:
         # Fetch planned orders that contribute to this work center on this date
         # These are orders whose operations fall on the overload date
         with self._conn.cursor() as cur:
+            # Migration 034: work_centers merged into resources.
+            #   wc.code         → wc.external_id
+            #   wc.work_center_id → wc.resource_id
+            #   op.work_center_id → op.resource_id
+            # The alias `wc` and the SQL column alias `work_center_code`
+            # are kept so downstream Python (suggestion dict keys) is
+            # untouched.
             cur.execute("""
-                SELECT 
+                SELECT
                     ps.planned_supply_id,
                     ps.item_id,
                     ps.quantity,
@@ -822,15 +839,15 @@ class CRPEngine:
                     op.sequence,
                     op.run_time_per_unit,
                     op.setup_time,
-                    wc.code AS work_center_code
+                    wc.external_id AS work_center_code
                 FROM planned_supply ps
                 JOIN items i ON ps.item_id = i.item_id
                 JOIN routings r ON i.item_id = r.item_id AND r.active = true
                 JOIN routing_operations op ON r.routing_id = op.routing_id AND op.active = true
-                JOIN work_centers wc ON op.work_center_id = wc.work_center_id
+                JOIN resources wc ON op.resource_id = wc.resource_id
                 WHERE ps.due_date >= %s
                   AND ps.due_date <= %s
-                  AND wc.work_center_id = %s
+                  AND wc.resource_id = %s
                   AND ps.status IN ('RELEASED', 'APPROVED', 'PLANNED')
                 ORDER BY ps.due_date DESC, op.sequence DESC
             """, (horizon_start, horizon_end, work_center_id))

--- a/src/ootils_core/db/migrations/034_merge_work_centers_into_resources.sql
+++ b/src/ootils_core/db/migrations/034_merge_work_centers_into_resources.sql
@@ -1,0 +1,303 @@
+-- ============================================================
+-- Ootils Core — Migration 034: Fusion work_centers → resources (ADR-014)
+--
+-- Implements:
+--   D1 — Single `resources` table replaces `work_centers`.
+--        resource_type enum extended with 'work_center'. Existing
+--        UUIDs are preserved so all downstream FKs (and any external
+--        references) remain valid.
+--   D2 — capacity_unit / time_unit ENUM CHECK constraint:
+--        only 'unit' and 'minute' allowed in DB. 'hour' is converted
+--        to 'minute' at the ingest layer (×60), not in DB.
+--   D2 — `routing_operations.time_unit` added (default 'unit').
+--
+-- DROP TABLE rationale (CLAUDE.md "migrations are idempotent" carve-out):
+--   DROP TABLE work_centers below is a one-shot consolidation per
+--   ADR-014. Data is migrated into the unified `resources` table
+--   first, preserving UUIDs. Subsequent migrations rely on
+--   `resources` as the single source of truth. Re-running 034 after
+--   the fact is a no-op because every ALTER uses IF NOT EXISTS /
+--   IF EXISTS, the INSERT FROM is wrapped in a DO $$ guard on
+--   work_centers existence, and DROP TABLE IF EXISTS is the final step.
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. Enrich resources schema (efficiency, calendar_id, active)
+-- ------------------------------------------------------------
+
+ALTER TABLE resources
+    ADD COLUMN IF NOT EXISTS efficiency NUMERIC(5,4) NOT NULL DEFAULT 1.0,
+    ADD COLUMN IF NOT EXISTS calendar_id UUID,
+    ADD COLUMN IF NOT EXISTS active BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- Efficiency constraint (drop+recreate for idempotence)
+ALTER TABLE resources DROP CONSTRAINT IF EXISTS chk_resources_efficiency;
+ALTER TABLE resources ADD CONSTRAINT chk_resources_efficiency
+    CHECK (efficiency >= 0 AND efficiency <= 1);
+
+-- ------------------------------------------------------------
+-- 2. Normalize capacity_unit + enforce ENUM ('unit' | 'minute')
+-- ------------------------------------------------------------
+
+-- Backfill legacy values BEFORE adding the CHECK constraint
+UPDATE resources SET capacity_unit = 'unit'   WHERE capacity_unit IN ('units', 'unit', '');
+UPDATE resources SET capacity_unit = 'minute' WHERE capacity_unit IN ('hour', 'hours', 'minutes', 'min', 'mn');
+
+-- Anything else gets caught — fail loudly rather than silently coerce
+-- (e.g. 'kg', 'tonne' etc. are not supported as a capacity unit).
+DO $$
+DECLARE
+    bad_count INTEGER;
+BEGIN
+    SELECT COUNT(*) INTO bad_count
+    FROM resources
+    WHERE capacity_unit NOT IN ('unit', 'minute');
+    IF bad_count > 0 THEN
+        RAISE EXCEPTION
+            'Migration 034: % resources row(s) have capacity_unit outside the new enum (unit|minute). '
+            'Please normalize before re-running.', bad_count;
+    END IF;
+END $$;
+
+ALTER TABLE resources ALTER COLUMN capacity_unit SET DEFAULT 'unit';
+
+ALTER TABLE resources DROP CONSTRAINT IF EXISTS chk_resources_capacity_unit;
+ALTER TABLE resources ADD CONSTRAINT chk_resources_capacity_unit
+    CHECK (capacity_unit IN ('unit', 'minute'));
+
+-- ------------------------------------------------------------
+-- 3. Extend resource_type enum with 'work_center'
+-- ------------------------------------------------------------
+--
+-- The original CHECK constraint was unnamed (anonymous, auto-named
+-- by PG). We look it up by definition and drop it before adding the
+-- new named constraint.
+
+DO $$
+DECLARE
+    old_constraint_name TEXT;
+BEGIN
+    SELECT conname INTO old_constraint_name
+    FROM pg_constraint
+    WHERE conrelid = 'resources'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) LIKE '%resource_type%'
+      AND conname <> 'chk_resources_resource_type'  -- not the one we add below
+    LIMIT 1;
+
+    IF old_constraint_name IS NOT NULL THEN
+        EXECUTE 'ALTER TABLE resources DROP CONSTRAINT ' || quote_ident(old_constraint_name);
+    END IF;
+END $$;
+
+ALTER TABLE resources DROP CONSTRAINT IF EXISTS chk_resources_resource_type;
+ALTER TABLE resources ADD CONSTRAINT chk_resources_resource_type
+    CHECK (resource_type IN ('machine', 'line', 'team', 'tool', 'work_center'));
+
+-- ------------------------------------------------------------
+-- 4. Migrate work_centers data into resources (preserve UUIDs)
+-- ------------------------------------------------------------
+--
+-- Each row in work_centers becomes a resources row with the same UUID.
+-- This is what keeps every FK pointing into work_centers valid after
+-- the rename in step 5.
+--
+-- Default capacity_unit for migrated rows is 'unit' — ADR-014 D2 says
+-- existing work_centers are presumed to be in the 'unit' world unless
+-- the operator explicitly migrates them to 'minute' (manual step,
+-- out of scope here). The pattern matches APICS default.
+
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables
+               WHERE table_schema = 'public' AND table_name = 'work_centers') THEN
+        INSERT INTO resources (
+            resource_id,
+            external_id,
+            name,
+            resource_type,
+            location_id,
+            capacity_per_day,
+            capacity_unit,
+            efficiency,
+            calendar_id,
+            active,
+            created_at,
+            updated_at,
+            notes
+        )
+        SELECT
+            wc.work_center_id,
+            wc.code,
+            COALESCE(wc.description, wc.code),
+            'work_center',
+            NULL,  -- work_centers had no location_id; can be backfilled later
+            wc.capacity_per_day,
+            'unit',
+            wc.efficiency,
+            wc.calendar_id,
+            wc.active,
+            wc.created_at,
+            wc.updated_at,
+            NULL
+        FROM work_centers wc
+        ON CONFLICT (resource_id) DO NOTHING;
+    END IF;
+END $$;
+
+-- ------------------------------------------------------------
+-- 5. routing_operations: rename FK + add time_unit
+-- ------------------------------------------------------------
+
+-- 5a. Add time_unit column (ADR-014 D2)
+ALTER TABLE routing_operations
+    ADD COLUMN IF NOT EXISTS time_unit TEXT NOT NULL DEFAULT 'unit';
+
+ALTER TABLE routing_operations DROP CONSTRAINT IF EXISTS chk_routing_operations_time_unit;
+ALTER TABLE routing_operations ADD CONSTRAINT chk_routing_operations_time_unit
+    CHECK (time_unit IN ('unit', 'minute'));
+
+-- 5b. Rename column work_center_id → resource_id (idempotent)
+DO $$ BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'routing_operations'
+          AND column_name = 'work_center_id'
+    ) THEN
+        ALTER TABLE routing_operations RENAME COLUMN work_center_id TO resource_id;
+    END IF;
+END $$;
+
+-- 5c. Drop old FK to work_centers (any name) and add FK to resources
+DO $$
+DECLARE
+    old_fk_name TEXT;
+BEGIN
+    SELECT c.conname INTO old_fk_name
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    WHERE t.relname = 'routing_operations'
+      AND c.contype = 'f'
+      AND pg_get_constraintdef(c.oid) LIKE '%REFERENCES work_centers%'
+    LIMIT 1;
+
+    IF old_fk_name IS NOT NULL THEN
+        EXECUTE 'ALTER TABLE routing_operations DROP CONSTRAINT ' || quote_ident(old_fk_name);
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        WHERE t.relname = 'routing_operations'
+          AND c.contype = 'f'
+          AND pg_get_constraintdef(c.oid) LIKE '%REFERENCES resources%'
+    ) THEN
+        ALTER TABLE routing_operations
+            ADD CONSTRAINT fk_routing_operations_resource
+            FOREIGN KEY (resource_id) REFERENCES resources(resource_id);
+    END IF;
+END $$;
+
+-- ------------------------------------------------------------
+-- 6. work_center_calendar_edges: rename FK column + rebase FK
+-- ------------------------------------------------------------
+--
+-- This table is currently unread by the engine (ADR-014 §Ouvertures
+-- flags it as a follow-up). We keep the table but rebase its FK to
+-- resources so the work_centers DROP at the end doesn't fail.
+
+DO $$ BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'work_center_calendar_edges'
+          AND column_name = 'work_center_id'
+    ) THEN
+        ALTER TABLE work_center_calendar_edges RENAME COLUMN work_center_id TO resource_id;
+    END IF;
+END $$;
+
+DO $$
+DECLARE
+    old_fk_name TEXT;
+BEGIN
+    SELECT c.conname INTO old_fk_name
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    WHERE t.relname = 'work_center_calendar_edges'
+      AND c.contype = 'f'
+      AND pg_get_constraintdef(c.oid) LIKE '%REFERENCES work_centers%'
+    LIMIT 1;
+
+    IF old_fk_name IS NOT NULL THEN
+        EXECUTE 'ALTER TABLE work_center_calendar_edges DROP CONSTRAINT ' || quote_ident(old_fk_name);
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        WHERE t.relname = 'work_center_calendar_edges'
+          AND c.contype = 'f'
+          AND pg_get_constraintdef(c.oid) LIKE '%REFERENCES resources%'
+    ) THEN
+        ALTER TABLE work_center_calendar_edges
+            ADD CONSTRAINT fk_wcc_edges_resource
+            FOREIGN KEY (resource_id) REFERENCES resources(resource_id) ON DELETE CASCADE;
+    END IF;
+END $$;
+
+-- ------------------------------------------------------------
+-- 7. routing_requires_capacity_edges: rename FK column + rebase FK
+-- ------------------------------------------------------------
+
+DO $$ BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'routing_requires_capacity_edges'
+          AND column_name = 'work_center_id'
+    ) THEN
+        ALTER TABLE routing_requires_capacity_edges RENAME COLUMN work_center_id TO resource_id;
+    END IF;
+END $$;
+
+DO $$
+DECLARE
+    old_fk_name TEXT;
+BEGIN
+    SELECT c.conname INTO old_fk_name
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    WHERE t.relname = 'routing_requires_capacity_edges'
+      AND c.contype = 'f'
+      AND pg_get_constraintdef(c.oid) LIKE '%REFERENCES work_centers%'
+    LIMIT 1;
+
+    IF old_fk_name IS NOT NULL THEN
+        EXECUTE 'ALTER TABLE routing_requires_capacity_edges DROP CONSTRAINT ' || quote_ident(old_fk_name);
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        WHERE t.relname = 'routing_requires_capacity_edges'
+          AND c.contype = 'f'
+          AND pg_get_constraintdef(c.oid) LIKE '%REFERENCES resources%'
+    ) THEN
+        ALTER TABLE routing_requires_capacity_edges
+            ADD CONSTRAINT fk_rrc_edges_resource
+            FOREIGN KEY (resource_id) REFERENCES resources(resource_id);
+    END IF;
+END $$;
+
+-- ------------------------------------------------------------
+-- 8. Drop work_centers (one-shot, see header carve-out)
+-- ------------------------------------------------------------
+
+DROP TABLE IF EXISTS work_centers;

--- a/src/ootils_core/demo/phase1.py
+++ b/src/ootils_core/demo/phase1.py
@@ -102,10 +102,16 @@ def _execute_phase1_demo(database_url: str, token: str) -> dict:
                 historical,
             )
 
+        # Migration 034 (ADR-014 D1): work_centers merged into resources.
+        # Maps: work_center_id→resource_id, code→external_id,
+        # description→name. resource_type='work_center', capacity_unit='unit'.
         conn.execute(
             """
-            INSERT INTO work_centers (work_center_id, code, description, capacity_per_day, efficiency, active)
-            VALUES (%s, %s, 'Demo assembly cell', 80, 1.0, true)
+            INSERT INTO resources (
+                resource_id, external_id, name, resource_type,
+                capacity_per_day, capacity_unit, efficiency, active
+            )
+            VALUES (%s, %s, 'Demo assembly cell', 'work_center', 80, 'unit', 1.0, true)
             """,
             (work_center_id, f"DEMO-WC-{uuid4().hex[:8]}"),
         )
@@ -116,10 +122,11 @@ def _execute_phase1_demo(database_url: str, token: str) -> dict:
             """,
             (routing_id, item_id),
         )
+        # Migration 034: routing_operations.work_center_id renamed to resource_id.
         conn.execute(
             """
             INSERT INTO routing_operations (
-                operation_id, routing_id, sequence, work_center_id,
+                operation_id, routing_id, sequence, resource_id,
                 setup_time, run_time_per_unit, description, active
             ) VALUES (%s, %s, 10, %s, 2, 0.5, 'Assemble', true)
             """,

--- a/tests/integration/test_crp_engine_integration.py
+++ b/tests/integration/test_crp_engine_integration.py
@@ -6,9 +6,9 @@ Ported from tests/test_crp_engine.py — the mock-heavy test file that
 relied on a ``mock_db_connection`` fixture and scripted ``cursor.fetchall``
 side-effects. The "no mocks" rule (CLAUDE.md) means every fetch_* /
 calculate() branch is exercised by inserting real rows into the
-``items``, ``locations``, ``work_centers``, ``routings``,
-``routing_operations`` and ``planned_supply`` tables and reading back
-the engine's load profiles.
+``items``, ``locations``, ``resources`` (post-migration 034: formerly
+``work_centers``), ``routings``, ``routing_operations`` and
+``planned_supply`` tables and reading back the engine's load profiles.
 
 Each test seeds its own rows and tears them down. The function-scoped
 ``conn`` fixture rolls back any uncommitted changes; we ``commit()``
@@ -62,15 +62,24 @@ def _seed_work_center(
     efficiency: Decimal = Decimal("0.9"),
     active: bool = True,
 ) -> UUID:
+    """
+    Seed a work-center-flavoured row in the unified ``resources`` table
+    (migration 034 / ADR-014 D1). Column mapping:
+      work_center_id  → resource_id
+      code            → external_id
+      description     → name
+    Always inserts resource_type='work_center' and capacity_unit='unit'
+    to match the ADR-014 D2 defaults for migrated work_centers.
+    """
     wc_id = uuid4()
     if code is None:
         code = f"WC-{wc_id.hex[:8]}"
     conn.execute(
         """
-        INSERT INTO work_centers (
-            work_center_id, code, description,
-            capacity_per_day, efficiency, calendar_id, active
-        ) VALUES (%s, %s, %s, %s, %s, NULL, %s)
+        INSERT INTO resources (
+            resource_id, external_id, name, resource_type,
+            capacity_per_day, capacity_unit, efficiency, calendar_id, active
+        ) VALUES (%s, %s, %s, 'work_center', %s, 'unit', %s, NULL, %s)
         """,
         (wc_id, code, description, capacity_per_day, efficiency, active),
     )
@@ -107,11 +116,17 @@ def _seed_operation(
     description: str = "Test Op",
     active: bool = True,
 ) -> UUID:
+    """
+    Seed a routing_operations row. Migration 034 renamed the column
+    ``work_center_id`` to ``resource_id``; the Python kwarg name
+    ``work_center_id`` is kept as the internal helper contract so
+    callers don't have to change.
+    """
     operation_id = uuid4()
     conn.execute(
         """
         INSERT INTO routing_operations (
-            operation_id, routing_id, sequence, work_center_id,
+            operation_id, routing_id, sequence, resource_id,
             setup_time, run_time_per_unit, description, active
         ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
         """,
@@ -183,8 +198,12 @@ def _teardown(
     Delete every row written during the test so the DB stays clean.
     Order matters because of FK chain:
       planned_supply  → items, locations, scenarios
-      routing_operations → routings, work_centers
+      routing_operations → routings, resources (formerly work_centers)
       routings        → items
+
+    Migration 034 (ADR-014 D1): ``work_centers`` table dropped; rows
+    live in ``resources``. The ``work_centers`` kwarg name is kept for
+    helper-call compatibility.
     """
     if planned_orders:
         conn.execute(
@@ -200,7 +219,7 @@ def _teardown(
         conn.execute("DELETE FROM routings WHERE routing_id = ANY(%s)", (routings,))
     if work_centers:
         conn.execute(
-            "DELETE FROM work_centers WHERE work_center_id = ANY(%s)",
+            "DELETE FROM resources WHERE resource_id = ANY(%s)",
             (work_centers,),
         )
     if locations:
@@ -226,12 +245,11 @@ class TestCRPEngineEmpty:
         """No work centers in DB → CRPResult is empty, no SQL further runs."""
         # Make sure we don't accidentally see other test rows: we don't insert
         # any work center. CRPEngine's _fetch_work_centers filters WHERE
-        # active = true, so any leftover inactive rows wouldn't matter — but
-        # if there are residual active work_centers from other tests/modules,
-        # the engine will still return them. To be safe, deactivate all
-        # existing rows for the duration of this test (rolled back at the
-        # end by the conn fixture).
-        conn.execute("UPDATE work_centers SET active = false")
+        # active = true on `resources` (post-migration 034 / ADR-014 D1).
+        # Per ADR-014 the engine does not discriminate by resource_type, so
+        # we deactivate every resources row for the duration of this test
+        # (rolled back at the end by the conn fixture).
+        conn.execute("UPDATE resources SET active = false")
         conn.commit()
         try:
             engine = CRPEngine(db_conn=conn)
@@ -281,7 +299,9 @@ class TestFetchWorkCenters:
             work_centers = engine._fetch_work_centers([wc_id])
             assert len(work_centers) == 1
             assert wc_id in work_centers
-            assert work_centers[wc_id].capacity_per_day == Decimal("8.000000")
+            # resources.capacity_per_day is NUMERIC(18,4) (migration 009);
+            # post-034 the work_centers source — NUMERIC(18,6) — is gone.
+            assert work_centers[wc_id].capacity_per_day == Decimal("8.0000")
         finally:
             _teardown(conn, work_centers=[wc_id])
 

--- a/tests/integration/test_phase1_e2e.py
+++ b/tests/integration/test_phase1_e2e.py
@@ -85,10 +85,16 @@ def test_phase1_forecast_mps_crp_atp_rest_e2e(api_client, auth, seeded_db):
                 historical,
             )
 
+        # Migration 034 (ADR-014 D1+D2): work_centers merged into resources.
+        # Maps: work_center_id→resource_id, code→external_id, description→name.
+        # routing_operations.work_center_id renamed to resource_id.
         conn.execute(
             """
-            INSERT INTO work_centers (work_center_id, code, description, capacity_per_day, efficiency, active)
-            VALUES (%s, %s, 'Phase 1 E2E Cell', 80, 1.0, true)
+            INSERT INTO resources (
+                resource_id, external_id, name, resource_type,
+                capacity_per_day, capacity_unit, efficiency, active
+            )
+            VALUES (%s, %s, 'Phase 1 E2E Cell', 'work_center', 80, 'unit', 1.0, true)
             """,
             (work_center_id, f"E2E-WC-{uuid4().hex[:8]}"),
         )
@@ -102,7 +108,7 @@ def test_phase1_forecast_mps_crp_atp_rest_e2e(api_client, auth, seeded_db):
         conn.execute(
             """
             INSERT INTO routing_operations (
-                operation_id, routing_id, sequence, work_center_id,
+                operation_id, routing_id, sequence, resource_id,
                 setup_time, run_time_per_unit, description, active
             ) VALUES (%s, %s, 10, %s, 2, 0.5, 'Assemble', true)
             """,

--- a/tests/integration/test_rccp.py
+++ b/tests/integration/test_rccp.py
@@ -84,7 +84,7 @@ def _insert_resource(conn, external_id: str, capacity_per_day: float = 10.0,
     conn.execute(
         """
         INSERT INTO resources (resource_id, external_id, name, resource_type, capacity_per_day, capacity_unit)
-        VALUES (%s, %s, 'Test Resource', %s, %s, 'units')
+        VALUES (%s, %s, 'Test Resource', %s, %s, 'unit')
         """,
         (resource_id, external_id, resource_type, capacity_per_day),
     )

--- a/tests/integration/test_router_rccp_integration.py
+++ b/tests/integration/test_router_rccp_integration.py
@@ -100,11 +100,13 @@ def _insert_resource(
 ) -> dict:
     """Insert a resource row + corresponding 'Resource' graph node."""
     resource_id = uuid4()
+    # Migration 034 (ADR-014 D2) restricted capacity_unit to ('unit', 'minute').
+    # Legacy 'hours' violates the new CHECK constraint; default to 'unit'.
     conn.execute(
         """
         INSERT INTO resources
             (resource_id, external_id, name, resource_type, capacity_per_day, capacity_unit, location_id)
-        VALUES (%s, %s, 'Test Resource', %s, %s, 'hours', %s)
+        VALUES (%s, %s, 'Test Resource', %s, %s, 'unit', %s)
         """,
         (resource_id, external_id, resource_type, capacity_per_day, location_id),
     )


### PR DESCRIPTION
## Summary
Phase B+C de l'ADR-014. Migration DB + refactor code dans un seul PR (sinon la migration seule casserait CRP côté CI).

| Décision ADR-014 | Implémentation |
|---|---|
| D1 — Fusion work_centers → resources | Mig 034 : drop work_centers, backfill resources avec UUIDs préservés, 3 FK rebasés |
| D2 — Unités typées (`unit` \| `minute`) | CHECK ENUM sur `resources.capacity_unit` et nouvelle `routing_operations.time_unit` |

## Migration 034
- `resources` enrichie : `efficiency NUMERIC(5,4)`, `calendar_id UUID`, `active BOOLEAN`
- `capacity_unit` CHECK constraint stricte. Backfill `'units'→'unit'`, `'hour(s)'→'minute'`, fail loud sinon.
- `resource_type` enum étendu avec `'work_center'`
- `routing_operations.work_center_id` → `resource_id` + ajout `time_unit`
- `work_center_calendar_edges` et `routing_requires_capacity_edges` : FK rebasés (tables conservées per ADR §Ouvertures)
- `DROP TABLE work_centers` final (rationale dans header)

Migration testée localement en 3 scenarios :
1. Fresh DB (toutes les 34 migrations appliquées ensemble) → schéma final correct
2. DB pré-034 avec work_centers peuplée → backfill UUIDs préservés, FK rebasés
3. Re-run migration sur DB déjà migrée → idempotent (DO $$ IF EXISTS guards)

## Refactor code (ADR-014 D1)
- `crp/engine.py` : 3 queries SQL refondues (`FROM work_centers` → `FROM resources`, `code` → `external_id`, `description` → `name`)
- `demo/phase1.py` : INSERT INTO resources
- 3 tests intégration (CRP + RCCP + phase1) : helpers réécrits

**Attribut Python `WorkCenter.work_center_id` conservé** (interne CRP, remappé au fetch) — minimise le diff. Le rename Python est cosmétique et hors scope.

## Hors scope (futurs PRs)
- Endpoint `/v1/ingest/work-centers` à supprimer/rediriger (Phase F)
- Lookup `calendar_id` dans CRP engine (ADR §Ouvertures)
- Pre-existing ruff F811 dans test_phase1_e2e.py (vu avant mig 034)
- Phase E : SCD2 transparent pour planning_params (PR séparé)

## Verification
- 2 paths de migration testés (fresh + backfill)
- 1 path d'idempotence testé (re-run sur DB déjà migrée)
- pytest unit : **1616 passed, 21 skipped, 0 failed**
- pytest integration ciblé contre `ootils_test_mig034` : **19 passed, 11 skipped, 0 failed**