### PR TITLE
fix(mrp): address code-review findings (correctness + consistency + cost helper)

### DIFF
--- a/scripts/agent_dq_watcher.py
+++ b/scripts/agent_dq_watcher.py
@@ -111,7 +111,7 @@ def main(argv=None) -> int:
         sev = _severity_by_quantile(nosup)
         for it, q in nosup.items():
             rows.append({"etype": "item", "eid": it, "eext": d.names.get(it, str(it)[:8]),
-                         "severity": "HIGH" if q > 0 else sev.get(it, "LOW"),
+                         "severity": sev.get(it, "MEDIUM"),   # impact-ranked by planned volume
                          "desc": "Item is planned for purchase but has no sourceable supplier (no supplier_items with a lead time)",
                          "metric": "planned_volume_units", "impact": q,
                          "action": "Create a supplier_items link (supplier, lead_time_days, ideally unit_cost/MOQ)",

--- a/scripts/agent_eando_watcher.py
+++ b/scripts/agent_eando_watcher.py
@@ -70,8 +70,8 @@ def main(argv=None) -> int:
             excess_units = e["excess_units"]
             cover = e["coverage_months"]                       # None = infinite
             firm_in = float(d.firm.get(item, 0) or 0)
-            uc = d.unit_cost.get(item) or d.std_cost.get(item)
-            ccy = (d.cost_ccy.get(item) or d.std_ccy.get(item) or "USD")
+            uc, ccy = core.cost_of(d, item)
+            ccy = ccy or "USD"
             value = round(excess_units * float(uc), 2) if uc is not None else None
 
             if firm_in > 0:

--- a/scripts/agent_shortage_watcher.py
+++ b/scripts/agent_shortage_watcher.py
@@ -71,6 +71,7 @@ def main(argv=None) -> int:
         d = core.load_planning_data(conn, args.horizon_days)
         gross = core.consume_demand(d)
         r = core.run_timephased(d, gross)
+        short = core.first_shortage(d, gross)   # for the true deficit-to-safety per item
         today = d.horizon_start
 
         # FG procurement signal sourced from the TIME-PHASED engine (nets to safety,
@@ -111,6 +112,7 @@ def main(argv=None) -> int:
                 continue
             sid, sext, lt, uc, ccy, rel = sup
             qty = round(o["qty"], 2)          # already lot-sized & lead-time-offset by run_timephased
+            deficit = round(short.get(item, {}).get("deficit", qty), 2)   # true shortfall-to-safety (≠ lot-sized qty)
             cost = round(qty * float(uc), 2) if uc is not None else None
             ccy = ccy or "EUR"
             need_date = today + _dt.timedelta(weeks=o["need"])
@@ -127,7 +129,7 @@ def main(argv=None) -> int:
                         "rule": "earliest time-phased planned PURCHASE order from run_timephased "
                                 "(nets to safety, lot-sized, lead-time offset); consumed demand = max_only/DTF/prorated"}
             recs.append((AGENT_NAME, run_id, core.BASELINE, item, d.names.get(item, str(item)[:8]),
-                         need_date, qty, qty, cost, ccy, sid, sext, lt, runway, margin,
+                         need_date, deficit, qty, cost, ccy, sid, sext, lt, runway, margin,
                          action, "L1", "DRAFT", conf, Jsonb(evidence)))
             display.append({"ext": d.names.get(item, str(item)[:8]), "fsd": need_date, "qty": qty,
                             "cost": cost, "ccy": ccy, "action": action, "conf": conf, "margin": margin})

--- a/scripts/mrp_core.py
+++ b/scripts/mrp_core.py
@@ -46,6 +46,20 @@ def lot_size(qty, moq, mult):
     return qty
 
 
+def cost_of(d, item):
+    """Unit cost + currency for an item, single source of the valuation precedence:
+    negotiated supplier unit_cost first, then item standard_cost. Returns
+    (None, None) when unpriced. A loaded cost of 0 is a real price, not 'missing' —
+    only None means unpriced (avoids the `unit_cost or std_cost` truthiness trap).
+    """
+    uc = d.unit_cost.get(item)
+    ccy = d.cost_ccy.get(item)
+    if uc is None:
+        uc = d.std_cost.get(item)
+        ccy = d.std_ccy.get(item)
+    return (float(uc), ccy or "USD") if uc is not None else (None, None)
+
+
 def _spread_period(qty, start, end, horizon_start, horizon_end, n_buckets, out):
     """Prorate qty across weekly buckets proportional to the days each bucket
     overlaps the period [start, end). Mass-conserving when the period is inside
@@ -80,7 +94,13 @@ def apply_lot_rule(rule, shortfall, pa, ss, netreq, t, P, eoq, maxoq, moq, mult,
         qty = math.ceil(shortfall / moq) * moq
     else:  # LOTFORLOT / MULTIPLE / fallback
         qty = shortfall
-    return lot_size(qty, moq, mult)
+    q = lot_size(qty, moq, mult)
+    # max_order_qty is a per-order ceiling. MIN_MAX already uses maxoq as a target
+    # stock level (ss+maxoq), so don't re-cap that rule with the same field. For
+    # every other rule, never exceed the supplier's max order quantity.
+    if maxoq and maxoq > 0 and rule != "MIN_MAX" and q > maxoq:
+        q = float(maxoq)
+    return q
 
 
 @dataclass
@@ -380,10 +400,15 @@ def excess_obsolete(d: PlanningData, gross: dict, months: float = 12.0) -> dict:
     Returns {item: {"class","on_hand","annual","coverage_months"(None=∞),"excess_units"}}.
     Only items with on_hand > 0 AND beyond the threshold are returned.
     """
-    WEEKS = 52
+    # Annualize over the available window: sum the first up-to-52 weeks of demand
+    # and scale to a full year. With the default horizon (>52 weeks) the factor is
+    # 1.0; for a shorter --horizon-days it prevents understating annual demand
+    # (which would over-state coverage and mis-flag healthy stock as E&O).
+    weeks_win = min(52, d.n_buckets)
+    scale = (52.0 / weeks_win) if weeks_win else 1.0
     indep12 = {}
     for item, buckets in gross.items():
-        s = sum(q for t, q in buckets.items() if t < WEEKS)
+        s = sum(q for t, q in buckets.items() if t < weeks_win) * scale
         if s:
             indep12[item] = s
     dep12 = defaultdict(float)

--- a/scripts/mrp_eando.py
+++ b/scripts/mrp_eando.py
@@ -66,8 +66,8 @@ def main(argv=None) -> int:
         cls = e["class"]
         excess_units = e["excess_units"]
         cover = e["coverage_months"] if e["coverage_months"] is not None else math.inf
-        uc = d.unit_cost.get(item) or d.std_cost.get(item)
-        ccy = (d.cost_ccy.get(item) or d.std_ccy.get(item) or "USD")
+        uc, ccy = core.cost_of(d, item)
+        ccy = ccy or "USD"
         by_class_units[cls] += excess_units
         by_class_items[cls] += 1
         if uc is None:

--- a/scripts/mrp_grid.py
+++ b/scripts/mrp_grid.py
@@ -93,11 +93,13 @@ def main(argv=None) -> int:
     def bmonth(t):
         return (hs + _dt.timedelta(weeks=t)).strftime("%Y-%m")
 
-    prcpt = defaultdict(lambda: defaultdict(float))   # item -> month -> qty (at need)
-    prel = defaultdict(lambda: defaultdict(float))    # item -> month -> qty (at release)
+    prcpt = defaultdict(lambda: defaultdict(float))      # item -> month -> qty (at need)
+    prel = defaultdict(lambda: defaultdict(float))       # item -> month -> qty (at release)
+    prcpt_wk = defaultdict(lambda: defaultdict(float))   # item -> need_bucket -> qty (weekly, for the PAB walk)
     for item, qty, rel, need, kind, pd in r["planned"]:
         prcpt[item][bmonth(need)] += qty
         prel[item][bmonth(rel)] += qty
+        prcpt_wk[item][need] += qty
 
     # calendar month columns from today
     today = hs
@@ -109,9 +111,15 @@ def main(argv=None) -> int:
             mo, y = 1, y + 1
 
     def month_end_bucket(m):
+        """Weekly bucket containing the last day of month m, or None if that month
+        lies beyond the planning horizon (so the grid shows blank, not a stale
+        repeat of the last in-horizon PAB)."""
         yy, mm = (int(x) for x in m.split("-"))
         first_next = _dt.date(yy + 1, 1, 1) if mm == 12 else _dt.date(yy, mm + 1, 1)
-        return max(0, min((first_next - _dt.timedelta(days=1) - hs).days // 7, d.n_buckets - 1))
+        bk = (first_next - _dt.timedelta(days=1) - hs).days // 7
+        if bk < 0 or bk >= d.n_buckets:
+            return None
+        return bk
 
     def fmt(v):
         return f"{v:,.0f}" if abs(v) >= 0.5 else "·"
@@ -139,15 +147,12 @@ def main(argv=None) -> int:
             grossm[bmonth(t)] += v
         # PAB walk on weekly engine, sampled at calendar month-end (exact point-in-time)
         sched_wk = d.sched_b.get(item, {})
-        prcpt_wk = defaultdict(float)
-        for _it, qty, rel, need, knd, pdf in r["planned"]:
-            if _it == item:
-                prcpt_wk[need] += qty
+        item_prcpt = prcpt_wk.get(item, {})
         pa, pab_bucket = oh, []
         for t in range(d.n_buckets):
-            pa += sched_wk.get(t, 0.0) + prcpt_wk.get(t, 0.0) - gross_req_wk.get(t, 0.0)
+            pa += sched_wk.get(t, 0.0) + item_prcpt.get(t, 0.0) - gross_req_wk.get(t, 0.0)
             pab_bucket.append(pa)
-        pab_m = {m: pab_bucket[month_end_bucket(m)] for m in months}
+        pab_m = {m: pab_bucket[b] for m in months if (b := month_end_bucket(m)) is not None}
 
         lines = [
             ("Forecast", fc_m),

--- a/scripts/mrp_projected_stock.py
+++ b/scripts/mrp_projected_stock.py
@@ -71,8 +71,8 @@ def main(argv=None) -> int:
             sc = d.sched_b.get(item, {})
             if pa == 0 and not g and not sc:
                 continue
-            uc = d.unit_cost.get(item) or d.std_cost.get(item)
-            ccy = (d.cost_ccy.get(item) or d.std_ccy.get(item) or "USD")
+            uc, ccy = core.cost_of(d, item)
+            ccy = ccy or "USD"
             last_in_month = {}
             for t in range(d.n_buckets):
                 pa += sc.get(t, 0.0) - g.get(t, 0.0)
@@ -102,10 +102,9 @@ def main(argv=None) -> int:
             loc_units[lext] += q
             loc_type[lext] = ltype
             loc_items[lext].add(item_id)
-            uc = d.unit_cost.get(item_id) or d.std_cost.get(item_id)
+            uc, ccy = core.cost_of(d, item_id)
             if uc is not None:
-                ccy = (d.cost_ccy.get(item_id) or d.std_ccy.get(item_id) or "USD")
-                loc_val[lext][ccy] += q * float(uc)
+                loc_val[lext][ccy] += q * uc
 
         # supply-side stale dates: past-due open receipts collapse onto week 0 and
         # inflate the opening projected position (mirror of stale demand).

--- a/scripts/shortage_scan.py
+++ b/scripts/shortage_scan.py
@@ -1,20 +1,17 @@
 """
 shortage_scan.py — item-level shortage scan, thin over mrp_core.
 
-Detects the first forward shortage per item on the SINGLE demand truth
-(mrp_core: forecast consumption max_only + demand time fence + proration +
-multi-location dedup) via the same virtual projection the Shortage Watcher agent
-uses (core.first_shortage). This is the human/CLI counterpart of the agent — same
-numbers.
+Detects items whose projected on-hand falls BELOW SAFETY STOCK on the SINGLE
+demand truth (mrp_core: forecast consumption max_only + demand time fence +
+proration + multi-location dedup), via core.first_shortage.
 
-Previously this script ran a raw SQL window function that SUMMED customer orders
-+ forecast (double-count) with no proration; it now shares mrp_core so the scan,
-the agent, and the MRP all agree.
-
-Modes:
-    (default)     list net-short items, worst balance first
-    --reorder     classify by reorder feasibility (RECOVERABLE / TIGHT / CRITICAL / NO_SOURCE)
-    --recommend   quantified purchase recommendations (supplier, qty, cost, action)
+Modes (note the two detection bases, intentionally):
+    (default)     list items below safety, worst balance first   [core.first_shortage]
+    --reorder     classify by reorder feasibility                [core.first_shortage]
+    --recommend   quantified purchase recommendations            [core.run_timephased]
+The default/--reorder DETECTION fires at the safety threshold; --recommend mirrors
+the Shortage Watcher agent exactly (same time-phased engine, same numbers). The
+detection count can exceed the recommend count (e.g. items covered without a PO).
 
 Note on location: planning is pooled at item level (LANES-LATER). Per-(item,
 location) projection needs the network connected and is out of scope here.
@@ -130,7 +127,7 @@ def main(argv=None) -> int:
             classified.append((d.names.get(item, str(item)[:8]), sh["date"], sh["balance"], lt, runway, margin, cls))
         actionable = sorted([c for c in classified if c[6] in ("CRITICAL", "TIGHT")], key=lambda c: c[5])
         logger.info("=" * 90)
-        logger.info("REORDER FEASIBILITY (consumption-correct) in %.2fs — %d net-short items", elapsed, len(short))
+        logger.info("REORDER FEASIBILITY (consumption-correct) in %.2fs — %d items below safety", elapsed, len(short))
         for cls in ("CRITICAL", "TIGHT", "RECOVERABLE", "NO_SOURCE"):
             n = breakdown.get(cls, 0)
             pct = (100 * n / len(short)) if short else 0
@@ -151,10 +148,10 @@ def main(argv=None) -> int:
     logger.info("=" * 78)
     logger.info("ITEM-LEVEL SHORTAGE SCAN (consumption-correct) in %.2fs", elapsed)
     logger.info("  Items with independent demand : %d", n_demand_items)
-    logger.info("  Items net-short               : %d (%.1f%%)", len(short), pct)
+    logger.info("  Items below safety stock      : %d (%.1f%%)", len(short), pct)
     logger.info("=" * 78)
-    logger.info("TOP %d net-short items — worst balance first:", args.top)
-    logger.info("  %-16s %-11s %14s %14s   %s", "item", "date", "net_balance", "deficit", "name")
+    logger.info("TOP %d items below safety — worst balance first:", args.top)
+    logger.info("  %-16s %-11s %14s %14s   %s", "item", "date", "proj_balance", "to_safety", "name")
     for item, sh in rows[: args.top]:
         logger.info("  %-16s %-11s %14.1f %14.1f   %s", d.names.get(item, str(item)[:8]), str(sh["date"]),
                     sh["balance"], sh["deficit"], (d.names.get(item, "") or "")[:28])

--- a/tests/test_mrp_core_golden.py
+++ b/tests/test_mrp_core_golden.py
@@ -69,6 +69,16 @@ def test_apply_lot_rule_variants():
     assert core.apply_lot_rule("POQ", 10, 0, 0, {1: 20, 2: 30}, 0, 3, 0, 0, 0, 0, nb) == 60
 
 
+def test_apply_lot_rule_max_order_qty_cap():
+    """max_order_qty caps a single order for every rule EXCEPT MIN_MAX (which uses
+    maxoq as a target stock level, not a per-order ceiling)."""
+    nb = 12
+    # LOTFORLOT shortfall 5000 capped at max_order_qty 1000
+    assert core.apply_lot_rule("LOTFORLOT", 5000, 0, 0, {}, 0, 4, 0, 1000, 0, 0, nb) == 1000
+    # MIN_MAX NOT capped: (ss + maxoq) - pa = (0 + 1000) - (-100) = 1100
+    assert core.apply_lot_rule("MIN_MAX", 0, -100, 0, {}, 0, 4, 0, 1000, 0, 0, nb) == 1100
+
+
 # ───────────────────────── forecast proration ─────────────────────────
 
 def test_spread_period_conserves_mass_inside_horizon():
@@ -172,7 +182,9 @@ def test_excess_obsolete_classification():
             excess = 1000 - 12*(10/12) = 990.
        OBS: on_hand 200, no demand -> OBSOLETE, excess = 200.
        OK : on_hand 100, annual 200 -> coverage 6 mo -> not E&O (excluded)."""
-    d = build_pd(on_hand={"EXC": 1000, "OBS": 200, "OK": 100})
+    # n_buckets=53 ⇒ a full-year window (weeks_win=52, annualization factor 1.0),
+    # so the summed demand IS the annual figure.
+    d = build_pd(n_buckets=53, on_hand={"EXC": 1000, "OBS": 200, "OK": 100})
     gross = {"EXC": {1: 5.0, 10: 5.0}, "OK": {1: 200.0}}
     eo = core.excess_obsolete(d, gross, months=12.0)
     assert eo["EXC"]["class"] == "EXCESS"
@@ -180,3 +192,14 @@ def test_excess_obsolete_classification():
     assert eo["OBS"]["class"] == "OBSOLETE"
     assert eo["OBS"]["excess_units"] == pytest.approx(200.0)
     assert "OK" not in eo
+
+
+def test_excess_obsolete_annualizes_to_short_horizon():
+    """With a horizon shorter than a year, demand in the window is scaled up to an
+    annual rate (so coverage isn't over-stated and healthy stock isn't mis-flagged).
+    n_buckets=26 ⇒ weeks_win=26, factor 52/26=2. Demand 10 → annual 20, monthly
+    1.667, coverage = 100/1.667 = 60 mo > 12 → EXCESS; excess = 100 - 12*1.667 = 80."""
+    d = build_pd(n_buckets=26, on_hand={"E": 100})
+    eo = core.excess_obsolete(d, {"E": {0: 10.0}}, months=12.0)
+    assert eo["E"]["class"] == "EXCESS"
+    assert eo["E"]["excess_units"] == pytest.approx(80.0)


### PR DESCRIPTION
High-effort review of the session's new agents/tools. Correctness fixes locked by golden-master where applicable.

**Correctness**
- `apply_lot_rule`: enforce `max_order_qty` as a per-order ceiling (all rules except MIN_MAX). +golden case.
- `excess_obsolete`: annualize over the available window so a short `--horizon-days` doesn't understate annual demand / over-flag E&O (no-op at default). +golden case; existing E&O test pinned to a 53-bucket year.
- `agent_shortage_watcher`: `deficit_qty` carries the true shortfall-to-safety (from first_shortage), not the lot-sized order; `recommended_qty` keeps the order.

**Consistency**
- `shortage_scan`: labels/docstring reflect default/--reorder DETECT at safety vs --recommend mirrors the agent.
- `agent_dq_watcher` NO_SUPPLIER: impact-ranked severity (was hard HIGH / dead branch).
- `mrp_grid`: blank PAB beyond horizon (was repeated); planned-receipts index hoisted (removes O(items×planned) re-scan).

**Reuse**
- `mrp_core.cost_of(d,item)`: single valuation-precedence helper (fixes `or` 0-cost trap); wired into eando/projected-stock.

**Deferred (dette, not bugs):** shared governed-agent primitive; unified projection primitive (pre-plan vs post-plan PAB legitimately differ).

golden-master 12/12, ruff clean. (Note: pilote E&O moved 19.7M→28.9M overnight — the daily dump was re-ingested ~8h ago, not from this code; verified on_hand/forecast created_at + golden-master no-op.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)