### PR TITLE
fix(ingest): make daily reload fast + idempotent (17min → ~2min)

### DIFF
--- a/scripts/bulk_ingest.py
+++ b/scripts/bulk_ingest.py
@@ -366,17 +366,41 @@ def load_item_planning_params(conn: psycopg.Connection, tsv_path: Path) -> dict[
             bad_item + bad_loc + bad_sup, bad_item, bad_loc, bad_sup,
         )
 
-    # Close existing active rows for matching (item, location) pairs
+    # Resolve the target (item_id, location_id) pairs once into a temp table so the
+    # close/replace below joins on an indexable key instead of a row-constructor IN
+    # subquery (faster, and reused by both statements).
+    cur.execute(
+        """
+        CREATE TEMP TABLE _b_ipp_keys ON COMMIT DROP AS
+        SELECT DISTINCT it.item_id, l.location_id
+        FROM _b_ipp b
+        JOIN items it ON it.external_id = b.item_external_id
+        JOIN locations l ON l.external_id = b.location_external_id
+        """
+    )
+    # Same-day reload (idempotency): active rows whose effective_from is today were
+    # written by an earlier load on the same day and carry no SCD2 history value.
+    # They must be DELETED, not closed — closing them to (CURRENT_DATE - 1) would set
+    # effective_to < effective_from and violate the ipp_effective_order check.
+    cur.execute(
+        """
+        DELETE FROM item_planning_params ipp
+        USING _b_ipp_keys k
+        WHERE ipp.effective_to IS NULL
+          AND ipp.effective_from >= CURRENT_DATE
+          AND ipp.item_id = k.item_id AND ipp.location_id = k.location_id
+        """
+    )
+    # Older active rows: close them at (CURRENT_DATE - 1), preserving SCD2 history.
+    # effective_from < CURRENT_DATE guarantees effective_to >= effective_from.
     cur.execute(
         """
         UPDATE item_planning_params ipp
         SET effective_to = CURRENT_DATE - INTERVAL '1 day', updated_at = now()
-        WHERE effective_to IS NULL
-          AND (ipp.item_id, ipp.location_id) IN (
-              SELECT it.item_id, l.location_id FROM _b_ipp b
-              JOIN items it ON it.external_id = b.item_external_id
-              JOIN locations l ON l.external_id = b.location_external_id
-          )
+        FROM _b_ipp_keys k
+        WHERE ipp.effective_to IS NULL
+          AND ipp.effective_from < CURRENT_DATE
+          AND ipp.item_id = k.item_id AND ipp.location_id = k.location_id
         """
     )
 
@@ -571,16 +595,18 @@ def load_on_hand(conn: psycopg.Connection, tsv_path: Path) -> dict[str, Any]:
     if bad_item or bad_loc:
         logger.warning("on_hand: rows with unresolved FKs will be skipped (items=%d, locations=%d)", bad_item, bad_loc)
 
-    # Delete existing OnHandSupply nodes for the affected (item, location) pairs
+    # Delete existing OnHandSupply nodes for the affected (item, location) pairs.
+    # DELETE ... USING a join (not a row-constructor IN subquery, which Postgres
+    # plans as a pathological nested loop — observed 17 min on 15k pairs) so the
+    # planner uses idx_nodes_item_location_scenario. Seconds instead of minutes.
     cur.execute(
         """
-        DELETE FROM nodes
-        WHERE node_type = 'OnHandSupply' AND scenario_id = %s::uuid
-          AND (item_id, location_id) IN (
-              SELECT it.item_id, loc.location_id FROM _b_oh b
-              JOIN items it ON it.external_id = TRIM(b.item_external_id)
-              JOIN locations loc ON loc.external_id = TRIM(b.location_external_id)
-          )
+        DELETE FROM nodes n
+        USING _b_oh b
+        JOIN items it      ON it.external_id  = TRIM(b.item_external_id)
+        JOIN locations loc ON loc.external_id = TRIM(b.location_external_id)
+        WHERE n.node_type = 'OnHandSupply' AND n.scenario_id = %s::uuid
+          AND n.item_id = it.item_id AND n.location_id = loc.location_id
         """,
         (BASELINE_SCENARIO_ID,),
     )
