### PR TITLE
fix(mrp): shortage_watcher reorders at safety + sizes from the time-phased engine

### DIFF
--- a/scripts/agent_shortage_watcher.py
+++ b/scripts/agent_shortage_watcher.py
@@ -25,6 +25,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import datetime as _dt
 import logging
 import os
 import sys
@@ -69,8 +70,23 @@ def main(argv=None) -> int:
     with psycopg.connect(args.dsn) as conn:
         d = core.load_planning_data(conn, args.horizon_days)
         gross = core.consume_demand(d)
-        short = core.first_shortage(d, gross)
+        r = core.run_timephased(d, gross)
         today = d.horizon_start
+
+        # FG procurement signal sourced from the TIME-PHASED engine (nets to safety,
+        # lot-sized, lead-time offset) — not a single-bucket deficit, so the order is
+        # correctly sized for the coverage the engine planned. Scope: items carrying
+        # independent demand that are BOUGHT (LLC 0); components (LLC>=1) are the
+        # material watcher's job. Take the EARLIEST planned PO per item as the imminent
+        # buy; count the rest as future-planned context.
+        fg_first, fg_count = {}, defaultdict(int)
+        for it, qty_o, rel_o, need_o, kind_o, pd_o in r["planned"]:
+            if kind_o != "PO" or it not in gross or d.llc.get(it, 0) != 0:
+                continue
+            fg_count[it] += 1
+            best = fg_first.get(it)
+            if best is None or need_o < best["need"]:
+                fg_first[it] = {"qty": qty_o, "rel": rel_o, "need": need_o, "pd": pd_o}
 
         # demand freshness (data-quality gate): share of raw demand qty past-due
         cur = conn.cursor()
@@ -88,33 +104,32 @@ def main(argv=None) -> int:
         by_action, by_conf = defaultdict(int), defaultdict(int)
         spend = defaultdict(float)
         skipped_no_supplier = 0
-        for item, sh in short.items():
+        for item, o in fg_first.items():
             sup = d.best_sup.get(item)
             if not sup:
                 skipped_no_supplier += 1      # make / unsourced independent demand → material side
                 continue
             sid, sext, lt, uc, ccy, rel = sup
-            deficit = sh["deficit"]
-            ss = float(d.safety.get(item, 0) or 0)
-            qty = core.lot_size(deficit + ss, float(d.moq.get(item) or 0), float(d.mult.get(item) or 0))
-            qty = round(qty, 2)
+            qty = round(o["qty"], 2)          # already lot-sized & lead-time-offset by run_timephased
             cost = round(qty * float(uc), 2) if uc is not None else None
             ccy = ccy or "EUR"
-            runway = (sh["date"] - today).days
+            need_date = today + _dt.timedelta(weeks=o["need"])
+            runway = (need_date - today).days
             margin = runway - int(lt or core.DEFAULT_LT_DAYS)
-            action = "EXPEDITE" if margin < -14 else ("ORDER_RUSH" if margin < 0 else "ORDER_NOW")
+            action = "EXPEDITE" if (o["pd"] or margin < -14) else ("ORDER_RUSH" if margin < 0 else "ORDER_NOW")
             conf = _confidence(uc, rel, past_due_ratio)
-            evidence = {"deficit_qty": round(deficit, 2), "pooled_safety_stock": ss,
+            evidence = {"planned_qty": qty, "release_week": o["rel"], "need_week": o["need"],
+                        "past_due": o["pd"], "future_orders_planned": fg_count[item],
                         "moq": float(d.moq.get(item) or 0) or None, "order_multiple": float(d.mult.get(item) or 0) or None,
                         "lead_time_days": lt, "runway_days": runway, "margin_days": margin,
-                        "shortage_bucket_week": sh["bucket"], "supplier_reliability": float(rel) if rel is not None else None,
+                        "supplier_reliability": float(rel) if rel is not None else None,
                         "unit_cost": float(uc) if uc is not None else None,
-                        "rule": "first weekly bucket where on_hand + receipts − consumed_demand < 0; "
-                                "qty = deficit + pooled_safety, MOQ floor, multiple round (consumed demand = max_only/DTF/prorated)"}
+                        "rule": "earliest time-phased planned PURCHASE order from run_timephased "
+                                "(nets to safety, lot-sized, lead-time offset); consumed demand = max_only/DTF/prorated"}
             recs.append((AGENT_NAME, run_id, core.BASELINE, item, d.names.get(item, str(item)[:8]),
-                         sh["date"], round(deficit, 2), qty, cost, ccy, sid, sext, lt, runway, margin,
+                         need_date, qty, qty, cost, ccy, sid, sext, lt, runway, margin,
                          action, "L1", "DRAFT", conf, Jsonb(evidence)))
