### PR TITLE
test(arch-b): comprehensive test battery for Rust engine service

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ markers = [
     "smoke: marks tests as smoke tests",
     "critical: marks tests as critical path",
     "requires_db: marks tests that require a live DB connection",
+    "live_db: tests that need a real Postgres + ootils-engine binary (engine_service battery)",
 ]
 
 [tool.coverage.run]

--- a/tests/engine_service/__init__.py
+++ b/tests/engine_service/__init__.py
@@ -1,0 +1,16 @@
+"""
+tests/engine_service/ — battery for the standalone Rust engine service
+(ADR-017 Architecture B).
+
+Tests require:
+  - the ootils-engine binary built in rust/target/release/
+  - a reachable Postgres with a seeded baseline (DATABASE_URL env)
+  - grpcio installed in the venv
+
+If any of those is missing, tests in this directory are skipped at
+collection time via the `engine_ready` fixture in conftest.py.
+
+Markers:
+  - `slow`  : long-running tests (recovery cycles, soak loads)
+  - `live_db` : requires a real DB connection
+"""

--- a/tests/engine_service/conftest.py
+++ b/tests/engine_service/conftest.py
@@ -1,0 +1,177 @@
+"""
+conftest.py — shared fixtures for the engine-service test battery.
+
+Key fixtures:
+  - `engine_binary`   : Path to the built ootils-engine executable.
+  - `dsn`             : DATABASE_URL from env (skip if absent).
+  - `pick_pi_node`    : factory yielding a PI node UUID from the seeded DB.
+  - `engine`          : EngineHarness already started + EngineClient connected,
+                        torn down at end of test. One per test (clean WAL).
+  - `engine_session`  : Module-scoped, shared engine instance for fast
+                        tests that don't mutate.
+"""
+from __future__ import annotations
+
+import os
+import socket
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Optional
+from uuid import UUID
+
+import pytest
+
+# Make sure the src layout is on sys.path even if pytest doesn't pick it up.
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+BASELINE = UUID("00000000-0000-0000-0000-000000000001")
+
+
+def pytest_collection_modifyitems(config, items):
+    """Tag all tests in this directory with `live_db`. Allows
+    `pytest -m 'not live_db'` to skip them on CI cells without DB."""
+    for item in items:
+        if "engine_service" in str(item.fspath):
+            item.add_marker(pytest.mark.live_db)
+
+
+@pytest.fixture(scope="session")
+def engine_binary() -> Path:
+    base = ROOT / "rust" / "target" / "release"
+    for name in ("ootils-engine.exe", "ootils-engine"):
+        p = base / name
+        if p.exists():
+            return p
+    pytest.skip(
+        f"ootils-engine binary not found in {base}. "
+        "Build it: cd rust && cargo build --release -p ootils_engine"
+    )
+
+
+@pytest.fixture(scope="session")
+def dsn() -> str:
+    v = os.environ.get("DATABASE_URL")
+    if not v:
+        pytest.skip("DATABASE_URL not set — engine_service tests require a live DB")
+    return v
+
+
+@pytest.fixture(scope="session")
+def grpc_module():
+    """Skip cleanly if grpcio isn't installed (CI cells without it)."""
+    grpc = pytest.importorskip("grpc")
+    return grpc
+
+
+def _free_port(start: int = 50100) -> int:
+    """Find an unused TCP port — multiple harnesses can run in parallel."""
+    for p in range(start, start + 100):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("127.0.0.1", p))
+                return p
+            except OSError:
+                continue
+    raise RuntimeError(f"no free port in [{start}, {start + 100})")
+
+
+@pytest.fixture
+def engine(engine_binary, dsn, grpc_module):
+    """Function-scoped engine — clean WAL, fresh process per test.
+
+    Yields a tuple `(harness, client)`. The client is closed and the
+    process stopped at teardown.
+    """
+    from ootils_core.engine_rust_service import EngineClient, EngineHarness
+
+    port = _free_port()
+    addr = f"127.0.0.1:{port}"
+    wal = Path(tempfile.gettempdir()) / f"engine-test-{os.getpid()}-{port}.wal"
+    if wal.exists():
+        wal.unlink()
+
+    harness = EngineHarness(
+        binary_path=engine_binary,
+        dsn=dsn,
+        listen_addr=addr,
+        wal_path=wal,
+        flush_interval_ms=100,
+    )
+    harness.start(wait_for_ready=True, ready_timeout_s=30.0)
+    client = EngineClient.connect(addr)
+    try:
+        yield harness, client
+    finally:
+        client.close()
+        harness.stop()
+        if wal.exists():
+            try:
+                wal.unlink()
+            except OSError:
+                pass
+
+
+@pytest.fixture(scope="module")
+def engine_session(engine_binary, dsn, grpc_module):
+    """Module-scoped engine — shared across read-only tests for speed.
+    Don't use this if your test mutates state in a way other tests
+    will read."""
+    from ootils_core.engine_rust_service import EngineClient, EngineHarness
+
+    port = _free_port(start=50200)
+    addr = f"127.0.0.1:{port}"
+    wal = Path(tempfile.gettempdir()) / f"engine-session-{os.getpid()}.wal"
+    if wal.exists():
+        wal.unlink()
+
+    harness = EngineHarness(
+        binary_path=engine_binary,
+        dsn=dsn,
+        listen_addr=addr,
+        wal_path=wal,
+        flush_interval_ms=200,
+    )
+    harness.start(wait_for_ready=True, ready_timeout_s=30.0)
+    client = EngineClient.connect(addr)
+    yield harness, client
+    client.close()
+    harness.stop()
+    if wal.exists():
+        try:
+            wal.unlink()
+        except OSError:
+            pass
+
+
+@pytest.fixture
+def pick_pi_node(dsn):
+    """Factory that returns a fresh PI node UUID + its (item, location)
+    couple from the live DB. Useful for triggering Propagate."""
+    import psycopg
+    from psycopg.rows import dict_row
+
+    def _pick(must_have_shortage: Optional[bool] = None) -> tuple[UUID, UUID, UUID]:
+        with psycopg.connect(dsn, row_factory=dict_row) as conn:
+            sql = (
+                "SELECT node_id, item_id, location_id FROM nodes "
+                "WHERE node_type='ProjectedInventory' AND scenario_id=%s "
+                "AND active=TRUE "
+            )
+            params: list = [BASELINE]
+            if must_have_shortage is not None:
+                sql += "AND has_shortage = %s "
+                params.append(must_have_shortage)
+            sql += "ORDER BY random() LIMIT 1"
+            row = conn.execute(sql, tuple(params)).fetchone()
+            if row is None:
+                raise pytest.skip("no PI node matches the filter")
+            return (
+                UUID(str(row["node_id"])),
+                UUID(str(row["item_id"])),
+                UUID(str(row["location_id"])),
+            )
+
+    return _pick