@@ -613,16 +639,18 @@ def load_forecasts(conn: psycopg.Connection, tsv_path: Path) -> dict[str, Any]:
     if bad_item or bad_loc:
         logger.warning("forecasts: rows with unresolved FKs will be skipped (items=%d, locations=%d)", bad_item, bad_loc)
 
-    # Wipe ForecastDemand nodes for affected (item, location) pairs (full reload)
+    # Wipe ForecastDemand nodes for affected (item, location) pairs (full reload).
+    # DELETE ... USING a join instead of a row-constructor IN subquery, so the
+    # planner uses idx_nodes_item_location_scenario (the IN form was a 17-min
+    # nested loop on the pilote).
     cur.execute(
         """
-        DELETE FROM nodes
-        WHERE node_type = 'ForecastDemand' AND scenario_id = %s::uuid
-          AND (item_id, location_id) IN (
-              SELECT DISTINCT it.item_id, loc.location_id FROM _b_fc b
-              JOIN items it ON it.external_id = TRIM(b.item_external_id)
-              JOIN locations loc ON loc.external_id = TRIM(b.location_external_id)
-          )
+        DELETE FROM nodes n
+        USING _b_fc b
+        JOIN items it      ON it.external_id  = TRIM(b.item_external_id)
+        JOIN locations loc ON loc.external_id = TRIM(b.location_external_id)
+        WHERE n.node_type = 'ForecastDemand' AND n.scenario_id = %s::uuid
+          AND n.item_id = it.item_id AND n.location_id = loc.location_id
         """,
         (BASELINE_SCENARIO_ID,),
     )

