### PR TITLE
refactor(agents): governed_run primitive + migrate shortage_watcher (Revue #8)

### DIFF
--- a/scripts/agent_dq_watcher.py
+++ b/scripts/agent_dq_watcher.py
@@ -33,6 +33,7 @@ from collections import defaultdict
 import psycopg
 from psycopg.types.json import Jsonb
 import mrp_core as core
+from agent_governance import governed_run
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
 logger = logging.getLogger("dq_watcher")
@@ -200,28 +201,25 @@ def main(argv=None) -> int:
         emit("STALE_SUPPLY", rows)
 
         # ── persist: open run, supersede prior OPEN set, insert ──
-        run_id = cur.execute(
-            "INSERT INTO agent_runs (agent_name, scenario_id, status) VALUES (%s,%s,'RUNNING') RETURNING agent_run_id",
-            (AGENT_NAME, core.BASELINE)).fetchone()[0]
-        superseded = cur.execute(
-            "UPDATE dq_findings SET status='SUPERSEDED', updated_at=now() "
-            "WHERE agent_name=%s AND scenario_id=%s AND status='OPEN'", (AGENT_NAME, core.BASELINE)).rowcount
-        rows_to_insert = [(AGENT_NAME, run_id, core.BASELINE, *f) for f in findings]
-        cur.executemany(
-            """INSERT INTO dq_findings
-               (agent_name, agent_run_id, scenario_id, rule_code, entity_type, entity_id,
-                entity_external_id, severity, description, impact_metric, impact_value,
-                suggested_action, evidence)
-               VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""", rows_to_insert)
-        metrics = {"findings_persisted": len(findings), "superseded": superseded,
-                   "by_rule": totals, "elapsed_s": round(time.perf_counter() - t0, 2)}
-        cur.execute("UPDATE agent_runs SET status='COMPLETED', finished_at=now(), metrics=%s WHERE agent_run_id=%s",
-                    (Jsonb(metrics), run_id))
-        conn.commit()
+        with governed_run(conn, AGENT_NAME, core.BASELINE, t0=t0) as run:
+            rows_to_insert = [(AGENT_NAME, run.run_id, core.BASELINE, *f) for f in findings]
+            superseded = run.supersede("dq_findings", "OPEN", "SUPERSEDED")
+            run.insert(
+                "dq_findings",
+                ["agent_name", "agent_run_id", "scenario_id", "rule_code", "entity_type",
+                 "entity_id", "entity_external_id", "severity", "description",
+                 "impact_metric", "impact_value", "suggested_action", "evidence"],
+                rows_to_insert,
+            )
+            run.set_metrics({
+                "findings_persisted": len(findings), "superseded": superseded, "by_rule": totals,
+            })
+            metrics = run.metrics
 
+    elapsed = round(time.perf_counter() - t0, 2)
     logger.info("=" * 100)
-    logger.info("DQ WATCHER — run %s COMPLETED in %.2fs", str(run_id)[:8], metrics["elapsed_s"])
-    logger.info("  Findings persisted (OPEN) : %d   (prior OPEN superseded: %d)", len(findings), superseded)
+    logger.info("DQ WATCHER — run %s COMPLETED in %.2fs", str(run.run_id)[:8], elapsed)
+    logger.info("  Findings persisted (OPEN) : %d   (prior OPEN superseded: %d)", len(findings), metrics["superseded"])
     logger.info("  By rule (count / total impact / persisted):")
     for rule in ("MISSING_COST", "NO_SUPPLIER", "MAKE_WITHOUT_BOM", "STALE_DEMAND", "STALE_SUPPLY",
                  "ORPHAN_MAKE_FLAG", "EXPIRED_SUPPLIER_TERM"):

--- a/scripts/agent_eando_watcher.py
+++ b/scripts/agent_eando_watcher.py
@@ -35,6 +35,7 @@ from collections import defaultdict
 import psycopg
 from psycopg.types.json import Jsonb
 import mrp_core as core
+from agent_governance import governed_run
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
 logger = logging.getLogger("eando_watcher")
@@ -62,7 +63,8 @@ def main(argv=None) -> int:
         gross = core.consume_demand(d)
         eo = core.excess_obsolete(d, gross, months=args.months)
 
-        built = []   # full reco tuples (pre-cap), each with its excess_value for ranking
+        # Pre-compute the full E&O set (needed for cap + ranking) before opening the run.
+        pre_built = []
         totals = defaultdict(lambda: {"items": 0, "units": 0.0, "value": 0.0})
         unpriced_items = 0
         for item, e in eo.items():
@@ -95,14 +97,16 @@ def main(argv=None) -> int:
                         "excess_units": round(excess_units, 2), "firm_inbound_units": round(firm_in, 2),
                         "unit_cost": float(uc) if uc is not None else None,
                         "rule": "on-hand beyond %.0f months of gross-usage coverage; value = excess_units × cost" % args.months}
-            built.append({
+            pre_built.append({
                 "value_sort": value if value is not None else 0.0,
-                "row": (AGENT_NAME, None, core.BASELINE, item, d.names.get(item, str(item)[:8]),
-                        cls, round(e["on_hand"], 2), round(e["annual"], 2),
-                        (round(cover, 4) if cover is not None else None), round(excess_units, 2), value, ccy,
-                        disposition, "L1", "DRAFT", conf, Jsonb(evidence)),
+                # agent_run_id placeholder filled once the run is open
+                "partial": (AGENT_NAME, core.BASELINE, item, d.names.get(item, str(item)[:8]),
+                            cls, round(e["on_hand"], 2), round(e["annual"], 2),
+                            (round(cover, 4) if cover is not None else None), round(excess_units, 2), value, ccy,
+                            disposition, "L1", "DRAFT", conf, Jsonb(evidence)),
                 "disp": disposition, "cls": cls, "value": value, "units": excess_units,
-                "ext": d.names.get(item, str(item)[:8]), "cover": cover, "conf": conf})
+                "ext": d.names.get(item, str(item)[:8]), "cover": cover, "conf": conf,
+                "ccy_col": ccy})
             t = totals[cls]
             t["items"] += 1
             t["units"] += excess_units
