### PR TITLE
feat(api): POST /v1/ingest/routings with typed time units (ADR-014 D2 — Phase F)

### DIFF
--- a/docs/staging-templates/routings.md
+++ b/docs/staging-templates/routings.md
@@ -1,0 +1,129 @@
+# Template `routings` — gammes de fabrication
+
+**Endpoint** : `POST /v1/ingest/routings`
+**Refresh model** : **full-reload par `(item, sequence)`**. Une routing par item en V1 (sequence=1 par défaut). Chaque routing porte N opérations. Si une routing active existe déjà pour `(item, sequence)`, elle est intégralement remplacée (CASCADE delete des opérations).
+
+**Target canoniques** : `routings` (header) + `routing_operations` (lignes).
+
+## Payload — header routing
+
+| Champ | Type | Obligatoire | Contraintes |
+|---|---|:---:|---|
+| `item_external_id` | TEXT | ✓ | FK → items.external_id |
+| `sequence` | INT | ✗ | > 0, défaut `1`. V1 fixe `1` par convention ; multi-routing par item est V2. |
+| `description` | TEXT | ✗ | Libellé libre |
+| `operations[]` | ARRAY | ✓ | Au moins 1 |
+
+## Payload — opérations (`operations[i]`)
+
+| Champ | Type | Obligatoire | Contraintes |
+|---|---|:---:|---|
+| `sequence` | INT | ✓ | > 0, unique au sein du même routing |
+| `resource_external_id` | TEXT | ✓ | FK → resources.external_id |
+| `setup_time` | NUMERIC | ✗ | ≥ 0, défaut 0 |
+| `run_time_per_unit` | NUMERIC | ✗ | ≥ 0, défaut 0 |
+| `time_unit` | ENUM | ✗ | `unit` \| `minute` \| `hour` — défaut `unit`. `hour` est converti en `minute` à l'ingest (×60). |
+| `description` | TEXT | ✗ | — |
+
+## ⚠️ Cohérence des unités (ADR-014 D2)
+
+Le `time_unit` de chaque opération, **après normalisation `hour→minute`**, doit matcher exactement le `capacity_unit` de la ressource cible. Sinon = erreur 422.
+
+| Resource.capacity_unit | Op.time_unit autorisés | Conversion |
+|---|---|---|
+| `unit` | `unit` | aucune |
+| `minute` | `minute`, `hour` | hour→minute (×60) à l'ingest |
+| `unit` | `minute`, `hour` → **REFUSÉ** (mismatch) | — |
+| `minute` | `unit` → **REFUSÉ** (mismatch) | — |
+
+Le mismatch `unit ↔ minute` est volontairement refusé : un client qui mélange les deux mondes a un bug d'intégration silencieux dans le moteur capacité.
+
+## Réponse type
+
+```json
+{
+  "status": "completed",
+  "summary": {
+    "total": 1,
+    "inserted": 1,
+    "updated": 0,
+    "errors": 0
+  },
+  "results": [
+    {
+      "item_external_id": "PUMP-01",
+      "sequence": 1,
+      "routing_id": "uuid-...",
+      "operations_count": 2,
+      "action": "created" | "replaced"
+    }
+  ],
+  "batch_id": "uuid"
+}
+```
+
+## Erreurs typiques
+
+| HTTP | Cause |
+|---|---|
+| 422 | `item_external_id` inconnu |
+| 422 | `operations[i].resource_external_id` inconnu |
+| 422 | `operations[i].time_unit` ne matche pas la `capacity_unit` de la ressource (ADR-014 D2) |
+| 422 | Deux opérations avec le même `sequence` dans le même routing |
+| 422 | `setup_time` ou `run_time_per_unit` négatif |
+
+## Exemple curl
+
+Routing en heures (normalisé en minutes à l'ingest) :
+
+```bash
+curl -X POST "${OOTILS_API_URL}/v1/ingest/routings" \
+  -H "Authorization: Bearer ${OOTILS_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "routings": [
+      {
+        "item_external_id": "PUMP-01",
+        "sequence": 1,
+        "description": "Standard PUMP-01 assembly",
+        "operations": [
+          {
+            "sequence": 1,
+            "resource_external_id": "LINE-ATL-01",
+            "setup_time": 0.5,
+            "run_time_per_unit": 0.05,
+            "time_unit": "hour",
+            "description": "Pre-assembly"
+          },
+          {
+            "sequence": 2,
+            "resource_external_id": "LINE-ATL-01",
+            "setup_time": 0.25,
+            "run_time_per_unit": 0.02,
+            "time_unit": "hour",
+            "description": "Final assembly"
+          }
+        ]
+      }
+    ],
+    "dry_run": false
+  }'
+```
+
+Après ingest, en DB :
+- `routing_operations.setup_time = 30` (0.5h × 60), `time_unit = 'minute'`
+- `routing_operations.run_time_per_unit = 3` (0.05h × 60), `time_unit = 'minute'`
+
+## Comportement full-reload
+
+À chaque ingestion d'une routing pour un `(item, sequence)` existant :
+1. La routing active est **supprimée** (`DELETE FROM routings WHERE routing_id = ...`)
+2. Les `routing_operations` associées sont supprimées par CASCADE
+3. Une nouvelle routing est insérée avec un nouveau `routing_id` (les UUIDs ne sont pas préservés)
+4. Les nouvelles opérations sont insérées
+
+Conséquence : **toute référence externe au `routing_id` est invalidée après un re-push**. Si tu as besoin de tracker une routing à travers les versions, garde le `(item_external_id, sequence)` comme clé stable.
+
+## Dry run
+
+Pose `"dry_run": true` pour valider la structure + cohérence FK + cohérence d'unités sans rien écrire.

--- a/src/ootils_core/api/routers/ingest.py
+++ b/src/ootils_core/api/routers/ingest.py
@@ -2424,3 +2424,240 @@ async def ingest_planning_params(
     ingest_response = _ok(inserted, updated, len(body.params), results, batch_id=batch_id, dq_status=dq_status)
     _finalize_ingest_batch(db, batch_id, ingest_response)
     return ingest_response
+
+
+# ─────────────────────────────────────────────────────────────
+# 12. POST /v1/ingest/routings (ADR-014 D2 — typed time units)
+# ─────────────────────────────────────────────────────────────
+#
+# Full-reload per (item, sequence). One routing per item in V1
+# (sequence defaults to 1). Each routing carries N operations.
+# Each operation declares its time_unit; must match the target
+# resource's capacity_unit (ADR-014 D2). Mismatch = 422.
+#
+# Normalisation at ingest: time_unit='hour' is converted to 'minute'
+# (run_time_per_unit and setup_time multiplied by 60) before storage.
+
+_VALID_TIME_UNITS_INGEST = {"unit", "minute", "hour"}
+_VALID_TIME_UNITS_DB = {"unit", "minute"}
+
+
+class RoutingOperationRow(BaseModel):
+    sequence: int = Field(..., gt=0, description="Operation sequence within the routing (1, 2, 3...).")
+    resource_external_id: str = Field(..., description="Target resource (work_center / machine / line).")
+    setup_time: float = Field(default=0.0, ge=0, description="Setup time (per routing run, not per unit).")
+    run_time_per_unit: float = Field(default=0.0, ge=0, description="Time consumed per produced unit.")
+    time_unit: str = Field(default="unit", description="Unit for setup_time + run_time_per_unit. One of: unit, minute, hour. 'hour' is normalized to minute (x60) at ingest.")
+    description: Optional[str] = None
+
+    @field_validator("resource_external_id")
+    @classmethod
+    def non_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("resource_external_id must not be empty")
+        return v
+
+    @field_validator("time_unit")
+    @classmethod
+    def valid_time_unit(cls, v: str) -> str:
+        if v not in _VALID_TIME_UNITS_INGEST:
+            raise ValueError(f"time_unit must be one of {sorted(_VALID_TIME_UNITS_INGEST)}")
+        return v
+
+
+class RoutingRow(BaseModel):
+    item_external_id: str = Field(..., description="Item this routing produces.")
+    sequence: int = Field(default=1, gt=0, description="Routing sequence per item. V1 fixes sequence=1.")
+    description: Optional[str] = None
+    operations: list[RoutingOperationRow] = Field(..., min_length=1, description="Operations list, at least one.")
+
+    @field_validator("item_external_id")
+    @classmethod
+    def non_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("item_external_id must not be empty")
+        return v
+
+    @field_validator("operations")
+    @classmethod
+    def unique_operation_sequences(cls, ops: list[RoutingOperationRow]) -> list[RoutingOperationRow]:
+        seqs = [op.sequence for op in ops]
+        if len(seqs) != len(set(seqs)):
+            raise ValueError("operations must have unique sequence numbers within a routing")
+        return ops
+
+
+class IngestRoutingsRequest(BaseModel):
+    routings: list[RoutingRow]
+    dry_run: bool = False
+
+
+def _normalize_op_time_unit(op: RoutingOperationRow) -> tuple[str, float, float]:
+    """Return (db_time_unit, setup_time_normalized, run_time_per_unit_normalized).
+
+    'hour' → 'minute' with x60 scaling.
+    'unit' and 'minute' stored as-is.
+    """
+    if op.time_unit == "hour":
+        return ("minute", op.setup_time * 60.0, op.run_time_per_unit * 60.0)
+    return (op.time_unit, op.setup_time, op.run_time_per_unit)
+
+
+@router.post(
+    "/routings",
+    response_model=IngestResponse,
+    summary="Import routings (with typed time units, ADR-014 D2)",
+    description=(
+        "Full-reload per (item, sequence). Each routing carries N operations. "
+        "Each operation declares its time_unit (unit | minute | hour); hour is "
+        "normalized to minute at ingest. The op's normalized time_unit must "
+        "match the target resource's capacity_unit — mismatch = 422."
+    ),
+)
+async def ingest_routings(
+    body: IngestRoutingsRequest,
+    request: Request,
+    response: Response,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> IngestResponse:
+    """Full-reload routings + operations per (item, sequence). ADR-014 D2 unit checks at ingest."""
+    # 1. Resolve item + resource external_ids in batch
+    item_ext_ids = list({r.item_external_id for r in body.routings})
+    resource_ext_ids = list({
+        op.resource_external_id
+        for r in body.routings
+        for op in r.operations
+    })
+
+    item_map = _batch_existing(db, "items", "external_id", "item_id", item_ext_ids)
+    resource_rows = db.execute(
+        "SELECT external_id, resource_id, capacity_unit FROM resources WHERE external_id = ANY(%s)",
+        (resource_ext_ids,),
+    ).fetchall() if resource_ext_ids else []
+    resource_map: dict[str, dict] = {
+        r["external_id"]: {"resource_id": r["resource_id"], "capacity_unit": r["capacity_unit"]}
+        for r in resource_rows
+    }
+
+    # 2. Validate FK + unit cohérence in one pass — collect ALL errors
+    errors: list[dict] = []
+    for i, r in enumerate(body.routings):
+        row_errs = []
+        if r.item_external_id not in item_map:
+            row_errs.append(f"item_external_id '{r.item_external_id}' not found in DB")
+        for op_idx, op in enumerate(r.operations):
+            if op.resource_external_id not in resource_map:
+                row_errs.append(
+                    f"operations[{op_idx}].resource_external_id '{op.resource_external_id}' not found in DB"
+                )
+                continue
+            # ADR-014 D2 unit cohérence: normalized op time_unit must match resource capacity_unit
+            normalized_unit, _, _ = _normalize_op_time_unit(op)
+            res_unit = resource_map[op.resource_external_id]["capacity_unit"]
+            if normalized_unit != res_unit:
+                row_errs.append(
+                    f"operations[{op_idx}] time_unit '{op.time_unit}' (normalized to '{normalized_unit}') "
+                    f"does not match resource '{op.resource_external_id}' capacity_unit '{res_unit}' "
+                    f"— ADR-014 D2 forbids unit ↔ minute mixing"
+                )
+        if row_errs:
+            errors.append({
+                "item_external_id": r.item_external_id,
+                "row": i,
+                "errors": row_errs,
+            })
+
+    if errors:
+        _raise_422(errors)
+
+    if body.dry_run:
+        return IngestResponse(
+            status="dry_run",
+            summary=IngestSummary(total=len(body.routings), inserted=0, updated=0, errors=0),
+            results=[
+                {
+                    "item_external_id": r.item_external_id,
+                    "sequence": r.sequence,
+                    "operations_count": len(r.operations),
+                    "action": "dry_run",
+                }
+                for r in body.routings
+            ],
+        )
+
+    idempotency_key, request_hash, replay = _load_idempotent_response(db, "routings", request, response, body)
+    if replay is not None:
+        return replay
+
+    batch_id = _create_ingest_batch(
+        db, "routings", body.routings,
+        submitted_by=getattr(request.state, "client_id", "ingest_api"),
+        idempotency_key=idempotency_key,
+        request_hash=request_hash,
+        correlation_id=getattr(request.state, "correlation_id", None),
+    )
+
+    inserted = updated = 0
+    results: list[dict] = []
+
+    for r in body.routings:
+        item_id = item_map[r.item_external_id]
+        # Look up existing routing for (item, sequence)
+        existing = db.execute(
+            "SELECT routing_id FROM routings WHERE item_id = %s AND sequence = %s AND active = TRUE",
+            (item_id, r.sequence),
+        ).fetchone()
+
+        if existing is not None:
+            # Full-reload: DELETE existing routing (CASCADE delete operations) + INSERT new.
+            # Preserves the routing_id is NOT a goal — we re-create with a new id.
+            db.execute("DELETE FROM routings WHERE routing_id = %s", (existing["routing_id"],))
+            action = "replaced"
+            updated += 1
+        else:
+            action = "created"
+            inserted += 1
+
+        # INSERT routing
+        routing_id = uuid4()
+        db.execute(
+            """
+            INSERT INTO routings (routing_id, item_id, sequence, description, active)
+            VALUES (%s, %s, %s, %s, TRUE)
+            """,
+            (routing_id, item_id, r.sequence, r.description),
+        )
+
+        # INSERT operations (normalize units)
+        for op in r.operations:
+            db_unit, setup_n, run_per_unit_n = _normalize_op_time_unit(op)
+            resource_id = resource_map[op.resource_external_id]["resource_id"]
+            db.execute(
+                """
+                INSERT INTO routing_operations (
+                    operation_id, routing_id, sequence, resource_id,
+                    setup_time, run_time_per_unit, time_unit, description, active
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, TRUE)
+                """,
+                (uuid4(), routing_id, op.sequence, resource_id,
+                 setup_n, run_per_unit_n, db_unit, op.description),
+            )
+
+        results.append({
+            "item_external_id": r.item_external_id,
+            "sequence": r.sequence,
+            "routing_id": str(routing_id),
+            "operations_count": len(r.operations),
+            "action": action,
+        })
+
+    logger.info(
+        "ingest.routings total=%d created=%d replaced=%d",
+        len(body.routings), inserted, updated,
+    )
+    dq_status = _trigger_dq(db, batch_id)
+    ingest_response = _ok(inserted, updated, len(body.routings), results, batch_id=batch_id, dq_status=dq_status)
+    _finalize_ingest_batch(db, batch_id, ingest_response)
+    return ingest_response

--- a/src/ootils_core/db/migrations/036_ingest_batches_routings.sql
+++ b/src/ootils_core/db/migrations/036_ingest_batches_routings.sql
@@ -1,0 +1,30 @@
+-- ============================================================
+-- Ootils Core — Migration 036: allow 'routings' in ingest_batches.entity_type
+--
+-- POST /v1/ingest/routings (ADR-014 D2 — Phase F) creates an
+-- ingest_batches row with entity_type='routings'. Migration 035
+-- only added 'planning_params'. This one adds 'routings' too.
+--
+-- Idempotent: DROP+ADD via existing constraint name lookup.
+-- ============================================================
+
+DO $$ BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'ingest_batches_entity_type_check'
+          AND conrelid = 'ingest_batches'::regclass
+    ) THEN
+        ALTER TABLE ingest_batches DROP CONSTRAINT ingest_batches_entity_type_check;
+    END IF;
+END $$;
+
+ALTER TABLE ingest_batches
+    ADD CONSTRAINT ingest_batches_entity_type_check
+    CHECK (
+        entity_type IN (
+            'items', 'locations', 'suppliers', 'supplier_items',
+            'purchase_orders', 'customer_orders', 'forecasts',
+            'work_orders', 'transfers', 'on_hand', 'resources',
+            'planning_params', 'routings'
+        )
+    );

--- a/tests/integration/test_ingest_routings_integration.py
+++ b/tests/integration/test_ingest_routings_integration.py
@@ -1,0 +1,332 @@
+"""
+Integration tests for POST /v1/ingest/routings (ADR-014 D2 — Phase F).
+
+Covers:
+  - CREATED: new routing inserted with operations
+  - REPLACED: existing routing dropped + re-created (full-reload)
+  - Hour normalization: time_unit='hour' → 'minute' with x60 scaling
+  - Unit cohérence: op time_unit must match resource capacity_unit (422)
+  - Missing FK (item / resource): 422
+  - Duplicate operation sequence in payload: 422 (Pydantic)
+  - dry_run does not persist
+"""
+from __future__ import annotations
+
+import os
+from uuid import UUID, uuid4
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+
+from .conftest import requires_db, TEST_DB_URL
+
+pytestmark = requires_db
+
+AUTH_HEADERS = {"Authorization": "Bearer integration-test-token"}
+
+
+@pytest.fixture(scope="module")
+def api_client(migrated_db):
+    """Module-scoped FastAPI TestClient bound to the real test DB."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = "integration-test-token"
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+def _conn():
+    return psycopg.connect(TEST_DB_URL, row_factory=psycopg.rows.dict_row)
+
+
+def _seed(capacity_unit: str = "minute") -> tuple[str, str, UUID, UUID]:
+    """Create unique item + resource, return their externals + UUIDs."""
+    item_ext = f"RT-ITEM-{uuid4().hex[:8]}"
+    res_ext = f"RT-RES-{uuid4().hex[:8]}"
+    item_id = uuid4()
+    res_id = uuid4()
+    with _conn() as c:
+        c.execute(
+            "INSERT INTO items (item_id, name, item_type, uom, external_id) "
+            "VALUES (%s, %s, 'finished_good', 'EA', %s)",
+            (item_id, f"Routing test {item_id}", item_ext),
+        )
+        c.execute(
+            "INSERT INTO resources (resource_id, external_id, name, resource_type, "
+            "capacity_per_day, capacity_unit, active) "
+            "VALUES (%s, %s, 'Test WC', 'work_center', 480.0, %s, TRUE)",
+            (res_id, res_ext, capacity_unit),
+        )
+        c.commit()
+    return item_ext, res_ext, item_id, res_id
+
+
+def _cleanup(item_id: UUID, res_id: UUID):
+    with _conn() as c:
+        c.execute("DELETE FROM routings WHERE item_id = %s", (item_id,))
+        c.execute("DELETE FROM resources WHERE resource_id = %s", (res_id,))
+        c.execute("DELETE FROM items WHERE item_id = %s", (item_id,))
+        c.commit()
+
+
+class TestRoutingsIngest:
+    def test_creates_routing_with_operations(self, api_client):
+        item_ext, res_ext, item_id, res_id = _seed(capacity_unit="minute")
+        try:
+            r = api_client.post(
+                "/v1/ingest/routings",
+                json={
+                    "routings": [{
+                        "item_external_id": item_ext,
+                        "sequence": 1,
+                        "description": "Std routing",
+                        "operations": [
+                            {"sequence": 1, "resource_external_id": res_ext,
+                             "setup_time": 30, "run_time_per_unit": 1.5,
+                             "time_unit": "minute"},
+                            {"sequence": 2, "resource_external_id": res_ext,
+                             "setup_time": 0, "run_time_per_unit": 0.5,
+                             "time_unit": "minute"},
+                        ],
+                    }],
+                    "dry_run": False,
+                },
+                headers=AUTH_HEADERS,
+            )
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["summary"]["inserted"] == 1
+            assert body["results"][0]["action"] == "created"
+            assert body["results"][0]["operations_count"] == 2
+            # Verify in DB
+            with _conn() as c:
+                row = c.execute(
+                    "SELECT COUNT(*) AS cnt FROM routing_operations WHERE routing_id = %s",
+                    (UUID(body["results"][0]["routing_id"]),),
+                ).fetchone()
+                assert row["cnt"] == 2
+        finally:
+            _cleanup(item_id, res_id)
+
+    def test_replace_existing_routing(self, api_client):
+        item_ext, res_ext, item_id, res_id = _seed(capacity_unit="minute")
+        try:
+            # First push: 2 ops
+            api_client.post("/v1/ingest/routings", json={
+                "routings": [{
+                    "item_external_id": item_ext,
+                    "sequence": 1,
+                    "operations": [
+                        {"sequence": 1, "resource_external_id": res_ext, "run_time_per_unit": 1.0, "time_unit": "minute"},
+                        {"sequence": 2, "resource_external_id": res_ext, "run_time_per_unit": 2.0, "time_unit": "minute"},
+                    ],
+                }],
+                "dry_run": False,
+            }, headers=AUTH_HEADERS)
+            # Second push: 1 op only — must replace, not coexist
+            r2 = api_client.post("/v1/ingest/routings", json={
+                "routings": [{
+                    "item_external_id": item_ext,
+                    "sequence": 1,
+                    "operations": [
+                        {"sequence": 1, "resource_external_id": res_ext, "run_time_per_unit": 5.0, "time_unit": "minute"},
+                    ],
+                }],
+                "dry_run": False,
+            }, headers=AUTH_HEADERS | {"Idempotency-Key": "force-no-replay"})
+            assert r2.status_code == 200, r2.text
+            assert r2.json()["results"][0]["action"] == "replaced"
+            # DB has exactly 1 active routing for this item, with 1 op
+            with _conn() as c:
+                routings = c.execute(
+                    "SELECT routing_id FROM routings WHERE item_id = %s AND active = TRUE",
+                    (item_id,),
+                ).fetchall()
+                assert len(routings) == 1
+                ops = c.execute(
+                    "SELECT run_time_per_unit FROM routing_operations WHERE routing_id = %s",
+                    (routings[0]["routing_id"],),
+                ).fetchall()
+                assert len(ops) == 1
+                assert float(ops[0]["run_time_per_unit"]) == 5.0
+        finally:
+            _cleanup(item_id, res_id)
+
+    def test_hour_normalized_to_minute(self, api_client):
+        item_ext, res_ext, item_id, res_id = _seed(capacity_unit="minute")
+        try:
+            r = api_client.post("/v1/ingest/routings", json={
+                "routings": [{
+                    "item_external_id": item_ext,
+                    "sequence": 1,
+                    "operations": [
+                        {"sequence": 1, "resource_external_id": res_ext,
+                         "setup_time": 0.5, "run_time_per_unit": 2,
+                         "time_unit": "hour"},
+                    ],
+                }],
+                "dry_run": False,
+            }, headers=AUTH_HEADERS)
+            assert r.status_code == 200, r.text
+            with _conn() as c:
+                op = c.execute(
+                    "SELECT setup_time, run_time_per_unit, time_unit "
+                    "FROM routing_operations WHERE resource_id = %s ORDER BY sequence",
+                    (res_id,),
+                ).fetchone()
+                # 0.5 hour * 60 = 30 minute, 2 hour * 60 = 120 minute
+                assert float(op["setup_time"]) == 30.0
+                assert float(op["run_time_per_unit"]) == 120.0
+                assert op["time_unit"] == "minute"
+        finally:
+            _cleanup(item_id, res_id)
+
+    def test_unit_mismatch_minute_op_on_unit_resource_returns_422(self, api_client):
+        """ADR-014 D2: op time_unit must match resource capacity_unit."""
+        item_ext, res_ext, item_id, res_id = _seed(capacity_unit="unit")
+        try:
+            r = api_client.post("/v1/ingest/routings", json={
+                "routings": [{
+                    "item_external_id": item_ext,
+                    "sequence": 1,
+                    "operations": [
+                        {"sequence": 1, "resource_external_id": res_ext,
+                         "run_time_per_unit": 1.5,
+                         "time_unit": "minute"},  # resource is in 'unit' world
+                    ],
+                }],
+                "dry_run": False,
+            }, headers=AUTH_HEADERS)
+            assert r.status_code == 422, r.text
+            assert "does not match resource" in r.text
+        finally:
+            _cleanup(item_id, res_id)
+
+    def test_hour_op_on_unit_resource_returns_422(self, api_client):
+        """hour normalizes to minute, then must still match resource."""
+        item_ext, res_ext, item_id, res_id = _seed(capacity_unit="unit")
+        try:
+            r = api_client.post("/v1/ingest/routings", json={
+                "routings": [{
+                    "item_external_id": item_ext,
+                    "sequence": 1,
+                    "operations": [
+                        {"sequence": 1, "resource_external_id": res_ext,
+                         "run_time_per_unit": 0.5,
+                         "time_unit": "hour"},  # normalized to minute → still mismatches 'unit'
+                    ],
+                }],
+                "dry_run": False,
+            }, headers=AUTH_HEADERS)
+            assert r.status_code == 422, r.text
+        finally:
+            _cleanup(item_id, res_id)
+
+    def test_unit_op_on_unit_resource_succeeds(self, api_client):
+        item_ext, res_ext, item_id, res_id = _seed(capacity_unit="unit")
+        try:
+            r = api_client.post("/v1/ingest/routings", json={
+                "routings": [{
+                    "item_external_id": item_ext,
+                    "sequence": 1,
+                    "operations": [
+                        {"sequence": 1, "resource_external_id": res_ext,
+                         "run_time_per_unit": 1.0,
+                         "time_unit": "unit"},
+                    ],
+                }],
+                "dry_run": False,
+            }, headers=AUTH_HEADERS)
+            assert r.status_code == 200, r.text
+        finally:
+            _cleanup(item_id, res_id)
+
+    def test_unknown_item_returns_422(self, api_client):
+        item_ext, res_ext, item_id, res_id = _seed(capacity_unit="minute")
+        try:
+            r = api_client.post("/v1/ingest/routings", json={
+                "routings": [{
+                    "item_external_id": "DOES-NOT-EXIST",
+                    "sequence": 1,
+                    "operations": [
+                        {"sequence": 1, "resource_external_id": res_ext,
+                         "run_time_per_unit": 1.0, "time_unit": "minute"},
+                    ],
+                }],
+                "dry_run": False,
+            }, headers=AUTH_HEADERS)
+            assert r.status_code == 422
+        finally:
+            _cleanup(item_id, res_id)
+
+    def test_unknown_resource_returns_422(self, api_client):
+        item_ext, res_ext, item_id, res_id = _seed(capacity_unit="minute")
+        try:
+            r = api_client.post("/v1/ingest/routings", json={
+                "routings": [{
+                    "item_external_id": item_ext,
+                    "sequence": 1,
+                    "operations": [
+                        {"sequence": 1, "resource_external_id": "UNKNOWN-RES",
+                         "run_time_per_unit": 1.0, "time_unit": "minute"},
+                    ],
+                }],
+                "dry_run": False,
+            }, headers=AUTH_HEADERS)
+            assert r.status_code == 422
+        finally:
+            _cleanup(item_id, res_id)
+
+    def test_duplicate_operation_sequence_returns_422(self, api_client):
+        item_ext, res_ext, item_id, res_id = _seed(capacity_unit="minute")
+        try:
+            r = api_client.post("/v1/ingest/routings", json={
+                "routings": [{
+                    "item_external_id": item_ext,
+                    "sequence": 1,
+                    "operations": [
+                        {"sequence": 1, "resource_external_id": res_ext, "run_time_per_unit": 1.0, "time_unit": "minute"},
+                        {"sequence": 1, "resource_external_id": res_ext, "run_time_per_unit": 2.0, "time_unit": "minute"},
+                    ],
+                }],
+                "dry_run": False,
+            }, headers=AUTH_HEADERS)
+            assert r.status_code == 422  # Pydantic validator
+        finally:
+            _cleanup(item_id, res_id)
+
+    def test_dry_run_does_not_persist(self, api_client):
+        item_ext, res_ext, item_id, res_id = _seed(capacity_unit="minute")
+        try:
+            r = api_client.post("/v1/ingest/routings", json={
+                "routings": [{
+                    "item_external_id": item_ext,
+                    "sequence": 1,
+                    "operations": [
+                        {"sequence": 1, "resource_external_id": res_ext,
+                         "run_time_per_unit": 1.0, "time_unit": "minute"},
+                    ],
+                }],
+                "dry_run": True,
+            }, headers=AUTH_HEADERS)
+            assert r.status_code == 200
+            assert r.json()["status"] == "dry_run"
+            with _conn() as c:
+                cnt = c.execute("SELECT COUNT(*) AS cnt FROM routings WHERE item_id = %s", (item_id,)).fetchone()
+                assert cnt["cnt"] == 0
+        finally:
+            _cleanup(item_id, res_id)


### PR DESCRIPTION
## Summary
Phase F de l'ADR-014. Ferme la dernière entité du graphe sans chemin d'ingestion REST. Endpoint complet : routings + operations + unit cohérence + full-reload + tests.

## Endpoint

`POST /v1/ingest/routings`
- Full-reload par `(item, sequence)`. V1 fixe sequence=1, V2 = routings alternatifs (schéma compatible déjà en place).
- 1 header routing + N operations dans un seul payload.
- **ADR-014 D2 unit cohérence** : `op.time_unit` (après normalisation `hour→minute`) doit matcher `resource.capacity_unit`. Mismatch = **422 erreur dure**, pas de coercition silencieuse.
- `hour` est normalisé en `minute` (×60) à l'ingest. `unit` stocké tel quel.
- Re-push d'une routing existante = CASCADE delete des opérations + INSERT nouvelle routing avec nouveau `routing_id`.

## Migration 036

Ajoute `'routings'` au CHECK enum `ingest_batches.entity_type` (complète #267 qui ajoutait `'planning_params'`). Idempotente.

## Compatibilité d'unités (rappel)

| Resource | Op `unit` | Op `minute` | Op `hour` (→`minute`) |
|---|:---:|:---:|:---:|
| `unit` | ✓ | 422 | 422 |
| `minute` | 422 | ✓ | ✓ (normalisé ×60) |

## Verification
- ruff clean
- **10 integration tests** verts contre `ootils_test_mig034` couvrant : created, replaced, hour normalization, unit mismatch (2 variantes), unit match success, unknown item, unknown resource, duplicate sequence, dry_run

## Reste sur ADR-014
- **Phase G** : templates staging restants pour resources / BOM / calendars (pure doc, sans code)