--- a/scripts/daily_load.py
+++ b/scripts/daily_load.py
@@ -1,0 +1,124 @@
+"""
+daily_load.py — one command for the daily data refresh.
+
+Loading raw TSVs is NOT enough: the planning engine depends on DERIVED state that
+must be recomputed after every load — Low-Level Codes (the BOM level-by-level
+order) and item standard costs (BOM roll-up). bulk_ingest re-inserts bom_lines
+with llc=0, so skipping the recompute silently flattens the BOM graph and
+degrades every downstream number (E&O, shortages, valuation) — observed in the
+field: a re-ingest of the SAME dump inflated E&O +46% purely because LLC was left
+at 0.
+
+This chains the mandatory steps and validates the result so that silent
+degradation can't happen:
+
+    1. bulk_ingest   <dir>   (COPY+UPSERT all canonical TSVs in FK order)
+    2. compute_llc           (Low-Level Codes for the BOM graph)
+    3. compute_cost_rollup   (items.standard_cost via bottom-up BOM roll-up)
+    4. validate              (fail loud if the BOM exists but LLC is flat, etc.)
+
+Usage:
+    DATABASE_URL=... python scripts/daily_load.py data/inbox [--allow-dev] [--skip-cost]
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+
+import psycopg
+import mrp_core as core
+import bulk_ingest
+import compute_llc
+import compute_cost_rollup
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+logger = logging.getLogger("daily_load")
+
+
+def _validate(dsn: str) -> tuple[bool, list[str]]:
+    """Post-load sanity. Returns (ok, messages). Fails loud on the silent-degradation
+    traps (flat LLC, no on-hand, no demand) rather than letting them pass."""
+    msgs, ok = [], True
+    with psycopg.connect(dsn) as conn:
+        cur = conn.cursor()
+        bom_lines = cur.execute("SELECT COUNT(*) FROM bom_lines").fetchone()[0]
+        max_llc = cur.execute("SELECT COALESCE(MAX(llc), 0) FROM bom_lines").fetchone()[0]
+        items_costed = cur.execute("SELECT COUNT(*) FROM items WHERE standard_cost IS NOT NULL").fetchone()[0]
+        items_total = cur.execute("SELECT COUNT(*) FROM items").fetchone()[0]
+        on_hand = cur.execute("SELECT COUNT(*) FROM nodes WHERE node_type='OnHandSupply' AND active").fetchone()[0]
+        demand = cur.execute(
+            "SELECT COUNT(*) FROM nodes WHERE active AND node_type=ANY(%(t)s)",
+            {"t": core.DEMAND_TYPES}).fetchone()[0]
+
+    # The exact trap we hit: BOMs present but LLC never recomputed -> flat graph.
+    if bom_lines > 0 and max_llc == 0:
+        ok = False
+        msgs.append(f"✗ BOM graph is FLAT: {bom_lines} bom_lines but max LLC = 0 — compute_llc did not take. "
+                    "Planning (E&O, shortages, MRP) will be wrong.")
+    else:
+        msgs.append(f"✓ LLC computed: max level {max_llc} over {bom_lines} bom_lines")
+    cov = (100.0 * items_costed / items_total) if items_total else 0.0
+    msgs.append(f"{'✓' if items_costed else '✗'} standard_cost set on {items_costed}/{items_total} items ({cov:.0f}%)")
+    msgs.append(f"{'✓' if on_hand else '✗'} on-hand supply nodes: {on_hand}")
+    msgs.append(f"{'✓' if demand else '✗'} demand nodes: {demand}")
+    if not on_hand or not demand:
+        ok = False
+    return ok, msgs
+
+
+def _step(name: str, fn) -> bool:
+    logger.info("─" * 70)
+    logger.info("STEP: %s", name)
+    t0 = time.perf_counter()
+    rc = fn()
+    dt = time.perf_counter() - t0
+    if rc == 0:
+        logger.info("  ✓ %s done in %.1fs", name, dt)
+        return True
+    logger.error("  ✗ %s FAILED (rc=%s) after %.1fs — aborting refresh", name, rc, dt)
+    return False
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description="Daily data refresh: load + recompute derived state + validate.")
+    p.add_argument("path", help="directory of canonical TSVs (or a single file)")
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    p.add_argument("--allow-dev", action="store_true")
+    p.add_argument("--skip-cost", action="store_true", help="skip the standard_cost roll-up step")
+    args = p.parse_args(argv)
+    if not args.dsn:
+        logger.error("DATABASE_URL not set and --dsn not provided")
+        return 2
+    db = core.guard_db(args.dsn, args.allow_dev)
+    dev = ["--allow-dev"] if args.allow_dev else []
+    logger.info("DAILY REFRESH → DB=%s  source=%s", db, args.path)
+    t0 = time.perf_counter()
+
+    if not _step("bulk_ingest", lambda: bulk_ingest.main([args.path, "--dsn", args.dsn] + dev)):
+        return 1
+    if not _step("compute_llc", lambda: compute_llc.main(["--dsn", args.dsn] + dev)):
+        return 1
+    if not args.skip_cost:
+        if not _step("compute_cost_rollup", lambda: compute_cost_rollup.main(["--dsn", args.dsn] + dev)):
+            return 1
+
+    logger.info("─" * 70)
+    logger.info("STEP: validate")
+    ok, msgs = _validate(args.dsn)
+    for m in msgs:
+        logger.info("  %s", m)
+
+    logger.info("═" * 70)
+    if ok:
+        logger.info("DAILY REFRESH OK in %.1fs — engine state is consistent.", time.perf_counter() - t0)
+        return 0
+    logger.error("DAILY REFRESH COMPLETED WITH PROBLEMS in %.1fs — see ✗ above. Do NOT trust the plan.",
+                 time.perf_counter() - t0)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ootils_core/db/migrations/046_nodes_parent_node_id_index.sql
+++ b/src/ootils_core/db/migrations/046_nodes_parent_node_id_index.sql
@@ -1,0 +1,51 @@
+-- ============================================================
+-- Migration 046: index on nodes.parent_node_id (self-FK support)
+-- ============================================================
+-- Purpose: make every DELETE from `nodes` fast.
+--
+-- Background (field incident, daily-load slowness):
+-- `nodes` carries a self-referential foreign key
+--     nodes_parent_node_id_fkey: parent_node_id REFERENCES nodes(node_id)
+-- but NO index covered parent_node_id. Postgres does NOT auto-create an
+-- index on the *referencing* column of a FK. As a result, deleting any
+-- node forced a sequential scan of the whole table to verify that no
+-- surviving row still references it via parent_node_id.
+--
+-- With ~750k rows that turned every reload DELETE (on_hand, PO, CO,
+-- transfers — all "full-reload of nodes of this type") into an O(n²)
+-- operation: a single on_hand reload (~16k rows) was observed taking
+-- 463s (and the orphan-ProjectedInventory purge hung for 30+ minutes).
+-- After adding this index the same on_hand reload dropped to ~8s and the
+-- full daily_load (load + LLC + cost roll-up + validate) to ~123s.
+--
+-- Schema impact:
+-- - Partial btree on parent_node_id WHERE parent_node_id IS NOT NULL
+--   (the vast majority of rows have a NULL parent; only linked nodes
+--   carry one). Keeps the index small while still covering the FK
+--   referential-integrity probe `... WHERE parent_node_id = $deleted_id`
+--   (that predicate only matches non-null values).
+-- - Also accelerates any pegging / parent-child traversal that filters
+--   by parent_node_id.
+--
+-- Note: created non-CONCURRENTLY to stay inside the migration
+-- transaction, consistent with the other migrations in this tree. It
+-- takes a brief SHARE lock on `nodes` during the build; run during a
+-- maintenance window if the table is large and under live write load.
+-- ============================================================
+
+DO $$ BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'nodes'
+    ) THEN
+        CREATE INDEX IF NOT EXISTS idx_nodes_parent_node_id
+            ON nodes (parent_node_id)
+            WHERE parent_node_id IS NOT NULL;
+
+        COMMENT ON INDEX idx_nodes_parent_node_id IS
+            'Supports the nodes_parent_node_id_fkey self-FK referential '
+            'check so DELETE FROM nodes does not seq-scan the table per '
+            'deleted row. Partial (parent_node_id IS NOT NULL) to stay '
+            'small. See migration 046.';
+    END IF;
+END $$;


### PR DESCRIPTION
Fixes the painful daily import, diagnosed and verified end-to-end on the pilote (293k rows: full `daily_load` now **123s** vs **~17min**).

## Three root causes
1. **Missing index on `nodes.parent_node_id`** (dominant). The self-FK `nodes_parent_node_id_fkey` had no covering index, so every full-reload DELETE on `nodes` seq-scanned the whole table per deleted row → O(n²). on_hand reload **463s → 8.5s**. → migration **046** (partial index).
2. **`(item_id,location_id) IN (subquery)`** DELETE on on_hand/forecasts → rewritten `DELETE ... USING <join>` (index-driven).
3. **`item_planning_params` not idempotent within a day**: the SCD2 close set `effective_to = CURRENT_DATE - 1` on rows whose `effective_from` was *today* (earlier same-day load) → violated the `ipp_effective_order` check. Now: resolve keys once into a temp table, DELETE same-day active rows, close only older rows.

## New
`scripts/daily_load.py` — one command: bulk_ingest → compute_llc → compute_cost_rollup → **validate** (fails loud on flat LLC / no on-hand / no demand — the silent-degradation traps; the mandatory LLC recompute prevents the E&O-inflation regression).

## Proof (pilote)
`DAILY REFRESH OK in 123.4s` — ipp 2.5s · on_hand 8.5s · forecasts 91.9s (170k-row INSERT) · LLC max level 7 intact · validate ✓ (on-hand 15895, demand 188722).

🤖 Generated with [Claude Code](https://claude.com/claude-code)