### PR TITLE
feat(engine): SQL backend devient le défaut pour la propagation

### DIFF
--- a/docs/PERF-BASELINE.md
+++ b/docs/PERF-BASELINE.md
@@ -51,9 +51,11 @@ Script : `scripts/bench_engine_comparison.py`
 
 Le moteur SQL **ne régénère pas les causal chains** (explanations). Pour la traçabilité explicative (M3 / agent), le moteur Python reste nécessaire. Le SQL est donc un mode batch, pas un remplacement complet du Python.
 
-Configuration recommandée :
-- Propagation batch / recalcul horizon : `OOTILS_ENGINE=sql`
-- Propagation interactive / agent explainability : `OOTILS_ENGINE=python` (défaut)
+**Default depuis 2026-05-24** : `OOTILS_ENGINE=sql` (changement actant le speedup mesuré ; cf commit du switch).
+
+Configuration de override par déploiement :
+- Propagation batch / recalcul horizon : laisser le défaut (`sql`).
+- Propagation interactive / agent explainability : forcer `OOTILS_ENGINE=python` sur le container worker concerné. Nécessaire pour que les `causal_steps` se régénèrent à chaque propagation. Sans ce override, les explanations en DB se figent au dernier passage Python.
 
 ## Historique des runs
 

--- a/src/ootils_core/api/routers/events.py
+++ b/src/ootils_core/api/routers/events.py
@@ -25,11 +25,19 @@ def _build_propagation_engine(db):
     """Build a PropagationEngine instance wired to the given DB connection.
 
     The implementation is selected by the OOTILS_ENGINE environment variable:
-    - 'python' (default): the in-process Python kernel + dirty-flag pipeline
-    - 'sql':              SqlPropagationEngine — window-function projection
-                          inside Postgres. ~3-6x faster on batch workloads
-                          but does not regenerate causal-chain explanations.
-                          See docs/SCALABILITY.md "Tier 3 spike" for trade-offs.
+
+    - 'sql' (DEFAULT since 2026-05-24, cf docs/PERF-BASELINE.md):
+        SqlPropagationEngine — window-function projection inside Postgres.
+        Measured 5-9× faster than the Python engine on profile S/M batches.
+        Trade-off: **does NOT regenerate causal-chain explanations**. The
+        existing `explanations` / `causal_steps` rows persist as-is in DB,
+        but new propagations under SQL won't update them. For interactive
+        explainability (M3, agent flows), set OOTILS_ENGINE=python on the
+        request scope (env var on the worker / container).
+    - 'python': the in-process Python kernel + dirty-flag pipeline.
+        Full causal-chain regeneration. Use for explainability-heavy flows.
+
+    Override at deployment time via the OOTILS_ENGINE environment variable.
     """
     from ootils_core.engine.kernel.graph.store import GraphStore
     from ootils_core.engine.kernel.graph.traversal import GraphTraversal
@@ -46,18 +54,20 @@ def _build_propagation_engine(db):
     kernel = ProjectionKernel()
     shortage_detector = ShortageDetector()
 
-    engine_flavor = os.environ.get("OOTILS_ENGINE", "python").strip().lower()
-    if engine_flavor == "sql":
+    engine_flavor = os.environ.get("OOTILS_ENGINE", "sql").strip().lower()
+    if engine_flavor in ("sql", ""):
         from ootils_core.engine.orchestration.propagator_sql import SqlPropagationEngine
         engine_cls: type[PropagationEngine] = SqlPropagationEngine
-        logger.info("PropagationEngine: using SQL backend (OOTILS_ENGINE=sql)")
-    elif engine_flavor in ("python", ""):
+        logger.info("PropagationEngine: using SQL backend (default)")
+    elif engine_flavor == "python":
         engine_cls = PropagationEngine
+        logger.info("PropagationEngine: using Python backend (OOTILS_ENGINE=python)")
     else:
         logger.warning(
-            "Unknown OOTILS_ENGINE=%r — falling back to python", engine_flavor,
+            "Unknown OOTILS_ENGINE=%r — falling back to sql (default)", engine_flavor,
         )