--- a/tests/engine_service/test_concurrency.py
+++ b/tests/engine_service/test_concurrency.py
@@ -1,0 +1,146 @@
+"""
+test_concurrency.py — multi-client + parallel-call behavior.
+
+The engine uses Arc<RwLock<Graph>> + DashMap for scenarios — these
+tests validate the lock contract holds under real concurrent traffic.
+
+Marked `slow` because they spin multiple threads + measure latency
+distributions.
+"""
+from __future__ import annotations
+
+import statistics
+import threading
+import time
+from uuid import UUID, uuid4
+
+import pytest
+
+BASELINE = UUID("00000000-0000-0000-0000-000000000001")
+
+pytestmark = pytest.mark.slow
+
+
+def test_parallel_reads_during_propagation(engine_session, pick_pi_node):
+    """Multiple GetNode reads should not block, even while Propagate
+    is running on the baseline. Validates the RwLock read+write
+    interleaving."""
+    _, client = engine_session
+    trigger, _, _ = pick_pi_node()
+
+    stop_event = threading.Event()
+    read_count = 0
+    read_lock = threading.Lock()
+    errors: list[Exception] = []
+
+    def reader():
+        nonlocal read_count
+        try:
+            while not stop_event.is_set():
+                client.get_node(BASELINE, trigger)
+                with read_lock:
+                    read_count += 1
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    readers = [threading.Thread(target=reader, daemon=True) for _ in range(4)]
+    for t in readers:
+        t.start()
+
+    # Hammer Propagate from the main thread for 3 seconds.
+    deadline = time.perf_counter() + 3.0
+    propagations = 0
+    while time.perf_counter() < deadline:
+        client.propagate(
+            scenario_id=BASELINE,
+            event_id=uuid4(),
+            event_type="supply_qty_changed",
+            trigger_node_id=trigger,
+        )
+        propagations += 1
+
+    stop_event.set()
+    for t in readers:
+        t.join(timeout=2.0)
+
+    assert not errors, f"concurrent reads errored: {errors[:3]}"
+    assert read_count > 100, (
+        f"only {read_count} reads completed during 3s of Propagate — "
+        "lock contention?"
+    )
+    assert propagations > 10, f"only {propagations} propagations completed"
+
+
+def test_concurrent_fork_calls(engine_binary, dsn, grpc_module, tmp_path):
+    """Multiple ForkScenario calls in parallel — DashMap is supposed
+    to handle concurrent inserts. Validates no deadlock + all forks
+    listed at the end."""
+    from ootils_core.engine_rust_service import EngineClient, EngineHarness
+
+    wal = tmp_path / "concurrent-fork.wal"
+    from tests.engine_service.conftest import _free_port
+    port = _free_port(start=50600)
+    h = EngineHarness(engine_binary, dsn, f"127.0.0.1:{port}", wal_path=wal)
+    h.start(wait_for_ready=True, ready_timeout_s=30.0)
+
+    try:
+        n_forks = 10
+        results: list[str] = []
+        errors: list[Exception] = []
+        threads: list[threading.Thread] = []
+
+        def fork_one(i: int):
+            try:
+                c = EngineClient.connect(f"127.0.0.1:{port}")
+                info = c.fork_scenario(BASELINE, name=f"concurrent-{i}")
+                results.append(info.name)
+                c.close()
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+
+        for i in range(n_forks):
+            t = threading.Thread(target=fork_one, args=(i,))
+            threads.append(t)
+            t.start()
+        for t in threads:
+            t.join(timeout=10.0)
+
+        assert not errors, f"concurrent forks errored: {errors[:3]}"
+        assert len(results) == n_forks, f"expected {n_forks} forks, got {len(results)}"
+
+        # Verify all forks are listed.
+        with EngineClient.connect(f"127.0.0.1:{port}") as c:
+            sl = c.list_scenarios()
+            names = {s.name for s in sl.scenarios}
+            for i in range(n_forks):
+                assert f"concurrent-{i}" in names, f"missing fork {i}"
+    finally:
+        h.stop()
+
+
+def test_burst_propagations_no_failures(engine_session, pick_pi_node):
+    """Tight burst of 500 sequential propagations from one client
+    should produce zero failures + bounded latency."""
+    _, client = engine_session
+    trigger, _, _ = pick_pi_node()
+
+    latencies: list[float] = []
+    failures = 0
+    for _ in range(500):
+        t0 = time.perf_counter()
+        try:
+            client.propagate(
+                scenario_id=BASELINE,
+                event_id=uuid4(),
+                event_type="supply_qty_changed",
+                trigger_node_id=trigger,
+            )
+            latencies.append((time.perf_counter() - t0) * 1000)
+        except Exception:
+            failures += 1
+
+    assert failures == 0, f"{failures} failures in 500-event burst"
+    assert len(latencies) == 500
+
+    p95 = sorted(latencies)[int(0.95 * len(latencies))]
+    assert p95 < 50.0, f"p95 too high: {p95:.2f} ms"