@@ -110,40 +114,41 @@ def main(argv=None) -> int:
             if uc is None:
                 unpriced_items += 1
 
-        built.sort(key=lambda x: -x["value_sort"])
-        kept = built[: args.cap]
+        pre_built.sort(key=lambda x: -x["value_sort"])
+        kept = pre_built[: args.cap]
 
-        cur = conn.cursor()
-        run_id = cur.execute(
-            "INSERT INTO agent_runs (agent_name, scenario_id, status) VALUES (%s,%s,'RUNNING') RETURNING agent_run_id",
-            (AGENT_NAME, core.BASELINE)).fetchone()[0]
-        superseded = cur.execute(
-            "UPDATE eando_recommendations SET status='EXPIRED', updated_at=now() "
-            "WHERE agent_name=%s AND scenario_id=%s AND status='DRAFT'", (AGENT_NAME, core.BASELINE)).rowcount
-        recs = [(a, run_id, *rest) for (a, _none, *rest) in (b["row"] for b in kept)]
-        cur.executemany(
-            """INSERT INTO eando_recommendations
-               (agent_name, agent_run_id, scenario_id, item_id, item_external_id, classification,
-                on_hand, annual_demand, coverage_months, excess_units, excess_value, currency,
-                disposition, decision_level, status, confidence, evidence)
-               VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""", recs)
-        by_disp = defaultdict(int)
-        for b in kept:
-            by_disp[b["disp"]] += 1
-        metrics = {"eando_items": len(built), "persisted": len(kept), "superseded": superseded,
-                   "unpriced_items": unpriced_items, "by_disposition": dict(by_disp),
-                   "by_class": {k: {"items": v["items"], "units": round(v["units"], 0), "value": round(v["value"], 2)}
-                                for k, v in totals.items()},
-                   "elapsed_s": round(time.perf_counter() - t0, 2)}
-        cur.execute("UPDATE agent_runs SET status='COMPLETED', finished_at=now(), metrics=%s WHERE agent_run_id=%s",
-                    (Jsonb(metrics), run_id))
-        conn.commit()
+        with governed_run(conn, AGENT_NAME, core.BASELINE, t0=t0) as run:
+            # Build final recs now that run.run_id is available.
+            recs = [
+                (b["partial"][0], run.run_id, *b["partial"][1:])
+                for b in kept
+            ]
+            superseded = run.supersede("eando_recommendations", "DRAFT", "EXPIRED")
+            run.insert(
+                "eando_recommendations",
+                ["agent_name", "agent_run_id", "scenario_id", "item_id", "item_external_id",
+                 "classification", "on_hand", "annual_demand", "coverage_months",
+                 "excess_units", "excess_value", "currency", "disposition",
+                 "decision_level", "status", "confidence", "evidence"],
+                recs,
+            )
+            by_disp = defaultdict(int)
+            for b in kept:
+                by_disp[b["disp"]] += 1
+            run.set_metrics({
+                "eando_items": len(pre_built), "persisted": len(kept), "superseded": superseded,
+                "unpriced_items": unpriced_items, "by_disposition": dict(by_disp),
+                "by_class": {k: {"items": v["items"], "units": round(v["units"], 0), "value": round(v["value"], 2)}
+                             for k, v in totals.items()},
+            })
+            metrics = run.metrics
 
+    elapsed = round(time.perf_counter() - t0, 2)
     m = metrics
     logger.info("=" * 100)
-    logger.info("E&O WATCHER — run %s COMPLETED in %.2fs", str(run_id)[:8], m["elapsed_s"])
+    logger.info("E&O WATCHER — run %s COMPLETED in %.2fs", str(run.run_id)[:8], elapsed)
     logger.info("  E&O items: %d  (persisted top %d by value; prior drafts superseded: %d)",
-                m["eando_items"], m["persisted"], superseded)
+                m["eando_items"], m["persisted"], m["superseded"])
     for cls in ("EXCESS", "OBSOLETE"):
         c = m["by_class"].get(cls)
         if c:
@@ -160,7 +165,7 @@ def main(argv=None) -> int:
         val_s = f"{b['value']:,.0f}" if b["value"] is not None else "—"
         logger.info("  %-16s %-9s %-9s %10s %14s %14s %-5s %-7s",
                     b["ext"], b["cls"], b["disp"], cov_s, f"{b['units']:,.0f}", val_s,
-                    b["row"][11], b["conf"])
+                    b["ccy_col"], b["conf"])
     logger.info("=" * 100)
     return 0
 

--- a/scripts/agent_governance.py
+++ b/scripts/agent_governance.py
@@ -98,6 +98,11 @@ class _Run:
         """Store the metrics dict that will be written to agent_runs on exit."""
         self._metrics = metrics
 
+    @property
+    def metrics(self) -> dict[str, Any]:
+        """The metrics dict set via set_metrics (read-back for summary logging)."""
+        return self._metrics
+
     # Internal helpers called by the context manager.
     def _bind(self, agent_name: str, scenario_id: object) -> None:
         self._agent_name = agent_name

