### PR TITLE
feat(api): POST /v1/ingest/planning-params with SCD2 transparent (ADR-014 D3)

### DIFF
--- a/docs/staging-templates/planning_params.md
+++ b/docs/staging-templates/planning_params.md
@@ -1,0 +1,150 @@
+# Template `planning_params` — paramètres MRP par (item × location)
+
+**Endpoint** : `POST /v1/ingest/planning-params`
+**Refresh model** : **SCD2 transparent** (ADR-014 D3). Le client pousse l'état courant ; l'API compare à la ligne active et :
+- ne fait rien si rien n'a changé (idempotent),
+- UPDATE en place si la ligne active a été créée aujourd'hui (changement intra-journée),
+- ferme l'active row (`effective_to = aujourd'hui`) + insère une nouvelle ligne (`effective_from = aujourd'hui`) sinon.
+
+L'historique est préservé automatiquement. Le client **ne gère jamais les dates `effective_*`** — c'est invisible pour lui.
+
+**Target canonique** : table `item_planning_params` (mig 007 + 021).
+
+## Champs
+
+| Champ | Type | Obligatoire | Contraintes | Mappe vers |
+|---|---|:---:|---|---|
+| `item_external_id` | TEXT | ✓ | FK → items.external_id | `item_id` (résolu) |
+| `location_external_id` | TEXT | ✓ | FK → locations.external_id | `location_id` (résolu) |
+| `lead_time_sourcing_days` | INT | ✗ | ≥ 0 | `lead_time_sourcing_days` |
+| `lead_time_manufacturing_days` | INT | ✗ | ≥ 0 | `lead_time_manufacturing_days` |
+| `lead_time_transit_days` | INT | ✗ | ≥ 0 | `lead_time_transit_days` |
+| `safety_stock_qty` | NUMERIC | ✗ | ≥ 0 | `safety_stock_qty` |
+| `safety_stock_days` | NUMERIC | ✗ | ≥ 0 | `safety_stock_days` |
+| `reorder_point_qty` | NUMERIC | ✗ | ≥ 0 | `reorder_point_qty` |
+| `min_order_qty` | NUMERIC | ✗ | > 0 | `min_order_qty` |
+| `max_order_qty` | NUMERIC | ✗ | > 0 | `max_order_qty` |
+| `order_multiple` | NUMERIC | ✗ | > 0 | `order_multiple` |
+| `lot_size_rule` | ENUM | ✗ | ∈ {`LOTFORLOT`, `FIXED_QTY`, `EOQ`, `POQ`, `MIN_MAX`, `MULTIPLE`} — défaut `LOTFORLOT` | `lot_size_rule` |
+| `planning_horizon_days` | INT | ✗ | > 0 — défaut 90 | `planning_horizon_days` |
+| `is_make` | BOOLEAN | ✗ | défaut `false` | `is_make` |
+| `preferred_supplier_external_id` | TEXT | ✗ | FK → suppliers.external_id | `preferred_supplier_id` |
+| `economic_order_qty` | NUMERIC | ✗ | > 0 (pour `lot_size_rule=EOQ`) | `economic_order_qty` |
+| `lot_size_poq_periods` | INT | ✗ | > 0 — défaut 1 | `lot_size_poq_periods` |
+| `order_multiple_qty` | NUMERIC | ✗ | > 0 | `order_multiple_qty` |
+| `frozen_time_fence_days` | INT | ✗ | ≥ 0 — défaut 7 | `frozen_time_fence_days` |
+| `slashed_time_fence_days` | INT | ✗ | > 0 — défaut 30 | `slashed_time_fence_days` |
+| `forecast_consumption_strategy` | ENUM | ✗ | ∈ {`max_only`, `consume_forward`, `consume_backward`, `consume_both`} | `forecast_consumption_strategy` |
+| `consumption_window_days` | INT | ✗ | > 0 — défaut 7 | `consumption_window_days` |
+
+**Note** : `lead_time_total_days` est une colonne **GÉNÉRÉE** côté DB (`sourcing + manufacturing + transit`). Jamais à pousser côté client.
+
+## Sémantique partial push (important)
+
+Un champ **omis** dans la requête signifie "garde la valeur active courante" — pas "remets à NULL". Si tu veux explicitement effacer un champ, pousse `null`.
+
+```json
+// Push 1 — installe les valeurs initiales
+{
+  "params": [{
+    "item_external_id": "PUMP-01",
+    "location_external_id": "DC-ATL",
+    "lead_time_sourcing_days": 5,
+    "safety_stock_qty": 50,
+    "lot_size_rule": "LOTFORLOT"
+  }]
+}
+
+// Push 2 (même jour) — ne change que safety_stock_qty
+// → UPDATE in place (même ligne, valeur écrasée)
+{
+  "params": [{
+    "item_external_id": "PUMP-01",
+    "location_external_id": "DC-ATL",
+    "safety_stock_qty": 80
+  }]
+}
+
+// Push 3 (lendemain) — ne change que safety_stock_qty
+// → ROTATED : ferme l'ancienne ligne avec effective_to=aujourd'hui,
+//   crée une nouvelle ligne avec effective_from=aujourd'hui
+//   et carry-over lead_time_sourcing_days=5 + lot_size_rule=LOTFORLOT
+{
+  "params": [{
+    "item_external_id": "PUMP-01",
+    "location_external_id": "DC-ATL",
+    "safety_stock_qty": 100
+  }]
+}
+```
+
+## Réponse type
+
+```json
+{
+  "status": "completed",
+  "summary": {
+    "total": 1,
+    "inserted": 1,        // CREATED + ROTATED (nouvelle ligne)
+    "updated": 0,         // UPDATED_INPLACE (ligne courante modifiée)
+    "errors": 0
+  },
+  "results": [
+    {
+      "item_external_id": "PUMP-01",
+      "location_external_id": "DC-ATL",
+      "action": "created" | "rotated" | "updated_inplace" | "noop",
+      "changed_fields": ["safety_stock_qty"],
+      "param_id": "uuid-de-la-ligne"
+    }
+  ],
+  "batch_id": "uuid"
+}
+```
+
+| `action` | Sens |
+|---|---|
+| `created` | Première ligne pour ce `(item, location)` — aucune historique préalable |
+| `noop` | Tous les champs poussés matchent la ligne active — idempotent |
+| `updated_inplace` | Changement le même jour que la création de la ligne active — UPDATE en place |
+| `rotated` | Changement à un jour ultérieur — close active + insert new |
+
+## Erreurs typiques
+
+| HTTP | Cause |
+|---|---|
+| 422 | `item_external_id` ou `location_external_id` inconnu — référence métier manquante |
+| 422 | `preferred_supplier_external_id` poussé mais inconnu |
+| 422 | `lot_size_rule` hors enum |
+| 422 | `forecast_consumption_strategy` hors enum |
+| 422 | `min_order_qty <= 0` (et autres contraintes positives) |
+
+## Exemple curl
+
+```bash
+curl -X POST "${OOTILS_API_URL}/v1/ingest/planning-params" \
+  -H "Authorization: Bearer ${OOTILS_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "params": [
+      {
+        "item_external_id": "PUMP-01",
+        "location_external_id": "DC-ATL",
+        "lead_time_sourcing_days": 5,
+        "lead_time_manufacturing_days": 0,
+        "lead_time_transit_days": 3,
+        "safety_stock_qty": 50,
+        "reorder_point_qty": 100,
+        "min_order_qty": 10,
+        "lot_size_rule": "LOTFORLOT",
+        "planning_horizon_days": 90,
+        "is_make": false
+      }
+    ],
+    "dry_run": false
+  }'
+```
+
+## Dry run
+
+Pose `"dry_run": true` pour voir les actions qui seraient appliquées sans écrire en DB. Utile pour previewer un batch avant de le committer.

