### PR TITLE
feat(agent): E&O Watcher — governed excess & obsolete dispositions (migration 045)

### DIFF
--- a/scripts/agent_eando_watcher.py
+++ b/scripts/agent_eando_watcher.py
@@ -1,0 +1,169 @@
+"""
+agent_eando_watcher.py — Excess & Obsolete Watcher, thin over mrp_core.
+
+The mirror image of the shortage tower: instead of "what to order", it surfaces
+"what to stop / free up". For each item whose on-hand sits beyond its coverage
+threshold (mrp_core.excess_obsolete), it proposes a governed L1 DRAFT disposition
+and values the excess (on-hand beyond the threshold) for capital recovery.
+
+Disposition logic (deterministic, conservative — never auto-scraps):
+  STOP_BUY : excess/obsolete AND still has firm inbound supply → stop replenishing
+  REVIEW   : obsolete (dead stock) or very deep excess (>3× threshold) → human disposition
+  HOLD     : moderate excess that demand will burn down within coverage
+
+Confidence is data-quality aware (an "obsolete" item still on order, or one with
+no cost, is NOT asserted as scrap):
+  NEEDS_DATA_REVIEW : obsolete but firm inbound exists (contradiction → suspect demand data)
+  LOW               : no cost (can't value, can't trust the exposure)
+  MEDIUM/HIGH       : clean signal (HIGH when the excess has firm inbound to cancel)
+
+North Star: deterministic core, L1 DRAFT only, auditable (agent_runs), evidence,
+idempotent supersede.
+
+Usage:
+    DATABASE_URL=... python scripts/agent_eando_watcher.py [--months 12] [--cap 300] [--top 15]
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from collections import defaultdict
+
+import psycopg
+from psycopg.types.json import Jsonb
+import mrp_core as core
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+logger = logging.getLogger("eando_watcher")
+AGENT_NAME = "eando_watcher"
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description="Excess & Obsolete Watcher — governed disposition recommendations.")
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    p.add_argument("--horizon-days", type=int, default=540)
+    p.add_argument("--months", type=float, default=12.0, help="coverage threshold; above = E&O")
+    p.add_argument("--cap", type=int, default=300, help="max recommendations persisted (ranked by excess value)")
+    p.add_argument("--top", type=int, default=15)
+    p.add_argument("--allow-dev", action="store_true")
+    args = p.parse_args(argv)
+    if not args.dsn:
+        logger.error("DATABASE_URL not set")
+        return 2
+    db = core.guard_db(args.dsn, args.allow_dev)
+    logger.info("E&O Watcher running on DB=%s (threshold %.0f months)", db, args.months)
+    t0 = time.perf_counter()
+
+    with psycopg.connect(args.dsn) as conn:
+        d = core.load_planning_data(conn, args.horizon_days)
+        gross = core.consume_demand(d)
+        eo = core.excess_obsolete(d, gross, months=args.months)
+
+        built = []   # full reco tuples (pre-cap), each with its excess_value for ranking
+        totals = defaultdict(lambda: {"items": 0, "units": 0.0, "value": 0.0})
+        unpriced_items = 0
+        for item, e in eo.items():
+            cls = e["class"]
+            excess_units = e["excess_units"]
+            cover = e["coverage_months"]                       # None = infinite
+            firm_in = float(d.firm.get(item, 0) or 0)
+            uc = d.unit_cost.get(item) or d.std_cost.get(item)
+            ccy = (d.cost_ccy.get(item) or d.std_ccy.get(item) or "USD")
+            value = round(excess_units * float(uc), 2) if uc is not None else None
+
+            if firm_in > 0:
+                disposition = "STOP_BUY"
+            elif cls == "OBSOLETE" or (cover is not None and cover > 3 * args.months):
+                disposition = "REVIEW"
+            else:
+                disposition = "HOLD"
+
+            if uc is None:
+                conf = "LOW"
+            elif cls == "OBSOLETE" and firm_in > 0:
+                conf = "NEEDS_DATA_REVIEW"                      # dead but on order → demand data suspect
+            elif firm_in > 0:
+                conf = "HIGH"                                  # clear: inbound to cancel
+            else:
+                conf = "MEDIUM"
+
+            evidence = {"on_hand": round(e["on_hand"], 2), "annual_demand": round(e["annual"], 2),
+                        "coverage_months": (round(cover, 1) if cover is not None else None),
+                        "excess_units": round(excess_units, 2), "firm_inbound_units": round(firm_in, 2),
+                        "unit_cost": float(uc) if uc is not None else None,
+                        "rule": "on-hand beyond %.0f months of gross-usage coverage; value = excess_units × cost" % args.months}
+            built.append({
+                "value_sort": value if value is not None else 0.0,
+                "row": (AGENT_NAME, None, core.BASELINE, item, d.names.get(item, str(item)[:8]),
+                        cls, round(e["on_hand"], 2), round(e["annual"], 2),
+                        (round(cover, 4) if cover is not None else None), round(excess_units, 2), value, ccy,
+                        disposition, "L1", "DRAFT", conf, Jsonb(evidence)),
+                "disp": disposition, "cls": cls, "value": value, "units": excess_units,
+                "ext": d.names.get(item, str(item)[:8]), "cover": cover, "conf": conf})
+            t = totals[cls]
+            t["items"] += 1
+            t["units"] += excess_units
+            t["value"] += value or 0.0
+            if uc is None:
+                unpriced_items += 1
+
+        built.sort(key=lambda x: -x["value_sort"])
+        kept = built[: args.cap]
+
+        cur = conn.cursor()
+        run_id = cur.execute(
+            "INSERT INTO agent_runs (agent_name, scenario_id, status) VALUES (%s,%s,'RUNNING') RETURNING agent_run_id",
+            (AGENT_NAME, core.BASELINE)).fetchone()[0]
+        superseded = cur.execute(
+            "UPDATE eando_recommendations SET status='EXPIRED', updated_at=now() "
+            "WHERE agent_name=%s AND scenario_id=%s AND status='DRAFT'", (AGENT_NAME, core.BASELINE)).rowcount
+        recs = [(a, run_id, *rest) for (a, _none, *rest) in (b["row"] for b in kept)]
+        cur.executemany(
+            """INSERT INTO eando_recommendations
+               (agent_name, agent_run_id, scenario_id, item_id, item_external_id, classification,
+                on_hand, annual_demand, coverage_months, excess_units, excess_value, currency,
+                disposition, decision_level, status, confidence, evidence)
+               VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""", recs)
+        by_disp = defaultdict(int)
+        for b in kept:
+            by_disp[b["disp"]] += 1
+        metrics = {"eando_items": len(built), "persisted": len(kept), "superseded": superseded,
+                   "unpriced_items": unpriced_items, "by_disposition": dict(by_disp),
+                   "by_class": {k: {"items": v["items"], "units": round(v["units"], 0), "value": round(v["value"], 2)}
+                                for k, v in totals.items()},
+                   "elapsed_s": round(time.perf_counter() - t0, 2)}
+        cur.execute("UPDATE agent_runs SET status='COMPLETED', finished_at=now(), metrics=%s WHERE agent_run_id=%s",
+                    (Jsonb(metrics), run_id))
+        conn.commit()
+
+    m = metrics
+    logger.info("=" * 100)
+    logger.info("E&O WATCHER — run %s COMPLETED in %.2fs", str(run_id)[:8], m["elapsed_s"])
+    logger.info("  E&O items: %d  (persisted top %d by value; prior drafts superseded: %d)",
+                m["eando_items"], m["persisted"], superseded)
+    for cls in ("EXCESS", "OBSOLETE"):
+        c = m["by_class"].get(cls)
+        if c:
+            logger.info("    %-9s : %5d items, %s units, value %s", cls, c["items"],
+                        f"{c['units']:,.0f}", f"{c['value']:,.0f}")
+    logger.info("  By disposition (persisted): %s", m["by_disposition"])
+    if unpriced_items:
+        logger.info("  ⚠ %d E&O items unpriced (value understated — see dq_watcher MISSING_COST)", unpriced_items)
+    logger.info("=" * 100)
+    logger.info("TOP %d E&O dispositions by value:", args.top)
+    logger.info("  %-16s %-9s %-9s %10s %14s %14s %-5s %-7s", "item", "class", "disp", "cover_mo", "excess_u", "value", "ccy", "conf")
+    for b in kept[: args.top]:
+        cov_s = "∞" if b["cover"] is None else f"{b['cover']:,.1f}"
+        val_s = f"{b['value']:,.0f}" if b["value"] is not None else "—"
+        logger.info("  %-16s %-9s %-9s %10s %14s %14s %-5s %-7s",
+                    b["ext"], b["cls"], b["disp"], cov_s, f"{b['units']:,.0f}", val_s,
+                    b["row"][11], b["conf"])
+    logger.info("=" * 100)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mrp_core.py
+++ b/scripts/mrp_core.py
@@ -366,6 +366,53 @@ def first_shortage(d: PlanningData, gross: dict) -> dict:
     return out
 
 
+def excess_obsolete(d: PlanningData, gross: dict, months: float = 12.0) -> dict:
+    """Classify on-hand stock against its consumption rate and quantify the part
+    sitting beyond `months` of coverage.
+
+    Annual usage per item = total GROSS demand over the next 52 weeks (independent
+    consumed demand + BOM-exploded dependent demand, no netting — the true burn
+    rate). coverage_months = on_hand / (annual / 12).
+      EXCESS   : coverage > months → excess_units = on_hand − months × monthly
+      OBSOLETE : annual == 0 (no demand on the horizon) → excess_units = on_hand
+
+    Returns {item: {"class","on_hand","annual","coverage_months"(None=∞),"excess_units"}}.
+    Only items with on_hand > 0 AND beyond the threshold are returned.
+    """
+    WEEKS = 52
+    indep12 = {}
+    for item, buckets in gross.items():
+        s = sum(q for t, q in buckets.items() if t < WEEKS)
+        if s:
+            indep12[item] = s
+    dep12 = defaultdict(float)
+    for level in range(0, d.max_llc + 1):
+        for item in d.by_level[level]:
+            use = indep12.get(item, 0.0) + dep12.get(item, 0.0)
+            if use <= 0 or not bool(d.is_make.get(item, False)):
+                continue
+            for comp, qpb, scrap in d.bom.get(item, []):
+                dep12[comp] += use * qpb * (1.0 + scrap)
+
+    out = {}
+    for item, oh in d.on_hand.items():
+        oh = float(oh or 0)
+        if oh <= 0:
+            continue
+        annual = indep12.get(item, 0.0) + dep12.get(item, 0.0)
+        if annual <= 0:
+            out[item] = {"class": "OBSOLETE", "on_hand": oh, "annual": 0.0,
+                         "coverage_months": None, "excess_units": oh}
+        else:
+            monthly = annual / 12.0
+            cover = oh / monthly
+            if cover <= months:
+                continue
+            out[item] = {"class": "EXCESS", "on_hand": oh, "annual": annual,
+                         "coverage_months": cover, "excess_units": oh - months * monthly}
+    return out
+
+
 def peg_origins(d: PlanningData, gross: dict):
     """Aggregate LLC cascade with origin attribution. Returns (dependent_total,
     origin) where origin[item] = {finished_good: qty}. Uses consumed demand.

