### PR TITLE
feat(rust): compute + parity 3-way (ADR-016 week 3)

### DIFF
--- a/rust/ootils_kernel/src/kernel.rs
+++ b/rust/ootils_kernel/src/kernel.rs
@@ -1,0 +1,219 @@
+//! kernel.rs — pure compute for one PI bucket (ADR-016 §week 3).
+//!
+//! Mirrors `ProjectionKernel.compute_pi_node` in Python. Same semantics,
+//! byte-identical results within Decimal precision (validated by the
+//! 3-way parity harness in week 3).
+//!
+//! Pure function, no IO, no allocation beyond the result tuple. The
+//! window-function part (cumulative opening_stock across buckets in a
+//! series) lives in `propagator.rs` — this file is only the per-bucket
+//! math.
+
+use crate::io::{Demand, Supply};
+use chrono::NaiveDate;
+use rust_decimal::Decimal;
+
+/// Result of one bucket compute. Same shape as the Python kernel's dict.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PiResult {
+    pub opening_stock: Decimal,
+    pub inflows: Decimal,
+    pub outflows: Decimal,
+    pub closing_stock: Decimal,
+    pub has_shortage: bool,
+    pub shortage_qty: Decimal,
+}
+
+/// Aggregate supplies whose `time_ref` falls in [bucket_start, bucket_end).
+///
+/// Mirrors the SQL engine's `SubPlan 2` (inflows correlated subquery) and
+/// the Python `compute_pi_node` inflows loop. The contribution rule is
+/// `point_in_bucket`: a supply contributes its full quantity iff its
+/// date lands strictly inside the bucket half-open interval.
+#[inline]
+pub fn sum_inflows(supplies: &[Supply], bucket_start: NaiveDate, bucket_end: NaiveDate) -> Decimal {
+    let mut total = Decimal::ZERO;
+    for s in supplies {
+        if s.time_ref >= bucket_start && s.time_ref < bucket_end {
+            total += s.quantity;
+        }
+    }
+    total
+}
+
+/// Aggregate demands. Handles two cases (mirrors the SQL engine `SubPlan 3`
+/// CASE expression and the Python kernel's allocation logic):
+///
+/// 1. **Time-span demand** (e.g. monthly ForecastDemand): allocate the
+///    quantity proportionally to the day-overlap between the demand
+///    span and the bucket. The numeric(50,28) cast matches Python's
+///    Decimal default precision so the SQL/Python parity holds.
+///
+/// 2. **Time-ref demand** (CustomerOrderDemand etc.): contribute full
+///    quantity if the date falls inside the bucket, else zero.
+#[inline]
+pub fn sum_outflows(demands: &[Demand], bucket_start: NaiveDate, bucket_end: NaiveDate) -> Decimal {
+    let mut total = Decimal::ZERO;
+    for d in demands {
+        // Case 1: time_span allocation.
+        if let (Some(ds), Some(de)) = (d.time_span_start, d.time_span_end) {
+            if de > ds {
+                let span_days = (de - ds).num_days();
+                if span_days > 0 {
+                    let overlap_start = bucket_start.max(ds);
+                    let overlap_end = bucket_end.min(de);
+                    let overlap_days = (overlap_end - overlap_start).num_days().max(0);
+                    if overlap_days > 0 {
+                        // qty / span_days * overlap_days, preserving Decimal precision
+                        let frac = d.quantity
+                            / Decimal::from(span_days)
+                            * Decimal::from(overlap_days);
+                        total += frac;
+                    }
+                }
+                continue;
+            }
+        }
+        // Case 2: time_ref point. Falls back to time_span_start if time_ref
+        // is None (CustomerOrderDemand can store its date either way).
+        let pt = d.time_ref.or(d.time_span_start);
+        if let Some(p) = pt {
+            if p >= bucket_start && p < bucket_end {
+                total += d.quantity;
+            }
+        }
+    }
+    total
+}
+
+/// One bucket compute. `opening_stock` is provided by the caller — it's
+/// either the seed opening (for the first dirty bucket of a series) or
+/// the cumulative `closing_stock` of the previous bucket (computed by
+/// `propagate_series` in `propagator.rs`).
+#[inline]
+pub fn compute_pi_bucket(
+    opening_stock: Decimal,
+    supplies: &[Supply],
+    demands: &[Demand],
+    bucket_start: NaiveDate,
+    bucket_end: NaiveDate,
+) -> PiResult {
+    let inflows = sum_inflows(supplies, bucket_start, bucket_end);
+    let outflows = sum_outflows(demands, bucket_start, bucket_end);
+    let closing_stock = opening_stock + inflows - outflows;
+    let has_shortage = closing_stock < Decimal::ZERO;
+    let shortage_qty = if has_shortage {
+        -closing_stock
+    } else {
+        Decimal::ZERO
+    };
+    PiResult {
+        opening_stock,
+        inflows,
+        outflows,
+        closing_stock,
+        has_shortage,
+        shortage_qty,
+    }
+}
+
+// -------------------------------------------------------------------- //
+//  Unit tests — apples-to-apples vs Python kernel semantics.
+// -------------------------------------------------------------------- //
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn date(s: &str) -> NaiveDate {
+        NaiveDate::parse_from_str(s, "%Y-%m-%d").unwrap()
+    }
+    fn dec(s: &str) -> Decimal {
+        Decimal::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn empty_bucket() {
+        let r = compute_pi_bucket(dec("100"), &[], &[], date("2026-01-01"), date("2026-01-08"));
+        assert_eq!(r.opening_stock, dec("100"));
+        assert_eq!(r.inflows, Decimal::ZERO);
+        assert_eq!(r.outflows, Decimal::ZERO);
+        assert_eq!(r.closing_stock, dec("100"));
+        assert!(!r.has_shortage);
+    }
+
+    #[test]
+    fn supply_point_inside_bucket() {
+        let supplies = vec![Supply {
+            quantity: dec("50"),
+            time_ref: date("2026-01-04"),
+        }];
+        let r = compute_pi_bucket(dec("10"), &supplies, &[], date("2026-01-01"), date("2026-01-08"));
+        assert_eq!(r.inflows, dec("50"));
+        assert_eq!(r.closing_stock, dec("60"));
+    }
+
+    #[test]
+    fn supply_on_bucket_end_excluded() {
+        // bucket_end is EXCLUSIVE
+        let supplies = vec![Supply {
+            quantity: dec("50"),
+            time_ref: date("2026-01-08"),
+        }];
+        let r = compute_pi_bucket(dec("10"), &supplies, &[], date("2026-01-01"), date("2026-01-08"));
+        assert_eq!(r.inflows, Decimal::ZERO);
+    }
+
+    #[test]
+    fn demand_span_full_overlap() {
+        let demands = vec![Demand {
+            quantity: dec("30"),
+            time_span_start: Some(date("2026-01-01")),
+            time_span_end: Some(date("2026-01-08")),
+            time_ref: None,
+        }];
+        let r = compute_pi_bucket(dec("100"), &[], &demands, date("2026-01-01"), date("2026-01-08"));
+        // Full 7-day span = 7 days overlap, so 100% of the 30 -> 30.
+        assert_eq!(r.outflows, dec("30"));
+    }
+
+    #[test]
+    fn demand_span_partial_overlap() {
+        // 30-day demand, 1-day bucket starting at day 0 of the span → 1/30 of qty.
+        let demands = vec![Demand {
+            quantity: dec("30"),
+            time_span_start: Some(date("2026-01-01")),
+            time_span_end: Some(date("2026-01-31")),
+            time_ref: None,
+        }];
+        let r = compute_pi_bucket(dec("100"), &[], &demands, date("2026-01-01"), date("2026-01-02"));
+        assert_eq!(r.outflows, dec("1"));
+    }
+
+    #[test]
+    fn demand_time_ref_inside() {
+        let demands = vec![Demand {
+            quantity: dec("20"),
+            time_span_start: None,
+            time_span_end: None,
+            time_ref: Some(date("2026-01-05")),
+        }];
+        let r = compute_pi_bucket(dec("100"), &[], &demands, date("2026-01-01"), date("2026-01-08"));
+        assert_eq!(r.outflows, dec("20"));
+    }
+
+    #[test]
+    fn shortage_negative_closing() {
+        let demands = vec![Demand {
+            quantity: dec("150"),
+            time_span_start: None,
+            time_span_end: None,
+            time_ref: Some(date("2026-01-04")),
+        }];
+        let r = compute_pi_bucket(dec("100"), &[], &demands, date("2026-01-01"), date("2026-01-08"));
+        assert_eq!(r.closing_stock, dec("-50"));
+        assert!(r.has_shortage);
+        assert_eq!(r.shortage_qty, dec("50"));
+    }
+}