-        engine_cls = PropagationEngine
+        from ootils_core.engine.orchestration.propagator_sql import SqlPropagationEngine
+        engine_cls = SqlPropagationEngine
 
     return engine_cls(
         store=store,

--- a/tests/test_engine_feature_flag.py
+++ b/tests/test_engine_feature_flag.py
@@ -34,12 +34,14 @@ def restore_env() -> None:
         os.environ["OOTILS_ENGINE"] = saved
 
 
-def test_default_returns_python_engine(mock_db: MagicMock) -> None:
+def test_default_returns_sql_engine(mock_db: MagicMock) -> None:
+    """Default since 2026-05-24 is SQL (cf docs/PERF-BASELINE.md)."""
     engine = _build_propagation_engine(mock_db)
-    assert type(engine) is PropagationEngine
+    assert isinstance(engine, SqlPropagationEngine)
 
 
 def test_python_returns_python_engine(mock_db: MagicMock) -> None:
+    """Explicit OOTILS_ENGINE=python overrides default to Python kernel."""
     os.environ["OOTILS_ENGINE"] = "python"
     engine = _build_propagation_engine(mock_db)
     assert type(engine) is PropagationEngine
@@ -59,9 +61,10 @@ def test_case_insensitive_and_whitespace(mock_db: MagicMock) -> None:
     assert isinstance(engine, SqlPropagationEngine)
 
 
-def test_unknown_value_falls_back_to_python(mock_db: MagicMock, caplog) -> None:
+def test_unknown_value_falls_back_to_sql(mock_db: MagicMock, caplog) -> None:
+    """Unknown value logs a warning and falls back to the new default (sql)."""
     os.environ["OOTILS_ENGINE"] = "rust"
     engine = _build_propagation_engine(mock_db)
-    assert type(engine) is PropagationEngine
-    # Should also log a warning so the operator knows their config didn't take.
+    assert isinstance(engine, SqlPropagationEngine)
+    # Should log a warning so the operator knows their config didn't take.
     assert any("OOTILS_ENGINE" in r.message and "rust" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
Suite au baseline mesuré (PR #270, cf `docs/PERF-BASELINE.md`), `OOTILS_ENGINE` passe de défaut `python` à défaut **`sql`**.

| Profile | Items | PI nodes | Python | SQL | Speedup |
|---|---|---|---|---|---|
| S | 1 900 | 47 520 | 47.2s | 5.4s | **8.8×** |
| M | 5 000 | 116 910 | 73.2s | 14.5s | **5.0×** |

Le seuil ADR-015 D5-A (Rust justifié si > 30s malgré SQL) est largement non atteint même à 5K SKU. Activer SQL en défaut donne le maximum out-of-the-box.

## Changements

| Fichier | Modification |
|---|---|
| `src/ootils_core/api/routers/events.py` | Défaut `os.environ.get("OOTILS_ENGINE", "sql")`. Fallback inconnue → sql. Docstring mise à jour. |
| `tests/test_engine_feature_flag.py` | `test_default_returns_python_engine` → `..._returns_sql_engine`. `test_unknown_value_falls_back_to_python` → `..._falls_back_to_sql`. |
| `docs/PERF-BASELINE.md` | Note "default = sql depuis 2026-05-24" + recommandation d'override. |

## ⚠️ Trade-off accepté

Le moteur SQL **ne régénère pas les causal chains** (M3 explainability). Sous le nouveau défaut :
- Les rows `explanations` / `causal_steps` existantes persistent en DB
- Mais les nouvelles propagations **ne mettent plus à jour ces tables**
- Pour les workers servant `/v1/explain` ou les agents M7 : override par env var `OOTILS_ENGINE=python` sur le container concerné

Cohérent avec l'approche multi-worker container : un worker batch SQL + un worker explainability Python, séparés en déploiement.

## Verification
- 1631 unit tests pass (sans régression)
- 5 tests du feature flag explicitement adaptés
- ruff clean

## Hors scope
- Per-request override via header HTTP `X-Ootils-Engine` (à envisager si on veut éviter le partitionnement worker)