--- a/scripts/mrp_eando.py
+++ b/scripts/mrp_eando.py
@@ -54,19 +54,7 @@ def main(argv=None) -> int:
     with psycopg.connect(args.dsn) as conn:
         d = core.load_planning_data(conn, args.horizon_days)
     gross = core.consume_demand(d)
-
-    # Total GROSS usage per item over the horizon = independent demand + dependent
-    # demand exploded through the BOM (no netting → true consumption rate).
-    indep = {i: sum(v.values()) for i, v in gross.items()}
-    dep = defaultdict(float)
-    for level in range(0, d.max_llc + 1):
-        for item in d.by_level[level]:
-            use = indep.get(item, 0.0) + dep.get(item, 0.0)
-            if use <= 0 or not bool(d.is_make.get(item, False)):
-                continue
-            for comp, qpb, scrap in d.bom.get(item, []):
-                dep[comp] += use * qpb * (1.0 + scrap)
-    ann_factor = 365.0 / args.horizon_days
+    eo = core.excess_obsolete(d, gross, months=args.months)
 
     by_class_ccy = defaultdict(lambda: defaultdict(float))   # class -> ccy -> value
     by_class_units = defaultdict(float)
@@ -74,19 +62,10 @@ def main(argv=None) -> int:
     unpriced_units = unpriced_items = 0
     rows = []                                                # (item, cls, oh, cover, excess_units, value, ccy)
 