--- a/rust/ootils_kernel/src/lib.rs
+++ b/rust/ootils_kernel/src/lib.rs
@@ -23,6 +23,8 @@
 //! 3.13+ without rebuild.
 
 mod io;
+mod kernel;
+mod propagator;
 
 use chrono::NaiveDate;
 use pyo3::prelude::*;
@@ -120,6 +122,70 @@ fn load_subgraph_stats<'py>(
     Ok(d)
 }
 
+/// Week 3: project all dirty PIs in the (calc_run_id, scenario_id) subgraph
+/// **in memory**, without writing back to Postgres. Returns a list of dicts
+/// where each entry corresponds to one PI, ready for parity comparison
+/// against the Python and SQL engines.
+///
+/// Each dict has the keys:
+///   - "node_id"      : str (UUID)
+///   - "opening_stock": str (Decimal)
+///   - "inflows"      : str (Decimal)
+///   - "outflows"     : str (Decimal)
+///   - "closing_stock": str (Decimal)
+///   - "has_shortage" : bool
+///   - "shortage_qty" : str (Decimal)
+///
+/// Also returns metadata in a separate dict (`stats`) with timings.
+#[pyfunction]
+fn project_subgraph<'py>(
+    py: Python<'py>,
+    dsn: &str,
+    calc_run_id_str: &str,
+    scenario_id_str: &str,
+) -> PyResult<(Vec<Bound<'py, pyo3::types::PyDict>>, Bound<'py, pyo3::types::PyDict>)> {
+    let calc_run_id = parse_uuid(calc_run_id_str)?;
+    let scenario_id = parse_uuid(scenario_id_str)?;
+
+    let t_load_start = std::time::Instant::now();
+    let mut loader = io::Loader::connect(dsn).map_err(|e| {
+        pyo3::exceptions::PyRuntimeError::new_err(format!("postgres connect failed: {e}"))
+    })?;
+    let sg = loader
+        .load_subgraph(calc_run_id, scenario_id)
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("load_subgraph failed: {e}")))?;
+    let load_ms = t_load_start.elapsed().as_secs_f64() * 1000.0;
+
+    let t_compute_start = std::time::Instant::now();
+    let projection = propagator::project(&sg);
+    let compute_ms = t_compute_start.elapsed().as_secs_f64() * 1000.0;
+
+    // Serialize the results back to Python.
+    let mut out: Vec<Bound<'py, pyo3::types::PyDict>> = Vec::with_capacity(projection.len());
+    for (node_id, r) in &projection.results {
+        let d = pyo3::types::PyDict::new_bound(py);
+        d.set_item("node_id", node_id.to_string())?;
+        d.set_item("opening_stock", r.opening_stock.to_string())?;
+        d.set_item("inflows", r.inflows.to_string())?;
+        d.set_item("outflows", r.outflows.to_string())?;
+        d.set_item("closing_stock", r.closing_stock.to_string())?;
+        d.set_item("has_shortage", r.has_shortage)?;
+        d.set_item("shortage_qty", r.shortage_qty.to_string())?;
+        out.push(d);
+    }
+
+    let stats = pyo3::types::PyDict::new_bound(py);
+    stats.set_item("n_dirty_pis", sg.n_dirty_pis())?;
+    stats.set_item("n_supplies", sg.n_supplies())?;
+    stats.set_item("n_demands", sg.n_demands())?;
+    stats.set_item("n_series_seeds", sg.n_series_seeds())?;
+    stats.set_item("n_shortages_detected", projection.n_shortages())?;
+    stats.set_item("load_ms", load_ms)?;
+    stats.set_item("compute_ms", compute_ms)?;
+
+    Ok((out, stats))
+}
+
 #[pymodule]
 fn ootils_kernel(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(echo, m)?)?;