--- a/tests/engine_service/test_correctness.py
+++ b/tests/engine_service/test_correctness.py
@@ -1,0 +1,83 @@
+"""
+test_correctness.py — basic correctness of the engine service.
+
+Health, Metrics, GetNode, simple Propagate. All read-only-style tests
+can share the module-scoped `engine_session` fixture for speed.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+
+BASELINE = UUID("00000000-0000-0000-0000-000000000001")
+
+
+def test_health_returns_serving(engine_session):
+    _, client = engine_session
+    h = client.health()
+    # status enum 1 = SERVING
+    assert h.status == 1, f"engine not serving: {h.detail}"
+    assert "baseline loaded" in h.detail
+    assert h.uptime_seconds >= 0
+
+
+def test_metrics_baseline_loaded(engine_session):
+    _, client = engine_session
+    m = client.metrics()
+    assert m.baseline_graph_bytes > 0
+    # Sane upper bound on profile L (we measured 76 MB; allow 3× for safety).
+    assert m.baseline_graph_bytes < 300 * 1024 * 1024
+
+
+def test_get_node_returns_valid_state(engine_session, pick_pi_node):
+    _, client = engine_session
+    node_id, item_id, loc_id = pick_pi_node()
+    state = client.get_node(BASELINE, node_id)
+    assert state.node_id == node_id
+    assert state.node_type == "ProjectedInventory"
+    assert state.item_id == item_id
+    assert state.location_id == loc_id
+    # Decimal fields parse cleanly + are non-negative-ish (closing_stock
+    # can be negative if there's a shortage, that's OK).
+    assert isinstance(state.opening_stock, Decimal)
+    assert isinstance(state.closing_stock, Decimal)
+
+
+def test_get_node_unknown_uuid_returns_not_found(engine_session, grpc_module):
+    _, client = engine_session
+    bogus = UUID("99999999-9999-9999-9999-999999999999")
+    with pytest.raises(grpc_module.RpcError) as exc_info:
+        client.get_node(BASELINE, bogus)
+    assert exc_info.value.code() == grpc_module.StatusCode.NOT_FOUND
+
+
+def test_propagate_smoke(engine_session, pick_pi_node):
+    _, client = engine_session
+    trigger, _, _ = pick_pi_node()
+    res = client.propagate(
+        scenario_id=BASELINE,
+        event_id=uuid4(),
+        event_type="supply_qty_changed",
+        trigger_node_id=trigger,
+    )
+    # On the seeded baseline, expect a series of 90 PIs to be processed
+    # (one PI series = 90 daily buckets).
+    assert res.nodes_processed >= 1, "propagation processed nothing"
+    assert res.nodes_processed <= 1_000, "propagation processed suspiciously many nodes"
+    # Compute is sub-millisecond per propagation.
+    assert res.compute_ms < 10.0, f"compute too slow: {res.compute_ms} ms"
+
+
+def test_propagate_with_unknown_trigger_returns_not_found(engine_session, grpc_module):
+    _, client = engine_session
+    bogus = UUID("11111111-2222-3333-4444-555555555555")
+    with pytest.raises(grpc_module.RpcError) as exc_info:
+        client.propagate(
+            scenario_id=BASELINE,
+            event_id=uuid4(),
+            event_type="supply_qty_changed",
+            trigger_node_id=bogus,
+        )
+    assert exc_info.value.code() == grpc_module.StatusCode.NOT_FOUND

--- a/tests/engine_service/test_edge_cases.py
+++ b/tests/engine_service/test_edge_cases.py
@@ -1,0 +1,114 @@
+"""
+test_edge_cases.py — boundary conditions + malformed inputs.
+
+Validate the engine fails gracefully (proper gRPC error codes) rather
+than panicking, and that it handles unusual-but-valid inputs.
+"""
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+
+BASELINE = UUID("00000000-0000-0000-0000-000000000001")
+
+
+def test_propagate_with_malformed_uuid_returns_invalid_argument(engine_session, grpc_module):
+    """Phase 6 client converts UUIDs to strings; if a malformed string
+    sneaks in, the engine should respond with INVALID_ARGUMENT."""
+    _, client = engine_session
+    # Bypass the typed client to send bogus strings directly.
+    from ootils_core._grpc import engine_pb2
+
+    bogus_req = engine_pb2.PropagateRequest(
+        scenario_id="not-a-uuid",
+        event_id=str(uuid4()),
+        event_type="supply_qty_changed",
+        trigger_node_id="also-not-a-uuid",
+    )
+    with pytest.raises(grpc_module.RpcError) as exc_info:
+        client._stub.Propagate(bogus_req, timeout=2.0)
+    assert exc_info.value.code() == grpc_module.StatusCode.INVALID_ARGUMENT
+
+
+def test_get_node_with_malformed_uuid_returns_invalid_argument(engine_session, grpc_module):
+    _, client = engine_session
+    from ootils_core._grpc import engine_pb2
+
+    bogus_req = engine_pb2.NodeQuery(
+        scenario_id=str(BASELINE),
+        node_id="bzzt",
+    )
+    with pytest.raises(grpc_module.RpcError) as exc_info:
+        client._stub.GetNode(bogus_req, timeout=2.0)
+    assert exc_info.value.code() == grpc_module.StatusCode.INVALID_ARGUMENT
+
+
+def test_propagate_returns_zero_dirty_for_isolated_trigger(engine_session, dsn, grpc_module):
+    """Trigger node whose (item, location) has no PI buckets in the
+    baseline scenario should propagate 0 PIs cleanly. Skipped if no
+    such orphan node exists in the seeded DB."""
+    import psycopg
+    from psycopg.rows import dict_row
+
+    with psycopg.connect(dsn, row_factory=dict_row) as conn:
+        # Pick any non-PI node — its (item, location) usually has no
+        # PI buckets in the FG-at-DC projection graph.
+        row = conn.execute(
+            "SELECT n.node_id FROM nodes n "
+            "WHERE n.scenario_id=%s AND n.active=TRUE "
+            "AND n.node_type IN ('PurchaseOrderSupply','WorkOrderSupply') "
+            "AND NOT EXISTS ( "
+            "  SELECT 1 FROM nodes p "
+            "  WHERE p.node_type='ProjectedInventory' "
+            "    AND p.scenario_id = n.scenario_id "
+            "    AND p.item_id = n.item_id "
+            "    AND p.location_id = n.location_id "
+            "    AND p.active = TRUE "
+            ") LIMIT 1",
+            (BASELINE,),
+        ).fetchone()
+    if row is None:
+        pytest.skip("no orphan supply node in baseline (all have PI coverage)")
+
+    _, client = engine_session
+    trigger = UUID(str(row["node_id"]))
+    res = client.propagate(
+        scenario_id=BASELINE,
+        event_id=uuid4(),
+        event_type="supply_qty_changed",
+        trigger_node_id=trigger,
+    )
+    # Orphan trigger → 0 PIs to recompute.
+    assert res.nodes_processed == 0
+    assert res.shortages_detected == 0
+
+
+def test_concurrent_propagate_returns_deterministic_state(engine_session, pick_pi_node):
+    """Two back-to-back Propagate calls on the same trigger should
+    leave the node in the same state (idempotent on a fixed-point
+    baseline)."""
+    _, client = engine_session
+    trigger, _, _ = pick_pi_node()
+
+    # First propagation.
+    client.propagate(
+        scenario_id=BASELINE,
+        event_id=uuid4(),
+        event_type="supply_qty_changed",
+        trigger_node_id=trigger,
+    )
+    state_1 = client.get_node(BASELINE, trigger)
+
+    # Second propagation on the same trigger.
+    client.propagate(
+        scenario_id=BASELINE,
+        event_id=uuid4(),
+        event_type="supply_qty_changed",
+        trigger_node_id=trigger,
+    )
+    state_2 = client.get_node(BASELINE, trigger)
+
+    # Idempotency — same inputs → same outputs.
+    assert state_1.closing_stock == state_2.closing_stock
+    assert state_1.has_shortage == state_2.has_shortage

--- a/tests/engine_service/test_performance_regression.py
+++ b/tests/engine_service/test_performance_regression.py
@@ -1,0 +1,129 @@
+"""
+test_performance_regression.py — pin current numbers as a baseline.
+
+These tests FAIL if engine perf regresses beyond a known threshold.
+The thresholds are tuned to the ADR-017 phase gates with some headroom
+to absorb noise.
+
+Marked `slow` — typically excluded from default CI; run in nightly or
+before a release.
+"""
+from __future__ import annotations
+
+import time
+from uuid import UUID, uuid4
+
+import pytest
+
+BASELINE = UUID("00000000-0000-0000-0000-000000000001")
+
+pytestmark = pytest.mark.slow
+
+# --------------------------------------------------------------------- #
+#  Single-event latency
+# --------------------------------------------------------------------- #
+
+
+def test_single_propagate_p50_under_5ms(engine_session, pick_pi_node):
+    """Phase 6 measured 0.35 ms end-to-end on profile L.
+    Allow 5 ms p50 — well under but with noise headroom for CI."""
+    _, client = engine_session
+    trigger, _, _ = pick_pi_node()
+
+    latencies = []
+    for _ in range(100):
+        t0 = time.perf_counter()
+        client.propagate(
+            scenario_id=BASELINE,
+            event_id=uuid4(),
+            event_type="supply_qty_changed",
+            trigger_node_id=trigger,
+        )
+        latencies.append((time.perf_counter() - t0) * 1000)
+
+    latencies.sort()
+    p50 = latencies[len(latencies) // 2]
+    p95 = latencies[int(0.95 * len(latencies))]
+    assert p50 < 5.0, f"single-propagate p50 regressed: {p50:.2f} ms"
+    assert p95 < 20.0, f"single-propagate p95 regressed: {p95:.2f} ms"
+
+
+# --------------------------------------------------------------------- #
+#  Fork latency
+# --------------------------------------------------------------------- #
+
+
+def test_fork_p95_under_100ms(engine):
+    """Phase 4 measured 32 ms p50 in-process. Client-side adds
+    1-3 ms gRPC overhead. Uses a function-scoped engine fixture
+    (clean state) — the module-scoped one accumulates forks from
+    other tests which drags up the latency."""
+    _, client = engine
+
+    # Warmup: first few forks pay cold page-fault cost on the 76 MB clone.
+    for _ in range(3):
+        client.fork_scenario(BASELINE, name="warmup")
+
+    latencies = []
+    for i in range(20):
+        t0 = time.perf_counter()
+        client.fork_scenario(BASELINE, name=f"perf-fork-{i}")
+        latencies.append((time.perf_counter() - t0) * 1000)
+
+    latencies.sort()
+    p50 = latencies[len(latencies) // 2]
+    p95 = latencies[int(0.95 * len(latencies))]
+    # 80 ms gives reasonable noise margin while still detecting a real regression.
+    assert p50 < 80.0, f"fork p50 regressed: {p50:.2f} ms (phase 4 baseline 32 ms)"
+    assert p95 < 150.0, f"fork p95 regressed: {p95:.2f} ms"
+
+
+# --------------------------------------------------------------------- #
+#  Compute throughput
+# --------------------------------------------------------------------- #
+
+
+def test_propagate_compute_under_10ms(engine_session, pick_pi_node):
+    """The engine reports compute_us in EngineTiming. Validate the
+    server-side compute (excluding gRPC roundtrip + Python overhead)
+    stays sub-10 ms. Phase 3 was 86 ms for full L; incremental is
+    sub-ms."""
+    _, client = engine_session
+    trigger, _, _ = pick_pi_node()
+
+    compute_times_ms = []
+    for _ in range(20):
+        res = client.propagate(
+            scenario_id=BASELINE,
+            event_id=uuid4(),
+            event_type="supply_qty_changed",
+            trigger_node_id=trigger,
+        )
+        compute_times_ms.append(res.compute_ms)
+
+    avg = sum(compute_times_ms) / len(compute_times_ms)
+    mx = max(compute_times_ms)
+    assert avg < 10.0, f"avg server-side compute regressed: {avg:.2f} ms"
+    assert mx < 50.0, f"max server-side compute regressed: {mx:.2f} ms"
+
+
+# --------------------------------------------------------------------- #
+#  Memory at idle
+# --------------------------------------------------------------------- #
+
+
+def test_engine_memory_after_warmup_under_600mb(engine):
+    """The graph itself is 76 MB on profile L. Total RSS settles
+    around 120-150 MB after warmup. Uses a function-scoped engine
+    fixture — the module-scoped one accumulates forks from previous
+    tests, each adding ~76 MB."""
+    psutil = pytest.importorskip("psutil")
+    harness, client = engine
+
+    # Warmup: a couple of operations.
+    client.list_scenarios()
+    client.metrics()
+
+    rss_bytes = psutil.Process(harness.process.pid).memory_info().rss
+    rss_mb = rss_bytes / 1_048_576
+    assert rss_mb < 600.0, f"engine RSS regressed: {rss_mb:.1f} MB"

--- a/tests/engine_service/test_recovery.py
+++ b/tests/engine_service/test_recovery.py
@@ -1,0 +1,181 @@
+"""
+test_recovery.py — WAL crash recovery (ADR-017 phase 5).
+
+These tests SIGKILL the engine at various moments and verify that the
+state across restart is consistent. Marked `slow` because each test
+spawns + tears down an engine (3-4 s each).
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+BASELINE = UUID("00000000-0000-0000-0000-000000000001")
+
+pytestmark = pytest.mark.slow
+
+
+def _engine_with_long_flush(engine_binary, dsn, port: int, wal: Path):
+    """Helper: harness with a long flush interval so we can kill
+    BEFORE Postgres catches up + reliably exercise WAL replay."""
+    from ootils_core.engine_rust_service import EngineHarness
+
+    return EngineHarness(
+        binary_path=engine_binary,
+        dsn=dsn,
+        listen_addr=f"127.0.0.1:{port}",
+        wal_path=wal,
+        flush_interval_ms=10_000,  # 10s — kill -9 before flush
+    )
+
+
+def test_kill9_preserves_state_across_restart(engine_binary, dsn, grpc_module, tmp_path):
+    """The canonical recovery test: propagate, SIGKILL, restart,
+    verify GetNode returns the same closing_stock."""
+    from ootils_core.engine_rust_service import EngineClient
+
+    wal = tmp_path / "recovery.wal"
+    from tests.engine_service.conftest import _free_port
+    port = _free_port(start=50300)
+
+    # Pick a trigger.
+    import psycopg
+    from psycopg.rows import dict_row
+    with psycopg.connect(dsn, row_factory=dict_row) as conn:
+        row = conn.execute(
+            "SELECT node_id FROM nodes WHERE node_type='ProjectedInventory' "
+            "AND scenario_id=%s AND active=TRUE LIMIT 1",
+            (BASELINE,),
+        ).fetchone()
+    if row is None:
+        pytest.skip("no PI nodes in baseline")
+    trigger = UUID(str(row["node_id"]))
+
+    # ---- First run ----
+    h1 = _engine_with_long_flush(engine_binary, dsn, port, wal)
+    h1.start(wait_for_ready=True, ready_timeout_s=30.0)
+    try:
+        with EngineClient.connect(f"127.0.0.1:{port}") as c1:
+            c1.propagate(
+                scenario_id=BASELINE,
+                event_id=uuid4(),
+                event_type="supply_qty_changed",
+                trigger_node_id=trigger,
+            )
+            pre_kill = c1.get_node(BASELINE, trigger)
+        time.sleep(0.2)  # ensure WAL fsync completed (already sync, this is paranoia)
+        h1.kill9()
+    finally:
+        # Defensive — if start raised, kill9() above won't have run.
+        pass
+
+    # ---- Second run, same WAL ----
+    h2 = _engine_with_long_flush(engine_binary, dsn, port, wal)
+    h2.start(wait_for_ready=True, ready_timeout_s=30.0)
+    try:
+        with EngineClient.connect(f"127.0.0.1:{port}") as c2:
+            post_restart = c2.get_node(BASELINE, trigger)
+    finally:
+        h2.stop()
+
+    assert post_restart.closing_stock == pre_kill.closing_stock
+    assert post_restart.has_shortage == pre_kill.has_shortage
+
+
+def test_repeated_kill9_remains_consistent(engine_binary, dsn, grpc_module, tmp_path):
+    """5 kill-9 cycles in a row — state must remain consistent."""
+    from ootils_core.engine_rust_service import EngineClient
+
+    wal = tmp_path / "recovery-loop.wal"
+    from tests.engine_service.conftest import _free_port
+    port = _free_port(start=50400)
+
+    # Pick a trigger.
+    import psycopg
+    from psycopg.rows import dict_row
+    with psycopg.connect(dsn, row_factory=dict_row) as conn:
+        row = conn.execute(
+            "SELECT node_id FROM nodes WHERE node_type='ProjectedInventory' "
+            "AND scenario_id=%s AND active=TRUE LIMIT 1",
+            (BASELINE,),
+        ).fetchone()
+    if row is None:
+        pytest.skip("no PI nodes in baseline")
+    trigger = UUID(str(row["node_id"]))
+
+    reference_closing = None
+    for i in range(5):
+        if wal.exists():
+            wal.unlink()
+        h = _engine_with_long_flush(engine_binary, dsn, port, wal)
+        h.start(wait_for_ready=True, ready_timeout_s=30.0)
+        try:
+            with EngineClient.connect(f"127.0.0.1:{port}") as c:
+                c.propagate(
+                    scenario_id=BASELINE,
+                    event_id=uuid4(),
+                    event_type="supply_qty_changed",
+                    trigger_node_id=trigger,
+                )
+                state = c.get_node(BASELINE, trigger)
+                if reference_closing is None:
+                    reference_closing = state.closing_stock
+                else:
+                    assert state.closing_stock == reference_closing, (
+                        f"iter {i}: drift detected closing={state.closing_stock} "
+                        f"vs ref={reference_closing}"
+                    )
+        finally:
+            h.kill9()
+
+
+def test_wal_truncated_after_clean_shutdown(engine_binary, dsn, tmp_path):
+    """A clean SIGTERM should trigger the bg flusher to drain + WAL
+    to truncate — on the next boot, replay should find no records."""
+    from ootils_core.engine_rust_service import EngineClient, EngineHarness
+
+    wal = tmp_path / "clean-shutdown.wal"
+    from tests.engine_service.conftest import _free_port
+    port = _free_port(start=50500)
+
+    h = EngineHarness(
+        binary_path=engine_binary,
+        dsn=dsn,
+        listen_addr=f"127.0.0.1:{port}",
+        wal_path=wal,
+        flush_interval_ms=50,  # short — flush before SIGTERM
+    )
+    h.start(wait_for_ready=True, ready_timeout_s=30.0)
+
+    # Trigger a propagation to write to WAL.
+    import psycopg
+    from psycopg.rows import dict_row
+    with psycopg.connect(dsn, row_factory=dict_row) as conn:
+        row = conn.execute(
+            "SELECT node_id FROM nodes WHERE node_type='ProjectedInventory' "
+            "AND scenario_id=%s AND active=TRUE LIMIT 1",
+            (BASELINE,),
+        ).fetchone()
+    if row is not None:
+        with EngineClient.connect(f"127.0.0.1:{port}") as c:
+            c.propagate(
+                scenario_id=BASELINE,
+                event_id=uuid4(),
+                event_type="supply_qty_changed",
+                trigger_node_id=UUID(str(row["node_id"])),
+            )
+
+    # Give flusher a beat to drain.
+    time.sleep(0.5)
+    h.stop()
+
+    # WAL should be at-or-near magic-header-only size (4 bytes) since
+    # the bg flusher truncated it. Allow some slack — if there's any
+    # late-arrival record it'd still be < 1 KB.
+    assert wal.exists()
+    assert wal.stat().st_size <= 1024, (
+        f"WAL not truncated post-shutdown: {wal.stat().st_size} bytes"
+    )