-    for item, oh in d.on_hand.items():
-        oh = float(oh or 0)
-        if oh <= 0:
-            continue
-        annual = (indep.get(item, 0.0) + dep.get(item, 0.0)) * ann_factor
-        monthly = annual / 12.0
-        if annual <= 0:
-            cls, cover, excess_units = "OBSOLETE", math.inf, oh
-        else:
-            cover = oh / monthly
-            if cover <= args.months:
-                continue                                     # healthy coverage
-            cls, excess_units = "EXCESS", oh - args.months * monthly
+    for item, e in eo.items():
+        cls = e["class"]
+        excess_units = e["excess_units"]
+        cover = e["coverage_months"] if e["coverage_months"] is not None else math.inf
         uc = d.unit_cost.get(item) or d.std_cost.get(item)
         ccy = (d.cost_ccy.get(item) or d.std_ccy.get(item) or "USD")
         by_class_units[cls] += excess_units
@@ -98,7 +77,7 @@ def main(argv=None) -> int:
         else:
             value = excess_units * float(uc)
             by_class_ccy[cls][ccy] += value
-        rows.append((d.names.get(item, str(item)[:8]), cls, oh, cover, excess_units, value, ccy))
+        rows.append((d.names.get(item, str(item)[:8]), cls, e["on_hand"], cover, excess_units, value, ccy))
 
     elapsed = round(time.perf_counter() - t0, 2)
     grand = defaultdict(float)