@@ -127,5 +193,6 @@ fn ootils_kernel(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(days_between, m)?)?;
     m.add_function(wrap_pyfunction!(version, m)?)?;
     m.add_function(wrap_pyfunction!(load_subgraph_stats, m)?)?;
+    m.add_function(wrap_pyfunction!(project_subgraph, m)?)?;
     Ok(())
 }

--- a/rust/ootils_kernel/src/propagator.rs
+++ b/rust/ootils_kernel/src/propagator.rs
@@ -1,0 +1,94 @@
+//! propagator.rs — orchestrate the per-bucket compute across a series.
+//!
+//! Mirrors the SQL engine's window-function CTE (`projected`) and the
+//! Python engine's topological loop. For each affected projection_series:
+//!
+//! 1. Sort its dirty buckets by `bucket_sequence`.
+//! 2. The seed opening for the lowest dirty bucket comes from
+//!    `Subgraph::seed_openings` (either OnHand sum at bucket 0 or
+//!    prev.closing_stock at seed_seq - 1).
+//! 3. Walk forward through the dirty buckets, using the previous
+//!    bucket's `closing_stock` as the current bucket's `opening_stock`.
+//!
+//! Output: one `PiResult` per dirty PI, keyed by `node_id`, ready for
+//! the writeback step (week 4).
+
+use crate::io::Subgraph;
+use crate::kernel::{compute_pi_bucket, PiResult};
+use rust_decimal::Decimal;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// Per-bucket compute results for every dirty PI in the subgraph.
+///
+/// Key = PI node_id. The map is sized to `dirty_pis.len()` exactly.
+pub struct Projection {
+    pub results: HashMap<Uuid, PiResult>,
+}
+
+impl Projection {
+    pub fn len(&self) -> usize {
+        self.results.len()
+    }
+
+    pub fn n_shortages(&self) -> usize {
+        self.results.values().filter(|r| r.has_shortage).count()
+    }
+}
+
+/// Project all dirty PIs in the subgraph.
+///
+/// Algorithm: group by `projection_series_id`, sort each group by
+/// `bucket_sequence`, then propagate `closing_stock` forward as the next
+/// bucket's `opening_stock`. Equivalent to the SQL CTE that does:
+///
+/// ```text
+///     SUM(oh_seed) OVER (...) + COALESCE(SUM(inflows - outflows) OVER (...), 0)
+/// ```
+///
+/// with `oh_seed` zero everywhere except at the seed bucket of each
+/// series (where it equals the seed opening).
+pub fn project(sg: &Subgraph) -> Projection {
+    let mut results: HashMap<Uuid, PiResult> = HashMap::with_capacity(sg.dirty_pis.len());
+
+    // Group dirty PIs by series id. We keep the index into sg.dirty_pis
+    // so we can preserve owned data on the heap; the borrow checker is
+    // happy because sg outlives this function call.
+    let mut by_series: HashMap<Uuid, Vec<&crate::io::DirtyPi>> = HashMap::new();
+    for pi in &sg.dirty_pis {
+        by_series.entry(pi.projection_series_id).or_default().push(pi);
+    }
+
+    for (series_id, mut buckets) in by_series {
+        // Sort by bucket_sequence ascending so we can chain closing_stock.
+        buckets.sort_by_key(|p| p.bucket_sequence);
+
+        // Seed opening: provided by io.rs's seed_openings query for
+        // (series_id, min(bucket_sequence)). If the series isn't present
+        // (shouldn't happen — seed_openings has one row per affected
+        // series), fall back to zero with a quiet default.
+        let seed_opening = sg
+            .seed_openings
+            .get(&series_id)
+            .map(|(_, v)| *v)
+            .unwrap_or(Decimal::ZERO);
+
+        // Walk forward.
+        let mut prev_closing = seed_opening;
+        for pi in buckets {
+            let supplies = sg.supplies_by_pi.get(&pi.node_id).map(|v| v.as_slice()).unwrap_or(&[]);
+            let demands = sg.demands_by_pi.get(&pi.node_id).map(|v| v.as_slice()).unwrap_or(&[]);
+            let r = compute_pi_bucket(
+                prev_closing,
+                supplies,
+                demands,
+                pi.time_span_start,
+                pi.time_span_end,
+            );
+            prev_closing = r.closing_stock;
+            results.insert(pi.node_id, r);
+        }
+    }
+
+    Projection { results }
+}