--- a/tests/engine_service/test_scenarios.py
+++ b/tests/engine_service/test_scenarios.py
@@ -1,0 +1,64 @@
+"""
+test_scenarios.py — Fork / Merge / Isolation behavior of the COW scenario
+manager (ADR-017 phase 4).
+"""
+from __future__ import annotations
+
+import time
+from uuid import UUID
+
+import pytest
+
+BASELINE = UUID("00000000-0000-0000-0000-000000000001")
+
+
+def test_list_scenarios_includes_baseline(engine_session):
+    _, client = engine_session
+    sl = client.list_scenarios()
+    assert len(sl.scenarios) >= 1
+    names = [s.name for s in sl.scenarios]
+    assert "baseline" in names
+
+
+def test_fork_scenario_returns_info(engine_session):
+    _, client = engine_session
+    info = client.fork_scenario(BASELINE, name="test-fork-info")
+    assert info.name == "test-fork-info"
+    assert info.id  # non-empty UUID string
+    assert info.overlay_size == 0
+    # snapshot Arc<Graph> memory is ~76 MB on profile L
+    assert info.memory_bytes > 10 * 1024 * 1024
+
+
+def test_fork_is_fast(engine_session):
+    """Fork latency gate from ADR-017 phase 4 was < 50 ms.
+    Validate it from the client side too — gRPC roundtrip included."""
+    _, client = engine_session
+    t0 = time.perf_counter()
+    info = client.fork_scenario(BASELINE, name="test-fork-perf")
+    elapsed_ms = (time.perf_counter() - t0) * 1000
+    # Add some buffer for first-call warm-up and the gRPC roundtrip
+    # (the engine internal is ~32 ms p50, network adds 1-3 ms).
+    assert elapsed_ms < 200, f"fork too slow from client side: {elapsed_ms:.1f} ms"
+
+
+def test_multiple_forks_listed(engine_session):
+    _, client = engine_session
+    names_before = {s.name for s in client.list_scenarios().scenarios}
+    new_names = []
+    for i in range(5):
+        info = client.fork_scenario(BASELINE, name=f"multi-fork-{i}")
+        new_names.append(info.name)
+    names_after = {s.name for s in client.list_scenarios().scenarios}
+    # All 5 new forks should appear, baseline still there.
+    assert "baseline" in names_after
+    for n in new_names:
+        assert n in names_after, f"missing fork {n} in list"
+
+
+def test_fork_default_name_is_generated(engine_session):
+    _, client = engine_session
+    info = client.fork_scenario(BASELINE, name="")
+    # Default name is "fork-XXXXXXXX" (8-char UUID prefix)
+    assert info.name.startswith("fork-")
+    assert len(info.name) > len("fork-")