--- a/src/ootils_core/db/migrations/045_eando_recommendations.sql
+++ b/src/ootils_core/db/migrations/045_eando_recommendations.sql
@@ -1,0 +1,54 @@
+-- ============================================================
+-- Migration 045 — Excess & Obsolete disposition recommendations
+-- ============================================================
+-- The E&O Watcher turns the read-only E&O valuation into governed, actionable
+-- dispositions: per item sitting beyond its coverage threshold, a proposed action
+-- (stop buying, review for disposition, hold to burn down…) at L1 DRAFT for human
+-- approval. Frees working capital — the mirror image of the shortage tower.
+--
+-- Confidence is data-quality aware: an "obsolete" item still being replenished,
+-- or one with no cost, is flagged NEEDS_DATA_REVIEW / LOW rather than asserting a
+-- scrap. Reuses agent_runs; same state machine + Decision Ladder as the fleet.
+-- ============================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS eando_recommendations (
+    eando_recommendation_id UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_name              TEXT        NOT NULL,
+    agent_run_id            UUID        NOT NULL REFERENCES agent_runs(agent_run_id),
+    scenario_id             UUID        NOT NULL,
+
+    item_id                 UUID        NOT NULL,
+    item_external_id        TEXT        NOT NULL,
+
+    classification          TEXT        NOT NULL CHECK (classification IN ('EXCESS','OBSOLETE')),
+    on_hand                 NUMERIC     NOT NULL,
+    annual_demand           NUMERIC,                 -- 0 for obsolete
+    coverage_months         NUMERIC,                 -- NULL = infinite (no demand)
+    excess_units            NUMERIC     NOT NULL,     -- on-hand beyond the threshold
+    excess_value            NUMERIC,                 -- excess_units × cost; NULL if unpriced
+    currency                TEXT,
+
+    disposition             TEXT        NOT NULL
+                            CHECK (disposition IN ('STOP_BUY','REVIEW','REDEPLOY','RETURN_SUPPLIER',
+                                                   'DISCOUNT_SELL','SCRAP','HOLD')),
+
+    decision_level          TEXT        NOT NULL DEFAULT 'L1'
+                            CHECK (decision_level IN ('L0','L1','L2','L3','L4')),
+    status                  TEXT        NOT NULL DEFAULT 'DRAFT'
+                            CHECK (status IN ('DRAFT','REVIEWED','APPROVED','REJECTED','APPLIED','EXPIRED')),
+    confidence              TEXT        NOT NULL DEFAULT 'MEDIUM'
+                            CHECK (confidence IN ('HIGH','MEDIUM','LOW','NEEDS_DATA_REVIEW')),
+
+    evidence                JSONB,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS ix_eando_status ON eando_recommendations (status);
+CREATE INDEX IF NOT EXISTS ix_eando_class  ON eando_recommendations (classification, status);
+CREATE INDEX IF NOT EXISTS ix_eando_value  ON eando_recommendations (excess_value DESC);
+CREATE INDEX IF NOT EXISTS ix_eando_item   ON eando_recommendations (item_id);
+CREATE INDEX IF NOT EXISTS ix_eando_run    ON eando_recommendations (agent_run_id);
+
+COMMIT;


### PR DESCRIPTION
Agentifies the E&O valuation into governed dispositions — the capital-recovery
mirror of the shortage tower.

- `mrp_core.excess_obsolete` (shared classifier, 12-mo gross-usage window);
  `mrp_eando.py` refactored onto it so CLI and agent share one engine.
- `agent_eando_watcher` + migration 045 `eando_recommendations`. Conservative,
  never auto-scraps: STOP_BUY / REVIEW / HOLD. Confidence is DQ-aware —
  obsolete-but-still-on-order → NEEDS_DATA_REVIEW. Idempotent, evidence, ledger.

Pilote @12mo: 5703 E&O items (~USD 19.7M), top 300 by value persisted
(REVIEW 206 / STOP_BUY 64 / HOLD 30). 5th fleet agent. ruff clean; scripts +
migration only (CI src/ unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)