--- a/src/ootils_core/api/routers/ingest.py
+++ b/src/ootils_core/api/routers/ingest.py
@@ -2060,3 +2060,367 @@ async def ingest_transfers(
     ingest_response = _ok(inserted, updated, len(body.transfers), results, batch_id=batch_id, dq_status=dq_status)
     _finalize_ingest_batch(db, batch_id, ingest_response)
     return ingest_response
+
+
+# ─────────────────────────────────────────────────────────────
+# 11. POST /v1/ingest/planning-params (ADR-014 D3 — SCD2 transparent)
+# ─────────────────────────────────────────────────────────────
+
+_LOT_SIZE_RULES = {"LOTFORLOT", "FIXED_QTY", "EOQ", "POQ", "MIN_MAX", "MULTIPLE"}
+_FORECAST_STRATEGIES = {"max_only", "consume_forward", "consume_backward", "consume_both"}
+
+# Fields tracked for SCD2 change detection.
+# A field omitted from the client payload is NOT compared — see ADR-014 D3
+# (partial-push semantics: omission = "keep current value").
+# NOTE: lead_time_total_days is GENERATED — derived from sourcing+mfg+transit;
+# never tracked / never inserted directly.
+_PLANNING_PARAMS_TRACKED_FIELDS = [
+    "lead_time_sourcing_days",
+    "lead_time_manufacturing_days",
+    "lead_time_transit_days",
+    "safety_stock_qty",
+    "safety_stock_days",
+    "reorder_point_qty",
+    "min_order_qty",
+    "max_order_qty",
+    "order_multiple",
+    "lot_size_rule",
+    "planning_horizon_days",
+    "is_make",
+    "preferred_supplier_id",  # resolved from preferred_supplier_external_id
+    "economic_order_qty",
+    "lot_size_poq_periods",
+    "order_multiple_qty",
+    "frozen_time_fence_days",
+    "slashed_time_fence_days",
+    "forecast_consumption_strategy",
+    "consumption_window_days",
+]
+
+
+class PlanningParamsRow(BaseModel):
+    item_external_id: str = Field(..., description="Target item external_id.")
+    location_external_id: str = Field(..., description="Target location external_id.")
+
+    # Lead times (integer days)
+    lead_time_sourcing_days: Optional[int] = Field(None, ge=0)
+    lead_time_manufacturing_days: Optional[int] = Field(None, ge=0)
+    lead_time_transit_days: Optional[int] = Field(None, ge=0)
+
+    # Safety stock
+    safety_stock_qty: Optional[float] = Field(None, ge=0)
+    safety_stock_days: Optional[float] = Field(None, ge=0)
+
+    # Reorder / lot
+    reorder_point_qty: Optional[float] = Field(None, ge=0)
+    min_order_qty: Optional[float] = Field(None, gt=0)
+    max_order_qty: Optional[float] = Field(None, gt=0)
+    order_multiple: Optional[float] = Field(None, gt=0)
+
+    # Policy
+    lot_size_rule: Optional[str] = Field(None, description="One of: LOTFORLOT/FIXED_QTY/EOQ/POQ/MIN_MAX/MULTIPLE.")
+    planning_horizon_days: Optional[int] = Field(None, gt=0)
+    is_make: Optional[bool] = Field(None)
+    preferred_supplier_external_id: Optional[str] = Field(None, description="External id of preferred supplier (optional).")
+
+    # APICS extensions (mig 021)
+    economic_order_qty: Optional[float] = Field(None, gt=0)
+    lot_size_poq_periods: Optional[int] = Field(None, gt=0)
+    order_multiple_qty: Optional[float] = Field(None, gt=0)
+    frozen_time_fence_days: Optional[int] = Field(None, ge=0)
+    slashed_time_fence_days: Optional[int] = Field(None, gt=0)
+    forecast_consumption_strategy: Optional[str] = Field(None)
+    consumption_window_days: Optional[int] = Field(None, gt=0)
+
+    @field_validator("item_external_id", "location_external_id")
+    @classmethod
+    def non_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("must not be empty")
+        return v
+
+    @field_validator("lot_size_rule")
+    @classmethod
+    def valid_lot_size_rule(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and v not in _LOT_SIZE_RULES:
+            raise ValueError(f"lot_size_rule must be one of {sorted(_LOT_SIZE_RULES)}")
+        return v
+
+    @field_validator("forecast_consumption_strategy")
+    @classmethod
+    def valid_consumption_strategy(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and v not in _FORECAST_STRATEGIES:
+            raise ValueError(f"forecast_consumption_strategy must be one of {sorted(_FORECAST_STRATEGIES)}")
+        return v
+
+
+class IngestPlanningParamsRequest(BaseModel):
+    params: list[PlanningParamsRow]
+    dry_run: bool = False
+
+
+def _planning_params_active_row(
+    db: psycopg.Connection, item_id: UUID, location_id: UUID
+) -> Optional[dict]:
+    """Return the currently active (effective_to IS NULL) row, or None."""
+    row = db.execute(
+        """
+        SELECT param_id, effective_from,
+               lead_time_sourcing_days, lead_time_manufacturing_days, lead_time_transit_days,
+               safety_stock_qty, safety_stock_days,
+               reorder_point_qty,
+               min_order_qty, max_order_qty, order_multiple,
+               lot_size_rule, planning_horizon_days, is_make,
+               preferred_supplier_id,
+               economic_order_qty, lot_size_poq_periods, order_multiple_qty,
+               frozen_time_fence_days, slashed_time_fence_days,
+               forecast_consumption_strategy, consumption_window_days
+        FROM item_planning_params
+        WHERE item_id = %s AND location_id = %s
+          AND (effective_to IS NULL OR effective_to = '9999-12-31'::DATE)
+        ORDER BY effective_from DESC
+        LIMIT 1
+        """,
+        (item_id, location_id),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def _row_to_db_dict(row: PlanningParamsRow, supplier_id: Optional[UUID]) -> dict:
+    """Build the dict of (DB-column-name → pushed-value) for SCD2 comparison.
+    Keys absent from this dict mean "client did not push that field" —
+    SCD2 will not consider them in change detection. We use Pydantic's
+    `model_dump(exclude_none=False)` minus the meta fields, then drop
+    keys whose value is None *iff* the client really didn't pass them.
+    Pydantic-V2 detects unset fields via __pydantic_fields_set__.
+    """
+    sent = row.__pydantic_fields_set__
+    incoming: dict = {}
+    if "lead_time_sourcing_days" in sent:
+        incoming["lead_time_sourcing_days"] = row.lead_time_sourcing_days
+    if "lead_time_manufacturing_days" in sent:
+        incoming["lead_time_manufacturing_days"] = row.lead_time_manufacturing_days
+    if "lead_time_transit_days" in sent:
+        incoming["lead_time_transit_days"] = row.lead_time_transit_days
+    if "safety_stock_qty" in sent:
+        incoming["safety_stock_qty"] = row.safety_stock_qty
+    if "safety_stock_days" in sent:
+        incoming["safety_stock_days"] = row.safety_stock_days
+    if "reorder_point_qty" in sent:
+        incoming["reorder_point_qty"] = row.reorder_point_qty
+    if "min_order_qty" in sent:
+        incoming["min_order_qty"] = row.min_order_qty
+    if "max_order_qty" in sent:
+        incoming["max_order_qty"] = row.max_order_qty
+    if "order_multiple" in sent:
+        incoming["order_multiple"] = row.order_multiple
+    if "lot_size_rule" in sent:
+        incoming["lot_size_rule"] = row.lot_size_rule
+    if "planning_horizon_days" in sent:
+        incoming["planning_horizon_days"] = row.planning_horizon_days
+    if "is_make" in sent:
+        incoming["is_make"] = row.is_make
+    if "preferred_supplier_external_id" in sent:
+        # `supplier_id` was resolved already (None means "clear").
+        incoming["preferred_supplier_id"] = supplier_id
+    if "economic_order_qty" in sent:
+        incoming["economic_order_qty"] = row.economic_order_qty
+    if "lot_size_poq_periods" in sent:
+        incoming["lot_size_poq_periods"] = row.lot_size_poq_periods
+    if "order_multiple_qty" in sent:
+        incoming["order_multiple_qty"] = row.order_multiple_qty
+    if "frozen_time_fence_days" in sent:
+        incoming["frozen_time_fence_days"] = row.frozen_time_fence_days
+    if "slashed_time_fence_days" in sent:
+        incoming["slashed_time_fence_days"] = row.slashed_time_fence_days
+    if "forecast_consumption_strategy" in sent:
+        incoming["forecast_consumption_strategy"] = row.forecast_consumption_strategy
+    if "consumption_window_days" in sent:
+        incoming["consumption_window_days"] = row.consumption_window_days
+    return incoming
+
+
+@router.post(
+    "/planning-params",
+    response_model=IngestResponse,
+    summary="Import planning parameters (SCD2 transparent)",
+    description=(
+        "Push current state of planning params per (item, location). The endpoint "
+        "implements ADR-014 D3 transparent SCD2: the client pushes its current values, "
+        "the API compares to the active row and either no-ops, updates in place "
+        "(same-day) or rotates (closes active + inserts new with effective_from=today)."
+    ),
+)
+async def ingest_planning_params(
+    body: IngestPlanningParamsRequest,
+    request: Request,
+    response: Response,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> IngestResponse:
+    """SCD2-transparent upsert of item_planning_params (ADR-014 D3)."""
+    from datetime import date
+    from ootils_core.scd2 import Scd2Action, decide_action
+
+    # 1. Resolve FKs (item/location/preferred_supplier) in batch — fail fast on missing refs
+    item_ext_ids = list({r.item_external_id for r in body.params})
+    loc_ext_ids = list({r.location_external_id for r in body.params})
+    sup_ext_ids = list({r.preferred_supplier_external_id for r in body.params if r.preferred_supplier_external_id})
+
+    item_map = _batch_existing(db, "items", "external_id", "item_id", item_ext_ids)
+    loc_map = _batch_existing(db, "locations", "external_id", "location_id", loc_ext_ids)
+    sup_map = _batch_existing(db, "suppliers", "external_id", "supplier_id", sup_ext_ids) if sup_ext_ids else {}
+
+    errors: list[dict] = []
+    for i, r in enumerate(body.params):
+        row_errs = []
+        if r.item_external_id not in item_map:
+            row_errs.append(f"item_external_id '{r.item_external_id}' not found in DB")
+        if r.location_external_id not in loc_map:
+            row_errs.append(f"location_external_id '{r.location_external_id}' not found in DB")
+        if r.preferred_supplier_external_id and r.preferred_supplier_external_id not in sup_map:
+            row_errs.append(
+                f"preferred_supplier_external_id '{r.preferred_supplier_external_id}' not found in DB"
+            )
+        if row_errs:
+            errors.append({
+                "item_external_id": r.item_external_id,
+                "location_external_id": r.location_external_id,
+                "row": i, "errors": row_errs,
+            })
+
+    if errors:
+        _raise_422(errors)
+
+    today = date.today()
+
+    if body.dry_run:
+        # Show what would happen without writing
+        results = []
+        for r in body.params:
+            item_id = item_map[r.item_external_id]
+            location_id = loc_map[r.location_external_id]
+            supplier_id = sup_map.get(r.preferred_supplier_external_id) if r.preferred_supplier_external_id else None
+            active = _planning_params_active_row(db, item_id, location_id)
+            incoming = _row_to_db_dict(r, supplier_id)
+            decision = decide_action(active, incoming, _PLANNING_PARAMS_TRACKED_FIELDS, today)
+            results.append({
+                "item_external_id": r.item_external_id,
+                "location_external_id": r.location_external_id,
+                "action": decision.action.value,
+                "changed_fields": list(decision.changed_fields.keys()),
+            })
+        return IngestResponse(
+            status="dry_run",
+            summary=IngestSummary(total=len(body.params), inserted=0, updated=0, errors=0),
+            results=results,
+        )
+
+    idempotency_key, request_hash, replay = _load_idempotent_response(db, "planning_params", request, response, body)
+    if replay is not None:
+        return replay
+
+    batch_id = _create_ingest_batch(
+        db, "planning_params", body.params,
+        submitted_by=getattr(request.state, "client_id", "ingest_api"),
+        idempotency_key=idempotency_key,
+        request_hash=request_hash,
+        correlation_id=getattr(request.state, "correlation_id", None),
+    )
+
+    inserted = updated = 0
+    results: list[dict] = []
+
+    for r in body.params:
+        item_id = item_map[r.item_external_id]
+        location_id = loc_map[r.location_external_id]
+        supplier_id = sup_map.get(r.preferred_supplier_external_id) if r.preferred_supplier_external_id else None
+
+        active = _planning_params_active_row(db, item_id, location_id)
+        incoming = _row_to_db_dict(r, supplier_id)
+        decision = decide_action(active, incoming, _PLANNING_PARAMS_TRACKED_FIELDS, today)
+
+        if decision.action == Scd2Action.NOOP:
+            results.append({
+                "item_external_id": r.item_external_id,
+                "location_external_id": r.location_external_id,
+                "action": "noop",
+            })
+            continue
+
+        if decision.action == Scd2Action.UPDATED_INPLACE:
+            # Same-day UPDATE on the active row's param_id
+            assignments = ", ".join(f"{k} = %s" for k in decision.changed_fields.keys())
+            params_values = list(decision.changed_fields.values()) + [active["param_id"]]
+            db.execute(
+                f"UPDATE item_planning_params SET {assignments}, updated_at = now() WHERE param_id = %s",
+                params_values,
+            )
+            updated += 1
+            results.append({
+                "item_external_id": r.item_external_id,
+                "location_external_id": r.location_external_id,
+                "action": "updated_inplace",
+                "changed_fields": list(decision.changed_fields.keys()),
+                "param_id": str(active["param_id"]),
+            })
+            continue
+
+        # CREATED or ROTATED — both need an INSERT. ROTATED also closes the active row first.
+        if decision.action == Scd2Action.ROTATED:
+            # Half-open interval: old.[effective_from, effective_to=today),
+            # new.[effective_from=today, effective_to=NULL). Matches the
+            # daterange(...) WITH && EXCLUDE constraint, and the CHECK
+            # effective_to > effective_from (strict) — even when the
+            # active row was created yesterday.
+            db.execute(
+                "UPDATE item_planning_params SET effective_to = %s, updated_at = now() WHERE param_id = %s",
+                (today, active["param_id"]),
+            )
+
+        # Build the new row from active values (carry-over) overridden by incoming fields.
+        # If no active row (CREATED), start from None values; if active exists (ROTATED),
+        # carry over the active values for unspecified fields.
+        new_row_values: dict = {}
+        for k in _PLANNING_PARAMS_TRACKED_FIELDS:
+            if k in incoming:
+                new_row_values[k] = incoming[k]
+            elif active is not None:
+                new_row_values[k] = active.get(k)
+            else:
+                new_row_values[k] = None
+
+        # lot_size_rule cannot be NULL in DB (DEFAULT 'LOTFORLOT'); enforce
+        if new_row_values.get("lot_size_rule") is None:
+            new_row_values["lot_size_rule"] = "LOTFORLOT"
+        if new_row_values.get("planning_horizon_days") is None:
+            new_row_values["planning_horizon_days"] = 90
+        if new_row_values.get("is_make") is None:
+            new_row_values["is_make"] = False
+
+        param_id = uuid4()
+        all_cols = ["param_id", "item_id", "location_id", "effective_from"] + list(new_row_values.keys())
+        all_values = [param_id, item_id, location_id, today] + list(new_row_values.values())
+        placeholders = ", ".join(["%s"] * len(all_cols))
+        col_list = ", ".join(all_cols)
+        db.execute(
+            f"INSERT INTO item_planning_params ({col_list}) VALUES ({placeholders})",
+            all_values,
+        )
+        inserted += 1
+        results.append({
+            "item_external_id": r.item_external_id,
+            "location_external_id": r.location_external_id,
+            "action": decision.action.value,
+            "changed_fields": list(decision.changed_fields.keys()),
+            "param_id": str(param_id),
+        })
+
+    logger.info(
+        "ingest.planning_params total=%d inserted=%d updated=%d noop=%d",
+        len(body.params), inserted, updated, len(body.params) - inserted - updated,
+    )
+    dq_status = _trigger_dq(db, batch_id)
+    ingest_response = _ok(inserted, updated, len(body.params), results, batch_id=batch_id, dq_status=dq_status)
+    _finalize_ingest_batch(db, batch_id, ingest_response)
+    return ingest_response

--- a/src/ootils_core/db/migrations/035_ingest_batches_planning_params.sql
+++ b/src/ootils_core/db/migrations/035_ingest_batches_planning_params.sql
@@ -1,0 +1,32 @@
+-- ============================================================
+-- Ootils Core — Migration 035: allow 'planning_params' in ingest_batches.entity_type
+--
+-- POST /v1/ingest/planning-params (ADR-014 D3) creates an
+-- ingest_batches row with entity_type='planning_params'. The CHECK
+-- constraint from migration 023 doesn't include this value, so
+-- the INSERT was rejected with check_violation.
+--
+-- Idempotent: drop the existing constraint (any name found by lookup)
+-- and re-add it with the extended enum.
+-- ============================================================
+
+DO $$ BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'ingest_batches_entity_type_check'
+          AND conrelid = 'ingest_batches'::regclass
+    ) THEN
+        ALTER TABLE ingest_batches DROP CONSTRAINT ingest_batches_entity_type_check;
+    END IF;
+END $$;
+
+ALTER TABLE ingest_batches
+    ADD CONSTRAINT ingest_batches_entity_type_check
+    CHECK (
+        entity_type IN (
+            'items', 'locations', 'suppliers', 'supplier_items',
+            'purchase_orders', 'customer_orders', 'forecasts',
+            'work_orders', 'transfers', 'on_hand', 'resources',
+            'planning_params'
+        )
+    );

--- a/src/ootils_core/scd2.py
+++ b/src/ootils_core/scd2.py
@@ -1,0 +1,108 @@
+"""
+Transparent SCD2 helpers (ADR-014 D3).
+
+Pattern: the client pushes its current state for an entity that has
+`effective_from` / `effective_to` columns. The API:
+
+  - looks up the currently active row (`effective_to IS NULL`),
+  - if every pushed field matches that row → no-op (idempotent),
+  - if any field differs and the active row was created TODAY →
+        UPDATE in place (cannot rotate within the same day — the
+        DB constraint forbids `effective_to <= effective_from`),
+  - if any field differs and the active row predates today →
+        UPDATE active SET effective_to = today - 1 day
+        INSERT new row WITH effective_from = today, effective_to = NULL
+
+Pure-function logic; no DB access. The caller orchestrates the SQL.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from enum import Enum
+from typing import Any, Mapping
+
+
+class Scd2Action(str, Enum):
+    """What the caller should do given the current state."""
+
+    CREATED = "created"             # no prior active row; INSERT
+    NOOP = "noop"                   # incoming matches active; do nothing
+    UPDATED_INPLACE = "updated_inplace"  # same-day change; UPDATE active row
+    ROTATED = "rotated"             # cross-day change; close active + INSERT new
+
+
+@dataclass(frozen=True)
+class Scd2Decision:
+    """Result of deciding what to do with one incoming row."""
+
+    action: Scd2Action
+    changed_fields: dict[str, Any]
+    """Subset of `tracked` keys whose new value differs from the active row.
+    Empty when action == NOOP or CREATED."""
+
+
+def diff_tracked_fields(
+    active_row: Mapping[str, Any] | None,
+    incoming: Mapping[str, Any],
+    tracked: list[str],
+) -> dict[str, Any]:
+    """Return {field: incoming_value} for every tracked field that the
+    client pushed AND whose value differs from `active_row`.
+
+    Fields the client did NOT push (key absent from `incoming`) are
+    ignored: SCD2 transparent treats omission as "keep current value".
+
+    If `active_row` is None, every present tracked field is returned —
+    nothing to compare against, so anything pushed is a change.
+    """
+    diff: dict[str, Any] = {}
+    for key in tracked:
+        if key not in incoming:
+            continue
+        if active_row is None:
+            diff[key] = incoming[key]
+            continue
+        if active_row.get(key) != incoming[key]:
+            diff[key] = incoming[key]
+    return diff
+
+
+def decide_action(
+    active_row: Mapping[str, Any] | None,
+    incoming: Mapping[str, Any],
+    tracked: list[str],
+    today: date,
+) -> Scd2Decision:
+    """Pick the SCD2 action for one incoming row.
+
+    Args:
+        active_row: The currently active row from DB
+            (with `effective_from` key), or None if no history exists.
+        incoming: The fields the client pushed (excludes effective_*).
+        tracked: List of field names that participate in change
+            detection. Typically every business value field; NOT
+            metadata like created_at / updated_at / param_id.
+        today: The date to use as `effective_from` / cut-off. Tests
+            pass a fixed date; production passes `date.today()`.
+
+    Returns:
+        Scd2Decision with the action and the changed fields.
+    """
+    if active_row is None:
+        # No prior version: every present tracked field is fresh content
+        return Scd2Decision(
+            action=Scd2Action.CREATED,
+            changed_fields=diff_tracked_fields(None, incoming, tracked),
+        )
+
+    changed = diff_tracked_fields(active_row, incoming, tracked)
+    if not changed:
+        return Scd2Decision(action=Scd2Action.NOOP, changed_fields={})
+
+    # Cross-day vs same-day rollover decision (ADR-014 D3 trade-off)
+    active_from = active_row.get("effective_from")
+    if active_from == today:
+        return Scd2Decision(action=Scd2Action.UPDATED_INPLACE, changed_fields=changed)
+
+    return Scd2Decision(action=Scd2Action.ROTATED, changed_fields=changed)

--- a/tests/integration/test_ingest_planning_params_integration.py
+++ b/tests/integration/test_ingest_planning_params_integration.py
@@ -1,0 +1,301 @@
+"""
+Integration tests for POST /v1/ingest/planning-params (ADR-014 D3).
+
+Exercises the SCD2-transparent endpoint against real Postgres:
+  - CREATED: first push, no prior history
+  - NOOP: re-push identical values → idempotent
+  - ROTATED: cross-day change → close active row, insert new
+  - UPDATED_INPLACE: same-day change → UPDATE active row in place
+"""
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+from uuid import UUID, uuid4
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+
+from .conftest import requires_db, TEST_DB_URL
+
+pytestmark = requires_db
+
+AUTH_HEADERS = {"Authorization": "Bearer integration-test-token"}
+
+
+@pytest.fixture(scope="module")
+def api_client(migrated_db):
+    """Module-scoped FastAPI TestClient bound to the real test DB."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = "integration-test-token"
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+def _conn():
+    return psycopg.connect(TEST_DB_URL, row_factory=psycopg.rows.dict_row)
+
+
+def _seed_item_location() -> tuple[str, str, UUID, UUID]:
+    """Create a unique item + location and return their external_ids + UUIDs."""
+    item_ext = f"PP-ITEM-{uuid4().hex[:8]}"
+    loc_ext = f"PP-LOC-{uuid4().hex[:8]}"
+    item_id = uuid4()
+    location_id = uuid4()
+    with _conn() as c:
+        c.execute(
+            "INSERT INTO items (item_id, name, item_type, uom, external_id) "
+            "VALUES (%s, %s, 'finished_good', 'EA', %s)",
+            (item_id, f"PP test item {item_id}", item_ext),
+        )
+        c.execute(
+            "INSERT INTO locations (location_id, name, location_type, external_id) "
+            "VALUES (%s, %s, 'dc', %s)",
+            (location_id, f"PP test loc {location_id}", loc_ext),
+        )
+        c.commit()
+    return item_ext, loc_ext, item_id, location_id
+
+
+def _cleanup(item_id: UUID, location_id: UUID):
+    with _conn() as c:
+        c.execute(
+            "DELETE FROM item_planning_params WHERE item_id = %s AND location_id = %s",
+            (item_id, location_id),
+        )
+        c.execute("DELETE FROM locations WHERE location_id = %s", (location_id,))
+        c.execute("DELETE FROM items WHERE item_id = %s", (item_id,))
+        c.commit()
+
+
+def _count_active(item_id: UUID, location_id: UUID) -> int:
+    with _conn() as c:
+        row = c.execute(
+            "SELECT COUNT(*) AS cnt FROM item_planning_params "
+            "WHERE item_id = %s AND location_id = %s AND effective_to IS NULL",
+            (item_id, location_id),
+        ).fetchone()
+        return row["cnt"]
+
+
+def _count_history(item_id: UUID, location_id: UUID) -> int:
+    with _conn() as c:
+        row = c.execute(
+            "SELECT COUNT(*) AS cnt FROM item_planning_params "
+            "WHERE item_id = %s AND location_id = %s",
+            (item_id, location_id),
+        ).fetchone()
+        return row["cnt"]
+
+
+class TestPlanningParamsScd2:
+    """End-to-end SCD2 transparent behaviour against real DB."""
+
+    def test_first_push_creates_new_active_row(self, api_client):
+        item_ext, loc_ext, item_id, location_id = _seed_item_location()
+        try:
+            resp = api_client.post(
+                "/v1/ingest/planning-params",
+                json={
+                    "params": [{
+                        "item_external_id": item_ext,
+                        "location_external_id": loc_ext,
+                        "lead_time_sourcing_days": 5,
+                        "safety_stock_qty": 50,
+                        "lot_size_rule": "LOTFORLOT",
+                    }],
+                    "dry_run": False,
+                },
+                headers=AUTH_HEADERS,
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["summary"]["inserted"] == 1
+            assert body["summary"]["updated"] == 0
+            assert body["results"][0]["action"] == "created"
+            # One active row, total history = 1
+            assert _count_active(item_id, location_id) == 1
+            assert _count_history(item_id, location_id) == 1
+        finally:
+            _cleanup(item_id, location_id)
+
+    def test_identical_repush_is_noop(self, api_client):
+        item_ext, loc_ext, item_id, location_id = _seed_item_location()
+        try:
+            payload = {
+                "params": [{
+                    "item_external_id": item_ext,
+                    "location_external_id": loc_ext,
+                    "lead_time_sourcing_days": 5,
+                    "safety_stock_qty": 50,
+                }],
+                "dry_run": False,
+            }
+            r1 = api_client.post("/v1/ingest/planning-params", json=payload, headers=AUTH_HEADERS)
+            assert r1.status_code == 200
+            assert r1.json()["results"][0]["action"] == "created"
+
+            # Repush the EXACT same values — must be no-op
+            r2 = api_client.post(
+                "/v1/ingest/planning-params",
+                json={**payload, "params": payload["params"]},  # different payload object, same content
+                headers=AUTH_HEADERS | {"Idempotency-Key": "force-no-replay"},
+            )
+            assert r2.status_code == 200, r2.text
+            assert r2.json()["summary"]["inserted"] == 0
+            assert r2.json()["summary"]["updated"] == 0
+            assert r2.json()["results"][0]["action"] == "noop"
+            assert _count_active(item_id, location_id) == 1
+            assert _count_history(item_id, location_id) == 1
+        finally:
+            _cleanup(item_id, location_id)
+
+    def test_same_day_change_updates_in_place(self, api_client):
+        item_ext, loc_ext, item_id, location_id = _seed_item_location()
+        try:
+            # First push — CREATED on today
+            api_client.post(
+                "/v1/ingest/planning-params",
+                json={
+                    "params": [{
+                        "item_external_id": item_ext,
+                        "location_external_id": loc_ext,
+                        "lead_time_sourcing_days": 5,
+                    }],
+                    "dry_run": False,
+                },
+                headers=AUTH_HEADERS,
+            )
+            # Second push, same day, different value — must UPDATE in place
+            r2 = api_client.post(
+                "/v1/ingest/planning-params",
+                json={
+                    "params": [{
+                        "item_external_id": item_ext,
+                        "location_external_id": loc_ext,
+                        "lead_time_sourcing_days": 8,
+                    }],
+                    "dry_run": False,
+                },
+                headers=AUTH_HEADERS | {"Idempotency-Key": "no-replay-2"},
+            )
+            assert r2.status_code == 200, r2.text
+            body = r2.json()
+            assert body["results"][0]["action"] == "updated_inplace"
+            assert "lead_time_sourcing_days" in body["results"][0]["changed_fields"]
+            # Still only one row total
+            assert _count_history(item_id, location_id) == 1
+            # And the value is the new one
+            with _conn() as c:
+                row = c.execute(
+                    "SELECT lead_time_sourcing_days FROM item_planning_params "
+                    "WHERE item_id = %s AND location_id = %s AND effective_to IS NULL",
+                    (item_id, location_id),
+                ).fetchone()
+                assert row["lead_time_sourcing_days"] == 8
+        finally:
+            _cleanup(item_id, location_id)
+
+    def test_cross_day_change_rotates(self, api_client):
+        """Simulate a cross-day change by inserting an active row with
+        effective_from = yesterday, then push a new value today."""
+        item_ext, loc_ext, item_id, location_id = _seed_item_location()
+        try:
+            # Seed an active row with effective_from = yesterday
+            yesterday = date.today() - timedelta(days=1)
+            with _conn() as c:
+                c.execute(
+                    "INSERT INTO item_planning_params "
+                    "(item_id, location_id, effective_from, effective_to, "
+                    "lead_time_sourcing_days, lot_size_rule, planning_horizon_days, is_make) "
+                    "VALUES (%s, %s, %s, NULL, %s, 'LOTFORLOT', 90, false)",
+                    (item_id, location_id, yesterday, 5),
+                )
+                c.commit()
+
+            # Now push a different value — must rotate
+            r = api_client.post(
+                "/v1/ingest/planning-params",
+                json={
+                    "params": [{
+                        "item_external_id": item_ext,
+                        "location_external_id": loc_ext,
+                        "lead_time_sourcing_days": 10,
+                    }],
+                    "dry_run": False,
+                },
+                headers=AUTH_HEADERS,
+            )
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["results"][0]["action"] == "rotated"
+
+            # 2 rows total now: the old one (effective_to = yesterday) + new one (active)
+            assert _count_history(item_id, location_id) == 2
+            assert _count_active(item_id, location_id) == 1
+
+            # The currently active row must hold the new value AND carry the old lot_size_rule
+            with _conn() as c:
+                row = c.execute(
+                    "SELECT lead_time_sourcing_days, lot_size_rule FROM item_planning_params "
+                    "WHERE item_id = %s AND location_id = %s AND effective_to IS NULL",
+                    (item_id, location_id),
+                ).fetchone()
+                assert row["lead_time_sourcing_days"] == 10
+                assert row["lot_size_rule"] == "LOTFORLOT"  # carried over from the closed row
+        finally:
+            _cleanup(item_id, location_id)
+
+    def test_dry_run_does_not_persist(self, api_client):
+        item_ext, loc_ext, item_id, location_id = _seed_item_location()
+        try:
+            r = api_client.post(
+                "/v1/ingest/planning-params",
+                json={
+                    "params": [{
+                        "item_external_id": item_ext,
+                        "location_external_id": loc_ext,
+                        "lead_time_sourcing_days": 5,
+                    }],
+                    "dry_run": True,
+                },
+                headers=AUTH_HEADERS,
+            )
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["status"] == "dry_run"
+            assert body["results"][0]["action"] == "created"
+            # Nothing persisted
+            assert _count_history(item_id, location_id) == 0
+        finally:
+            _cleanup(item_id, location_id)
+
+    def test_unknown_item_returns_422(self, api_client):
+        r = api_client.post(
+            "/v1/ingest/planning-params",
+            json={
+                "params": [{
+                    "item_external_id": "DOES-NOT-EXIST",
+                    "location_external_id": "DOES-NOT-EXIST-EITHER",
+                    "lead_time_sourcing_days": 5,
+                }],
+                "dry_run": False,
+            },
+            headers=AUTH_HEADERS,
+        )
+        assert r.status_code == 422

--- a/tests/test_scd2.py
+++ b/tests/test_scd2.py
@@ -1,0 +1,128 @@
+"""
+Unit tests for ootils_core.scd2 — pure SCD2 helpers (ADR-014 D3).
+
+No DB needed. Drives the decision logic with synthetic active-row /
+incoming-row dicts.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from ootils_core.scd2 import (
+    Scd2Action,
+    decide_action,
+    diff_tracked_fields,
+)
+
+
+# ---------------------------------------------------------------------------
+# diff_tracked_fields
+# ---------------------------------------------------------------------------
+
+
+class TestDiffTrackedFields:
+    TRACKED = ["lead_time_days", "safety_stock_qty", "reorder_point"]
+
+    def test_no_active_row_returns_all_present_fields(self):
+        incoming = {"lead_time_days": 7, "safety_stock_qty": 50}
+        out = diff_tracked_fields(None, incoming, self.TRACKED)
+        assert out == {"lead_time_days": 7, "safety_stock_qty": 50}
+
+    def test_active_row_identical_returns_empty(self):
+        active = {"lead_time_days": 7, "safety_stock_qty": 50, "reorder_point": 100}
+        incoming = {"lead_time_days": 7, "safety_stock_qty": 50, "reorder_point": 100}
+        assert diff_tracked_fields(active, incoming, self.TRACKED) == {}
+
+    def test_partial_push_does_not_clear_unspecified_fields(self):
+        active = {"lead_time_days": 7, "safety_stock_qty": 50, "reorder_point": 100}
+        incoming = {"lead_time_days": 10}  # didn't push safety/reorder
+        out = diff_tracked_fields(active, incoming, self.TRACKED)
+        # Only the diff for what was pushed
+        assert out == {"lead_time_days": 10}
+
+    def test_value_changed_returns_only_diff(self):
+        active = {"lead_time_days": 7, "safety_stock_qty": 50}
+        incoming = {"lead_time_days": 7, "safety_stock_qty": 80}
+        out = diff_tracked_fields(active, incoming, self.TRACKED)
+        assert out == {"safety_stock_qty": 80}
+
+    def test_untracked_field_ignored(self):
+        active = {"lead_time_days": 7, "weird_field": "a"}
+        incoming = {"lead_time_days": 7, "weird_field": "b"}
+        out = diff_tracked_fields(active, incoming, self.TRACKED)
+        assert out == {}
+
+    def test_none_value_explicitly_pushed_is_a_change(self):
+        """Client clearing a field by passing None ≠ omission."""
+        active = {"safety_stock_qty": 50, "lead_time_days": 7}
+        incoming = {"safety_stock_qty": None, "lead_time_days": 7}
+        out = diff_tracked_fields(active, incoming, self.TRACKED)
+        assert out == {"safety_stock_qty": None}
+
+
+# ---------------------------------------------------------------------------
+# decide_action
+# ---------------------------------------------------------------------------
+
+
+class TestDecideAction:
+    TRACKED = ["lead_time_days", "safety_stock_qty"]
+    TODAY = date(2026, 5, 24)
+
+    def test_no_active_row_creates(self):
+        d = decide_action(
+            active_row=None,
+            incoming={"lead_time_days": 7},
+            tracked=self.TRACKED,
+            today=self.TODAY,
+        )
+        assert d.action == Scd2Action.CREATED
+        assert d.changed_fields == {"lead_time_days": 7}
+
+    def test_identical_active_row_is_noop(self):
+        active = {"effective_from": date(2026, 5, 1), "lead_time_days": 7, "safety_stock_qty": 50}
+        incoming = {"lead_time_days": 7, "safety_stock_qty": 50}
+        d = decide_action(active, incoming, self.TRACKED, self.TODAY)
+        assert d.action == Scd2Action.NOOP
+        assert d.changed_fields == {}
+
+    def test_cross_day_change_rotates(self):
+        active = {"effective_from": date(2026, 5, 1), "lead_time_days": 7}
+        incoming = {"lead_time_days": 10}
+        d = decide_action(active, incoming, self.TRACKED, self.TODAY)
+        assert d.action == Scd2Action.ROTATED
+        assert d.changed_fields == {"lead_time_days": 10}
+
+    def test_same_day_change_updates_in_place(self):
+        active = {"effective_from": self.TODAY, "lead_time_days": 7}
+        incoming = {"lead_time_days": 10}
+        d = decide_action(active, incoming, self.TRACKED, self.TODAY)
+        assert d.action == Scd2Action.UPDATED_INPLACE
+        assert d.changed_fields == {"lead_time_days": 10}
+
+    def test_partial_push_with_only_unchanged_field_is_noop(self):
+        active = {"effective_from": date(2026, 5, 1), "lead_time_days": 7, "safety_stock_qty": 50}
+        incoming = {"lead_time_days": 7}  # only re-stated the existing value
+        d = decide_action(active, incoming, self.TRACKED, self.TODAY)
+        assert d.action == Scd2Action.NOOP
+        assert d.changed_fields == {}
+
+    def test_partial_push_with_one_changed_field_rotates(self):
+        active = {"effective_from": date(2026, 5, 1), "lead_time_days": 7, "safety_stock_qty": 50}
+        incoming = {"safety_stock_qty": 80}  # only push the changed field
+        d = decide_action(active, incoming, self.TRACKED, self.TODAY)
+        assert d.action == Scd2Action.ROTATED
+        assert d.changed_fields == {"safety_stock_qty": 80}
+
+    @pytest.mark.parametrize("active_from_offset_days", [1, 7, 365])
+    def test_any_day_in_the_past_rotates_not_updates_in_place(self, active_from_offset_days):
+        from datetime import timedelta
+        active = {
+            "effective_from": self.TODAY - timedelta(days=active_from_offset_days),
+            "lead_time_days": 7,
+        }
+        incoming = {"lead_time_days": 10}
+        d = decide_action(active, incoming, self.TRACKED, self.TODAY)
+        assert d.action == Scd2Action.ROTATED


### PR DESCRIPTION
## Summary
Phase E de l'ADR-014. Implémente le pattern SCD2 transparent (D3) pour les paramètres MRP : le client pousse son état courant, l'API détecte le diff et fait le rollover invisible.

## Composants
- `src/ootils_core/scd2.py` — helper générique, no DB, réutilisable pour toute table SCD2 future
- `POST /v1/ingest/planning-params` — endpoint REST avec 22 champs Pydantic + résolution FK batch + dry_run
- `migration 035` — ajoute `'planning_params'` au CHECK enum `ingest_batches.entity_type`
- Templates staging `docs/staging-templates/planning_params.md`

## SCD2 transparent — 4 actions
| Action | Quand | Effet |
|---|---|---|
| `created` | Pas d'historique sur `(item, location)` | INSERT nouvelle ligne |
| `noop` | Tous champs poussés matchent l'active | Rien |
| `updated_inplace` | Ligne active créée aujourd'hui, valeurs différentes | UPDATE in place (intra-journée) |
| `rotated` | Ligne active datée d'avant aujourd'hui, valeurs différentes | Close active (`effective_to=today`), INSERT new (`effective_from=today`) |

Sémantique partial-push : un champ omis = "garde la valeur active". Pour clearer un champ, le client doit explicitement passer `null`.

## Détail technique : half-open intervals
Le ROTATED ferme avec `effective_to = today` (pas `today - 1`). Compatible avec :
- CHECK strict `effective_to > effective_from` (sinon `[yesterday, yesterday)` violation)
- EXCLUDE constraint sur `daterange(effective_from, effective_to)` qui est nativement half-open

Carry-over implicite : lors d'un ROTATED, les champs non-poussés sont copiés depuis l'active row vers la nouvelle.

## Verification
- ruff clean
- 15 unit tests SCD2 (`tests/test_scd2.py`) — logique pure
- 6 integration tests (`tests/integration/test_ingest_planning_params_integration.py`) contre Postgres réel — couvrant les 4 actions + dry_run + 422
- Aucun code de prod modifié hors du nouvel endpoint

## Reste sur l'ADR-014
- Phase F : `POST /v1/ingest/routings` + supprimer `/v1/ingest/work-centers` (redirige vers `/v1/ingest/resources`)
- Phase G : templates staging restants (resources, BOM, calendars, routings)