--- a/scripts/agent_governance.py
+++ b/scripts/agent_governance.py
@@ -1,0 +1,176 @@
+"""
+agent_governance.py — Governed-run context manager for the watcher fleet.
+
+Every watcher agent must: open a work-ledger row in agent_runs with status
+RUNNING before doing any work, supersede its prior active artifact rows,
+insert the new artifact set, then close the run as COMPLETED — or FAILED on
+any unhandled exception. Without this bookkeeping a crashed watcher leaves a
+RUNNING orphan that is invisible to operators and breaks the idempotency
+contract.
+
+``governed_run`` centralises that lifecycle so individual watchers stay thin.
+
+Usage::
+
+    with governed_run(conn, "shortage_watcher", scenario_id) as run:
+        run_id = run.run_id          # available immediately after __enter__
+        superseded = run.supersede("recommendations", "DRAFT", "EXPIRED")
+        run.insert(
+            "recommendations",
+            ["agent_name", "agent_run_id", ...],
+            rows,
+        )
+        run.set_metrics({"recommendations": len(rows), ...})
+    # __exit__ writes COMPLETED + elapsed_s + calls conn.commit().
+    # On exception: writes FAILED (best-effort) + conn.commit() + re-raises.
+
+SQL safety: table names go through psycopg.sql.Identifier. Column lists are
+composed with psycopg.sql.SQL.join. No f-strings in SQL paths.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from contextlib import contextmanager
+from typing import Any, Generator, Sequence
+
+import psycopg
+from psycopg import sql
+from psycopg.types.json import Jsonb
+
+logger = logging.getLogger(__name__)
+
+
+class _Run:
+    """Handle exposed to the ``with`` block.
+
+    Callers use ``run.run_id`` (UUID) to build artifact tuples and call
+    ``run.supersede`` / ``run.insert`` / ``run.set_metrics`` to perform the
+    governed database operations.
+    """
+
+    def __init__(self, conn: psycopg.Connection, run_id: object, t0: float) -> None:
+        self._conn = conn
+        self._run_id = run_id
+        self._t0 = t0
+        self._metrics: dict[str, Any] = {}
+        self._agent_name: str = ""
+        self._scenario_id: object = None
+
+    @property
+    def run_id(self) -> object:
+        """UUID of the agent_runs row opened by __enter__."""
+        return self._run_id
+
+    def supersede(self, table: str, active_status: str, new_status: str) -> int:
+        """UPDATE rows in *table* for this agent/scenario from active_status to new_status.
+
+        Returns the rowcount (number of rows superseded). The agent_name and
+        scenario_id are taken from the agent_runs row opened by __enter__.
+        Table name is quoted via sql.Identifier — no dynamic SQL injection risk.
+        """
+        query = sql.SQL(
+            "UPDATE {tbl} SET status=%s, updated_at=now() "
+            "WHERE agent_name=%s AND scenario_id=%s AND status=%s"
+        ).format(tbl=sql.Identifier(table))
+        cur = self._conn.cursor()
+        cur.execute(query, (new_status, self._agent_name, self._scenario_id, active_status))
+        return cur.rowcount
+
+    def insert(self, table: str, columns: Sequence[str], rows: Sequence[Sequence[Any]]) -> None:
+        """executemany INSERT into *table* with the given column list and row tuples.
+
+        Table name and column identifiers are quoted via sql.Identifier /
+        sql.SQL.join — no string interpolation in the SQL path.
+        """
+        if not rows:
+            return
+        col_ids = sql.SQL(", ").join(sql.Identifier(c) for c in columns)
+        placeholders = sql.SQL(", ").join(sql.Placeholder() for _ in columns)
+        query = sql.SQL("INSERT INTO {tbl} ({cols}) VALUES ({vals})").format(
+            tbl=sql.Identifier(table),
+            cols=col_ids,
+            vals=placeholders,
+        )
+        self._conn.cursor().executemany(query, rows)
+
+    def set_metrics(self, metrics: dict[str, Any]) -> None:
+        """Store the metrics dict that will be written to agent_runs on exit."""
+        self._metrics = metrics
+
+    # Internal helpers called by the context manager.
+    def _bind(self, agent_name: str, scenario_id: object) -> None:
+        self._agent_name = agent_name
+        self._scenario_id = scenario_id
+
+    def _elapsed(self) -> float:
+        return round(time.perf_counter() - self._t0, 2)
+
+    def _close(self, status: str) -> None:
+        metrics = dict(self._metrics)
+        metrics["elapsed_s"] = self._elapsed()
+        self._conn.cursor().execute(
+            "UPDATE agent_runs SET status=%s, finished_at=now(), metrics=%s "
+            "WHERE agent_run_id=%s",
+            (status, Jsonb(metrics), self._run_id),
+        )
+
+
+@contextmanager
+def governed_run(
+    conn: psycopg.Connection,
+    agent_name: str,
+    scenario_id: object,
+    t0: float | None = None,
+) -> Generator[_Run, None, None]:
+    """Context manager that governs an agent watcher run lifecycle.
+
+    On entry: INSERTs a row into agent_runs with status='RUNNING', creates a
+    _Run handle and yields it. The caller uses ``run.run_id`` immediately.
+
+    On clean exit: writes status='COMPLETED', finished_at=now(), and the
+    metrics dict (with elapsed_s appended), then calls conn.commit().
+
+    On exception: writes status='FAILED' (best-effort, does not suppress
+    secondary errors) with finished_at and metrics, calls conn.commit(), then
+    re-raises the original exception.
+
+    The caller owns the connection lifecycle (open before, close after).
+    governed_run only drives commit/rollback of the transaction.
+
+    Args:
+        conn:        An open psycopg connection (autocommit=False).
+        agent_name:  Value stored in agent_runs.agent_name.
+        scenario_id: UUID (or string UUID) stored in agent_runs.scenario_id.
+        t0:          perf_counter start time. If None a new timer is started
+                     at entry, which excludes planning-data load time. Pass
+                     the caller's t0 to include the full elapsed time.
+    """
+    _t0 = t0 if t0 is not None else time.perf_counter()
+    cur = conn.cursor()
+    run_id = cur.execute(
+        "INSERT INTO agent_runs (agent_name, scenario_id, status) "
+        "VALUES (%s, %s, 'RUNNING') RETURNING agent_run_id",
+        (agent_name, scenario_id),
+    ).fetchone()[0]
+    logger.debug("agent=%s scenario=%s run_id=%s status=RUNNING", agent_name, scenario_id, run_id)
+
+    run = _Run(conn, run_id, _t0)
+    run._bind(agent_name, scenario_id)
+
+    try:
+        yield run
+    except Exception:
+        # Best-effort: write FAILED. If the UPDATE itself errors we still
+        # commit what we can so the RUNNING row is not left hanging.
+        try:
+            run._close("FAILED")
+            conn.commit()
+        except Exception:
+            logger.exception("agent=%s run_id=%s: error writing FAILED status", agent_name, run_id)
+        logger.error("agent=%s run_id=%s status=FAILED", agent_name, run_id)
+        raise
+    else:
+        run._close("COMPLETED")
+        conn.commit()
+        logger.debug("agent=%s run_id=%s status=COMPLETED elapsed_s=%.2f", agent_name, run_id, run._elapsed())

--- a/scripts/agent_lot_policy_watcher.py
+++ b/scripts/agent_lot_policy_watcher.py
@@ -37,6 +37,7 @@ from collections import defaultdict
 import psycopg
 from psycopg.types.json import Jsonb
 import mrp_core as core
+from agent_governance import governed_run
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
 logger = logging.getLogger("lot_policy_watcher")
@@ -81,93 +82,89 @@ def main(argv=None) -> int:
 
         recs, display = [], []
         ct_count = defaultdict(int)
-        for item, a in agg.items():
-            tot_dem = sum(gross.get(item, {}).values())
-            active_wk = sum(1 for v in gross.get(item, {}).values() if v > 0)
-            if tot_dem <= 0 or a["n"] == 0:
-                continue
-            weekly = tot_dem / n_weeks
-            annual = weekly * 52.0
-            avg_qty = a["qty"] / a["n"]
-            wos = avg_qty / weekly if weekly > 0 else 0.0
-            moq, mult = a["moq"], a["mult"]
-            moq_bound = a["moq_hits"] >= max(1, a["n"] * 0.5)
 
-            # confidence from demand signal strength
-            if tot_dem < 10 or active_wk < 4:
-                conf = "NEEDS_DATA_REVIEW"
-            elif active_wk >= 12 and tot_dem >= 100:
-                conf = "HIGH"
-            else:
-                conf = "MEDIUM"
+        with governed_run(conn, AGENT_NAME, core.BASELINE, t0=t0) as run:
+            for item, a in agg.items():
+                tot_dem = sum(gross.get(item, {}).values())
+                active_wk = sum(1 for v in gross.get(item, {}).values() if v > 0)
+                if tot_dem <= 0 or a["n"] == 0:
+                    continue
+                weekly = tot_dem / n_weeks
+                annual = weekly * 52.0
+                avg_qty = a["qty"] / a["n"]
+                wos = avg_qty / weekly if weekly > 0 else 0.0
+                moq, mult = a["moq"], a["mult"]
+                moq_bound = a["moq_hits"] >= max(1, a["n"] * 0.5)
 
-            param = cur_val = prop_val = change = rationale = None
-            impact = 0.0
-            if wos > args.wos_high and moq_bound and moq > 0:
-                # MOQ ties up capital: one order covers far more than the target band
-                target = max(1.0, weekly * args.wos_high)
-                prop = math.ceil(target)
-                if prop < moq:
-                    param, change, rationale = "moq", "RENEGOTIATE_MOQ", "MOQ_EXCESS_WOS"
-                    cur_val, prop_val = f"{moq:.0f}", f"{prop:.0f}"
-                    impact = -((moq - prop) / 2.0)  # cycle-stock reduction
-            elif wos > args.wos_high and mult and mult > 0 and weekly * args.wos_high < mult:
-                param, change, rationale = "order_multiple", "REVIEW_MULTIPLE", "MULTIPLE_OVERHANG"
-                prop = max(1.0, math.ceil(weekly * args.wos_low))
-                cur_val, prop_val = f"{mult:.0f}", f"{prop:.0f}"
-                impact = -((mult - prop) / 2.0)
-            elif wos < args.wos_low and a["rule"] == "LOTFORLOT" and not moq_bound:
-                # ordering every week or two with no MOQ discipline -> batch up
-                param, change, rationale = "lot_size_rule", "SET_LOT_RULE", "LFL_TOO_FREQUENT"
-                cur_val, prop_val = "LOTFORLOT", f"POQ:{args.poq_target}"
-                impact = +(weekly * args.poq_target / 2.0)  # cycle stock rises but order count falls
+                # confidence from demand signal strength
+                if tot_dem < 10 or active_wk < 4:
+                    conf = "NEEDS_DATA_REVIEW"
+                elif active_wk >= 12 and tot_dem >= 100:
+                    conf = "HIGH"
+                else:
+                    conf = "MEDIUM"
 
-            if param is None:
-                continue  # within the healthy band — leave the negotiated policy alone
+                param = cur_val = prop_val = change = rationale = None
+                impact = 0.0
+                if wos > args.wos_high and moq_bound and moq > 0:
+                    # MOQ ties up capital: one order covers far more than the target band
+                    target = max(1.0, weekly * args.wos_high)
+                    prop = math.ceil(target)
+                    if prop < moq:
+                        param, change, rationale = "moq", "RENEGOTIATE_MOQ", "MOQ_EXCESS_WOS"
+                        cur_val, prop_val = f"{moq:.0f}", f"{prop:.0f}"
+                        impact = -((moq - prop) / 2.0)  # cycle-stock reduction
+                elif wos > args.wos_high and mult and mult > 0 and weekly * args.wos_high < mult:
+                    param, change, rationale = "order_multiple", "REVIEW_MULTIPLE", "MULTIPLE_OVERHANG"
+                    prop = max(1.0, math.ceil(weekly * args.wos_low))
+                    cur_val, prop_val = f"{mult:.0f}", f"{prop:.0f}"
+                    impact = -((mult - prop) / 2.0)
+                elif wos < args.wos_low and a["rule"] == "LOTFORLOT" and not moq_bound:
+                    # ordering every week or two with no MOQ discipline -> batch up
+                    param, change, rationale = "lot_size_rule", "SET_LOT_RULE", "LFL_TOO_FREQUENT"
+                    cur_val, prop_val = "LOTFORLOT", f"POQ:{args.poq_target}"
+                    impact = +(weekly * args.poq_target / 2.0)  # cycle stock rises but order count falls
 
-            evidence = {
-                "orders_in_horizon": a["n"], "avg_order_qty": round(avg_qty, 1),
-                "weeks_of_supply_per_order": round(wos, 2), "weekly_demand": round(weekly, 2),
-                "active_demand_weeks": active_wk, "moq": moq, "order_multiple": mult,
-                "current_rule": a["rule"], "moq_bound": moq_bound,
-                "target_band_weeks": [args.wos_low, args.wos_high],
-                "rule": "WOS-per-order vs target band on the realized time-phased plan",
-            }
-            recs.append((AGENT_NAME, None, core.BASELINE, item, d.names.get(item, str(item)[:8]),
-                         param, cur_val, prop_val, change, rationale,
-                         round(wos, 2), round(annual, 1), round(impact, 1),
-                         "L1", "DRAFT", conf, Jsonb(evidence)))
-            display.append({"ext": d.names.get(item, str(item)[:8]), "param": param, "change": change,
-                            "cur": cur_val, "prop": prop_val, "wos": wos, "annual": annual,
-                            "impact": impact, "conf": conf})
-            ct_count[change] += 1
+                if param is None:
+                    continue  # within the healthy band — leave the negotiated policy alone
 
-        # persist: open run, supersede prior drafts, insert
-        cur = conn.cursor()
-        run_id = cur.execute(
-            "INSERT INTO agent_runs (agent_name, scenario_id, status) VALUES (%s,%s,'RUNNING') RETURNING agent_run_id",
-            (AGENT_NAME, core.BASELINE)).fetchone()[0]
-        recs = [(a, run_id, *rest) for (a, _none, *rest) in recs]  # fill agent_run_id
-        superseded = cur.execute(
-            "UPDATE parameter_recommendations SET status='EXPIRED', updated_at=now() "
-            "WHERE agent_name=%s AND scenario_id=%s AND status='DRAFT'", (AGENT_NAME, core.BASELINE)).rowcount
-        cur.executemany(
-            """INSERT INTO parameter_recommendations
-               (agent_name, agent_run_id, scenario_id, item_id, item_external_id,
-                parameter, current_value, proposed_value, change_type, rationale_code,
-                weeks_of_supply, annual_demand, est_inventory_impact_units,
-                decision_level, status, confidence, evidence)
-               VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""", recs)
-        metrics = {"proposals": len(recs), "by_change_type": dict(ct_count), "superseded": superseded,
-                   "items_planned": len(agg), "elapsed_s": round(time.perf_counter() - t0, 2)}
-        cur.execute("UPDATE agent_runs SET status='COMPLETED', finished_at=now(), metrics=%s WHERE agent_run_id=%s",
-                    (Jsonb(metrics), run_id))
-        conn.commit()
+                evidence = {
+                    "orders_in_horizon": a["n"], "avg_order_qty": round(avg_qty, 1),
+                    "weeks_of_supply_per_order": round(wos, 2), "weekly_demand": round(weekly, 2),
+                    "active_demand_weeks": active_wk, "moq": moq, "order_multiple": mult,
+                    "current_rule": a["rule"], "moq_bound": moq_bound,
+                    "target_band_weeks": [args.wos_low, args.wos_high],
+                    "rule": "WOS-per-order vs target band on the realized time-phased plan",
+                }
+                recs.append((AGENT_NAME, run.run_id, core.BASELINE, item, d.names.get(item, str(item)[:8]),
+                             param, cur_val, prop_val, change, rationale,
+                             round(wos, 2), round(annual, 1), round(impact, 1),
+                             "L1", "DRAFT", conf, Jsonb(evidence)))
+                display.append({"ext": d.names.get(item, str(item)[:8]), "param": param, "change": change,
+                                "cur": cur_val, "prop": prop_val, "wos": wos, "annual": annual,
+                                "impact": impact, "conf": conf})
+                ct_count[change] += 1
 
+            superseded = run.supersede("parameter_recommendations", "DRAFT", "EXPIRED")
+            run.insert(
+                "parameter_recommendations",
+                ["agent_name", "agent_run_id", "scenario_id", "item_id", "item_external_id",
+                 "parameter", "current_value", "proposed_value", "change_type", "rationale_code",
+                 "weeks_of_supply", "annual_demand", "est_inventory_impact_units",
+                 "decision_level", "status", "confidence", "evidence"],
+                recs,
+            )
+            run.set_metrics({
+                "proposals": len(recs), "by_change_type": dict(ct_count),
+                "superseded": superseded, "items_planned": len(agg),
+            })
+            metrics = run.metrics
+
+    elapsed = round(time.perf_counter() - t0, 2)
     logger.info("=" * 100)
-    logger.info("LOT POLICY WATCHER — run %s COMPLETED in %.2fs", str(run_id)[:8], metrics["elapsed_s"])
+    logger.info("LOT POLICY WATCHER — run %s COMPLETED in %.2fs", str(run.run_id)[:8], elapsed)
     logger.info("  Parameter proposals (DRAFT/L1) : %d   by type: %s", len(recs), dict(ct_count))
-    logger.info("  Prior drafts superseded        : %d", superseded)
+    logger.info("  Prior drafts superseded        : %d", metrics["superseded"])
     logger.info("=" * 100)
     display.sort(key=lambda x: -abs(x["impact"]))
     logger.info("TOP %d proposals (by |inventory impact|):", args.top)

--- a/scripts/agent_material_watcher.py
+++ b/scripts/agent_material_watcher.py
@@ -26,6 +26,7 @@ from collections import defaultdict
 import psycopg
 from psycopg.types.json import Jsonb
 import mrp_core as core
+from agent_governance import governed_run
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
 logger = logging.getLogger("material_watcher")
@@ -74,70 +75,68 @@ def main(argv=None) -> int:
             pastdue_need[item] = min(pastdue_need.get(item, need), need)
             kind_of[item] = kind
 
-        cur = conn.cursor()   # recommendations / agent_runs schema from migration 039
-        run_id = cur.execute(
-            "INSERT INTO agent_runs (agent_name, scenario_id, status) VALUES (%s,%s,'RUNNING') RETURNING agent_run_id",
-            (AGENT_NAME, core.BASELINE)).fetchone()[0]
-
         recs, display = [], []
         n_po = n_wo = 0
         spend = defaultdict(float)
-        for item, qty in pastdue_qty.items():
-            lvl = d.llc.get(item, 0)
-            kind = kind_of.get(item, "PO")
-            need_date = hs + _dt.timedelta(weeks=int(pastdue_need.get(item, 0)))
-            runway = (need_date - hs).days
-            org = origin.get(item, {})
-            tot = sum(org.values()) or 1.0
-            peg = [{"fg": d.names.get(fg, str(fg)[:8]), "pct": round(100 * q / tot, 1)}
-                   for fg, q in sorted(org.items(), key=lambda x: -x[1])[:5]]
-            sup = d.best_sup.get(item)
-            if kind == "PO" and sup:
-                sid, sext, lt, uc, ccy, rel = sup
-                ccy = ccy or "EUR"
-                cost = round(qty * float(uc), 2) if uc is not None else None
-                margin = runway - int(lt)
-                conf = _confidence(uc, rel)
-                if cost is not None:
-                    spend[ccy] += cost
-                n_po += 1
-            else:
-                sid = sext = lt = uc = None
-                ccy, cost = "EUR", None
-                margin = runway - int(d.make_lt.get(item) or core.DEFAULT_LT_DAYS)
-                conf = "MEDIUM"
-                n_wo += 1
-            evidence = {"kind": kind, "llc": lvl, "need_week": int(pastdue_need.get(item, 0)),
-                        "pastdue": True, "pegging": peg,
-                        "rule": "MRP time-phased past-due (need − lead_time < today)"}
-            recs.append((AGENT_NAME, run_id, core.BASELINE, item, d.names.get(item, str(item)[:8]),
-                         need_date, qty, qty, cost, ccy, sid, sext, lt, runway, margin,
-                         "EXPEDITE", "L1", "DRAFT", conf, Jsonb(evidence)))
-            display.append({"ext": d.names.get(item, str(item)[:8]), "kind": kind, "llc": lvl,
-                            "qty": qty, "cost": cost, "ccy": ccy, "need": str(need_date),
-                            "peg": peg[0]["fg"] if peg else "—", "pegpct": peg[0]["pct"] if peg else 0})
 
-        superseded = cur.execute(
-            "UPDATE recommendations SET status='EXPIRED', updated_at=now() "
-            "WHERE agent_name=%s AND scenario_id=%s AND status='DRAFT'", (AGENT_NAME, core.BASELINE)).rowcount
-        cur.executemany(
-            """INSERT INTO recommendations
-               (agent_name, agent_run_id, scenario_id, item_id, item_external_id,
-                shortage_date, deficit_qty, recommended_qty, estimated_cost, currency,
-                supplier_id, supplier_external_id, lead_time_days, runway_days, margin_days,
-                action, decision_level, status, confidence, evidence)
-               VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""", recs)
-        metrics = {"component_recommendations": len(recs), "po": n_po, "wo": n_wo,
-                   "superseded": superseded, "estimated_spend": {k: round(v, 2) for k, v in spend.items()},
-                   "max_llc": d.max_llc, "elapsed_s": round(time.perf_counter() - t0, 2)}
-        cur.execute("UPDATE agent_runs SET status='COMPLETED', finished_at=now(), metrics=%s WHERE agent_run_id=%s",
-                    (Jsonb(metrics), run_id))
-        conn.commit()
+        with governed_run(conn, AGENT_NAME, core.BASELINE, t0=t0) as run:
+            for item, qty in pastdue_qty.items():
+                lvl = d.llc.get(item, 0)
+                kind = kind_of.get(item, "PO")
+                need_date = hs + _dt.timedelta(weeks=int(pastdue_need.get(item, 0)))
+                runway = (need_date - hs).days
+                org = origin.get(item, {})
+                tot = sum(org.values()) or 1.0
+                peg = [{"fg": d.names.get(fg, str(fg)[:8]), "pct": round(100 * q / tot, 1)}
+                       for fg, q in sorted(org.items(), key=lambda x: -x[1])[:5]]
+                sup = d.best_sup.get(item)
+                if kind == "PO" and sup:
+                    sid, sext, lt, uc, ccy, rel = sup
+                    ccy = ccy or "EUR"
+                    cost = round(qty * float(uc), 2) if uc is not None else None
+                    margin = runway - int(lt)
+                    conf = _confidence(uc, rel)
+                    if cost is not None:
+                        spend[ccy] += cost
+                    n_po += 1
+                else:
+                    sid = sext = lt = uc = None
+                    ccy, cost = "EUR", None
+                    margin = runway - int(d.make_lt.get(item) or core.DEFAULT_LT_DAYS)
+                    conf = "MEDIUM"
+                    n_wo += 1
+                evidence = {"kind": kind, "llc": lvl, "need_week": int(pastdue_need.get(item, 0)),
+                            "pastdue": True, "pegging": peg,
+                            "rule": "MRP time-phased past-due (need − lead_time < today)"}
+                recs.append((AGENT_NAME, run.run_id, core.BASELINE, item, d.names.get(item, str(item)[:8]),
+                             need_date, qty, qty, cost, ccy, sid, sext, lt, runway, margin,
+                             "EXPEDITE", "L1", "DRAFT", conf, Jsonb(evidence)))
+                display.append({"ext": d.names.get(item, str(item)[:8]), "kind": kind, "llc": lvl,
+                                "qty": qty, "cost": cost, "ccy": ccy, "need": str(need_date),
+                                "peg": peg[0]["fg"] if peg else "—", "pegpct": peg[0]["pct"] if peg else 0})
 
+            superseded = run.supersede("recommendations", "DRAFT", "EXPIRED")
+            run.insert(
+                "recommendations",
+                ["agent_name", "agent_run_id", "scenario_id", "item_id", "item_external_id",
+                 "shortage_date", "deficit_qty", "recommended_qty", "estimated_cost", "currency",
+                 "supplier_id", "supplier_external_id", "lead_time_days", "runway_days", "margin_days",
+                 "action", "decision_level", "status", "confidence", "evidence"],
+                recs,
+            )
+            run.set_metrics({
+                "component_recommendations": len(recs), "po": n_po, "wo": n_wo,
+                "superseded": superseded,
+                "estimated_spend": {k: round(v, 2) for k, v in spend.items()},
+                "max_llc": d.max_llc,
+            })
+            metrics = run.metrics
+
+    elapsed = round(time.perf_counter() - t0, 2)
     logger.info("=" * 96)
-    logger.info("MATERIAL WATCHER — run %s COMPLETED in %.2fs", str(run_id)[:8], metrics["elapsed_s"])
+    logger.info("MATERIAL WATCHER — run %s COMPLETED in %.2fs", str(run.run_id)[:8], elapsed)
     logger.info("  Component recommendations (DRAFT/L1) : %d  (PO %d / WO %d)", len(recs), n_po, n_wo)
-    logger.info("  Prior drafts superseded              : %d", superseded)
+    logger.info("  Prior drafts superseded              : %d", metrics["superseded"])
     logger.info("  Est. procurement spend               : %s", metrics["estimated_spend"])
     logger.info("=" * 96)
     display.sort(key=lambda x: -(x["cost"] or 0))

--- a/scripts/agent_shortage_watcher.py
+++ b/scripts/agent_shortage_watcher.py
@@ -35,6 +35,7 @@ from collections import defaultdict
 import psycopg
 from psycopg.types.json import Jsonb
 import mrp_core as core
+from agent_governance import governed_run
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
 logger = logging.getLogger("shortage_watcher")
@@ -97,70 +98,66 @@ def main(argv=None) -> int:
             {"b": core.BASELINE, "t": core.DEMAND_TYPES}).fetchone()
         past_due_ratio = (pdn / dn) if dn else 0.0
 
-        run_id = cur.execute(
-            "INSERT INTO agent_runs (agent_name, scenario_id, status) VALUES (%s,%s,'RUNNING') RETURNING agent_run_id",
-            (AGENT_NAME, core.BASELINE)).fetchone()[0]
-
         recs, display = [], []
         by_action, by_conf = defaultdict(int), defaultdict(int)
         spend = defaultdict(float)
         skipped_no_supplier = 0
-        for item, o in fg_first.items():
-            sup = d.best_sup.get(item)
-            if not sup:
-                skipped_no_supplier += 1      # make / unsourced independent demand → material side
-                continue
-            sid, sext, lt, uc, ccy, rel = sup
-            qty = round(o["qty"], 2)          # already lot-sized & lead-time-offset by run_timephased
-            deficit = round(short.get(item, {}).get("deficit", qty), 2)   # true shortfall-to-safety (≠ lot-sized qty)
-            cost = round(qty * float(uc), 2) if uc is not None else None
-            ccy = ccy or "EUR"
-            need_date = today + _dt.timedelta(weeks=o["need"])
-            runway = (need_date - today).days
-            margin = runway - int(lt or core.DEFAULT_LT_DAYS)
-            action = "EXPEDITE" if (o["pd"] or margin < -14) else ("ORDER_RUSH" if margin < 0 else "ORDER_NOW")
-            conf = _confidence(uc, rel, past_due_ratio)
-            evidence = {"planned_qty": qty, "release_week": o["rel"], "need_week": o["need"],
-                        "past_due": o["pd"], "future_orders_planned": fg_count[item],
-                        "moq": float(d.moq.get(item) or 0) or None, "order_multiple": float(d.mult.get(item) or 0) or None,
-                        "lead_time_days": lt, "runway_days": runway, "margin_days": margin,
-                        "supplier_reliability": float(rel) if rel is not None else None,
-                        "unit_cost": float(uc) if uc is not None else None,
-                        "rule": "earliest time-phased planned PURCHASE order from run_timephased "
-                                "(nets to safety, lot-sized, lead-time offset); consumed demand = max_only/DTF/prorated"}
-            recs.append((AGENT_NAME, run_id, core.BASELINE, item, d.names.get(item, str(item)[:8]),
-                         need_date, deficit, qty, cost, ccy, sid, sext, lt, runway, margin,
-                         action, "L1", "DRAFT", conf, Jsonb(evidence)))
-            display.append({"ext": d.names.get(item, str(item)[:8]), "fsd": need_date, "qty": qty,
-                            "cost": cost, "ccy": ccy, "action": action, "conf": conf, "margin": margin})
-            by_action[action] += 1
-            by_conf[conf] += 1
-            if cost is not None:
-                spend[ccy] += cost
 
-        superseded = cur.execute(
-            "UPDATE recommendations SET status='EXPIRED', updated_at=now() "
-            "WHERE agent_name=%s AND scenario_id=%s AND status='DRAFT'", (AGENT_NAME, core.BASELINE)).rowcount
-        cur.executemany(
-            """INSERT INTO recommendations
-               (agent_name, agent_run_id, scenario_id, item_id, item_external_id,
-                shortage_date, deficit_qty, recommended_qty, estimated_cost, currency,
-                supplier_id, supplier_external_id, lead_time_days, runway_days, margin_days,
-                action, decision_level, status, confidence, evidence)
-               VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""", recs)
-        metrics = {"recommendations": len(recs), "superseded_prior_drafts": superseded,
-                   "by_action": dict(by_action), "by_confidence": dict(by_conf),
-                   "estimated_spend": {k: round(v, 2) for k, v in spend.items()},
-                   "skipped_no_supplier": skipped_no_supplier,
-                   "fg_items_to_order": len(fg_first), "demand_nodes": dn, "past_due_demand_nodes": pdn,
-                   "past_due_ratio": round(past_due_ratio, 4), "elapsed_s": round(time.perf_counter() - t0, 2)}
-        cur.execute("UPDATE agent_runs SET status='COMPLETED', finished_at=now(), metrics=%s WHERE agent_run_id=%s",
-                    (Jsonb(metrics), run_id))
-        conn.commit()
+        with governed_run(conn, AGENT_NAME, core.BASELINE, t0=t0) as run:
+            for item, o in fg_first.items():
+                sup = d.best_sup.get(item)
+                if not sup:
+                    skipped_no_supplier += 1      # make / unsourced independent demand → material side
+                    continue
+                sid, sext, lt, uc, ccy, rel = sup
+                qty = round(o["qty"], 2)          # already lot-sized & lead-time-offset by run_timephased
+                deficit = round(short.get(item, {}).get("deficit", qty), 2)   # true shortfall-to-safety (≠ lot-sized qty)
+                cost = round(qty * float(uc), 2) if uc is not None else None
+                ccy = ccy or "EUR"
+                need_date = today + _dt.timedelta(weeks=o["need"])
+                runway = (need_date - today).days
+                margin = runway - int(lt or core.DEFAULT_LT_DAYS)
+                action = "EXPEDITE" if (o["pd"] or margin < -14) else ("ORDER_RUSH" if margin < 0 else "ORDER_NOW")
+                conf = _confidence(uc, rel, past_due_ratio)
+                evidence = {"planned_qty": qty, "release_week": o["rel"], "need_week": o["need"],
+                            "past_due": o["pd"], "future_orders_planned": fg_count[item],
+                            "moq": float(d.moq.get(item) or 0) or None, "order_multiple": float(d.mult.get(item) or 0) or None,
+                            "lead_time_days": lt, "runway_days": runway, "margin_days": margin,
+                            "supplier_reliability": float(rel) if rel is not None else None,
+                            "unit_cost": float(uc) if uc is not None else None,
+                            "rule": "earliest time-phased planned PURCHASE order from run_timephased "
+                                    "(nets to safety, lot-sized, lead-time offset); consumed demand = max_only/DTF/prorated"}
+                recs.append((AGENT_NAME, run.run_id, core.BASELINE, item, d.names.get(item, str(item)[:8]),
+                             need_date, deficit, qty, cost, ccy, sid, sext, lt, runway, margin,
+                             action, "L1", "DRAFT", conf, Jsonb(evidence)))
+                display.append({"ext": d.names.get(item, str(item)[:8]), "fsd": need_date, "qty": qty,
+                                "cost": cost, "ccy": ccy, "action": action, "conf": conf, "margin": margin})
+                by_action[action] += 1
+                by_conf[conf] += 1
+                if cost is not None:
+                    spend[ccy] += cost
+
+            superseded = run.supersede("recommendations", "DRAFT", "EXPIRED")
+            run.insert(
+                "recommendations",
+                ["agent_name", "agent_run_id", "scenario_id", "item_id", "item_external_id",
+                 "shortage_date", "deficit_qty", "recommended_qty", "estimated_cost", "currency",
+                 "supplier_id", "supplier_external_id", "lead_time_days", "runway_days", "margin_days",
+                 "action", "decision_level", "status", "confidence", "evidence"],
+                recs,
+            )
+            metrics = {"recommendations": len(recs), "superseded_prior_drafts": superseded,
+                       "by_action": dict(by_action), "by_confidence": dict(by_conf),
+                       "estimated_spend": {k: round(v, 2) for k, v in spend.items()},
+                       "skipped_no_supplier": skipped_no_supplier,
+                       "fg_items_to_order": len(fg_first), "demand_nodes": dn, "past_due_demand_nodes": pdn,
+                       "past_due_ratio": round(past_due_ratio, 4)}
+            run.set_metrics(metrics)
 
     m = metrics
+    elapsed = round(time.perf_counter() - t0, 2)
     logger.info("=" * 92)
-    logger.info("SHORTAGE WATCHER — run %s COMPLETED in %.2fs", str(run_id)[:8], m["elapsed_s"])
+    logger.info("SHORTAGE WATCHER — run %s COMPLETED in %.2fs", str(run.run_id)[:8], elapsed)
     logger.info("  Recommendations written (DRAFT, L1) : %d", m["recommendations"])
     logger.info("  FG items needing a purchase order   : %d  (skipped, no supplier: %d)",
                 m["fg_items_to_order"], m["skipped_no_supplier"])


### PR DESCRIPTION
First increment of Revue #8 — DRY the 5 watchers' duplicated governance cycle.

## What
- **New `scripts/agent_governance.py`** — `governed_run` context manager owning the `agent_runs` lifecycle:
  - `__enter__` opens the run (`RUNNING`), exposes `run.run_id`.
  - clean exit → `COMPLETED` + metrics (+ `elapsed_s`) + `conn.commit()`.
  - exception → `FAILED` + commit + re-raise. **Closes a real gap**: no watcher wrote `FAILED` today, so a crash left a `RUNNING` orphan.
  - `run.supersede(table, active, new)` / `run.insert(table, cols, rows)` take table/columns/statuses as params — no business schema frozen. Table identifiers via `psycopg.sql.Identifier`, fully parameterized SQL, no f-strings.
- **`agent_shortage_watcher.py`** migrated as the first adopter — behaviour-identical (same columns, `DRAFT`/`EXPIRED`, metrics, logging).

## Why incremental
Migrating one watcher first lets CI's smoke test (#315) validate the primitive design before the other 4 follow. The 4 remaining watchers land in follow-up commits on this branch once green.

## Verification
- Local: `ruff` clean, `py_compile` OK.
- CI: `tests/integration/test_agent_fleet_smoke.py` is the regression net — `test_watcher_governed_run_is_idempotent[shortage_watcher]` + `test_shortage_watcher_drafts_purchase_for_fg_short` must stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)