### PR TITLE
docs(staging): templates for resources, bom, calendars + README update (Phase G)

### DIFF
--- a/docs/staging-templates/README.md
+++ b/docs/staging-templates/README.md
@@ -19,18 +19,31 @@ Each entity supported by `ingest_batches.entity_type` has:
 
 ## Catalogue par entité
 
-| Entité | Template | Refresh | Notes |
-|--------|----------|---------|-------|
-| items | [items.md](items.md) — [items.tsv](items.tsv) | full reload | Master, source SAP/ERP typique |
-| locations | [locations.md](locations.md) — [locations.tsv](locations.tsv) | full reload | Master, faible volume |
-| suppliers | [suppliers.md](suppliers.md) — [suppliers.tsv](suppliers.tsv) | full reload | Master, faible volume |
-| supplier_items | [supplier_items.md](supplier_items.md) — [supplier_items.tsv](supplier_items.tsv) | full reload | Master + commercial |
-| item_planning_params | *(à venir)* | **SCD2** | Versionné par effective_from/to |
-| on_hand | [on_hand.md](on_hand.md) — [on_hand.tsv](on_hand.tsv) | full reload | Snapshot WMS, quotidien |
-| purchase_orders | [purchase_orders.md](purchase_orders.md) — [purchase_orders.tsv](purchase_orders.tsv) | full reload | ERP, refresh quotidien |
-| work_orders | [work_orders.md](work_orders.md) — [work_orders.tsv](work_orders.tsv) | full reload | MES, refresh quotidien |
-| customer_orders | [customer_orders.md](customer_orders.md) — [customer_orders.tsv](customer_orders.tsv) | full reload | ERP commercial |
-| transfers | [transfers.md](transfers.md) — [transfers.tsv](transfers.tsv) | full reload | Inter-locations |
-| forecasts | [forecasts.md](forecasts.md) — [forecasts.tsv](forecasts.tsv) | full reload | Outil prévision |
+| Entité | Template | Refresh | Endpoint | Notes |
+|--------|----------|---------|----------|-------|
+| items | [items.md](items.md) — [items.tsv](items.tsv) | full reload | staging + `/v1/ingest/items` | Master, source SAP/ERP typique |
+| locations | [locations.md](locations.md) — [locations.tsv](locations.tsv) | full reload | staging + `/v1/ingest/locations` | Master, faible volume |
+| suppliers | [suppliers.md](suppliers.md) — [suppliers.tsv](suppliers.tsv) | full reload | staging + `/v1/ingest/suppliers` | Master, faible volume |
+| supplier_items | [supplier_items.md](supplier_items.md) — [supplier_items.tsv](supplier_items.tsv) | full reload | staging + `/v1/ingest/supplier-items` | Master + commercial |
+| planning_params | [planning_params.md](planning_params.md) | **SCD2 transparent** | `/v1/ingest/planning-params` | Versionné par effective_from/to invisible côté client. Voir [ADR-014 D3](../ADR-014-resources-units-scd2.md). |
+| on_hand | [on_hand.md](on_hand.md) — [on_hand.tsv](on_hand.tsv) | full reload | staging + `/v1/ingest/on-hand` | Snapshot WMS, quotidien |
+| purchase_orders | [purchase_orders.md](purchase_orders.md) — [purchase_orders.tsv](purchase_orders.tsv) | full reload | staging + `/v1/ingest/purchase-orders` | ERP, refresh quotidien |
+| work_orders | [work_orders.md](work_orders.md) — [work_orders.tsv](work_orders.tsv) | full reload | staging + `/v1/ingest/work-orders` | MES, refresh quotidien |
+| customer_orders | [customer_orders.md](customer_orders.md) — [customer_orders.tsv](customer_orders.tsv) | full reload | staging + `/v1/ingest/customer-orders` | ERP commercial |
+| transfers | [transfers.md](transfers.md) — [transfers.tsv](transfers.tsv) | full reload | staging + `/v1/ingest/transfers` | Inter-locations |
+| forecasts | [forecasts.md](forecasts.md) — [forecasts.tsv](forecasts.tsv) | full reload | staging + `/v1/ingest/forecast-demand` | Outil prévision |
+| resources | [resources.md](resources.md) | upsert par external_id | `/v1/ingest/resources` | Ressources capacitaires (machines, lignes, équipes, work centers). Voir [ADR-014 D1+D2](../ADR-014-resources-units-scd2.md). |
+| routings | [routings.md](routings.md) | full-reload par (item, sequence) | `/v1/ingest/routings` | Gammes de fabrication. Cohérence d'unités op ↔ resource (ADR-014 D2). |
+| bom | [bom.md](bom.md) | replace BOM active | `/v1/ingest/bom` | Nomenclature 1-parent → N-composants. LLC recalculé. |
+| calendars | [calendars.md](calendars.md) | upsert par (location, date) | `/v1/calendars/import` | Calendriers opérationnels par site. Fallback Mon-Fri si absent. |
 