--- a/scripts/parity_3way.py
+++ b/scripts/parity_3way.py
@@ -1,0 +1,325 @@
+"""
+parity_3way.py — Validate byte-identical compute across Python / SQL / Rust
+engines on the same realistic dataset.
+
+Setup:
+    1. Pick a target DB (DATABASE_URL or --dsn). Must be a profile-S/M/L
+       DB seeded with the realistic dataset generator (NOT prod).
+    2. Mark ALL active PIs dirty (one synthetic calc_run).
+    3. Run each engine's `_propagate` / `project_subgraph` over the same
+       dirty set.
+    4. Compare results row by row.
+
+The criterion is **0 mismatch**. The script exits non-zero on the first
+divergence found.
+
+This is the ADR-016 §week 3 go/no-go gate.
+
+Usage:
+    DATABASE_URL=postgresql://ootils:ootils@host:5432/ootils_bench_l \\
+        python scripts/parity_3way.py
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import psycopg
+from psycopg.rows import dict_row
+
+import ootils_kernel
+from ootils_core.engine.kernel.graph.dirty import DirtyFlagManager
+from ootils_core.engine.kernel.graph.store import GraphStore
+from ootils_core.engine.kernel.graph.traversal import GraphTraversal
+from ootils_core.engine.kernel.calc.projection import ProjectionKernel
+from ootils_core.engine.kernel.shortage.detector import ShortageDetector
+from ootils_core.engine.orchestration.calc_run import CalcRunManager
+from ootils_core.engine.orchestration.propagator import PropagationEngine
+from ootils_core.engine.orchestration.propagator_sql import SqlPropagationEngine
+
+BASELINE = UUID("00000000-0000-0000-0000-000000000001")
+# Decimal tolerance for cross-engine comparison. Both Python Decimal and
+# Postgres numeric should give bit-identical results in theory; in
+# practice the SQL-side numeric(50,28) cast can introduce a last-digit
+# diff vs. Python's default 28-digit context. We allow 1e-18 — far
+# tighter than any business value — to keep the test honest.
+TOLERANCE = Decimal("1e-18")
+
+
+def _setup_calc_run(conn) -> tuple[UUID, set[UUID]]:
+    """Insert a synthetic event + calc_run, mark all active PIs dirty."""
+    event_id = uuid4()
+    conn.execute(
+        "INSERT INTO events (event_id, event_type, scenario_id, processed, source) "
+        "VALUES (%s, 'calc_triggered', %s, FALSE, 'engine')",
+        (event_id, BASELINE),
+    )
+    cm = CalcRunManager()
+    cr = cm.start_calc_run(scenario_id=BASELINE, event_ids=[event_id], db=conn)
+    if cr is None:
+        raise SystemExit("Could not acquire scenario lock — is another run in progress?")
+
+    pi_ids: set[UUID] = {
+        UUID(str(r["node_id"]))
+        for r in conn.execute(
+            "SELECT node_id FROM nodes "
+            "WHERE node_type='ProjectedInventory' AND scenario_id=%s AND active=TRUE",
+            (BASELINE,),
+        ).fetchall()
+    }
+    d = DirtyFlagManager()
+    d.mark_dirty(pi_ids, BASELINE, cr.calc_run_id, conn)
+    d.flush_to_postgres(cr.calc_run_id, BASELINE, conn)
+    conn.commit()
+    return cr.calc_run_id, pi_ids
+
+
+def _python_results(conn, calc_run_id: UUID, pi_ids: set[UUID]) -> dict[UUID, dict]:
+    """Run Python engine in-place and read back results from DB."""
+    store = GraphStore(conn)
+    engine = PropagationEngine(
+        store=store,
+        traversal=GraphTraversal(store),
+        dirty=DirtyFlagManager(),
+        calc_run_mgr=CalcRunManager(),
+        kernel=ProjectionKernel(),
+        shortage_detector=ShortageDetector(),
+    )
+    # We bypass process_event since our event is already inserted; call
+    # _propagate directly on the dirty set we already have.
+    from ootils_core.models import CalcRun
+    # Reconstitute the CalcRun in memory from DB
+    row = conn.execute("SELECT * FROM calc_runs WHERE calc_run_id=%s", (calc_run_id,)).fetchone()
+    cr = CalcRun(
+        calc_run_id=UUID(str(row["calc_run_id"])),
+        scenario_id=UUID(str(row["scenario_id"])),
+        triggered_by_event_ids=[UUID(str(e)) for e in (row.get("triggered_by_event_ids") or [])],
+    )
+    t0 = time.perf_counter()
+    engine._propagate(cr, pi_ids, conn)
+    elapsed = time.perf_counter() - t0
+    conn.commit()
+    # Read back
+    rows = conn.execute(
+        "SELECT node_id, opening_stock, inflows, outflows, closing_stock, "
+        "has_shortage, shortage_qty FROM nodes "
+        "WHERE node_id = ANY(%s)",
+        (list(pi_ids),),
+    ).fetchall()
+    out = {
+        UUID(str(r["node_id"])): {
+            "opening_stock": Decimal(str(r["opening_stock"])),
+            "inflows": Decimal(str(r["inflows"])),
+            "outflows": Decimal(str(r["outflows"])),
+            "closing_stock": Decimal(str(r["closing_stock"])),
+            "has_shortage": bool(r["has_shortage"]),
+            "shortage_qty": Decimal(str(r["shortage_qty"])),
+        }
+        for r in rows
+    }
+    return out, elapsed
+
+
+def _sql_results(conn, calc_run_id: UUID, pi_ids: set[UUID]) -> dict[UUID, dict]:
+    """Run SQL engine in-place and read back results."""
+    # Reset dirty flags first (Python engine consumed them)
+    d = DirtyFlagManager()
+    d.mark_dirty(pi_ids, BASELINE, calc_run_id, conn)
+    d.flush_to_postgres(calc_run_id, BASELINE, conn)
+    conn.commit()
+
+    store = GraphStore(conn)
+    engine = SqlPropagationEngine(
+        store=store,
+        traversal=GraphTraversal(store),
+        dirty=DirtyFlagManager(),
+        calc_run_mgr=CalcRunManager(),
+        kernel=ProjectionKernel(),
+        shortage_detector=ShortageDetector(),
+    )
+    from ootils_core.models import CalcRun
+    row = conn.execute("SELECT * FROM calc_runs WHERE calc_run_id=%s", (calc_run_id,)).fetchone()
+    cr = CalcRun(
+        calc_run_id=UUID(str(row["calc_run_id"])),
+        scenario_id=UUID(str(row["scenario_id"])),
+        triggered_by_event_ids=[UUID(str(e)) for e in (row.get("triggered_by_event_ids") or [])],
+    )
+    t0 = time.perf_counter()
+    engine._propagate(cr, pi_ids, conn)
+    elapsed = time.perf_counter() - t0
+    conn.commit()
+    rows = conn.execute(
+        "SELECT node_id, opening_stock, inflows, outflows, closing_stock, "
+        "has_shortage, shortage_qty FROM nodes WHERE node_id = ANY(%s)",
+        (list(pi_ids),),
+    ).fetchall()
+    return {
+        UUID(str(r["node_id"])): {
+            "opening_stock": Decimal(str(r["opening_stock"])),
+            "inflows": Decimal(str(r["inflows"])),
+            "outflows": Decimal(str(r["outflows"])),
+            "closing_stock": Decimal(str(r["closing_stock"])),
+            "has_shortage": bool(r["has_shortage"]),
+            "shortage_qty": Decimal(str(r["shortage_qty"])),
+        }
+        for r in rows
+    }, elapsed
+
+
+def _rust_results(dsn: str, calc_run_id: UUID) -> dict[UUID, dict]:
+    """Call the Rust engine via PyO3. Doesn't touch the DB writes."""
+    # Mark dirty again so the Rust loader can see them.
+    with psycopg.connect(dsn, row_factory=dict_row) as c:
+        d = DirtyFlagManager()
+        # Pull active PIs again (idempotent re-marking)
+        pi_ids = {
+            UUID(str(r["node_id"]))
+            for r in c.execute(
+                "SELECT node_id FROM nodes WHERE node_type='ProjectedInventory' "
+                "AND scenario_id=%s AND active=TRUE",
+                (BASELINE,),
+            ).fetchall()
+        }
+        d.mark_dirty(pi_ids, BASELINE, calc_run_id, c)
+        d.flush_to_postgres(calc_run_id, BASELINE, c)
+        c.commit()
+
+    t0 = time.perf_counter()
+    results, stats = ootils_kernel.project_subgraph(dsn, str(calc_run_id), str(BASELINE))
+    elapsed = time.perf_counter() - t0
+    out = {
+        UUID(r["node_id"]): {
+            "opening_stock": Decimal(r["opening_stock"]),
+            "inflows": Decimal(r["inflows"]),
+            "outflows": Decimal(r["outflows"]),
+            "closing_stock": Decimal(r["closing_stock"]),
+            "has_shortage": bool(r["has_shortage"]),
+            "shortage_qty": Decimal(r["shortage_qty"]),
+        }
+        for r in results
+    }
+    return out, elapsed, stats
+
+
+def _compare(ref: dict[UUID, dict], other: dict[UUID, dict], name: str) -> int:
+    """Compare `other` against `ref`. Returns number of mismatches."""
+    n_mismatch = 0
+    first_5_mismatches: list[str] = []
+    missing = set(ref) - set(other)
+    extra = set(other) - set(ref)
+    if missing:
+        n_mismatch += len(missing)
+        first_5_mismatches.append(f"  {name} missing {len(missing)} PIs")
+    if extra:
+        n_mismatch += len(extra)
+        first_5_mismatches.append(f"  {name} has {len(extra)} extra PIs")
+
+    common = set(ref) & set(other)
+    for k in common:
+        r, o = ref[k], other[k]
+        for field in ("opening_stock", "inflows", "outflows", "closing_stock"):
+            diff = abs(r[field] - o[field])
+            if diff > TOLERANCE:
+                n_mismatch += 1
+                if len(first_5_mismatches) < 5:
+                    first_5_mismatches.append(
+                        f"  {name} mismatch on {k} {field}: ref={r[field]} other={o[field]} diff={diff}"
+                    )
+        if r["has_shortage"] != o["has_shortage"]:
+            n_mismatch += 1
+            if len(first_5_mismatches) < 5:
+                first_5_mismatches.append(
+                    f"  {name} shortage flag differs on {k}: ref={r['has_shortage']} other={o['has_shortage']}"
+                )
+        diff = abs(r["shortage_qty"] - o["shortage_qty"])
+        if diff > TOLERANCE:
+            n_mismatch += 1
+            if len(first_5_mismatches) < 5:
+                first_5_mismatches.append(
+                    f"  {name} shortage_qty mismatch on {k}: ref={r['shortage_qty']} other={o['shortage_qty']}"
+                )
+
+    print(f"  {name} vs reference: {n_mismatch} mismatches over {len(common)} common PIs")
+    for m in first_5_mismatches:
+        print(m)
+    return n_mismatch
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    p.add_argument(
+        "--skip-python",
+        action="store_true",
+        help="Skip the Python engine (saturates on profile L 227K PIs). Falls "
+        "back to SQL vs Rust only — sufficient since Python≡SQL is already "
+        "validated on S and M.",
+    )
+    args = p.parse_args()
+    if not args.dsn:
+        print("ERROR: set DATABASE_URL or pass --dsn", file=sys.stderr)
+        return 1
+
+    print(f"3-way parity check on {args.dsn.split('@')[-1]}")
+    if args.skip_python:
+        print("  (Python engine skipped — comparing SQL vs Rust only)")
+    print()
+
+    with psycopg.connect(args.dsn, row_factory=dict_row) as conn:
+        calc_run_id, pi_ids = _setup_calc_run(conn)
+        print(f"  calc_run_id = {calc_run_id}, {len(pi_ids)} PIs dirty")
+        print()
+
+        py_results = None
+        py_elapsed = 0.0
+        if not args.skip_python:
+            print("[Python engine] running...")
+            py_results, py_elapsed = _python_results(conn, calc_run_id, pi_ids)
+            print(f"  {len(py_results)} PIs computed in {py_elapsed:.2f}s")
+
+        print("[SQL engine] running...")
+        sql_results, sql_elapsed = _sql_results(conn, calc_run_id, pi_ids)
+        print(f"  {len(sql_results)} PIs computed in {sql_elapsed:.2f}s")
+
+    print("[Rust engine] running (separate connection)...")
+    rust_results, rust_elapsed, rust_stats = _rust_results(args.dsn, calc_run_id)
+    print(f"  {len(rust_results)} PIs computed in {rust_elapsed:.2f}s")
+    print(f"  stats: load_ms={rust_stats['load_ms']:.1f}, compute_ms={rust_stats['compute_ms']:.1f}, "
+          f"shortages={rust_stats['n_shortages_detected']}")
+    print()
+
+    # Comparison logic:
+    # - With Python: use Python as reference (canonical engine).
+    # - Without Python: use SQL as reference (proven equivalent to Python on S/M).
+    reference, ref_name = (
+        (py_results, "Python") if py_results is not None else (sql_results, "SQL")
+    )
+    print(f"=== Parity comparison (reference = {ref_name}) ===")
+    n_diffs = 0
+    if py_results is not None:
+        n_diffs += _compare(py_results, sql_results, "SQL")
+        n_diffs += _compare(py_results, rust_results, "Rust")
+    else:
+        n_diffs += _compare(reference, rust_results, "Rust")
+
+    print()
+    print("=== Summary ===")
+    if py_results is not None:
+        print(f"  Python : {py_elapsed:.2f}s")
+    print(f"  SQL    : {sql_elapsed:.2f}s")
+    print(f"  Rust   : {rust_elapsed:.2f}s (load {rust_stats['load_ms']:.0f}ms + compute {rust_stats['compute_ms']:.0f}ms)")
+    print()
+    if n_diffs == 0:
+        engines_compared = "3-way" if py_results is not None else "2-way (SQL/Rust)"
+        print(f"PARITY {engines_compared} : OK")
+        return 0
+    print(f"PARITY FAILED: {n_diffs} diffs total")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Week 3 deliverable of [ADR-016](docs/ADR-016-rust-engine-foundation.md). Implements the per-bucket kernel and series-level propagation in Rust, plus a parity harness comparing all three engines against the same dirty subgraph.