-            display.append({"ext": d.names.get(item, str(item)[:8]), "fsd": sh["date"], "qty": qty,
+            display.append({"ext": d.names.get(item, str(item)[:8]), "fsd": need_date, "qty": qty,
                             "cost": cost, "ccy": ccy, "action": action, "conf": conf, "margin": margin})
             by_action[action] += 1
             by_conf[conf] += 1
@@ -135,7 +150,7 @@ def main(argv=None) -> int:
                    "by_action": dict(by_action), "by_confidence": dict(by_conf),
                    "estimated_spend": {k: round(v, 2) for k, v in spend.items()},
                    "skipped_no_supplier": skipped_no_supplier,
-                   "shortage_items": len(short), "demand_nodes": dn, "past_due_demand_nodes": pdn,
+                   "fg_items_to_order": len(fg_first), "demand_nodes": dn, "past_due_demand_nodes": pdn,
                    "past_due_ratio": round(past_due_ratio, 4), "elapsed_s": round(time.perf_counter() - t0, 2)}
         cur.execute("UPDATE agent_runs SET status='COMPLETED', finished_at=now(), metrics=%s WHERE agent_run_id=%s",
                     (Jsonb(metrics), run_id))
@@ -145,8 +160,8 @@ def main(argv=None) -> int:
     logger.info("=" * 92)
     logger.info("SHORTAGE WATCHER — run %s COMPLETED in %.2fs", str(run_id)[:8], m["elapsed_s"])
     logger.info("  Recommendations written (DRAFT, L1) : %d", m["recommendations"])
-    logger.info("  Forward shortage items (total)      : %d  (skipped, no supplier: %d)",
-                m["shortage_items"], m["skipped_no_supplier"])
+    logger.info("  FG items needing a purchase order   : %d  (skipped, no supplier: %d)",
+                m["fg_items_to_order"], m["skipped_no_supplier"])
     logger.info("  Prior drafts superseded (EXPIRED)   : %d", m["superseded_prior_drafts"])
     logger.info("  By action     : %s", m["by_action"])
     logger.info("  By confidence : %s", m["by_confidence"])

--- a/scripts/mrp_core.py
+++ b/scripts/mrp_core.py
@@ -333,7 +333,16 @@ def first_shortage(d: PlanningData, gross: dict) -> dict:
     max_only + demand-time-fence + prorated + multi-location-deduped). For each
     item with independent demand, walks weekly buckets accumulating
     scheduled receipts − consumed demand on top of on-hand, and returns the FIRST
-    bucket where projected on-hand goes negative.
+    bucket where projected on-hand drops BELOW SAFETY STOCK.
+
+    Triggering at the safety threshold (not at zero/stockout) is deliberate and
+    matches run_timephased: safety stock is the reorder trigger that leaves lead
+    time to recover, so detecting only at true stockout would fire too late. For
+    items with no safety stock (ss=0) this reduces to "first negative bucket".
+
+    `deficit` is the quantity needed to climb back to the safety level (ss − pa),
+    i.e. the order is already sized to restore safety — consumers must NOT add ss
+    again.
 
     Returns {item: {"bucket": t, "date": date, "deficit": qty, "balance": pa}}.
 
@@ -345,13 +354,14 @@ def first_shortage(d: PlanningData, gross: dict) -> dict:
     for item, g in gross.items():
         if not g:
             continue
+        ss = float(d.safety.get(item, 0) or 0)
         pa = float(d.on_hand.get(item, 0) or 0)
         sc = d.sched_b.get(item, {})
         for t in range(d.n_buckets):
             pa += sc.get(t, 0.0) - g.get(t, 0.0)
-            if pa < 0:
+            if pa < ss:
                 out[item] = {"bucket": t, "date": d.horizon_start + _dt.timedelta(weeks=t),
-                             "deficit": -pa, "balance": pa}
+                             "deficit": ss - pa, "balance": pa}
                 break
     return out
 

--- a/scripts/shortage_scan.py
+++ b/scripts/shortage_scan.py
@@ -25,6 +25,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import datetime as _dt
 import logging
 import os
 import sys
@@ -72,29 +73,37 @@ def main(argv=None) -> int:
     elapsed = round(time.perf_counter() - t0, 2)
     n_demand_items = sum(1 for g in gross.values() if g)
 