-`item_planning_params` reste à faire (modèle SCD2 plus complexe) — n'est pas dans la CHECK constraint actuelle de `ingest_batches.entity_type` ; sera ajouté quand le pipeline SCD2 sera câblé.
+## Modes d'ingestion
+
+- **staging** : pipeline ADR-013 — upload fichier (TSV/CSV/XLSX/JSON) → DQ L1-L4 → diff → approve. Recommandé pour les volumes importants et les flux audités.
+- **REST direct** : `POST /v1/ingest/*` ou endpoint dédié — payload JSON, plus simple côté intégrateur quand le client a déjà la donnée en mémoire (API → API).
+
+Les deux modes finissent en table canonique. Les **règles DQ s'appliquent dans les deux cas**.
+
+## Entités sans pipeline staging dédié
+
+`resources`, `routings`, `bom`, `calendars` n'ont pas de chemin staging upload — uniquement REST direct. Leurs templates `.md` documentent le contrat JSON.

--- a/docs/staging-templates/bom.md
+++ b/docs/staging-templates/bom.md
@@ -1,0 +1,116 @@
+# Template `bom` — nomenclatures (Bill of Materials)
+
+**Endpoint** : `POST /v1/ingest/bom` (JSON, pas de staging upload).
+**Refresh model** : 1 appel = 1 BOM logique (= 1 article parent avec ses N composants).
+
+**Target canoniques** : `bom_headers` (en-tête par parent) + `bom_lines` (composants).
+
+## Sémantique d'appel
+
+Contrairement aux autres entités batch-oriented, **chaque appel concerne UN SEUL parent**. Si tu as 100 BOMs à pousser, fais 100 appels (ou un wrapper côté client).
+
+Comportement à l'ingest :
+- Si une BOM active existe déjà pour `(parent_external_id, bom_version)` → toutes ses lignes sont remplacées intégralement.
+- Sinon → nouvelle BOM créée.
+- LLC (Low-Level Code) est **recalculé automatiquement** sur l'ensemble du graphe BOM après chaque ingest.
+
+## Payload — header
+
+| Champ | Type | Obligatoire | Contraintes |
+|---|---|:---:|---|
+| `parent_external_id` | TEXT | ✓ | FK → items.external_id (l'article fabriqué) |
+| `bom_version` | TEXT | ✗ | Défaut `'1.0'`. Permet de coexister plusieurs versions d'une même BOM. |
+| `effective_from` | DATE | ✗ | ISO 8601, défaut `today` |
+| `components[]` | ARRAY | ✓ | Au moins 1 |
+
+## Payload — composants (`components[i]`)
+
+| Champ | Type | Obligatoire | Contraintes |
+|---|---|:---:|---|
+| `component_external_id` | TEXT | ✓ | FK → items.external_id |
+| `quantity_per` | NUMERIC | ✓ | > 0. Quantité de ce composant pour 1 unité du parent. |
+| `uom` | TEXT | ✗ | Défaut `'EA'`. Code UOM du composant. |
+| `scrap_factor` | NUMERIC | ✗ | ∈ [0, 1), défaut 0.0. Taux de perte (0.05 = 5% scrap). |
+
+## Réponse type
+
+```json
+{
+  "status": "completed",
+  "bom_id": "uuid-...",
+  "parent_item_id": "uuid-...",
+  "components_imported": 3,
+  "llc_updated": 12
+}
+```
+
+`llc_updated` = nombre de `bom_lines` dont le LLC a été recalculé suite à l'ingest (cascade sur le graphe BOM entier).
+
+## Erreurs typiques
+
+| HTTP | Cause |
+|---|---|
+| 422 | `parent_external_id` inconnu |
+| 422 | `components[i].component_external_id` inconnu |
+| 422 | `quantity_per <= 0` |
+| 422 | `scrap_factor` hors `[0, 1)` |
+| 422 | Cycle détecté dans le graphe BOM (un composant remonte vers son parent direct ou indirect) |
+
+## Exemple curl
+
+```bash
+curl -X POST "${OOTILS_API_URL}/v1/ingest/bom" \
+  -H "Authorization: Bearer ${OOTILS_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "parent_external_id": "PUMP-01",
+    "bom_version": "1.0",
+    "effective_from": "2026-01-01",
+    "components": [
+      {
+        "component_external_id": "MOTOR-03",
+        "quantity_per": 1,
+        "uom": "EA",
+        "scrap_factor": 0.02
+      },
+      {
+        "component_external_id": "VALVE-02",
+        "quantity_per": 2,
+        "uom": "EA"
+      },
+      {
+        "component_external_id": "GASKET-RBR",
+        "quantity_per": 4,
+        "uom": "EA",
+        "scrap_factor": 0.05
+      }
+    ],
+    "dry_run": false
+  }'
+```
+
+## Multi-niveau
+
+Une BOM n'est qu'un niveau parent → enfants directs. Pour modéliser une nomenclature multi-niveau (ex: `PUMP → SUB-ASSEMBLY → MOTOR → BEARING`), il faut **un appel par parent** :
+
+```
+POST /v1/ingest/bom { parent: PUMP, components: [SUB-ASSEMBLY, ...] }
+POST /v1/ingest/bom { parent: SUB-ASSEMBLY, components: [MOTOR, ...] }
+POST /v1/ingest/bom { parent: MOTOR, components: [BEARING, ...] }
+```
+
+Le LLC est recalculé à chaque ingest et reflète automatiquement la profondeur de chaque composant.
+
+## Versioning des BOMs
+
+`bom_version` permet de coexister plusieurs versions d'une même BOM (ex: `'1.0'`, `'1.1'`, `'2.0'`). À tout moment, **une seule version est active** par parent (les autres ont `status='inactive'`). Pour activer une version différente, c'est un endpoint séparé (hors scope de l'ingest).
+
+## Dry run
+
+Pose `"dry_run": true` pour valider les FKs + détection de cycle sans rien écrire ni recalculer le LLC.
+
+## Voir aussi
+
+- [items.md](items.md) — référentiel des articles (parent + composants)
+- `GET /v1/bom/{external_id}` — récupère la BOM active d'un article
+- `POST /v1/bom/explode` — explosion MRP (gross/net requirements)

--- a/docs/staging-templates/calendars.md
+++ b/docs/staging-templates/calendars.md
@@ -1,0 +1,133 @@
+# Template `calendars` — calendriers opérationnels par site
+
+**Endpoint** : `POST /v1/calendars/import` (chemin dédié, pas sous `/v1/ingest/`).
+**Refresh model** : upsert par `(location_id, calendar_date)`. Un appel peut couvrir plusieurs jours d'un même site (1 appel = 1 site, N entrées).
+
+**Target canonique** : table `operational_calendars` (mig 007).
+
+## Pourquoi des calendriers ?
+
+Les capacités quotidiennes des ressources sont modulées par le calendrier du site qui les héberge :
+- `is_working_day=false` → 0 jour ouvré (ferié, fermeture)
+- `capacity_factor=0.5` → demi-capacité (ex: dimanche réduit)
+- `shift_count` → indication du nombre d'équipes (0..3)
+
+Le module **RCCP** lit ces données pour calculer `capacity_per_bucket = capacity_per_day × nb_jours_ouvrés_du_bucket × capacity_factor_moyen`. Le module **CRP** ne lit pas encore le calendrier (follow-up ADR-014 §Ouvertures).
+
+## Payload — header (1 location)
+
+| Champ | Type | Obligatoire | Contraintes |
+|---|---|:---:|---|
+| `location_external_id` | TEXT | ✓ | FK → locations.external_id |
+| `entries[]` | ARRAY | ✓ | Liste d'entrées calendrier |
+| `dry_run` | BOOLEAN | ✗ | Défaut `false` |
+
+## Payload — entrées (`entries[i]`)
+
+| Champ | Type | Obligatoire | Contraintes |
+|---|---|:---:|---|
+| `calendar_date` | DATE | ✓ | ISO 8601 (`YYYY-MM-DD`) |
+| `is_working_day` | BOOLEAN | ✗ | Défaut `false` |
+| `shift_count` | INT | ✗ | ∈ [0, 3] |
+| `capacity_factor` | NUMERIC | ✗ | ∈ [0.0, 2.0]. `1.0` = capacité normale. Au-dessus de 1 = sur-capacité (heures sup, 2x équipes). |
+| `notes` | TEXT | ✗ | Libellé libre (ex: `'Noël'`, `'Pont du 14 juillet'`, `'Maintenance planifiée'`). |
+
+## Sémantique
+
+Pour chaque `(location_id, calendar_date)`, **un INSERT ON CONFLICT DO UPDATE** est exécuté. Pas de versioning historique : tu écrases la valeur précédente pour ce jour-là.
+
+Si une date n'est pas dans le payload, son entrée précédente reste inchangée. Le calendrier construit incrémentalement, pas full-reload.
+
+Pour effacer une entrée existante (ramener au comportement fallback "5/7 ouvré"), il n'y a pas d'endpoint dédié — soft delete via `is_working_day=false` + `capacity_factor=0`, ou DELETE SQL direct (administrateur).
+
+## Fallback Mon-Fri
+
+Si aucune entrée n'existe dans `operational_calendars` pour une date donnée à une location, le calcul RCCP retombe sur la convention **Mon-Fri ouvrés, Sam-Dim non**.
+
+Conséquence pratique : tu n'es **pas obligé** de pousser un calendrier exhaustif. Pousse uniquement les exceptions (fériés, fermetures planifiées, journées intensives).
+
+## Réponse type
+
+```json
+{
+  "status": "completed",
+  "summary": {
+    "total": 5,
+    "inserted": 3,
+    "updated": 2,
+    "errors": 0
+  },
+  "results": [
+    {"calendar_date": "2026-12-25", "action": "inserted"},
+    {"calendar_date": "2026-12-26", "action": "inserted"},
+    ...
+  ]
+}
+```
+
+## Erreurs typiques
+
+| HTTP | Cause |
+|---|---|
+| 422 | `location_external_id` inconnu ou vide |
+| 422 | `capacity_factor` hors `[0, 2]` |
+| 422 | `shift_count` hors `[0, 3]` |
+| 422 | `calendar_date` mal formaté (non ISO 8601) |
+
+## Exemple curl
+
+Pousser le calendrier de fin d'année 2026 pour DC-ATL :
+
+```bash
+curl -X POST "${OOTILS_API_URL}/v1/calendars/import" \
+  -H "Authorization: Bearer ${OOTILS_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "location_external_id": "DC-ATL",
+    "entries": [
+      {
+        "calendar_date": "2026-12-24",
+        "is_working_day": true,
+        "shift_count": 1,
+        "capacity_factor": 0.5,
+        "notes": "Veille de Noël — 1 équipe matin uniquement"
+      },
+      {
+        "calendar_date": "2026-12-25",
+        "is_working_day": false,
+        "capacity_factor": 0.0,
+        "notes": "Noël"
+      },
+      {
+        "calendar_date": "2026-12-26",
+        "is_working_day": false,
+        "capacity_factor": 0.0,
+        "notes": "Lendemain de Noël (US Bank holiday)"
+      },
+      {
+        "calendar_date": "2026-12-31",
+        "is_working_day": true,
+        "shift_count": 1,
+        "capacity_factor": 0.5,
+        "notes": "Saint-Sylvestre — demi-journée"
+      },
+      {
+        "calendar_date": "2027-01-01",
+        "is_working_day": false,
+        "capacity_factor": 0.0,
+        "notes": "Jour de l'an"
+      }
+    ],
+    "dry_run": false
+  }'
+```
+
+## Convention recommandée
+
+Pour un site donné, pousser au minimum les fériés nationaux de l'année à venir. Pour les fermetures industrielles (été en France, semaines de Noël en Allemagne), créer des plages spécifiques. Ne pas pousser tous les week-ends si le fallback Mon-Fri suffit.
+
+## Voir aussi
+
+- [resources.md](resources.md) — comment les ressources sont liées à une location (et donc au calendrier de cette location)
+- [locations.md](locations.md) — les locations dont on parle ici
+- ADR-014 §Ouvertures — le lookup calendar côté CRP engine est un follow-up (RCCP l'utilise déjà)

--- a/docs/staging-templates/resources.md
+++ b/docs/staging-templates/resources.md
@@ -1,0 +1,106 @@
+# Template `resources` — ressources capacitaires (RCCP + CRP unifié)
+
+**Endpoint** : `POST /v1/ingest/resources` (JSON, pas de staging upload pour cette entité).
+**Refresh model** : upsert par `external_id`. Un re-push avec le même `external_id` met à jour les attributs en place — pas de versioning SCD2.
+
+**Target canonique** : table `resources` (mig 009 + 034 fusionnée — voir [ADR-014 D1](../ADR-014-resources-units-scd2.md)).
+
+## Contexte ADR-014
+
+Cette table porte à la fois les **ressources RCCP** (machines, lignes, équipes, outils — vue agrégée) **et les work_centers CRP** (ordonnancement fin par opération). Le moteur ne discrimine pas par `resource_type` ; les deux modules CRP et RCCP lisent la même table.
+
+## Champs
+
+| Champ | Type | Obligatoire | Contraintes |
+|---|---|:---:|---|
+| `external_id` | TEXT | ✓ | Unique. Clé d'upsert. |
+| `name` | TEXT | ✓ | Non vide après trim |
+| `resource_type` | ENUM | ✓ | ∈ {`machine`, `line`, `team`, `tool`, `work_center`} |
+| `location_external_id` | TEXT | ✗ | FK → locations.external_id. Optionnel (utile pour le lookup calendrier). |
+| `capacity_per_day` | NUMERIC | ✗ | > 0, défaut 1.0. Voir unités ci-dessous. |
+| `capacity_unit` | ENUM | ✗ | ∈ {`unit`, `minute`}, défaut `unit`. Voir ADR-014 D2. |
+| `efficiency` | NUMERIC | ✗ | ∈ [0, 1], défaut 1.0. Facteur multiplicatif appliqué par le CRP. |
+| `notes` | TEXT | ✗ | Libellé libre |
+
+## ⚠️ Convention d'unités (ADR-014 D2)
+
+Le `capacity_unit` détermine le **monde dimensionnel** de la ressource. Deux mondes sont supportés en base :
+
+- `unit` — la capacité s'exprime en quantité produite par jour (ex: 100 unités/jour). Les opérations qui consomment cette ressource déclarent leur `run_time_per_unit` en `unit per produced item` (typiquement 1).
+- `minute` — la capacité s'exprime en minutes par jour (ex: 480 = 8h × 60). Les opérations déclarent leur temps en minutes par unité produite.
+
+Une opération avec `time_unit='minute'` ne peut **pas** consommer une ressource en `capacity_unit='unit'` (et inversement). Mismatch = erreur DQ L2.
+
+Note : à l'ingest de routings, `time_unit='hour'` est aussi accepté mais converti automatiquement en `minute` (×60). Pour les ressources, **pas de conversion à l'ingest** : tu déclares directement en `unit` ou `minute`.
+
+## Effet collatéral
+
+Lors de l'upsert, un nœud `Resource` correspondant est aussi créé/mis à jour dans la table `nodes` du graphe (pour permettre aux edges `consumes_resource` de pointer vers une entité graphe).
+
+## Réponse type
+
+```json
+{
+  "status": "completed",
+  "summary": {
+    "total": 1,
+    "inserted": 1,
+    "updated": 0,
+    "errors": 0
+  },
+  "results": [
+    {
+      "external_id": "LINE-ATL-01",
+      "resource_id": "uuid-...",
+      "action": "inserted" | "updated"
+    }
+  ],
+  "batch_id": "uuid"
+}
+```
+
+## Exemple curl
+
+```bash
+curl -X POST "${OOTILS_API_URL}/v1/ingest/resources" \
+  -H "Authorization: Bearer ${OOTILS_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "resources": [
+      {
+        "external_id": "LINE-ATL-01",
+        "name": "Atlanta Assembly Line 1",
+        "resource_type": "line",
+        "location_external_id": "DC-ATL",
+        "capacity_per_day": 480,
+        "capacity_unit": "minute",
+        "efficiency": 0.92,
+        "notes": "Shift 1 only"
+      },
+      {
+        "external_id": "WC-PUMP-MAIN",
+        "name": "Pump Assembly Work Center",
+        "resource_type": "work_center",
+        "location_external_id": "DC-ATL",
+        "capacity_per_day": 100,
+        "capacity_unit": "unit"
+      }
+    ],
+    "dry_run": false
+  }'
+```
+
+## Erreurs typiques
+
+| HTTP | Cause |
+|---|---|
+| 422 | `external_id` ou `name` vide |
+| 422 | `resource_type` hors enum |
+| 422 | `location_external_id` poussé mais inconnu |
+| 422 | `capacity_unit` hors `{unit, minute}` |
+| 422 | `capacity_per_day <= 0` ou `efficiency` hors `[0, 1]` |
+
+## Voir aussi
+
+- [routings.md](routings.md) — comment les opérations consomment cette ressource (avec contrainte d'unité)
+- [ADR-014](../ADR-014-resources-units-scd2.md) — décisions architecturales (fusion + unités typées)


### PR DESCRIPTION
## Summary
Phase G de l'ADR-014. Pure doc — clôture les 3 templates manquants côté `docs/staging-templates/` + met à jour le README index.

## Nouveaux templates

| Template | Endpoint | Contenu |
|---|---|---|
| [resources.md](docs/staging-templates/resources.md) | `POST /v1/ingest/resources` | 8 champs post-fusion (resource_type, capacity_unit unit\|minute, efficiency, location_id...). Convention d'unités ADR-014 D2 explicitée. |
| [bom.md](docs/staging-templates/bom.md) | `POST /v1/ingest/bom` | Header + components avec quantity_per / scrap_factor. Sémantique replace BOM active. Détection de cycle. Multi-niveau via N appels. |
| [calendars.md](docs/staging-templates/calendars.md) | `POST /v1/calendars/import` | location + entries[date+is_working_day+shift+capacity_factor]. Upsert par (location,date). Fallback Mon-Fri si absent. |

## README mis à jour

- Colonne **Endpoint** ajoutée pour distinguer staging / REST / dédié
- `planning_params` + `routings` désormais listés comme livrés (PRs #267 #268)
- Section **Modes d'ingestion** explicite : staging (ADR-013) vs REST direct
- Note des **4 entités sans staging upload** (resources / routings / bom / calendars — REST uniquement)

## Reste sur ADR-014
Tout est livré. ADR-014 est techniquement clos pour le périmètre V1 :
- ✅ D1 fusion work_centers / resources
- ✅ D2 unités typées + cohérence à l'ingest
- ✅ D3 SCD2 transparent pour planning_params

Ouvertures restantes (cf ADR §Ouvertures) hors scope V1 :
- Routings alternatifs (multi-sequence) — V2
- Lookup `calendar_id` côté CRP engine (RCCP l'utilise déjà)
- Fusion `operational_calendars` ↔ `work_center_calendar_edges`