### PR TITLE
docs(perf): burst-incremental validation (100 events, no degradation)

### DIFF
--- a/docs/PERF-BASELINE.md
+++ b/docs/PERF-BASELINE.md
@@ -66,6 +66,35 @@ Mesuré via `scripts/bench_incremental.py` sur profile M, 10 events
 à p95 7 s venaient d'un tunnel SSH qui ajoutait ~500 ms/event d'overhead
 network.
 
+### Bench burst (session agent simulée — 100 events séquentiels)
+
+Mesuré sur profile M, 100 `demand_qty_changed` enchaînés sans pause, SQL
+engine direct LAN. Bucketing par position pour détecter une éventuelle
+dégradation cumulative (lock contention, autovacuum, WAL checkpoint).
+
+| Position | count | p50 (ms) | p95 (ms) | max (ms) |
+|---|---|---|---|---|
+| 1-5 (cold start) | 5 | 167 | 649 | 649 |
+| 6-20 | 15 | **93** | 646 | 646 |
+| 21-50 | 30 | **98** | 677 | 764 |
+| 51-100 | 50 | **91** | 664 | 700 |
+
+**Stats globales sur 100 events :** min=81, p50=**93**, mean=218,
+p95=**664**, p99=764, max=764. 0 failures.
+
+**Lecture :**
+- **Pas de dégradation cumulative.** Le p50 descend de 167ms (cold,
+  buffer cache vide) à ~93ms après 5 events et reste plat jusqu'au 100e.
+- Les outliers ~5% (latences à ~650-760ms) sont **uniformément
+  distribués** dans le temps, pas concentrés à la fin → bruit Postgres
+  (autovacuum/checkpoint statistiques), pas un comportement systémique.
+- Throughput burst = 417 PI/s ≈ throughput single-event (425 PI/s) →
+  aucun overhead supplémentaire à enchaîner les events.
+
+**Conséquence pour les agents** : une session de 50-100 modifs en
+quelques dizaines de secondes reste fluide (p50 ~100ms par event,
+quelques pics ponctuels à ~700ms acceptables).
+
 ### Extrapolation V2
 
 À throughput SQL ~8 000 PI/s constant et ~25 buckets PI par couple (item × location) :

--- a/scripts/bench_incremental.py
+++ b/scripts/bench_incremental.py
@@ -207,6 +207,40 @@ def main():
             print(f"=== Throughput (dirty-based, cross-engine comparable) ===")
             print(f"    {tput:.0f} node/s   (total {total_dirty} dirty PIs in {total_time_s:.2f}s)")
 
+        # --------------------------------------------------------------
+        # Burst analysis — detect degradation over the session
+        # --------------------------------------------------------------
+        # Slice the latency timeline into position buckets to expose any
+        # lock contention / autovacuum / WAL-checkpoint stalls that build
+        # up over a sustained sequence of events.
+        if len(latencies_ms) >= 20:
+            buckets = [(1, 5), (6, 20), (21, 50), (51, 100)]
+            print()
+            print("=== Burst degradation (latency by position in session) ===")
+            print(f"  {'position':<10} {'count':>6} {'p50':>8} {'p95':>8} {'max':>8}")
+            for lo, hi in buckets:
+                slice_ = latencies_ms[lo - 1 : hi]
+                if not slice_:
+                    continue
+                ss = sorted(slice_)
+                p50_b = statistics.median(ss)
+                p95_b = ss[int(0.95 * len(ss))] if len(ss) >= 5 else ss[-1]
+                mx_b = max(ss)
+                print(f"  {lo:>3}-{hi:<5} {len(slice_):>6d} {p50_b:>8.1f} {p95_b:>8.1f} {mx_b:>8.1f}")
+
+            # Simple monotonic-degradation check: compare bucket p50s
+            p50s = [
+                statistics.median(latencies_ms[lo - 1 : hi])
+                for lo, hi in buckets
+                if latencies_ms[lo - 1 : hi]
+            ]
+            if len(p50s) >= 2 and p50s[-1] > 2 * p50s[0]:
+                print()
+                print(f"  WARNING: p50 doubled between bucket 1 and bucket {len(p50s)} — sustained degradation detected.")
+            elif len(p50s) >= 2 and p50s[-1] < 1.2 * p50s[0]:
+                print()
+                print(f"  OK: no sustained degradation (p50 stable from start to end).")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

Validates the SQL engine for sustained interactive use — simulates an agent making 100 rapid modifications in sequence and checks for cumulative degradation (lock contention, autovacuum buildup, WAL checkpoint stalls).

## Results (profile M, SQL engine, direct LAN)

| Position | count | p50 (ms) | p95 (ms) | max (ms) |
|----------|------:|---------:|---------:|---------:|
| 1-5 (cold start) | 5 | 167 | 649 | 649 |
| 6-20 | 15 | **93** | 646 | 646 |
| 21-50 | 30 | **98** | 677 | 764 |
| 51-100 | 50 | **91** | 664 | 700 |

Global: p50=**93ms**, p95=**664ms**, 0 failures / 100 events.

## Verdict

- ✅ No cumulative degradation. p50 stable from event #6 to #100.
- ✅ ~5% outliers uniformly distributed → Postgres background noise, not systemic.
- ✅ Burst throughput = single-event throughput → no overhead piles up.

**SQL engine is cleared for agent-driven sessions.**

## Files

- `docs/PERF-BASELINE.md` — new "Bench burst" section
- `scripts/bench_incremental.py` — added bucketed degradation analysis + warning

## Test plan

- [x] 100-event burst on `ootils_bench_m` direct LAN, results in commit message