### PR TITLE
ASP + returns series (shipping-plan dependencies)

### DIFF
--- a/scripts/compute_asp.py
+++ b/scripts/compute_asp.py
@@ -1,0 +1,73 @@
+"""
+compute_asp.py — (re)compute the rolling-12-month ASP into item_asp.
+
+ASP = T12M SUM(value_ext) / SUM(ordered_quantity) over ASP-eligible demand
+(demand_history.counts_for_asp = TRUE), per (item, org). Full recompute,
+idempotent (DELETE + INSERT in one transaction). Run on the monthly cycle.
+
+Usage:
+    DATABASE_URL=... python scripts/compute_asp.py
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import psycopg
+
+RECOMPUTE_SQL = """
+INSERT INTO item_asp (item_id, org_id, asp, units_12m, value_12m, window_start, window_end, computed_at)
+SELECT dh.item_id,
+       dh.org_id,
+       ROUND(SUM(dh.value_ext) / NULLIF(SUM(dh.ordered_quantity), 0), 6) AS asp,
+       SUM(dh.ordered_quantity) AS units_12m,
+       SUM(dh.value_ext)        AS value_12m,
+       %(start)s::date          AS window_start,
+       %(end)s::date            AS window_end,
+       now()
+FROM demand_history dh
+WHERE dh.counts_for_asp = TRUE
+  AND dh.item_id IS NOT NULL
+  AND dh.booked_date >= %(start)s
+  AND dh.booked_date <= %(end)s
+GROUP BY dh.item_id, dh.org_id
+HAVING SUM(dh.ordered_quantity) > 0
+"""
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    p.add_argument("--months", type=int, default=12, help="trailing window length")
+    args = p.parse_args(argv)
+    if not args.dsn:
+        print("ERROR: set DATABASE_URL", file=sys.stderr)
+        return 2
+
+    with psycopg.connect(args.dsn) as conn:
+        conn.execute("SET statement_timeout = '180s'")
+        end = conn.execute("SELECT max(booked_date) FROM demand_history").fetchone()[0]
+        if end is None:
+            print("demand_history is empty — nothing to compute")
+            return 1
+        start = end.replace(year=end.year - 1) if args.months == 12 else end
+        # full recompute in one transaction
+        conn.execute("DELETE FROM item_asp")
+        cur = conn.execute(RECOMPUTE_SQL, {"start": start, "end": end})
+        n = cur.rowcount
+        conn.commit()
+        # quick summary
+        row = conn.execute(
+            "SELECT count(*), "
+            "percentile_cont(0.5) WITHIN GROUP (ORDER BY asp), "
+            "min(asp), max(asp) FROM item_asp WHERE org_id = 'PPS' AND asp > 0"
+        ).fetchone()
+    print(f"[asp] window {start} → {end} | {n:,} (item,org) ASP rows written")
+    print(f"[asp] PPS: {row[0]:,} priced items | median ASP=${float(row[1]):,.2f} "
+          f"| range ${float(row[2]):,.2f}–${float(row[3]):,.0f}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ingest_returns.py
+++ b/scripts/ingest_returns.py
@@ -1,0 +1,92 @@
+"""
+ingest_returns.py — load the returns series into returns_history.
+
+Returns = negative-quantity sales lines (the sign rule: never netted into demand).
+Streams SALES_MARINE, keeps qty < 0, stores POSITIVE magnitudes, resolves item_id.
+Idempotent (DELETE + reload). Read-only on the file.
+
+Usage:
+    DATABASE_URL=... python scripts/ingest_returns.py
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import date
+
+import psycopg
+
+C_BOOKED, C_ITEM, C_AMOUNT, C_LINE_TYPE = 1, 3, 5, 12
+C_QTY, C_ORG, C_COUNTRY, C_CHANNEL, C_STATE, C_WAREHOUSE = 19, 20, 23, 27, 28, 35
+
+COLS = ("item_id", "item_code", "org_id", "return_date", "return_quantity",
+        "return_value", "line_type", "warehouse_id", "ship_state", "channel")
+
+
+def _g(r, i):
+    return r[i] if i < len(r) else ""
+
+
+def _d(s):
+    try:
+        return date.fromisoformat(s[:10])
+    except (ValueError, TypeError):
+        return None
+
+
+def _f(s):
+    try:
+        return float(s)
+    except (ValueError, TypeError):
+        return None
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--sales", default="Raw Data/SALES_MARINE.full.tsv")
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    args = p.parse_args(argv)
+    if not args.dsn:
+        print("ERROR: set DATABASE_URL", file=sys.stderr)
+        return 2
+
+    with psycopg.connect(args.dsn) as conn:
+        conn.execute("SET statement_timeout = '600s'")
+        ext2id = {
+            row[1]: row[0]
+            for row in conn.execute(
+                "SELECT item_id, external_id FROM items WHERE external_id IS NOT NULL"
+            ).fetchall()
+        }
+        deleted = conn.execute("DELETE FROM returns_history").rowcount
+        print(f"[returns] cleared {deleted} existing rows")
+        n = unresolved = 0
+        with conn.cursor() as cur, cur.copy(
+            f"COPY returns_history ({', '.join(COLS)}) FROM STDIN"
+        ) as cp, open(args.sales, encoding="utf-8-sig") as f:
+            next(f)  # header
+            for line in f:
+                r = line.rstrip("\n").split("\t")
+                qty = _f(_g(r, C_QTY))
+                if qty is None or qty >= 0:        # returns only (negative qty)
+                    continue
+                code = _g(r, C_ITEM)
+                iid = ext2id.get(code)
+                if iid is None:
+                    unresolved += 1
+                amt = _f(_g(r, C_AMOUNT)) or 0.0
+                cp.write_row((
+                    iid, code, _g(r, C_ORG) or None, _d(_g(r, C_BOOKED)),
+                    abs(qty), abs(amt), _g(r, C_LINE_TYPE) or None,
+                    _g(r, C_WAREHOUSE) or None, _g(r, C_STATE) or None,
+                    _g(r, C_CHANNEL) or None,
+                ))
+                n += 1
+        conn.commit()
+    print(f"[returns] inserted {n:,} return rows (unresolved item_id={unresolved:,})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ootils_core/db/migrations/049_item_asp.sql
+++ b/src/ootils_core/db/migrations/049_item_asp.sql
@@ -1,0 +1,44 @@
+-- ============================================================
+-- Migration 049 — item_asp: derived Average Selling Price (rolling T12M)
+-- ============================================================
+-- ASP is a DERIVED metric, NOT a maintained static price:
+--   ASP = trailing-12-month SUM(value_ext) / SUM(ordered_quantity)
+--         over ASP-ELIGIBLE demand (demand_history.counts_for_asp = TRUE),
+--         per (item, org).
+--
+-- ASP-eligible excludes warranty ($0), intercompany & drop-ship (billed
+-- at-cost, not list), no-bill/invoice-only, and returns — i.e. it is the
+-- real customer selling price. Recomputed periodically (scripts/compute_asp.py),
+-- never hand-maintained.
+--
+-- Used as the units <-> $ bridge:
+--   - Shipping Plan: Ad'hoc $ target -> units to ship  (docs/DESIGN-shipping-plan.md)
+--   - Demand valuation: forecast $ = forecast units x current ASP
+--
+-- Per (item, org) because the two operating companies (PPS = USA / PCC =
+-- Canada) price in different currencies; ASP is in the org's order currency.
+-- (MVP granularity = item x org; extensible later to x channel/region.)
+--
+-- Additive new table; idempotent.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS item_asp (
+    item_id       UUID        NOT NULL REFERENCES items(item_id) ON DELETE RESTRICT,
+    org_id        TEXT        NOT NULL,
+    asp           NUMERIC,                 -- value_12m / units_12m
+    units_12m     NUMERIC,
+    value_12m     NUMERIC,
+    window_start  DATE,
+    window_end    DATE,
+    computed_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (item_id, org_id)
+);
+
+COMMENT ON TABLE item_asp IS
+    'Derived Average Selling Price per (item, org): trailing-12-month '
+    'SUM(value_ext)/SUM(ordered_quantity) over ASP-eligible demand '
+    '(counts_for_asp). Recomputed by scripts/compute_asp.py; the units<->$ '
+    'bridge for the shipping plan and demand valuation. Currency = org order ccy.';
+
+CREATE INDEX IF NOT EXISTS idx_item_asp_org ON item_asp (org_id);

--- a/src/ootils_core/db/migrations/050_returns_history.sql
+++ b/src/ootils_core/db/migrations/050_returns_history.sql
@@ -1,0 +1,40 @@
+-- ============================================================
+-- Migration 050 — returns_history: the returns series (separate from demand)
+-- ============================================================
+-- Per the sign rule (memory/demand-business-rule-booking): demand =
+-- POSITIVE quantities only; NEGATIVE quantities are RETURNS and are NEVER
+-- netted into demand. demand_history holds only positive demand; this table
+-- holds the returns (the negative-quantity lines), as a SEPARATE series.
+--
+-- Used for:
+--   - the NET of the shipping-plan Ad'hoc  (net $ = shipments $ − returns $,
+--     at company level / month) — docs/DESIGN-shipping-plan.md
+--   - return-rate analytics per item (cf. T_DTK.RETURN_PERCENTAGE)
+--
+-- Magnitudes stored POSITIVE (return_quantity / return_value ≥ 0); the
+-- consumer subtracts. Additive new table; idempotent.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS returns_history (
+    id              BIGSERIAL   NOT NULL PRIMARY KEY,
+    item_id         UUID        REFERENCES items(item_id) ON DELETE RESTRICT,
+    item_code       TEXT        NOT NULL,
+    org_id          TEXT,
+    return_date     DATE,                    -- booked date of the credit / return line
+    return_quantity NUMERIC,                 -- positive magnitude
+    return_value    NUMERIC,                 -- positive magnitude ($)
+    line_type       TEXT,
+    warehouse_id    TEXT,
+    ship_state      TEXT,
+    channel         TEXT,
+    ingested_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE returns_history IS
+    'Returns series (negative-quantity sales lines), kept SEPARATE from '
+    'demand_history per the sign rule (returns are never netted into demand). '
+    'Magnitudes stored positive. Feeds the net of the shipping-plan Ad''hoc '
+    '(shipments $ − returns $) and per-item return-rate analytics.';
+
+CREATE INDEX IF NOT EXISTS idx_returns_history_item_date ON returns_history (item_id, return_date);
+CREATE INDEX IF NOT EXISTS idx_returns_history_org_date  ON returns_history (org_id, return_date);


### PR DESCRIPTION
Stacked on #325 (demand foundation). Materializes the two blocking deps of the shipping plan (#327 PAS 1):

- **ASP** (migration 049 `item_asp`): rolling-T12M `SUM(value_ext)/SUM(ordered_quantity)` per (item, org) over ASP-eligible demand — the units↔$ bridge. 7,822 (item,org) rows; `scripts/compute_asp.py` recomputes it (monthly cycle).
- **Returns** (migration 050 `returns_history`): the negative-quantity lines, kept separate from demand per the sign rule. 102,072 rows; feeds the **net** of the Ad'hoc (shipments $ − returns $) + per-item return-rate.

Verified: net Ad'hoc-style monthly value computes end-to-end; ASP×units = value (bridge). Migrations 049/050 applied to the pilot DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)