### PR DESCRIPTION
## Test battery — 25 pytest cases covering Architecture B

Adds `tests/engine_service/` — a real pytest battery that exercises the standalone Rust engine end-to-end:

| Module | Tests | Marker | Runtime |
|---|---|---|---|
| `test_correctness.py` | 6 | fast | ~3s |
| `test_scenarios.py` | 5 | fast | ~5s |
| `test_edge_cases.py` | 4 | fast | ~3s |
| `test_recovery.py` | 3 | slow | ~20s |
| `test_concurrency.py` | 3 | slow | ~15s |
| `test_performance_regression.py` | 4 | slow | ~15s |
| **Total** | **25** | mixed | **~64s** |

## Run examples

```bash
# All 25 (fast + slow) — ~64s on profile L
DATABASE_URL=... pytest tests/engine_service/

# Fast only — ~11s, CI-friendly
DATABASE_URL=... pytest tests/engine_service/ -m "not slow"

# Slow only — ~54s, run nightly or pre-release
DATABASE_URL=... pytest tests/engine_service/ -m "slow"
```

## Coverage areas

| Category | What's validated |
|---|---|
| **Correctness** | Health, Metrics, GetNode, Propagate basics, NOT_FOUND on bad inputs |
| **Scenarios** | Fork, ListScenarios, default name generation, sequential forks |
| **Edge cases** | Malformed UUIDs → INVALID_ARGUMENT, orphan triggers → 0 nodes, idempotency |
| **Recovery** | kill -9 preserves state, 5× kill-9 stays consistent, clean SIGTERM truncates WAL |
| **Concurrency** | Parallel reads during writes, 10 concurrent forks, 500-event burst |
| **Perf regression** | Single Propagate p50<5ms, Fork p50<80ms, RSS<600MB |

