### PR TITLE
Pyramide demand foundation — schema + ingestion + forecasting PoCs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # Environment secrets — never commit
 .env
 
+# Raw ERP extracts — large input data, never commit (SALES_MARINE.full.tsv ~2.3 GB)
+Raw Data/
+*.tsv.rar
+.valve_*.txt
+
 # Python byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/data/demand/buy_program_calendar.template.tsv
+++ b/data/demand/buy_program_calendar.template.tsv
@@ -1,0 +1,29 @@
+# Buy-program / S&OP seasonal calendar — template to fill (Pyramide axis C).
+# One row per (season_year, program[, phase][, scope]). Dates as YYYY-MM-DD.
+# Goal: tell the forecast WHEN demand lands each year, in the business's own
+# seasonal calendar (buy programs), because the timing shifts year to year.
+# We have 6 seasons of history (2020..2026) — give those + the upcoming season.
+#
+# Columns:
+#   season_year   : the selling season the program belongs to (e.g. 2025)
+#   program       : named program — March Buy / June Buy / Early Buy / In-Season ...
+#   phase         : optional sub-window inside a program ('' if none) — e.g. pre / peak / late
+#   booking_start : date orders OPEN for this program (the booking signal we forecast)
+#   booking_end   : date orders CLOSE
+#   scope_type    : 'ALL' | 'family' | 'channel' | 'family+channel'  (who the program covers)
+#   scope_value   : GEN_FAM code(s) and/or channel; '' when scope_type=ALL
+#                   (comma-separate multiple, e.g. 'F001,F007')
+#   ship_start    : optional — when the program's demand starts shipping ('' if n/a)
+#   ship_end      : optional
+#   notes
+#
+# The example rows below are PLACEHOLDERS — replace with your real S&OP dates.
+# Note how March Buy 2024 vs 2025 have DIFFERENT windows: that year-to-year
+# shift is exactly what we need to capture (and why calendar-month is wrong).
+season_year	program	phase	booking_start	booking_end	scope_type	scope_value	ship_start	ship_end	notes
+2024	March Buy		2024-01-15	2024-03-31	ALL		2024-02-01	2024-04-30	example — replace
+2024	June Buy		2024-05-01	2024-06-30	ALL		2024-05-15	2024-07-15	example — replace
+2024	Early Buy		2024-09-01	2024-10-31	ALL		2024-09-15	2024-11-30	example — replace
+2025	March Buy		2025-01-10	2025-03-20	ALL		2025-01-25	2025-04-20	example — note earlier than 2024
+2025	June Buy		2025-05-05	2025-07-05	ALL		2025-05-20	2025-07-20	example — replace
+2025	Early Buy		2025-09-05	2025-11-05	ALL		2025-09-20	2025-12-05	example — replace

--- a/data/demand/line_type_classification.tsv
+++ b/data/demand/line_type_classification.tsv
@@ -1,0 +1,86 @@
+# LINE_TYPE -> demand classification (SALES_MARINE). Decided 2026-05-31. See memory demand-business-rule-booking.
+# Demand = positive quantities only; negatives = returns (separate series, never netted into demand).
+# in_asp=no for warranty($0), intercompany(at-cost), drop-ship(at-cost). PROMO=REGULAR. All confirmed 2026-05-31.
+# fulfillment: direct = ships supplier->customer, BYPASSES DCs (no DRP deploy); inter_entity = Group replenishment.
+line_type	class	in_demand	in_asp	forecast_stream	fulfillment	sign	demand_units	returns_units	lines	pos_value
+STANDARD LINE	REGULAR	yes	yes	regular	standard	positive	59977994	0	2165188	5824389406
+INTERCOMPANY LINE	INTERCOMPANY	yes	no	regular	inter_entity	positive	4329436	0	37524	119553531
+CMP DROP SHIP LINE	DROP_SHIP	yes	no	regular	direct	positive	4109772	0	2201	9943013
+SRS IMPORT LINE	REGULAR	yes	yes	regular	standard	positive	1822047	0	388858	436833869
+WARRANTY CS	WARRANTY	yes	no	warranty	standard	positive	1353242	0	1106263	6921
+CN STANDARD LINE	REGULAR	yes	yes	regular	standard	positive	1137152	0	86277	251719261
+INVOICE ONLY LINE	EXCLUDE_INVOICE	no	no	-	-	positive	691691	0	15017	95754632
+NO BILL LINE	EXCLUDE_NOBILL	no	no	-	-	positive	580620	0	119904	250675
+REP NON WARRANTY	EXCLUDE_SERVICE	no	no	-	-	positive	84641	0	32762	0
+NO BILL REG	EXCLUDE_NOBILL	no	no	-	-	positive	53166	0	14622	20855
+DROP INTERCO	INTERCOMPANY	yes	no	regular	inter_entity	positive	39600	0	56	3600835
+CN WARRANTY	WARRANTY	yes	no	warranty	standard	positive	35755	0	30339	0
+CN NO BILL LINE	EXCLUDE_NOBILL	no	no	-	-	positive	28953	0	12140	25623
+CUSTOMER OPS NON WARRANTY	EXCLUDE_SERVICE	no	no	-	-	positive	20333	0	14542	0
+BR NO BILL	EXCLUDE_NOBILL	no	no	-	-	positive	16903	0	1395	0
+SERVICE CENTER NON WARRANTY	EXCLUDE_SERVICE	no	no	-	-	positive	15154	0	8568	0
+FREE GOOD - NO BILL LINE	EXCLUDE_NOBILL	no	no	-	-	positive	12581	0	634	0
+SERVICE PROMO	REGULAR	yes	yes	regular	standard	positive	9694	0	2334	1130
+DISTRIBUTION WARRANTY	WARRANTY	yes	no	warranty	standard	positive	7525	0	3371	0
+TECH TOOL CS	EXCLUDE_INTERNAL	no	no	-	-	positive	7070	0	3939	0
+ASTRAL EXIT RESOLUTION	EXCLUDE_INTERNAL	no	no	-	-	positive	5351	0	54	0
+DROP SHIP	DROP_SHIP	yes	no	regular	direct	positive	4400	0	11	2801700
+TRAINING PRODUCT	EXCLUDE_INTERNAL	no	no	-	-	positive	3742	0	725	0
+CLEANING SUSTAINING	EXCLUDE_INTERNAL	no	no	-	-	positive	3289	0	381	0
+RETAIL PROMO	REGULAR	yes	yes	regular	standard	positive	3048	0	2858	2653
+LAB SUSTAINING	EXCLUDE_INTERNAL	no	no	-	-	positive	2473	0	160	0
+CN NON WARRANTY	EXCLUDE_SERVICE	no	no	-	-	positive	1448	0	628	5037
+HYDRAULICS SUSTAINING	EXCLUDE_INTERNAL	no	no	-	-	positive	1130	0	237	0
+VI QUALIFICATION	EXCLUDE_INTERNAL	no	no	-	-	positive	977	0	79	0
+TS NON WARRANTY	EXCLUDE_SERVICE	no	no	-	-	positive	885	0	568	0
+PCC INVOICE ONLY	EXCLUDE_INVOICE	no	no	-	-	positive	651	0	218	62425
+PPP WARRANTY CS	WARRANTY	yes	no	warranty	standard	positive	635	0	534	0
+AUTOMATION SUSTAINING	EXCLUDE_INTERNAL	no	no	-	-	positive	579	0	174	0
+ELECTRO NEW	EXCLUDE_INTERNAL	no	no	-	-	positive	571	0	129	0
+ELECTRO SUSTAINING	EXCLUDE_INTERNAL	no	no	-	-	positive	461	0	119	0
+CLEANING NEW	EXCLUDE_INTERNAL	no	no	-	-	positive	374	0	91	0
+OPTIMA ENGINEERING	EXCLUDE_INTERNAL	no	no	-	-	positive	338	0	92	0
+HYDRAULICS NEW	EXCLUDE_INTERNAL	no	no	-	-	positive	294	0	65	0
+HEAT SUSTAINING	EXCLUDE_INTERNAL	no	no	-	-	positive	264	0	79	0
+LAB NEW	EXCLUDE_INTERNAL	no	no	-	-	positive	232	0	53	0
+SAFETY COMPLIANCE	EXCLUDE_INTERNAL	no	no	-	-	positive	216	0	85	0
+AUTOMATION NEW	EXCLUDE_INTERNAL	no	no	-	-	positive	209	0	66	0
+FILTRATION - SUSTAINING	EXCLUDE_INTERNAL	no	no	-	-	positive	192	0	45	0
+FIELD TEST SUSTAINING	EXCLUDE_INTERNAL	no	no	-	-	positive	177	0	61	0
+STANDARD DROP SHIP	DROP_SHIP	yes	no	regular	direct	positive	149	0	115	1267129
+HEAT NEW	EXCLUDE_INTERNAL	no	no	-	-	positive	118	0	54	0
+MFG ENGINEER	EXCLUDE_INTERNAL	no	no	-	-	positive	93	0	47	0
+COMMERCIAL NEW	EXCLUDE_INTERNAL	no	no	-	-	positive	87	0	21	0
+BUILT RIGHT NEW	EXCLUDE_INTERNAL	no	no	-	-	positive	68	0	4	0
+BUILDER PROMO	REGULAR	yes	yes	regular	standard	positive	64	0	63	0
+DISTRIBUTION NON WARRANTY	EXCLUDE_SERVICE	no	no	-	-	positive	62	0	23	0
+DTV LAB TESTING	EXCLUDE_INTERNAL	no	no	-	-	positive	55	0	24	0
+WATERCARE NEW	EXCLUDE_INTERNAL	no	no	-	-	positive	55	0	11	0
+FILTRATION - NEW	EXCLUDE_INTERNAL	no	no	-	-	positive	49	0	11	0
+WATERCARE SUSTAINING	EXCLUDE_INTERNAL	no	no	-	-	positive	41	0	13	0
+FIELD TEST NEW	EXCLUDE_INTERNAL	no	no	-	-	positive	34	0	16	0
+FEATURES SUSTAINING	EXCLUDE_INTERNAL	no	no	-	-	positive	24	0	8	0
+COMMERCIAL SUSTAINING	EXCLUDE_INTERNAL	no	no	-	-	positive	19	0	8	0
+SALES SUPPORT NON WARRANTY	EXCLUDE_SERVICE	no	no	-	-	positive	13	0	11	0
+CUSTOMER SAMPLE CS	EXCLUDE_INTERNAL	no	no	-	-	positive	5	0	3	0
+PROD QUALITY NON WARRANTY	EXCLUDE_SERVICE	no	no	-	-	positive	4	0	4	0
+AM PROMO NO BILL LINE	EXCLUDE_NOBILL	no	no	-	-	positive	3	0	3	0
+3900 GEN 2 NON WARRANTY	EXCLUDE_SERVICE	no	no	-	-	positive	3	0	2	0
+FRAME WARRANTY CS	WARRANTY	yes	no	warranty	standard	positive	1	0	1	0
+CREDIT ONLY	RETURN	no	no	-	-	negative	0	-889390	34468	11040
+CN RETURN ONLY	RETURN	no	no	-	-	negative	0	-827	242	0
+RMA DEFECTIVE PRODUCT CS	RETURN	no	no	-	-	negative	0	-815	55	0
+BR RETURN LINE	RETURN	no	no	-	-	negative	0	-72	4	0
+DD REPLACEMENT CREDIT ONLY	RETURN	no	no	-	-	negative	0	-71074	52608	0
+APPROVE, RECEIVE, CREDIT LINE	RETURN	no	no	-	-	negative	0	-69129	2660	391
+CN RMA CREDIT ONLY LINE	RETURN	no	no	-	-	negative	0	-5222	437	0
+INTERCOMPANY CREDIT ONLY	RETURN	no	no	-	-	negative	0	-28392	602	0
+INTERCOMPANY RETURN LINE	RETURN	no	no	-	-	negative	0	-204	4	0
+RMA FG ENGINEERING CS	RETURN	no	no	-	-	negative	0	-2	2	0
+RMA RETURN TO STOCK CS	RETURN	no	no	-	-	negative	0	-19704	92	0
+CANADA INTERCO CREDIT ONLY	RETURN	no	no	-	-	negative	0	-1925	53	0
+RMA ENGINEERING CS	RETURN	no	no	-	-	negative	0	-16	14	0
+RMA FG RETURN TO STOCK CS	RETURN	no	no	-	-	negative	0	-150	25	0
+RECEIVE ONLY LINE	RETURN	no	no	-	-	negative	0	-116237	8412	106657
+CN RETURN WITH CREDIT	RETURN	no	no	-	-	negative	0	-11076	2394	0
+RMA FG DEFECTIVE PRODUCT CS	RETURN	no	no	-	-	negative	0	-1	1	0