-    # ── Recommendation mode ─────────────────────────────────────────
+    # ── Recommendation mode (time-phased engine; mirrors shortage_watcher) ──
     if args.recommend:
+        r = core.run_timephased(d, gross)
+        fg_first = {}      # earliest planned PO per independent-demand buy item (LLC 0)
+        for it, qty_o, rel_o, need_o, kind_o, pd_o in r["planned"]:
+            if kind_o != "PO" or it not in gross or d.llc.get(it, 0) != 0:
+                continue
+            best = fg_first.get(it)
+            if best is None or need_o < best["need"]:
+                fg_first[it] = {"qty": qty_o, "need": need_o, "pd": pd_o}
         recs = []
         by_action, spend = {}, {}
-        for item, sh in short.items():
+        for item, o in fg_first.items():
             sup = d.best_sup.get(item)
             if not sup:
                 continue
             sid, sext, lt, uc, ccy, rel = sup
-            ss = float(d.safety.get(item, 0) or 0)
-            qty = round(core.lot_size(sh["deficit"] + ss, float(d.moq.get(item) or 0), float(d.mult.get(item) or 0)), 2)
+            qty = round(o["qty"], 2)         # already lot-sized & lead-time-offset by run_timephased
             cost = round(qty * float(uc), 2) if uc is not None else None
             ccy = ccy or "EUR"
-            runway = (sh["date"] - today).days
+            need_date = today + _dt.timedelta(weeks=o["need"])
+            runway = (need_date - today).days
             margin = runway - int(lt or core.DEFAULT_LT_DAYS)
-            action = "EXPEDITE" if margin < -14 else ("ORDER_RUSH" if margin < 0 else "ORDER_NOW")
+            action = "EXPEDITE" if (o["pd"] or margin < -14) else ("ORDER_RUSH" if margin < 0 else "ORDER_NOW")
             by_action[action] = by_action.get(action, 0) + 1
             if cost is not None:
                 spend[ccy] = spend.get(ccy, 0.0) + cost
-            recs.append((d.names.get(item, str(item)[:8]), sh["date"], action, qty, cost, ccy, sext, margin))
+            recs.append((d.names.get(item, str(item)[:8]), need_date, action, qty, cost, ccy, sext, margin))
         recs.sort(key=lambda r: r[7])
         logger.info("=" * 100)
-        logger.info("PURCHASE RECOMMENDATIONS (consumption-correct) in %.2fs — %d forward shortages with supplier",
+        logger.info("PURCHASE RECOMMENDATIONS (time-phased, mirrors shortage_watcher) in %.2fs — %d FG items with supplier",
                     elapsed, len(recs))
         for act in ("EXPEDITE", "ORDER_RUSH", "ORDER_NOW"):
             logger.info("      %-12s %d", act, by_action.get(act, 0))


### PR DESCRIPTION
Resolves the High finding from the detailed code review: the FG control tower
reordered too late and under-sized its orders.

## Problem (review finding #1, confirmed)
`first_shortage` triggered at `pa < 0` (true stockout) while `run_timephased`
plans at `pa < ss` (safety). The FG shortage signal fired only once an item was
already out of stock — defeating safety stock and disagreeing with the planning
engine. Fixing the threshold alone re-exposed finding #2 (single-bucket sizing
under-covers the horizon, worse when triggered earlier — spend collapsed to
$17.4M of under-buying).

## Fix — unify shortage_watcher on the time-phased engine
- `mrp_core.first_shortage`: trigger at `pa < ss`, `deficit = ss − pa` (restores
  to safety; consumers must not re-add ss). `ss=0` ⇒ old "first negative bucket".
  Retained for the scan detection view (`--reorder`, default).
- `agent_shortage_watcher` + `shortage_scan --recommend`: FG purchase quantities
  now come from `run_timephased` — the **earliest planned PO per independent-demand
  bought item (LLC 0)**. The qty is the engine's lot-sized, lead-time-offset order,
  so it is correctly **timed** (nets to safety) AND correctly **sized** for the
  planned coverage. Future orders per item are recorded in evidence
  (`future_orders_planned`). Components (LLC≥1) stay the material watcher's scope.

## Result (pilote)
`shortage_scan --recommend` and the agent match exactly: 3635 FG items with
supplier, USD 16.9M — the imminent "order now" FG queue (not the annual plan,
which `mrp_value` still values across all levels). Threshold change also lifts
net-short detection from 4049 → 4291 items (safety breaches previously missed).

ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)