## What's in

- **`src/kernel.rs`** — pure compute for one PI bucket. Mirrors `compute_pi_node` line-for-line, including the monthly-forecast allocation. 7 unit tests pass.
- **`src/propagator.rs`** — series-level orchestration (window function equivalent). Groups dirty PIs by series, sorts by bucket_sequence, chains `closing_stock` → next `opening_stock`.
- **`lib.rs`** — new PyO3 export `project_subgraph(dsn, calc_run_id, scenario_id) -> (results, stats)`.
- **`scripts/parity_3way.py`** — runs all 3 engines on the same realistic dirty set, byte-diffs results (tolerance `1e-18`).

## Results — 0 mismatch across 385K PI comparisons

| Profile | PIs | Python | SQL | **Rust** | Speedup Rust vs SQL |
|---|---|---|---|---|---|
| S | 47 520 | 53.5s | 3.16s | **0.86s** | **3.7×** |
| M | 111 240 | 80.8s | 5.98s | **1.86s** | **3.2×** |
| L | 226 800 | _crash_ | 16.13s | **2.92s** | **5.5×** |

Rust compute alone (load excluded):
- S: 23 ms → **2.06 M PI/s**
- M: 48 ms → **2.32 M PI/s**
- L: 121 ms → **1.87 M PI/s**

→ The Rust kernel sustains ~2 million PI computes per second. The remaining bottleneck (~2.2s on L) is Postgres I/O. Week 4 adds writeback via COPY for the integration.

## Side finding: Python engine fails on L

`psycopg.OperationalError: server closed the connection unexpectedly` mid-propagation on 226K PIs. The Python engine is no longer reliable at this scale. The parity script falls back to SQL ≡ Rust on L (already proven Python ≡ SQL on S and M).

## Out of scope (week 4)

- Bulk writeback to Postgres via COPY
- `OOTILS_ENGINE=rust` dispatch in `events.py`
- Integration tests
- Concurrency / hardening (week 5)

## Test plan

- [x] 7/7 Rust unit tests pass (cargo test --release)
- [x] 13/13 Python smoke tests pass (round-trip primitives)
- [x] Parity 3-way OK on S and M (Python ≡ SQL ≡ Rust)
- [x] Parity 2-way OK on L (SQL ≡ Rust, with 0/226800 mismatches)
- [ ] CI Linux + Windows green (this PR triggers it)