--- a/scripts/forecast_autoets_poc.py
+++ b/scripts/forecast_autoets_poc.py
@@ -1,0 +1,117 @@
+"""
+forecast_autoets_poc.py — does a real seasonal model (AutoETS) beat the
+seasonal-naive baseline at the aggregate level? (Pyramide axis A/B, heavier path).
+
+On PPS end-demand (interco excluded), per local gen_group monthly total, holds
+out the last 12 months and compares:
+  - seasonal-naive (the cheap baseline used so far)
+  - AutoETS (statsforecast, season_length=12) — the real seasonal model the
+    whole hierarchy inherits via middle-out.
+
+Read-only.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import psycopg
+from statsforecast.models import AutoETS
+
+H = "product_local_gen"
+
+SQL = """
+SELECT grp.code AS grp, to_char(dh.booked_date, 'YYYY-MM') AS ym,
+       SUM(dh.ordered_quantity) AS u
+FROM demand_history dh
+JOIN item_hierarchy ih ON ih.item_id = dh.item_id AND ih.hierarchy_id = %(h)s
+JOIN hierarchy_node prod ON prod.hierarchy_id = %(h)s AND prod.code = ih.leaf_code
+JOIN hierarchy_node grp  ON grp.hierarchy_id = %(h)s  AND grp.code = prod.parent_code
+WHERE dh.stream = 'regular' AND dh.fulfillment <> 'inter_entity'
+  AND dh.org_id = 'PPS' AND dh.booked_date IS NOT NULL
+GROUP BY 1, 2
+"""
+
+
+def seasonal_naive(vals: np.ndarray, h: int) -> np.ndarray:
+    vals = vals.astype(float)
+    if len(vals) < 24:
+        last12 = vals[-12:] if len(vals) >= 12 else np.pad(vals, (12 - len(vals), 0))
+        return np.array([last12[i % 12] for i in range(h)])
+    recent, prior = vals[-12:].sum(), vals[-24:-12].sum()
+    trend = float(np.clip((recent / prior) if prior > 0 else 1.0, 0.5, 2.0))
+    last12 = vals[-12:]
+    return np.array([last12[i % 12] * trend for i in range(h)])
+
+
+def autoets(train: np.ndarray, h: int) -> np.ndarray:
+    try:
+        res = AutoETS(season_length=12).forecast(y=train.astype(np.float64), h=h)
+        pred = np.asarray(res["mean"], dtype=float)
+        return np.clip(pred, 0, None)
+    except Exception:
+        return seasonal_naive(train, h)  # fall back if the fit fails
+
+
+def autoselect(train: np.ndarray, h: int) -> tuple[np.ndarray, str]:
+    """Pick naive vs AutoETS per series using a validation holdout (no oracle):
+    score both on the last 12 months of `train`, apply the winner to forecast h."""
+    if len(train) >= 36:
+        tr_v, va = train[:-12], train[-12:]
+        dv = np.abs(va).sum() or 1.0
+        en = np.abs(va - seasonal_naive(tr_v, 12)).sum() / dv
+        ee = np.abs(va - autoets(tr_v, 12)).sum() / dv
+        if ee < en:
+            return autoets(train, h), "AutoETS"
+    return seasonal_naive(train, h), "naive"
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    p.add_argument("--top", type=int, default=10)
+    args = p.parse_args(argv)
+    if not args.dsn:
+        print("ERROR: set DATABASE_URL", file=sys.stderr)
+        return 2
+
+    with psycopg.connect(args.dsn) as conn:
+        conn.execute("SET default_transaction_read_only = on")
+        conn.execute("SET statement_timeout = '180s'")
+        rows = conn.execute(SQL, {"h": H}).fetchall()
+
+    df = pd.DataFrame(rows, columns=["grp", "ym", "u"])
+    df["u"] = df["u"].astype(float)
+    df["period"] = pd.PeriodIndex(df["ym"], freq="M")
+    idx = pd.period_range(df["period"].min(), df["period"].max(), freq="M")
+    top = df.groupby("grp")["u"].sum().sort_values(ascending=False).head(args.top).index
+
+    print(f"PPS end-demand, {idx.min()}→{idx.max()}\n")
+    print(f"{'group':9s} {'naive':>8s} {'AutoETS':>8s} {'auto-sel':>9s} {'(picked)':>10s}")
+    print("-" * 50)
+    an = ae = asel = act = 0.0
+    for g in top:
+        s = df[df["grp"] == g].groupby("period")["u"].sum().reindex(idx, fill_value=0.0)
+        if len(s) < 36:
+            continue
+        train, test = s.iloc[:-12].values, s.iloc[-12:].values
+        pn, pe = seasonal_naive(train, 12), autoets(train, 12)
+        ps, picked = autoselect(train, 12)
+        d = np.abs(test).sum()
+        wn, we, ws = (np.abs(test - x).sum() / d for x in (pn, pe, ps))
+        print(f"{g:9s} {wn:>7.1%} {we:>7.1%} {ws:>8.1%} {picked:>10s}")
+        an += np.abs(test - pn).sum()
+        ae += np.abs(test - pe).sum()
+        asel += np.abs(test - ps).sum()
+        act += d
+    print("-" * 50)
+    best = min([("naive", an), ("AutoETS", ae), ("auto-sel", asel)], key=lambda x: x[1])[0]
+    print(f"{'OVERALL':9s} {an/act:>7.1%} {ae/act:>7.1%} {asel/act:>8.1%}   best={best}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/forecast_eval_by_group.py
+++ b/scripts/forecast_eval_by_group.py
@@ -1,0 +1,106 @@
+"""
+forecast_eval_by_group.py — quarterly forecast precision by Gen_Group.
+
+PPS end-demand (interco excluded). For each local gen_group: last-4-quarter volume
+(importance) + quarterly WMAPE (hold out the last 4 complete quarters, seasonal-naive
+season=4 — the planning-level accuracy). Sorted by volume, with a volume-weighted
+summary so you can judge how much of the business forecasts well. Read-only.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import psycopg
+
+H = "product_local_gen"
+SQL = """
+SELECT grp.code AS grp, grp.description AS desc, to_char(dh.booked_date,'YYYY-MM') AS ym,
+       SUM(dh.ordered_quantity) AS u
+FROM demand_history dh
+JOIN item_hierarchy ih ON ih.item_id = dh.item_id AND ih.hierarchy_id = %(h)s
+JOIN hierarchy_node prod ON prod.hierarchy_id = %(h)s AND prod.code = ih.leaf_code
+JOIN hierarchy_node grp  ON grp.hierarchy_id = %(h)s  AND grp.code = prod.parent_code
+WHERE dh.stream = 'regular' AND dh.fulfillment <> 'inter_entity'
+  AND dh.org_id = 'PPS' AND dh.booked_date IS NOT NULL
+GROUP BY 1, 2, 3
+"""
+
+
+def snaive(vals, h, season):
+    vals = np.asarray(vals, float)
+    if len(vals) < 2 * season:
+        last = vals[-season:] if len(vals) >= season else np.pad(vals, (season - len(vals), 0))
+        return np.array([last[i % season] for i in range(h)])
+    recent, prior = vals[-season:].sum(), vals[-2 * season:-season].sum()
+    trend = float(np.clip((recent / prior) if prior > 0 else 1.0, 0.5, 2.0))
+    last = vals[-season:]
+    return np.array([last[i % season] * trend for i in range(h)])
+
+
+def band(w):
+    return "GOOD " if w < 0.25 else ("MED  " if w < 0.40 else "POOR ")
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    p.add_argument("--show", type=int, default=30, help="rows to print (rest summarized)")
+    args = p.parse_args(argv)
+    if not args.dsn:
+        print("ERROR: set DATABASE_URL", file=sys.stderr)
+        return 2
+    with psycopg.connect(args.dsn) as conn:
+        conn.execute("SET default_transaction_read_only = on")
+        conn.execute("SET statement_timeout = '180s'")
+        rows = conn.execute(SQL, {"h": H}).fetchall()
+    df = pd.DataFrame(rows, columns=["grp", "desc", "ym", "u"])
+    df["u"] = df["u"].astype(float)
+    df["per"] = pd.PeriodIndex(df["ym"], freq="M")
+    qcount = df.groupby(df["per"].dt.asfreq("Q"))["per"].nunique()
+    last_q = max(q for q in qcount.index if qcount[q] >= 3)
+    cut = pd.period_range(df["per"].min(), last_q.asfreq("M", "end"), freq="M")
+
+    res = []
+    for (g, desc), sub in df.groupby(["grp", "desc"]):
+        s = sub.groupby("per")["u"].sum().reindex(cut, fill_value=0.0)
+        if len(s) < 24:
+            continue
+        sq = s.groupby(s.index.asfreq("Q")).sum()
+        if len(sq) < 8:
+            continue
+        train, test = sq.iloc[:-4].values, sq.iloc[-4:].values
+        d = np.abs(test).sum()
+        if d <= 0:
+            continue
+        w = np.abs(test - snaive(train, 4, 4)).sum() / d
+        res.append((g, desc, float(test.sum()), w))   # vol = last 4Q units
+
+    res.sort(key=lambda x: -x[2])
+    tot_vol = sum(r[2] for r in res)
+    print(f"PPS end-demand — quarterly WMAPE by Gen_Group  ({len(res)} groups, "
+          f"eval last 4 complete quarters)\n")
+    print(f"{'group':9s} {'description':26s} {'vol(4Q)':>11s} {'WMAPE':>7s} {'%vol':>6s}  band")
+    print("-" * 70)
+    for g, desc, vol, w in res[:args.show]:
+        print(f"{g:9s} {str(desc)[:26]:26s} {vol:>11,.0f} {w:>6.0%} {vol/tot_vol:>5.1%}  {band(w)}")
+    if len(res) > args.show:
+        rest = res[args.show:]
+        print(f"... +{len(rest)} smaller groups ({sum(r[2] for r in rest)/tot_vol:.0%} of volume)")
+
+    # volume-weighted summary + bands
+    wavg = sum(r[3] * r[2] for r in res) / tot_vol
+    print("\n=== Synthèse (pondérée par le volume) ===")
+    print(f"   WMAPE moyen pondéré volume : {wavg:.1%}")
+    for lab, lo, hi in [("GOOD  (<25%)", 0, 0.25), ("MED   (25-40%)", 0.25, 0.40), ("POOR  (>40%)", 0.40, 9)]:
+        v = sum(r[2] for r in res if lo <= r[3] < hi)
+        n = sum(1 for r in res if lo <= r[3] < hi)
+        print(f"   {lab:16s}: {v/tot_vol:>5.1%} du volume  ({n} groupes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/forecast_poc.py
+++ b/scripts/forecast_poc.py
@@ -1,0 +1,116 @@
+"""
+forecast_poc.py — first forecasting slice on the real demand foundation.
+
+Demonstrates Pyramide axis A (seasonality at an aggregate level) on the loaded
+demand_history: builds the monthly BOOKING series per local gen_group, fits a
+seasonal-naive + trend baseline, and backtests it (hold out the last 12 months).
+
+Pure numpy/pandas — no statsforecast/Chronos (not installed). This is the
+axis-A seasonal baseline the design builds hierarchical reconciliation +
+foundation models on top of. Read-only.
+
+Usage:
+    DATABASE_URL=... python scripts/forecast_poc.py --top 6 --horizon 12
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import psycopg
+
+H_LOCAL = "product_local_gen"
+
+SERIES_SQL = """
+SELECT grp.code AS grp_code, grp.description AS grp_desc,
+       to_char(dh.booked_date, 'YYYY-MM') AS ym,
+       SUM(dh.ordered_quantity) AS units
+FROM demand_history dh
+JOIN item_hierarchy ih ON ih.item_id = dh.item_id AND ih.hierarchy_id = %(h)s
+JOIN hierarchy_node prod ON prod.hierarchy_id = %(h)s AND prod.code = ih.leaf_code
+JOIN hierarchy_node grp  ON grp.hierarchy_id = %(h)s  AND grp.code = prod.parent_code
+WHERE dh.stream = 'regular' AND dh.booked_date IS NOT NULL
+GROUP BY 1, 2, 3
+"""
+
+
+def seasonal_naive_trend(series: pd.Series, horizon: int) -> np.ndarray:
+    """Forecast = same month last year, scaled by the YoY trend of the last
+    12 months vs the prior 12. The simplest baseline that respects seasonality."""
+    vals = series.values.astype(float)
+    if len(vals) < 24:
+        # not enough for YoY trend → flat seasonal naive
+        last12 = vals[-12:]
+        return np.array([last12[i % 12] for i in range(horizon)])
+    recent = vals[-12:].sum()
+    prior = vals[-24:-12].sum()
+    trend = (recent / prior) if prior > 0 else 1.0
+    trend = float(np.clip(trend, 0.5, 2.0))  # guard against wild ratios
+    last12 = vals[-12:]
+    return np.array([last12[i % 12] * trend for i in range(horizon)])
+
+
+def wmape(actual: np.ndarray, pred: np.ndarray) -> float:
+    denom = np.abs(actual).sum()
+    return float(np.abs(actual - pred).sum() / denom) if denom else float("nan")
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    p.add_argument("--top", type=int, default=6, help="top N gen_groups by volume")
+    p.add_argument("--horizon", type=int, default=12)
+    args = p.parse_args(argv)
+    if not args.dsn:
+        print("ERROR: set DATABASE_URL", file=sys.stderr)
+        return 2
+
+    with psycopg.connect(args.dsn) as conn:
+        conn.execute("SET default_transaction_read_only = on")
+        conn.execute("SET statement_timeout = '120s'")
+        rows = conn.execute(SERIES_SQL, {"h": H_LOCAL}).fetchall()
+
+    df = pd.DataFrame(rows, columns=["grp_code", "grp_desc", "ym", "units"])
+    df["units"] = df["units"].astype(float)
+    df["period"] = pd.PeriodIndex(df["ym"], freq="M")
+
+    totals = df.groupby(["grp_code", "grp_desc"])["units"].sum().sort_values(ascending=False)
+    top_groups = totals.head(args.top).index.tolist()
+
+    full_idx = pd.period_range(df["period"].min(), df["period"].max(), freq="M")
+    print(f"history: {full_idx.min()} → {full_idx.max()} ({len(full_idx)} months)\n")
+
+    for code, desc in top_groups:
+        s = (df[df["grp_code"] == code]
+             .set_index("period")["units"]
+             .reindex(full_idx, fill_value=0.0))
+        # Backtest: hold out last 12 months
+        if len(s) >= 36:
+            train, test = s.iloc[:-12], s.iloc[-12:]
+            bt = seasonal_naive_trend(train, 12)
+            err = wmape(test.values.astype(float), bt)
+            bt_str = f"backtest WMAPE={err:6.1%}"
+        else:
+            bt_str = "backtest n/a (short history)"
+
+        fc = seasonal_naive_trend(s, args.horizon)
+        fut_idx = pd.period_range(full_idx.max() + 1, periods=args.horizon, freq="M")
+        hist_12 = s.iloc[-12:].sum()
+        fc_12 = fc[:12].sum()
+
+        print(f"=== {code}  {str(desc)[:28]:28s} | {bt_str} ===")
+        print(f"    last 12m booked = {hist_12:>12,.0f}   forecast next 12m = {fc_12:>12,.0f}"
+              f"   ({(fc_12/hist_12-1)*100:+.0f}%)")
+        # show the forecast monthly (seasonality visible)
+        line = "    fc: " + "  ".join(
+            f"{ix.strftime('%y-%m')}:{v:,.0f}" for ix, v in zip(fut_idx[:6], fc[:6])
+        )
+        print(line + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/forecast_program_poc.py
+++ b/scripts/forecast_program_poc.py
@@ -1,0 +1,114 @@
+"""
+forecast_program_poc.py — does buy-program segmentation beat a blended calendar
+forecast? (Pyramide axis C, using order_type).
+
+On PPS end-demand (interco excluded), per local gen_group, holds out the last 12
+months and compares:
+  - A (calendar) : seasonal-naive on the blended group monthly total.
+  - B (segmented): seasonal-naive per order_type bucket (SPRING/SUMMER/EARLY/
+                   FWD/BASE), recombined.
+
+Pure numpy/pandas, read-only.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import psycopg
+
+H = "product_local_gen"
+
+SQL = """
+SELECT grp.code AS grp, dh.order_type AS ot,
+       to_char(dh.booked_date, 'YYYY-MM') AS ym, SUM(dh.ordered_quantity) AS u
+FROM demand_history dh
+JOIN item_hierarchy ih ON ih.item_id = dh.item_id AND ih.hierarchy_id = %(h)s
+JOIN hierarchy_node prod ON prod.hierarchy_id = %(h)s AND prod.code = ih.leaf_code
+JOIN hierarchy_node grp  ON grp.hierarchy_id = %(h)s  AND grp.code = prod.parent_code
+WHERE dh.stream = 'regular' AND dh.fulfillment <> 'inter_entity'
+  AND dh.org_id = 'PPS' AND dh.booked_date IS NOT NULL
+GROUP BY 1, 2, 3
+"""
+
+
+def bucket(ot: str | None) -> str:
+    o = (ot or "").upper()
+    if "SPRING BUY" in o:
+        return "SPRING"
+    if "SUMMER BUY" in o:
+        return "SUMMER"
+    if "EARLY BUY" in o:
+        return "EARLY"
+    if "FWD BUY" in o or "FORWARD BUY" in o:
+        return "FWD"
+    return "BASE"
+
+
+def seasonal_naive(vals: np.ndarray, horizon: int) -> np.ndarray:
+    vals = vals.astype(float)
+    if len(vals) < 24:
+        last12 = vals[-12:] if len(vals) >= 12 else np.pad(vals, (12 - len(vals), 0))
+        return np.array([last12[i % 12] for i in range(horizon)])
+    recent, prior = vals[-12:].sum(), vals[-24:-12].sum()
+    trend = float(np.clip((recent / prior) if prior > 0 else 1.0, 0.5, 2.0))
+    last12 = vals[-12:]
+    return np.array([last12[i % 12] * trend for i in range(horizon)])
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    p.add_argument("--top", type=int, default=8)
+    args = p.parse_args(argv)
+    if not args.dsn:
+        print("ERROR: set DATABASE_URL", file=sys.stderr)
+        return 2
+
+    with psycopg.connect(args.dsn) as conn:
+        conn.execute("SET default_transaction_read_only = on")
+        conn.execute("SET statement_timeout = '180s'")
+        rows = conn.execute(SQL, {"h": H}).fetchall()
+
+    df = pd.DataFrame(rows, columns=["grp", "ot", "ym", "u"])
+    df["u"] = df["u"].astype(float)
+    df["bucket"] = df["ot"].map(bucket)
+    df["period"] = pd.PeriodIndex(df["ym"], freq="M")
+    idx = pd.period_range(df["period"].min(), df["period"].max(), freq="M")
+
+    top = df.groupby("grp")["u"].sum().sort_values(ascending=False).head(args.top).index
+    print(f"PPS end-demand, {idx.min()}→{idx.max()}  ({len(idx)} months)\n")
+    print(f"{'group':9s} {'calendar(A)':>12s} {'segmented(B)':>13s} {'winner':>11s}")
+    print("-" * 50)
+    agg_a = agg_b = agg_act = 0.0
+    for g in top:
+        sub = df[df["grp"] == g]
+        total = sub.groupby("period")["u"].sum().reindex(idx, fill_value=0.0)
+        if len(total) < 36:
+            continue
+        test = total.iloc[-12:].values
+        # A: calendar on blended total
+        a = seasonal_naive(total.iloc[:-12].values, 12)
+        # B: per-bucket seasonal naive, recombined
+        b = np.zeros(12)
+        for bk, sb in sub.groupby("bucket"):
+            s = sb.groupby("period")["u"].sum().reindex(idx, fill_value=0.0)
+            b += seasonal_naive(s.iloc[:-12].values, 12)
+        denom = np.abs(test).sum()
+        wa = np.abs(test - a).sum() / denom if denom else float("nan")
+        wb = np.abs(test - b).sum() / denom if denom else float("nan")
+        print(f"{g:9s} {wa:>11.1%} {wb:>12.1%} {('segmented' if wb < wa else 'calendar'):>11s}")
+        agg_a += np.abs(test - a).sum()
+        agg_b += np.abs(test - b).sum()
+        agg_act += denom
+    print("-" * 50)
+    print(f"{'OVERALL':9s} {agg_a/agg_act:>11.1%} {agg_b/agg_act:>12.1%} "
+          f"{('segmented' if agg_b < agg_a else 'calendar'):>11s}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/forecast_q2m_poc.py
+++ b/scripts/forecast_q2m_poc.py
@@ -1,0 +1,114 @@
+"""
+forecast_q2m_poc.py — the business method: forecast at QUARTER, disaggregate to
+MONTH on historical share (temporal middle-out).
+
+Compares, at MONTHLY accuracy (held-out last 4 complete quarters = 12 months):
+  - DIRECT MONTHLY : seasonal-naive on the monthly series (the ~37% baseline).
+  - Q->MONTH       : seasonal-naive on the QUARTER series, then split each quarter
+                     to its 3 months via the historical month-in-quarter share.
+
+Hypothesis: Q->month inherits the cleaner quarterly signal and beats direct
+monthly — the temporal analogue of spatial middle-out. Read-only.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import psycopg
+
+H = "product_local_gen"
+SQL = """
+SELECT grp.code AS grp, to_char(dh.booked_date, 'YYYY-MM') AS ym, SUM(dh.ordered_quantity) AS u
+FROM demand_history dh
+JOIN item_hierarchy ih ON ih.item_id = dh.item_id AND ih.hierarchy_id = %(h)s
+JOIN hierarchy_node prod ON prod.hierarchy_id = %(h)s AND prod.code = ih.leaf_code
+JOIN hierarchy_node grp  ON grp.hierarchy_id = %(h)s  AND grp.code = prod.parent_code
+WHERE dh.stream = 'regular' AND dh.fulfillment <> 'inter_entity'
+  AND dh.org_id = 'PPS' AND dh.booked_date IS NOT NULL
+GROUP BY 1, 2
+"""
+
+
+def snaive(vals, h, season):
+    vals = np.asarray(vals, float)
+    if len(vals) < 2 * season:
+        last = vals[-season:] if len(vals) >= season else np.pad(vals, (season - len(vals), 0))
+        return np.array([last[i % season] for i in range(h)])
+    recent, prior = vals[-season:].sum(), vals[-2 * season:-season].sum()
+    trend = float(np.clip((recent / prior) if prior > 0 else 1.0, 0.5, 2.0))
+    last = vals[-season:]
+    return np.array([last[i % season] * trend for i in range(h)])
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    p.add_argument("--top", type=int, default=10)
+    args = p.parse_args(argv)
+    if not args.dsn:
+        print("ERROR: set DATABASE_URL", file=sys.stderr)
+        return 2
+    with psycopg.connect(args.dsn) as conn:
+        conn.execute("SET default_transaction_read_only = on")
+        conn.execute("SET statement_timeout = '180s'")
+        rows = conn.execute(SQL, {"h": H}).fetchall()
+    df = pd.DataFrame(rows, columns=["grp", "ym", "u"])
+    df["u"] = df["u"].astype(float)
+    df["per"] = pd.PeriodIndex(df["ym"], freq="M")
+    full = pd.period_range(df["per"].min(), df["per"].max(), freq="M")
+
+    # Truncate to the last COMPLETE calendar quarter (3 months present in data).
+    qcount = df.groupby([df["per"].dt.asfreq("Q")])["per"].nunique()
+    complete = [q for q in qcount.index if qcount[q] >= 3]
+    last_q = max(complete)
+    cut = full[full <= last_q.asfreq("M", "end")]
+    print(f"PPS end-demand — eval on last 4 complete quarters, history ends {last_q}\n")
+    print(f"{'group':9s} {'direct-month':>13s} {'Q->month':>10s} {'winner':>10s}")
+    print("-" * 46)
+
+    num_d = num_q = den = 0.0
+    for g in df.groupby("grp")["u"].sum().sort_values(ascending=False).head(args.top).index:
+        s = df[df["grp"] == g].groupby("per")["u"].sum().reindex(cut, fill_value=0.0)
+        if len(s) < 24:
+            continue
+        train_m, test_m = s.iloc[:-12], s.iloc[-12:]
+
+        # DIRECT MONTHLY
+        d_pred = snaive(train_m.values, 12, 12)
+
+        # Q -> MONTH
+        sq = s.groupby(s.index.asfreq("Q")).sum()
+        q_fc = snaive(sq.iloc[:-4].values, 4, 4)              # 4 forecast quarters
+        # month-in-quarter share from training months
+        tr = train_m
+        share = {}
+        for (cq, pos), v in tr.groupby([tr.index.quarter, ((tr.index.month - 1) % 3) + 1]).sum().items():
+            share[(cq, pos)] = v
+        qtot = tr.groupby(tr.index.quarter).sum()
+        q_pred = np.zeros(12)
+        for i, per in enumerate(test_m.index):
+            cq = per.quarter
+            pos = ((per.month - 1) % 3) + 1
+            sh = share.get((cq, pos), 0.0) / qtot.get(cq, np.nan) if qtot.get(cq, 0) else 1 / 3
+            q_pred[i] = q_fc[i // 3] * sh
+
+        act = test_m.values
+        d = np.abs(act).sum()
+        wd = np.abs(act - d_pred).sum() / d
+        wq = np.abs(act - q_pred).sum() / d
+        print(f"{g:9s} {wd:>12.1%} {wq:>9.1%} {('Q->month' if wq < wd else 'direct'):>10s}")
+        num_d += np.abs(act - d_pred).sum()
+        num_q += np.abs(act - q_pred).sum()
+        den += d
+    print("-" * 46)
+    print(f"{'OVERALL':9s} {num_d/den:>12.1%} {num_q/den:>9.1%} "
+          f"{('Q->month' if num_q < num_d else 'direct'):>10s}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/forecast_quarter_poc.py
+++ b/scripts/forecast_quarter_poc.py
@@ -1,0 +1,98 @@
+"""
+forecast_quarter_poc.py — the quarterly dynamic (Pyramide).
+
+The buy programs land at quarter boundaries (Spring=Mar=Q1-end, Summer=Jun=Q2-end,
+Early=Sep/Oct=Q3/Q4). This looks at PPS end-demand at the QUARTER level:
+  1. quarterly seasonal shape (share by Q1..Q4),
+  2. month-within-quarter concentration (the quarter-end buy effect),
+  3. quarterly forecast accuracy (hold out last 4 quarters) — vs the ~37% monthly.
+
+Read-only.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import psycopg
+
+H = "product_local_gen"
+SQL = """
+SELECT grp.code AS grp, to_char(dh.booked_date, 'YYYY-MM') AS ym,
+       SUM(dh.ordered_quantity) AS u
+FROM demand_history dh
+JOIN item_hierarchy ih ON ih.item_id = dh.item_id AND ih.hierarchy_id = %(h)s
+JOIN hierarchy_node prod ON prod.hierarchy_id = %(h)s AND prod.code = ih.leaf_code
+JOIN hierarchy_node grp  ON grp.hierarchy_id = %(h)s  AND grp.code = prod.parent_code
+WHERE dh.stream = 'regular' AND dh.fulfillment <> 'inter_entity'
+  AND dh.org_id = 'PPS' AND dh.booked_date IS NOT NULL
+GROUP BY 1, 2
+"""
+
+
+def snaive(vals, h, season):
+    vals = np.asarray(vals, float)
+    if len(vals) < 2 * season:
+        last = vals[-season:] if len(vals) >= season else np.pad(vals, (season - len(vals), 0))
+        return np.array([last[i % season] for i in range(h)])
+    recent, prior = vals[-season:].sum(), vals[-2 * season:-season].sum()
+    trend = float(np.clip((recent / prior) if prior > 0 else 1.0, 0.5, 2.0))
+    last = vals[-season:]
+    return np.array([last[i % season] * trend for i in range(h)])
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    p.add_argument("--top", type=int, default=10)
+    args = p.parse_args(argv)
+    if not args.dsn:
+        print("ERROR: set DATABASE_URL", file=sys.stderr)
+        return 2
+    with psycopg.connect(args.dsn) as conn:
+        conn.execute("SET default_transaction_read_only = on")
+        conn.execute("SET statement_timeout = '180s'")
+        rows = conn.execute(SQL, {"h": H}).fetchall()
+    df = pd.DataFrame(rows, columns=["grp", "ym", "u"])
+    df["u"] = df["u"].astype(float)
+    df["per"] = pd.PeriodIndex(df["ym"], freq="M")
+    df["q"] = df["per"].dt.quarter
+    df["miq"] = ((df["per"].dt.month - 1) % 3) + 1  # month-in-quarter 1..3
+
+    tot = df["u"].sum()
+    print("=== Forme saisonnière par TRIMESTRE (part du volume total) ===")
+    for q, u in df.groupby("q")["u"].sum().items():
+        print(f"   Q{q}: {u/tot:6.1%}  {'#' * int(u/tot*120)}")
+    print("\n=== Concentration MOIS-DANS-LE-TRIMESTRE (effet fin-de-trimestre / buy) ===")
+    for m, u in df.groupby("miq")["u"].sum().items():
+        print(f"   mois {m} du trimestre: {u/tot:6.1%}  {'#' * int(u/tot*120)}")
+
+    # quarterly backtest per top group (hold out last 4 quarters)
+    df["qper"] = df["per"].dt.asfreq("Q")
+    qidx = pd.period_range(df["qper"].min(), df["qper"].max(), freq="Q")
+    top = df.groupby("grp")["u"].sum().sort_values(ascending=False).head(args.top).index
+    print(f"\n=== Précision au TRIMESTRE (hold-out 4 derniers Q) — {qidx.min()}→{qidx.max()} ===")
+    print(f"{'group':9s} {'quarterly WMAPE':>16s}")
+    print("-" * 28)
+    num = den = 0.0
+    for g in top:
+        s = df[df["grp"] == g].groupby("qper")["u"].sum().reindex(qidx, fill_value=0.0)
+        if len(s) < 12:
+            continue
+        train, test = s.iloc[:-4].values, s.iloc[-4:].values
+        pred = snaive(train, 4, 4)
+        d = np.abs(test).sum()
+        w = np.abs(test - pred).sum() / d if d else float("nan")
+        print(f"{g:9s} {w:>15.1%}")
+        num += np.abs(test - pred).sum()
+        den += d
+    print("-" * 28)
+    print(f"{'OVERALL':9s} {num/den:>15.1%}   (rappel mensuel ~37-39%)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/forecast_reconcile_poc.py
+++ b/scripts/forecast_reconcile_poc.py
@@ -1,0 +1,139 @@
+"""
+forecast_reconcile_poc.py — does middle-out beat bottom-up? (Pyramide axis A).
+
+Tests the core thesis of the Pyramide forecasting design on real demand_history:
+forecasting at the clean AGGREGATE level (gen_group) and disaggregating to SKUs
+via historical share beats forecasting each noisy SKU series directly.
+
+For each top gen_group, holds out the last 12 months and compares SKU-level
+accuracy of:
+  - BOTTOM-UP : seasonal-naive per SKU, summed.
+  - MIDDLE-OUT: seasonal-naive on the GROUP total, split to SKUs by their
+                training-period share.
+
+Pure numpy/pandas, read-only.
+
+Usage:
+    DATABASE_URL=... python scripts/forecast_reconcile_poc.py --top 5
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import psycopg
+
+H = "product_local_gen"
+
+TOP_GROUPS_SQL = """
+SELECT grp.code, grp.description, SUM(dh.ordered_quantity) AS u
+FROM demand_history dh
+JOIN item_hierarchy ih ON ih.item_id = dh.item_id AND ih.hierarchy_id = %(h)s
+JOIN hierarchy_node prod ON prod.hierarchy_id = %(h)s AND prod.code = ih.leaf_code
+JOIN hierarchy_node grp  ON grp.hierarchy_id = %(h)s  AND grp.code = prod.parent_code
+WHERE dh.stream = 'regular' AND dh.booked_date IS NOT NULL
+GROUP BY 1, 2 ORDER BY u DESC LIMIT %(n)s
+"""
+
+SKU_SERIES_SQL = """
+SELECT dh.item_id::text AS sku, to_char(dh.booked_date, 'YYYY-MM') AS ym,
+       SUM(dh.ordered_quantity) AS u
+FROM demand_history dh
+JOIN item_hierarchy ih ON ih.item_id = dh.item_id AND ih.hierarchy_id = %(h)s
+JOIN hierarchy_node prod ON prod.hierarchy_id = %(h)s AND prod.code = ih.leaf_code
+JOIN hierarchy_node grp  ON grp.hierarchy_id = %(h)s  AND grp.code = prod.parent_code
+WHERE dh.stream = 'regular' AND dh.booked_date IS NOT NULL AND grp.code = %(g)s
+GROUP BY 1, 2
+"""
+
+
+def seasonal_naive(vals: np.ndarray, horizon: int) -> np.ndarray:
+    vals = vals.astype(float)
+    if len(vals) < 24:
+        last12 = vals[-12:] if len(vals) >= 12 else np.pad(vals, (12 - len(vals), 0))
+        return np.array([last12[i % 12] for i in range(horizon)])
+    recent, prior = vals[-12:].sum(), vals[-24:-12].sum()
+    trend = float(np.clip((recent / prior) if prior > 0 else 1.0, 0.5, 2.0))
+    last12 = vals[-12:]
+    return np.array([last12[i % 12] * trend for i in range(horizon)])
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    p.add_argument("--top", type=int, default=5)
+    args = p.parse_args(argv)
+    if not args.dsn:
+        print("ERROR: set DATABASE_URL", file=sys.stderr)
+        return 2
+
+    with psycopg.connect(args.dsn) as conn:
+        conn.execute("SET default_transaction_read_only = on")
+        conn.execute("SET statement_timeout = '180s'")
+        groups = conn.execute(TOP_GROUPS_SQL, {"h": H, "n": args.top}).fetchall()
+
+        print(f"{'group':9s} {'description':24s} {'#SKU':>5s} "
+              f"{'bottom-up':>9s} {'mid-flat':>9s} {'mid-seasonal':>11s} {'best':>13s}")
+        print("-" * 86)
+        agg_bu = agg_mo = agg_ms = agg_act = 0.0
+        for code, desc, _ in groups:
+            rows = conn.execute(SKU_SERIES_SQL, {"h": H, "g": code}).fetchall()
+            df = pd.DataFrame(rows, columns=["sku", "ym", "u"])
+            df["u"] = df["u"].astype(float)
+            df["period"] = pd.PeriodIndex(df["ym"], freq="M")
+            idx = pd.period_range(df["period"].min(), df["period"].max(), freq="M")
+            if len(idx) < 30:
+                continue
+            mat = (df.pivot_table(index="sku", columns="period", values="u", aggfunc="sum")
+                     .reindex(columns=idx, fill_value=0.0).fillna(0.0))
+            train = mat.iloc[:, :-12]
+            test = mat.iloc[:, -12:].values  # (n_sku, 12)
+
+            # BOTTOM-UP: seasonal naive per SKU
+            bu = np.vstack([seasonal_naive(train.iloc[i].values, 12) for i in range(len(train))])
+
+            # MIDDLE-OUT (flat share): forecast the GROUP total, split by total share
+            grp_train = train.values.sum(axis=0)
+            grp_fc = seasonal_naive(grp_train, 12)            # (12,)
+            sku_tot = train.values.sum(axis=1)
+            share = sku_tot / sku_tot.sum() if sku_tot.sum() > 0 else np.zeros_like(sku_tot)
+            mo = share[:, None] * grp_fc[None, :]             # (n_sku, 12)
+
+            # MIDDLE-OUT (seasonal share): each SKU's share varies by calendar month
+            # share_seasonal[sku, c] = SKU's fraction of the group in calendar month c.
+            cal = np.array([per.month for per in train.columns])      # 1..12 per train col
+            fc_months = [per.month for per in idx[-12:]]              # calendar months of the 12 fc periods
+            mo_s = np.zeros_like(mo)
+            for j, c in enumerate(fc_months):
+                cols = cal == c
+                grp_c = train.values[:, cols].sum()
+                if grp_c > 0:
+                    share_c = train.values[:, cols].sum(axis=1) / grp_c
+                else:
+                    share_c = share
+                mo_s[:, j] = share_c * grp_fc[j]
+
+            denom = np.abs(test).sum()
+            wmape_bu = np.abs(test - bu).sum() / denom if denom else float("nan")
+            wmape_mo = np.abs(test - mo).sum() / denom if denom else float("nan")
+            wmape_ms = np.abs(test - mo_s).sum() / denom if denom else float("nan")
+            best = min([("bottom-up", wmape_bu), ("mid-flat", wmape_mo), ("mid-seasonal", wmape_ms)], key=lambda x: x[1])[0]
+            print(f"{code:9s} {str(desc)[:24]:24s} {len(mat):>5d} "
+                  f"{wmape_bu:>9.1%} {wmape_mo:>9.1%} {wmape_ms:>11.1%} {best:>13s}")
+            agg_bu += np.abs(test - bu).sum()
+            agg_mo += np.abs(test - mo).sum()
+            agg_ms += np.abs(test - mo_s).sum()
+            agg_act += denom
+
+        print("-" * 86)
+        best_overall = min([("bottom-up", agg_bu), ("mid-flat", agg_mo), ("mid-seasonal", agg_ms)], key=lambda x: x[1])[0]
+        print(f"{'OVERALL (SKU-level WMAPE)':30s} "
+              f"{agg_bu/agg_act:>9.1%} {agg_mo/agg_act:>9.1%} {agg_ms/agg_act:>11.1%} {best_overall:>13s}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ingest_demand_history.py
+++ b/scripts/ingest_demand_history.py
@@ -1,0 +1,206 @@
+"""
+ingest_demand_history.py — the demand-facts import path (Pyramide D5/D6).
+
+Streams the raw ERP sales export (SALES_MARINE.full.tsv) and turns each line into
+a demand-history fact, applying the LOCKED business rules:
+  - LINE_TYPE classification (data/demand/line_type_classification.tsv): only
+    `in_demand=yes` classes count; the rest (invoice-only, no-bill, non-warranty
+    service, internal, returns) are dropped from demand.
+  - SIGN RULE: demand = POSITIVE ORDERED_QUANTITY only. Negatives are returns and
+    are NEVER netted into demand.
+  - Two streams: REGULAR vs WARRANTY (warranty forecast separately; value-excluded).
+  - Value/ASP: sum LINE_AMOUNT_EXT only when `in_asp=yes`.
+  - Booking series keys on BOOKED_DATE (forecast-on-booking rule).
+  - Per-site dimensions: SHIP_STATE (demand geo) + WAREHOUSE_ID (fulfilling DC).
+
+Modes:
+  --preview (default): aggregate in-memory and print the demand series, NO DB write.
+  --load:   resolve item_code -> items.item_id and COPY qualifying rows into
+            demand_history (bounded by --since for safety). Idempotent: deletes the
+            loaded window first, so re-runs replace it cleanly.
+
+Usage:
+    python scripts/ingest_demand_history.py --load --since 2025-06-01
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections import defaultdict
+from datetime import date
+from pathlib import Path
+
+# SALES_MARINE column indices (0-based).
+C_SHIP_DATE, C_BOOKED, C_ITEM, C_AMOUNT = 0, 1, 3, 5
+C_LINE_ID, C_LINE_TYPE, C_ORDER_TYPE, C_ORDER_NUM, C_QTY = 9, 12, 17, 14, 19
+C_ORG, C_COUNTRY, C_CHANNEL, C_STATE = 20, 23, 27, 28
+C_WAREHOUSE, C_FULFILLED = 35, 51
+
+DH_COLS = (
+    "item_id", "item_code", "stream", "booked_date", "shipment_date",
+    "ordered_quantity", "fulfilled_quantity", "value_ext", "counts_for_asp",
+    "ship_state", "ship_country", "warehouse_id", "channel", "fulfillment",
+    "order_number", "line_id", "org_id", "order_type",
+)
+
+
+def load_classification(path: Path) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    with open(path, encoding="utf-8") as f:
+        header = None
+        for line in f:
+            if line.startswith("#") or not line.strip():
+                continue
+            parts = line.rstrip("\n").split("\t")
+            if header is None:
+                header = parts
+                continue
+            row = dict(zip(header, parts))
+            out[row["line_type"]] = {
+                "in_demand": row["in_demand"] == "yes",
+                "in_asp": row["in_asp"] == "yes",
+                "stream": row["forecast_stream"],
+                "fulfillment": row["fulfillment"],
+            }
+    return out
+
+
+def _g(r: list[str], i: int) -> str:
+    """Safe field getter (handles trailing-empty truncation)."""
+    return r[i] if i < len(r) else ""
+
+
+def _d(s: str):
+    try:
+        return date.fromisoformat(s[:10])
+    except (ValueError, TypeError):
+        return None
+
+
+def _f(s: str):
+    try:
+        return float(s)
+    except (ValueError, TypeError):
+        return None
+
+
+def iter_demand_rows(sales: Path, cls: dict, since: str | None):
+    """Yield qualifying demand facts as dicts. Applies all locked rules."""
+    with open(sales, encoding="utf-8-sig") as f:
+        next(f)  # header
+        for line in f:
+            r = line.rstrip("\n").split("\t")
+            lt = _g(r, C_LINE_TYPE)
+            rule = cls.get(lt)
+            if rule is None or not rule["in_demand"]:
+                continue
+            qty = _f(_g(r, C_QTY))
+            if qty is None or qty <= 0:        # sign rule: positives only
+                continue
+            booked = _g(r, C_BOOKED)[:10]
+            if since and booked < since:
+                continue
+            in_asp = rule["in_asp"]
+            amt = _f(_g(r, C_AMOUNT)) or 0.0
+            yield {
+                "item_code": _g(r, C_ITEM),
+                "stream": rule["stream"],
+                "booked_date": booked,
+                "shipment_date": _g(r, C_SHIP_DATE)[:10],
+                "ordered_quantity": qty,
+                "fulfilled_quantity": _f(_g(r, C_FULFILLED)),
+                "value_ext": amt if in_asp else 0.0,
+                "counts_for_asp": in_asp,
+                "ship_state": _g(r, C_STATE) or None,
+                "ship_country": _g(r, C_COUNTRY) or None,
+                "warehouse_id": _g(r, C_WAREHOUSE) or None,
+                "channel": _g(r, C_CHANNEL) or None,
+                "fulfillment": rule["fulfillment"],
+                "order_number": _g(r, C_ORDER_NUM) or None,
+                "line_id": _g(r, C_LINE_ID) or None,
+                "org_id": _g(r, C_ORG) or None,
+                "order_type": _g(r, C_ORDER_TYPE) or None,
+            }
+
+
+def do_load(dsn: str, sales: Path, cls: dict, since: str) -> None:
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        conn.execute("SET statement_timeout = '600s'")
+        ext2id = {
+            row[1]: row[0]
+            for row in conn.execute(
+                "SELECT item_id, external_id FROM items WHERE external_id IS NOT NULL"
+            ).fetchall()
+        }
+        # idempotent: clear the window we're about to (re)load
+        deleted = conn.execute(
+            "DELETE FROM demand_history WHERE booked_date >= %s", (since,)
+        ).rowcount
+        print(f"[load] cleared {deleted} existing rows in window >= {since}")
+
+        n = unresolved = 0
+        with conn.cursor() as cur:
+            with cur.copy(
+                f"COPY demand_history ({', '.join(DH_COLS)}) FROM STDIN"
+            ) as cp:
+                for d in iter_demand_rows(sales, cls, since):
+                    iid = ext2id.get(d["item_code"])
+                    if iid is None:
+                        unresolved += 1
+                    cp.write_row((
+                        iid, d["item_code"], d["stream"],
+                        _d(d["booked_date"]), _d(d["shipment_date"]),
+                        d["ordered_quantity"], d["fulfilled_quantity"],
+                        d["value_ext"], d["counts_for_asp"],
+                        d["ship_state"], d["ship_country"], d["warehouse_id"],
+                        d["channel"], d["fulfillment"], d["order_number"], d["line_id"],
+                        d["org_id"], d["order_type"],
+                    ))
+                    n += 1
+        conn.commit()
+        print(f"[load] inserted {n:,} demand_history rows "
+              f"(unresolved item_id={unresolved:,}) since {since}")
+
+
+def do_preview(sales: Path, cls: dict, since: str | None) -> None:
+    by_stream_u: dict[str, float] = defaultdict(float)
+    by_month: dict[str, float] = defaultdict(float)
+    n = 0
+    for d in iter_demand_rows(sales, cls, since):
+        by_stream_u[d["stream"]] += d["ordered_quantity"]
+        by_month[d["booked_date"][:7]] += d["ordered_quantity"]
+        n += 1
+    print(f"[preview] {n:,} demand rows" + (f" since {since}" if since else ""))
+    for s in sorted(by_stream_u, key=lambda x: -by_stream_u[x]):
+        print(f"   {s:10s} units={by_stream_u[s]:>14,.0f}")
+    for m, u in sorted(by_month.items())[-14:]:
+        print(f"   {m}  {u:>12,.0f}")
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--sales", default="Raw Data/SALES_MARINE.full.tsv")
+    p.add_argument("--classification", default="data/demand/line_type_classification.tsv")
+    p.add_argument("--load", action="store_true", help="write to demand_history (else preview)")
+    p.add_argument("--since", default="2025-06-01", help="only booked_date >= this (YYYY-MM-DD)")
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    args = p.parse_args(argv)
+
+    cls = load_classification(Path(args.classification))
+    print(f"[classification] {len(cls)} LINE_TYPE rules loaded")
+
+    if args.load:
+        if not args.dsn:
+            print("ERROR: set DATABASE_URL for --load", file=sys.stderr)
+            return 2
+        do_load(args.dsn, Path(args.sales), cls, args.since)
+    else:
+        do_preview(Path(args.sales), cls, args.since)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ingest_tdtk.py
+++ b/scripts/ingest_tdtk.py
@@ -1,0 +1,170 @@
+"""
+ingest_tdtk.py — load the T_DTK item master into the demand foundation.
+
+Populates, idempotently (safe to re-run):
+  - items.item_cost  <- T_DTK.CDS  (the single at-cost basis; business name CDS)
+  - hierarchy + hierarchy_node + item_hierarchy for the TWO product hierarchies:
+      * product_local_gen  : GEN_FAM > GEN_GROUP > GEN_PROD  (native codes, is_default)
+      * product_corp_oracle: ORACLE_SECTOR > SOLUTION > CATEGORY > FAMILY > LINE
+        (labels — coded as the cumulative ">"-joined PATH, because corporate labels
+         repeat across levels and would collide on a raw-label PK)
+
+Read-only on items identity (resolves external_id -> item_id); writes item_cost,
+hierarchy_node, item_hierarchy. Wrapped in one transaction with a server-side
+statement_timeout.
+
+Usage:
+    DATABASE_URL=postgresql://ootils:ootils@host:5432/ootils_pilote_test \
+        python scripts/ingest_tdtk.py
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import psycopg
+
+# T_DTK column indices (0-based)
+C_ITEM, C_CDS = 0, 27
+C_GEN = {"fam": (9, 10), "group": (11, 12), "prod": (13, 14)}  # (code, desc)
+C_ORA = [50, 51, 52, 53, 54]  # sector, solution, category, family, line
+ORA_LEVELS = ["sector", "solution", "category", "family", "line"]
+
+H_LOCAL = "product_local_gen"
+H_CORP = "product_corp_oracle"
+
+
+def parse_tdtk(path: Path):
+    nodes: dict[str, dict[str, tuple]] = {H_LOCAL: {}, H_CORP: {}}  # code -> (level, desc, parent)
+    item_leaf: list[tuple[str, str, str]] = []  # (external_id, hierarchy_id, leaf_code)
+    costs: list[tuple[str, float]] = []
+    n = 0
+    with open(path, encoding="utf-8-sig") as f:
+        next(f)  # header
+        for line in f:
+            r = line.rstrip("\n").split("\t")
+            if len(r) <= C_ORA[-1]:
+                continue
+            n += 1
+            ext = r[C_ITEM].strip()
+            if not ext:
+                continue
+
+            # item_cost (CDS) — keep even 0 (a real $0 cost); skip blank
+            cds = r[C_CDS].strip()
+            if cds != "":
+                try:
+                    costs.append((ext, float(cds)))
+                except ValueError:
+                    pass
+
+            # local GEN hierarchy (native codes)
+            gf, gfd = r[C_GEN["fam"][0]].strip(), r[C_GEN["fam"][1]].strip()
+            gg, ggd = r[C_GEN["group"][0]].strip(), r[C_GEN["group"][1]].strip()
+            gp, gpd = r[C_GEN["prod"][0]].strip(), r[C_GEN["prod"][1]].strip()
+            if gf and gg and gp:
+                nodes[H_LOCAL].setdefault(gf, ("family", gfd, None))
+                nodes[H_LOCAL].setdefault(gg, ("group", ggd, gf))
+                nodes[H_LOCAL].setdefault(gp, ("product", gpd, gg))
+                item_leaf.append((ext, H_LOCAL, gp))
+
+            # corporate ORACLE hierarchy (labels -> cumulative PATH codes)
+            labels = [r[i].strip() for i in C_ORA]
+            if all(labels):
+                path = ""
+                parent = None
+                for lvl, lbl in zip(ORA_LEVELS, labels):
+                    path = lbl if not path else f"{path}>{lbl}"
+                    nodes[H_CORP].setdefault(path, (lvl, lbl, parent))
+                    parent = path
+                item_leaf.append((ext, H_CORP, path))  # leaf = full 5-level path
+    return nodes, item_leaf, costs, n
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    p.add_argument("--tdtk", default="Raw Data/T_DTK.full.tsv")
+    args = p.parse_args(argv)
+    if not args.dsn:
+        print("ERROR: set DATABASE_URL", file=sys.stderr)
+        return 2
+
+    nodes, item_leaf, costs, n = parse_tdtk(Path(args.tdtk))
+    print(f"[parse] {n} T_DTK rows | local nodes={len(nodes[H_LOCAL])} "
+          f"corp nodes={len(nodes[H_CORP])} | item-leaf links={len(item_leaf)} "
+          f"| item_cost rows={len(costs)}")
+
+    with psycopg.connect(args.dsn) as conn:
+        conn.execute("SET statement_timeout = '180s'")
+
+        # 1. hierarchy registry
+        conn.execute(
+            "INSERT INTO hierarchy (hierarchy_id, domain, scope, label, levels, is_default) "
+            "VALUES (%s,'product','local','Local product (GEN)', %s, true), "
+            "       (%s,'product','corporate','Corporate product (Oracle)', %s, false) "
+            "ON CONFLICT (hierarchy_id) DO NOTHING",
+            (H_LOCAL, ["family", "group", "product"], H_CORP, ORA_LEVELS),
+        )
+
+        # 2. hierarchy_node (bulk per hierarchy, idempotent)
+        for hid, nd in nodes.items():
+            codes = list(nd.keys())
+            levels = [nd[c][0] for c in codes]
+            descs = [nd[c][1] for c in codes]
+            parents = [nd[c][2] for c in codes]
+            conn.execute(
+                "INSERT INTO hierarchy_node (hierarchy_id, code, level, description, parent_code) "
+                "SELECT %s, c, l, d, p FROM UNNEST(%s::text[], %s::text[], %s::text[], %s::text[]) "
+                "  AS t(c, l, d, p) "
+                "ON CONFLICT (hierarchy_id, code) DO UPDATE "
+                "  SET description=EXCLUDED.description, level=EXCLUDED.level, parent_code=EXCLUDED.parent_code",
+                (hid, codes, levels, descs, parents),
+            )
+
+        # 3. resolve external_id -> item_id
+        ext2id = {
+            row[1]: row[0]
+            for row in conn.execute("SELECT item_id, external_id FROM items WHERE external_id IS NOT NULL").fetchall()
+        }
+
+        # 4. item_cost (CDS) bulk update
+        ce = [e for e, _ in costs if e in ext2id]
+        cv = [c for e, c in costs if e in ext2id]
+        conn.execute(
+            "UPDATE items i SET item_cost = d.cost, updated_at = now() "
+            "FROM (SELECT * FROM UNNEST(%s::text[], %s::numeric[]) AS t(ext, cost)) d "
+            "WHERE i.external_id = d.ext",
+            (ce, cv),
+        )
+        n_cost = len(ce)
+
+        # 5. item_hierarchy links (resolve to item_id; skip unresolved)
+        iid, hids, leaves = [], [], []
+        n_unresolved = 0
+        for ext, hid, leaf in item_leaf:
+            uid = ext2id.get(ext)
+            if uid is None:
+                n_unresolved += 1
+                continue
+            iid.append(uid)
+            hids.append(hid)
+            leaves.append(leaf)
+        conn.execute(
+            "INSERT INTO item_hierarchy (item_id, hierarchy_id, leaf_code) "
+            "SELECT * FROM UNNEST(%s::uuid[], %s::text[], %s::text[]) "
+            "ON CONFLICT (item_id, hierarchy_id) DO UPDATE SET leaf_code=EXCLUDED.leaf_code",
+            (iid, hids, leaves),
+        )
+
+        conn.commit()
+
+    print(f"[load] item_cost set={n_cost} | item_hierarchy links={len(iid)} "
+          f"(unresolved item codes skipped={n_unresolved})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ootils_core/db/migrations/047_demand_foundation.sql
+++ b/src/ootils_core/db/migrations/047_demand_foundation.sql
@@ -1,0 +1,301 @@
+-- ============================================================
+-- Migration 047 — Demand module foundation (Pyramide — D1)
+-- ============================================================
+-- Builds the three-layer demand master needed before any Pyramide
+-- forecast run can produce reconcilable, hierarchy-aware output.
+--
+-- Why one migration?  All four DDL blocks form a single referential
+-- closure: demand_history.item_id → items, item_hierarchy →
+-- hierarchy_node → hierarchy.  A partial apply would leave a schema
+-- that either has orphaned FKs or a half-usable demand_history table.
+-- Rolling back is clean because every object is new (no mutation of
+-- existing production tables, except the additive item_cost column).
+--
+-- Business context
+-- ----------------
+-- Ootils tracks BOOKING events, not shipments, as the demand signal
+-- (rule locked in memory/demand-business-rule-booking.md).  The pool
+-- business has three streams: regular (booked → forecast driver),
+-- warranty (after-sales, separate forecast), and interco/dropship
+-- (excluded from external ASP).  Per-DC granularity in demand_history
+-- drives DRP site-level netting; the central MRP consumes the rolled-up
+-- signal (ADR-020).
+--
+-- Objects created
+-- ---------------
+--   hierarchy           — registry of named hierarchies (product-local,
+--                         product-corporate, region-climate, channel …)
+--   hierarchy_node      — nodes (any depth) within a hierarchy
+--   item_hierarchy      — leaf membership: which node each item sits in
+--                         for each hierarchy
+--   items.item_cost     — at-cost basis column (CDS, source T_DTK.CDS);
+--                         distinct from the BOM-rollup items.standard_cost
+--                         added in migration 042
+--   demand_history      — granular booking/shipping facts after
+--                         classification and sign-rule application
+--
+-- No JSONB used.  All columns are typed; CHECK constraints are applied
+-- on the enum-like columns following the project convention
+-- (cf. migrations 017, 044, 045).
+-- ============================================================
+
+BEGIN;
+
+-- ============================================================
+-- 1. HIERARCHY REGISTRY
+-- ============================================================
+-- Supports multiple coexisting hierarchies for the same domain
+-- (e.g. product/local from the ERP, product/corporate from Oracle BI).
+-- is_default marks the hierarchy used by default for Pyramide
+-- reconciliation within its domain (should be the local one per
+-- the Pyramide design: reconciliation drives down to the ERP leaf).
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS hierarchy (
+    hierarchy_id  TEXT        NOT NULL PRIMARY KEY,
+    -- Expected: 'product' | 'region' | 'channel' | 'customer'
+    -- Left permissive (TEXT + CHECK) so new domains can be added via
+    -- migration without an ALTER TABLE on the enum type.
+    domain        TEXT        NOT NULL
+                  CHECK (domain IN ('product', 'region', 'channel', 'customer')),
+    -- Expected: 'local' | 'corporate'
+    scope         TEXT        NOT NULL
+                  CHECK (scope IN ('local', 'corporate')),
+    label         TEXT,
+    -- Ordered level names, e.g. local product: '{family,group,product}'
+    -- corporate product: '{sector,solution,category,family,line}'
+    levels        TEXT[]      NOT NULL,
+    -- TRUE for the hierarchy used by default for forecast/reconciliation
+    -- in this domain.  Enforced at application layer; DB allows multiple
+    -- (no unique constraint) to avoid a partial-unique maintenance trap
+    -- during hierarchy migrations.
+    is_default    BOOLEAN     NOT NULL DEFAULT false,
+    notes         TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE hierarchy IS
+    'Registry of named item/region/channel hierarchies. Multiple hierarchies '
+    'can coexist for the same domain (local ERP vs corporate BI). The '
+    'is_default flag identifies the one used for Pyramide reconciliation.';
+
+COMMENT ON COLUMN hierarchy.levels IS
+    'Ordered level names from root to leaf, e.g. ''{family,group,product}'' '
+    'for the local product hierarchy.';
+
+COMMENT ON COLUMN hierarchy.is_default IS
+    'Marks the default reconciliation hierarchy for this domain. Multiple '
+    'rows may have is_default=true (e.g. one per domain); enforced at the '
+    'application layer.';
+
+-- ============================================================
+-- 2. HIERARCHY NODES
+-- ============================================================
+-- Stores every node at every level of a hierarchy.
+-- parent_code is NULL at the root.  We deliberately avoid a strict
+-- self-referential FK on (hierarchy_id, parent_code) to keep bulk
+-- inserts order-independent during ERP sync — the application layer
+-- validates parent existence.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS hierarchy_node (
+    hierarchy_id  TEXT        NOT NULL REFERENCES hierarchy(hierarchy_id) ON DELETE RESTRICT,
+    code          TEXT        NOT NULL,
+    level         TEXT        NOT NULL,
+    description   TEXT,
+    -- NULL at root; no self-referential FK (see comment above)
+    parent_code   TEXT,
+
+    PRIMARY KEY (hierarchy_id, code)
+);
+
+COMMENT ON TABLE hierarchy_node IS
+    'Nodes (at any depth) within a named hierarchy. parent_code is NULL '
+    'at the root. No self-referential FK: bulk ERP syncs insert children '
+    'before parents in some extract orderings.';
+
+COMMENT ON COLUMN hierarchy_node.parent_code IS
+    'Code of the parent node within the same hierarchy. NULL = root. '
+    'No DB FK constraint (insert-order-independent); validated at the '
+    'application layer.';
+
+-- Index to navigate upward/sideways: "give me all children of node X"
+CREATE INDEX IF NOT EXISTS idx_hierarchy_node_parent
+    ON hierarchy_node (hierarchy_id, parent_code);
+
+-- Index on level to support "all nodes at level family in hierarchy X"
+CREATE INDEX IF NOT EXISTS idx_hierarchy_node_level
+    ON hierarchy_node (hierarchy_id, level);
+
+-- ============================================================
+-- 3. ITEM → HIERARCHY LEAF MEMBERSHIP
+-- ============================================================
+-- One row per (item, hierarchy): the leaf node to which this item
+-- belongs.  An item may belong to several hierarchies simultaneously
+-- (product-local, product-corporate, region-climate, channel …).
+--
+-- FK on (hierarchy_id, leaf_code) enforces that the leaf actually
+-- exists in the hierarchy.  ON DELETE RESTRICT on items: an item
+-- referenced in demand history must not vanish silently.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS item_hierarchy (
+    item_id       UUID        NOT NULL REFERENCES items(item_id) ON DELETE RESTRICT,
+    hierarchy_id  TEXT        NOT NULL,
+    leaf_code     TEXT        NOT NULL,
+
+    PRIMARY KEY (item_id, hierarchy_id),
+    FOREIGN KEY (hierarchy_id, leaf_code)
+        REFERENCES hierarchy_node (hierarchy_id, code)
+        ON DELETE RESTRICT
+);
+
+COMMENT ON TABLE item_hierarchy IS
+    'Leaf membership of each item in each hierarchy. One row per '
+    '(item, hierarchy). Supports multiple simultaneous hierarchies '
+    '(local product, corporate product, channel …).';
+
+-- Supports "which items sit under leaf X / hierarchy Y" (Pyramide
+-- top-down allocation and middle-out reconciliation)
+CREATE INDEX IF NOT EXISTS idx_item_hierarchy_leaf
+    ON item_hierarchy (hierarchy_id, leaf_code);
+
+-- ============================================================
+-- 4. ITEM AT-COST BASIS (CDS)
+-- ============================================================
+-- item_cost is the SINGLE at-cost value used for ALL demand-module
+-- calculations (ASP, E&O valuation, demand-value aggregation).
+-- Business name: CDS.  Source: T_DTK.CDS in the ERP.
+--
+-- This is DISTINCT from items.standard_cost (migration 042), which
+-- is the BOM-rollup / supplier-fallback used by the supply/MRP side.
+-- The two columns coexist intentionally: demand-side valuation and
+-- supply-side costing differ in scope and update cadence.
+-- ============================================================
+
+ALTER TABLE items ADD COLUMN IF NOT EXISTS item_cost NUMERIC;
+
+COMMENT ON COLUMN items.item_cost IS
+    'Item at-cost basis — single cost used for demand-module calculations '
+    '(ASP, E&O valuation, demand-value aggregation). Business name: CDS. '
+    'Source: T_DTK.CDS. Distinct from items.standard_cost (migration 042, '
+    'BOM roll-up / supply-side costing).';
+
+-- ============================================================
+-- 5. DEMAND HISTORY
+-- ============================================================
+-- Granular booking and shipping facts, loaded from SALES_MARINE
+-- (or equivalent ERP extract) after classification and sign-rule
+-- application (positives only at ingestion time; returns are a
+-- separate stream at a higher layer).
+--
+-- Design notes:
+-- - item_id is NULLABLE: a row whose item code has not yet been
+--   resolved to an items.item_id may still be stored for audit and
+--   deferred resolution (item_code preserves the source key).
+-- - booked_date drives the forecast signal (forecast-on-booking rule).
+--   shipment_date is stored for shipping-series analytics only.
+-- - warehouse_id (TEXT, not FK to locations) stores the DC identifier
+--   as it arrives from the ERP.  Resolution to a locations.location_id
+--   happens at the DRP layer, not at ingestion.
+-- - value_ext = 0 for flows that are excluded from ASP computation
+--   (warranty, interco, dropship); counts_for_asp is the explicit flag.
+-- - fulfillment drives DRP routing: 'standard' = via DC, 'direct' =
+--   customer-direct, 'inter_entity' = interco flow.
+-- - bigserial PK: demand_history is an append-only fact table; UUID
+--   PKs add 8 bytes per row overhead for no join benefit here.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS demand_history (
+    id                BIGSERIAL   NOT NULL PRIMARY KEY,
+
+    -- Item resolution
+    -- item_id is nullable: unresolved codes land here for deferred linking
+    item_id           UUID        REFERENCES items(item_id) ON DELETE RESTRICT,
+    item_code         TEXT        NOT NULL,
+
+    -- Demand stream
+    -- 'regular': standard customer bookings (main forecast driver)
+    -- 'warranty': after-sales / warranty replacements (separate forecast)
+    stream            TEXT        NOT NULL
+                      CHECK (stream IN ('regular', 'warranty')),
+
+    -- Temporal axes
+    booked_date       DATE,       -- booking date — primary forecast signal
+    shipment_date     DATE,       -- actual or promised ship date
+
+    -- Quantities
+    ordered_quantity  NUMERIC,    -- booked demand; positive only at ingestion
+    fulfilled_quantity NUMERIC,   -- shipped qty (shipping series)
+
+    -- Value / ASP
+    value_ext         NUMERIC,    -- extended value ($); 0 if excluded from ASP
+    counts_for_asp    BOOLEAN     NOT NULL DEFAULT false,
+
+    -- Geography
+    ship_state        TEXT,
+    ship_country      TEXT,
+
+    -- Distribution routing
+    -- warehouse_id: DC identifier from the ERP; resolved to
+    -- locations.location_id at the DRP layer, not at ingestion.
+    warehouse_id      TEXT,
+
+    -- Sales channel
+    channel           TEXT,
+
+    -- Fulfillment routing (drives DRP netting path)
+    -- 'standard'     = fulfilled via DC stock
+    -- 'direct'       = customer-direct (bypasses DC)
+    -- 'inter_entity' = intercompany / interco flow
+    fulfillment       TEXT
+                      CHECK (fulfillment IN ('standard', 'direct', 'inter_entity')),
+
+    -- ERP traceability
+    order_number      TEXT,
+    line_id           TEXT,
+
+    -- Audit
+    ingested_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE demand_history IS
+    'Granular demand facts (bookings + shipments) loaded from SALES_MARINE '
+    'after classification and sign-rule application. Append-only at '
+    'ingestion; returns/corrections are a separate adjustment stream. '
+    'Primary forecast signal is booked_date (forecast-on-booking rule).';
+
+COMMENT ON COLUMN demand_history.item_id IS
+    'Resolved items FK. NULLABLE: unresolved item codes land here for '
+    'deferred resolution. item_code always preserves the source ERP key.';
+
+COMMENT ON COLUMN demand_history.value_ext IS
+    'Extended booking value ($). Set to 0 for flows excluded from ASP '
+    '(warranty, interco, dropship). See counts_for_asp.';
+
+COMMENT ON COLUMN demand_history.warehouse_id IS
+    'DC identifier as received from the ERP extract (text key, not a FK). '
+    'Resolution to locations.location_id is done at the DRP layer.';
+
+COMMENT ON COLUMN demand_history.fulfillment IS
+    'DRP routing: standard = via DC, direct = customer-direct (bypasses DC '
+    'stock), inter_entity = intercompany flow excluded from external demand.';
+
+-- Hot-path: time-series aggregation by item (Pyramide bottom-up,
+-- DRP per-item netting, E&O coverage calculation)
+CREATE INDEX IF NOT EXISTS idx_demand_history_item_booked
+    ON demand_history (item_id, booked_date);
+
+-- Hot-path: per-DC demand aggregation for DRP site-level netting
+CREATE INDEX IF NOT EXISTS idx_demand_history_warehouse_booked
+    ON demand_history (warehouse_id, booked_date);
+
+-- Geographic aggregation (region-climate hierarchy, ASP by state)
+CREATE INDEX IF NOT EXISTS idx_demand_history_state_booked
+    ON demand_history (ship_state, booked_date);
+
+-- Stream filter: most analytical queries slice by stream first
+CREATE INDEX IF NOT EXISTS idx_demand_history_stream
+    ON demand_history (stream, booked_date);
+
+COMMIT;

--- a/src/ootils_core/db/migrations/048_demand_history_entity_program.sql
+++ b/src/ootils_core/db/migrations/048_demand_history_entity_program.sql
@@ -1,0 +1,43 @@
+-- ============================================================
+-- Migration 048 — demand_history: org_id (entity) + order_type (buy program)
+-- ============================================================
+-- Two additive, nullable columns on demand_history (no data change):
+--
+--   org_id     — operating company from the ERP (ORG_ID):
+--                'PPS' = USA (+ intl), 'PCC' = Canada. Canada is an
+--                independent end-market; the `CN *` line/order types are PCC.
+--                Needed to (a) forecast per company and (b) avoid the
+--                multi-entity double-count: intercompany PPS->PCC replenishes
+--                Canada, so the SAME demand appears as PCC end-customer demand
+--                AND as the interco order. End-demand forecast filters
+--                fulfillment != 'inter_entity'; the DRP generates interco as
+--                dependent demand. See memory/demand-business-rule-booking.
+--
+--   order_type — the ERP ORDER_TYPE, which carries the BUY PROGRAM
+--                (SPRING BUY / SUMMER BUY / EARLY BUY / CN EARLY BUY /
+--                LESLIES FWD BUY ...) alongside STANDARD VISTA etc. The buy
+--                programs ARE the aggregate seasonality; segmenting by program
+--                isolates clean, near-deterministic-timing signals.
+--
+-- Additive nullable columns: no backfill needed at DDL time (the re-ingest
+-- repopulates demand_history). Idempotent.
+-- ============================================================
+
+ALTER TABLE demand_history ADD COLUMN IF NOT EXISTS org_id     TEXT;
+ALTER TABLE demand_history ADD COLUMN IF NOT EXISTS order_type TEXT;
+
+COMMENT ON COLUMN demand_history.org_id IS
+    'Operating company (ERP ORG_ID): PPS = USA (+intl), PCC = Canada. '
+    'Forecast/DRP run per company. Canada end-demand vs PPS->PCC intercompany '
+    'must not be double-counted (see fulfillment=inter_entity).';
+
+COMMENT ON COLUMN demand_history.order_type IS
+    'ERP ORDER_TYPE — carries the buy program (SPRING/SUMMER/EARLY BUY, '
+    'FWD BUY, CN *) plus STANDARD VISTA etc. Buy programs drive the seasonality; '
+    'forecast segments by (org_id, buy program).';
+
+-- Common access paths: by company over time, and by order_type (program).
+CREATE INDEX IF NOT EXISTS idx_demand_history_org_booked
+    ON demand_history (org_id, booked_date);
+CREATE INDEX IF NOT EXISTS idx_demand_history_order_type
+    ON demand_history (order_type);


### PR DESCRIPTION
## Pyramide demand foundation + forecasting PoCs

- **feat(demand)**: the demand-facts foundation (migrations 047/048) — `hierarchy`/`hierarchy_node`/`item_hierarchy` (multi-hierarchy: local GEN + corporate ORACLE), `demand_history` (per company/buy-program/site/stream, booking+shipping, no-double-count interco), `items.item_cost` (CDS). Ingestion: T_DTK (item_cost + both product hierarchies) + SALES_MARINE → demand_history (LINE_TYPE classification + sign rule). **3.76M demand facts / 6 yr**.
- **chore(forecast)**: read-only forecasting PoCs establishing the landscape (middle-out wins; finer decomposition overfits; AutoETS plateaus ~37%; quarter→month is the right method). Not wired into the engine yet.

⚠️ Migrations 047/048 are already applied to the pilot DB. Raw ERP extracts are gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)