### PR TITLE
fix(mrp): mrp_grid — exact calendar-month data lines + labelled WO/PO

### DIFF
--- a/scripts/mrp_grid.py
+++ b/scripts/mrp_grid.py
@@ -1,22 +1,24 @@
 """
 mrp_grid.py — monthly MPS/MRP time-phased grid per item (CLI over mrp_core).
 
-The planner's validation lens: for an item, the canonical time-phased record laid
-out month by month, so demand, supply, the projected balance and the plan can be
-eyeballed period by period — exactly where lumps, stale dates and netting errors
-become visible.
+The planner's data-validation lens: the canonical time-phased record laid out by
+calendar month, so demand, supply, the projected balance and the plan can be
+eyeballed period by period — where lumps, stale dates and netting issues become
+visible.
 
-Lines (standard MPS/MRP record):
-    Forecast               raw forecast (prorated monthly→weekly upstream)
-    Customer orders        booked CO
-    Gross requirements     netting demand = consumed independent (max_only/DTF) + dependent (BOM)
-    Scheduled receipts     firm PO/WO/transfer arriving
-    Planned receipts       MRP planned orders, by need period
-    Proj. on-hand (PAB)    on_hand + Σ(receipts + planned − gross), end-of-month
-    Planned releases       MRP planned orders, lead-time-offset by release period
+Two layers, deliberately:
+  DATA (exact, from source by calendar month) — what the planner validates:
+    Forecast            raw forecast demand (forward)
+    Customer orders     booked CO (forward)
+    Scheduled receipts  firm PO/WO/transfer arriving
+  PLAN (from the locked weekly engine, mrp_core) — what the engine decided:
+    Gross requirements  consumed demand (max_only / DTF) + dependent (BOM)
+    Planned WO/PO recpt MRP planned orders by need month
+    Proj. on-hand (PAB) engine projected on-hand, sampled at calendar month-end
+    Planned WO/PO rel.  MRP planned orders, lead-time-offset by release month
 
-Demand is consumption-correct (max_only / demand-time-fence / prorated). Numbers
-match run_timephased (same engine).
+Gross requirements may differ from raw Forecast/CO by design — that gap IS the
+forecast-consumption + proration effect, which is part of what you validate.
 
 Usage:
     DATABASE_URL=... python scripts/mrp_grid.py --item JXIQ400NK [--months-out 12]
@@ -59,42 +61,57 @@ def main(argv=None) -> int:
 
     with psycopg.connect(args.dsn) as conn:
         d = core.load_planning_data(conn, args.horizon_days)
+        ext_to_id = {v: k for k, v in d.names.items()}
+        if args.item:
+            ids = [ext_to_id[args.item]] if args.item in ext_to_id else []
+            if not ids:
+                logger.error("item %s not found", args.item)
+                return 3
+        else:
+            pat = args.like.upper()
+            ids = sorted((i for i, e in d.names.items() if pat in (e or "").upper()),
+                         key=lambda i: d.names.get(i, ""))[: args.max_items]
+            if not ids:
+                logger.error("no item matches --like %s", args.like)
+                return 3
+        # DATA lines: exact source aggregation by calendar month (forward only)
+        src = defaultdict(lambda: defaultdict(lambda: defaultdict(float)))  # item -> kind -> month -> qty
+        for item_id, ntype, m, qty in conn.cursor().execute(
+            "SELECT n.item_id, n.node_type, to_char(date_trunc('month', n.time_ref),'YYYY-MM') m, SUM(n.quantity) "
+            "FROM nodes n WHERE n.scenario_id=%(b)s AND n.active AND n.item_id = ANY(%(ids)s) "
+            "  AND n.time_ref IS NOT NULL AND n.time_ref >= CURRENT_DATE AND n.quantity IS NOT NULL "
+            "  AND n.node_type = ANY(%(t)s) GROUP BY 1,2,3",
+            {"b": core.BASELINE, "ids": list(ids), "t": core.FIRM_RECEIPT_TYPES + core.DEMAND_TYPES}).fetchall():
+            kind = "RECEIPT" if ntype in core.FIRM_RECEIPT_TYPES else ntype
+            src[item_id][kind][m] += float(qty or 0)
+
     gross = core.consume_demand(d)
     r = core.run_timephased(d, gross)
     hs = d.horizon_start
 
-    ext_to_id = {v: k for k, v in d.names.items()}
-    if args.item:
-        ids = [ext_to_id[args.item]] if args.item in ext_to_id else []
-        if not ids:
-            logger.error("item %s not found", args.item)
-            return 3
-    else:
-        pat = args.like.upper()
-        ids = [i for i, ext in d.names.items() if pat in (ext or "").upper()]
-        ids = sorted(ids, key=lambda i: d.names.get(i, ""))[: args.max_items]
-        if not ids:
-            logger.error("no item matches --like %s", args.like)
-            return 3
+    # PLAN: planned orders indexed by their calendar month (discrete events → exact)
+    def bmonth(t):
+        return (hs + _dt.timedelta(weeks=t)).strftime("%Y-%m")
 
-    # planned orders indexed per item (receipt at need bucket, release at rel bucket)
-    prcpt = defaultdict(lambda: defaultdict(float))
-    prel = defaultdict(lambda: defaultdict(float))
+    prcpt = defaultdict(lambda: defaultdict(float))   # item -> month -> qty (at need)
+    prel = defaultdict(lambda: defaultdict(float))    # item -> month -> qty (at release)
     for item, qty, rel, need, kind, pd in r["planned"]:
-        prcpt[item][need] += qty
-        prel[item][rel] += qty
+        prcpt[item][bmonth(need)] += qty
+        prel[item][bmonth(rel)] += qty
 
-    # month label per weekly bucket + ordered month list
-    bmonth = {t: (hs + _dt.timedelta(weeks=t)).strftime("%Y-%m") for t in range(d.n_buckets)}
-    months = sorted(set(bmonth.values()))[: args.months_out]
-    mset = set(months)
+    # calendar month columns from today
+    today = hs
+    months, y, mo = [], today.year, today.month
+    for _ in range(args.months_out):
+        months.append(f"{y:04d}-{mo:02d}")
+        mo += 1
+        if mo > 12:
+            mo, y = 1, y + 1
 
-    def monthly_sum(weekly: dict) -> dict:
-        out = defaultdict(float)
-        for t, v in weekly.items():
-            if bmonth.get(t) in mset:
-                out[bmonth[t]] += v
-        return out
+    def month_end_bucket(m):
+        yy, mm = (int(x) for x in m.split("-"))
+        first_next = _dt.date(yy + 1, 1, 1) if mm == 12 else _dt.date(yy, mm + 1, 1)
+        return max(0, min((first_next - _dt.timedelta(days=1) - hs).days // 7, d.n_buckets - 1))
 
     def fmt(v):
         return f"{v:,.0f}" if abs(v) >= 0.5 else "·"
@@ -106,38 +123,50 @@ def main(argv=None) -> int:
         make = bool(d.is_make.get(item, False))
         lt = (d.make_lt.get(item) if make else d.buy_lt.get(item)) or core.DEFAULT_LT_DAYS
         llc = d.llc.get(item, 0)
+        kind = "WO" if make else "PO"
 
+        s = src.get(item, {})
+        fc_m = s.get("ForecastDemand", {})
+        co_m = s.get("CustomerOrderDemand", {})
+        sched_m = s.get("RECEIPT", {})
+
+        # PLAN: engine gross (consumed + dependent) and PAB, mapped to calendar months
         consumed = gross.get(item, {})
         dep = r["dependent"].get(item, {})
-        gross_req = {t: consumed.get(t, 0.0) + dep.get(t, 0.0) for t in set(consumed) | set(dep)}
-        sched = d.sched_b.get(item, {})
-        pr = prcpt.get(item, {})
-
-        # weekly PAB walk (matches run_timephased), then end-of-month sample
-        pab_month = {}
-        pa = oh
+        gross_req_wk = {t: consumed.get(t, 0.0) + dep.get(t, 0.0) for t in set(consumed) | set(dep)}
+        grossm = defaultdict(float)
+        for t, v in gross_req_wk.items():
+            grossm[bmonth(t)] += v
+        # PAB walk on weekly engine, sampled at calendar month-end (exact point-in-time)
+        sched_wk = d.sched_b.get(item, {})
+        prcpt_wk = defaultdict(float)
+        for _it, qty, rel, need, knd, pdf in r["planned"]:
+            if _it == item:
+                prcpt_wk[need] += qty
+        pa, pab_bucket = oh, []
         for t in range(d.n_buckets):
-            pa += sched.get(t, 0.0) + pr.get(t, 0.0) - gross_req.get(t, 0.0)
-            if bmonth.get(t) in mset:
-                pab_month[bmonth[t]] = pa
+            pa += sched_wk.get(t, 0.0) + prcpt_wk.get(t, 0.0) - gross_req_wk.get(t, 0.0)
+            pab_bucket.append(pa)
+        pab_m = {m: pab_bucket[month_end_bucket(m)] for m in months}
 
         lines = [
-            ("Forecast", monthly_sum(d.fc_b.get(item, {}))),
-            ("Customer orders", monthly_sum(d.co_b.get(item, {}))),
-            ("Gross requirements", monthly_sum(gross_req)),
-            ("Scheduled receipts", monthly_sum(sched)),
-            ("Planned receipts", monthly_sum(pr)),
-            ("Proj. on-hand (PAB)", pab_month),
-            ("Planned releases", monthly_sum(prel.get(item, {}))),
+            ("Forecast", fc_m),
+            ("Customer orders", co_m),
+            ("Scheduled receipts", sched_m),
+            ("Gross requirements", grossm),
+            (f"Planned {kind} receipts", prcpt.get(item, {})),
+            ("Proj. on-hand (PAB)", pab_m),
+            (f"Planned {kind} releases", prel.get(item, {})),
         ]
-
-        logger.info("=" * (22 + 9 * len(months)))
+        width = 22 + 9 * len(months)
+        logger.info("=" * width)
         logger.info("ITEM %s  | %s | LLC %d | on-hand %s | safety %s | lead time %dd",
                     ext, "MAKE" if make else "BUY", llc, f"{oh:,.0f}", f"{ss:,.0f}", int(lt))
-        logger.info("  %-20s%s", "month →", "".join(f"{m[2:]:>9}" for m in months))  # YY-MM
+        logger.info("  %-20s%s", "month →", "".join(f"{m[2:]:>9}" for m in months))
         for label, series in lines:
             logger.info("  %-20s%s", label, "".join(f"{fmt(series.get(m, 0.0)):>9}" for m in months))
-        logger.info("=" * (22 + 9 * len(months)))
+        logger.info("  (Forecast/CO/Scheduled = source calendar months; Gross/Planned/PAB = weekly engine)")
+        logger.info("=" * width)
     return 0
 
 


### PR DESCRIPTION
Fixes two issues reported on the grid:

1. **Calendar accuracy** — weekly buckets (from horizon_start) don't align to
   calendar months, smearing demand across boundaries (June 2758 → 2375). The DATA
   lines (Forecast / Customer orders / Scheduled receipts) now aggregate EXACTLY
   from source by calendar month. PLAN lines (Gross req, Planned, PAB) stay from
   the locked weekly engine; PAB sampled at month-end, planned at order month.
   Gross req ≠ raw Forecast by design (consumption + proration effect).
2. **WO visibility** — planned orders labelled Planned WO (make) / PO (buy).

Pilote JXIQ400NK: Forecast June 2758 / July 797 / Aug 770 match source exactly.
ruff clean; scripts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)