## Validation run (profile L)

```
============================== 25 passed in 64.31s ==============================
  fast subset    : 11.50s (15/15 PASSED)
  slow subset    : 54.22s (10/10 PASSED)
```

## Fixture design

- `engine` — function-scoped, fresh process per test (clean WAL, isolated state)
- `engine_session` — module-scoped, shared process for read-only tests (speed)
- `pick_pi_node` — factory pulling random PI from live DB
- `_free_port` — Windows-TIME_WAIT-safe dynamic port allocation
- `engine_binary` / `dsn` — skip cleanly if dependencies missing

Auto-applied `live_db` marker on all tests in this directory, so CI cells without a live DB skip the entire battery cleanly via `pytest -m "not live_db"`.

## What's deferred

- Postgres-down failure injection (needs pg container manipulation)
- WAL corruption injection at the file level
- 24h soak (needs CI infrastructure)
- Per-scenario propagation tests (today only baseline mutates)
- Byte-level 4-way parity (Python ≡ SQL ≡ Rust-svc) on full propagation

These each deserve their own PR and infrastructure.

## Files

- `tests/engine_service/__init__.py`
- `tests/engine_service/conftest.py` — shared fixtures
- `tests/engine_service/test_*.py` — 6 test modules
- `pyproject.toml` — registers `live_db` marker