### PR TITLE
fix(scenario): correctness scénarios — C0 vague 1 (on-hand fork, purge re-run, ATP/RCCP scoping, simulate status)

### DIFF
--- a/docs/REVIEW-2026-07-APS.md
+++ b/docs/REVIEW-2026-07-APS.md
@@ -1,0 +1,153 @@
+# Revue experte APS — Juillet 2026
+
+**Commit revu :** `b752a38` (main, 2026-07-01)
+**Méthode :** revue multi-agents (32 agents) — cartographie de 8 sous-systèmes, évaluation par 6 lentilles d'expert APS (demand planning, supply planning MRP/DRP, S&OP/capacité, what-if/scénarios, master data/architecture, control tower/autonomie), puis **contre-vérification adversariale de 16 affirmations structurantes dans le code** (12 confirmées, 4 nuancées — voir §Nuances).
+**Statut :** backlog ouvert — voir le tableau des chantiers (§Backlog) et l'issue épique #351.
+
+---
+
+## Verdict
+
+**Ootils n'est pas un APS faible — c'est un excellent moteur de diagnostic avec une périphérie de planification qui trahit son propre cœur.** Le noyau mathématique MRP est de qualité quasi-professionnelle (golden-master dérivé à la main, 2,88 s pour 36 635 items / ~220 K ordres), le substrat scénarios est conceptuellement la bonne réponse au fossé Kinaxis (sandbox Rust fork ~1 µs, cycle agent p50 12,45 ms), mais la promesse centrale du projet — *tout est forkable, les recommandations sont adossées à des scénarios* — est **factuellement fausse au runtime à la date de la revue**.
+
+Le triplet réellement différenciant et défendable — **déterminisme reproductible + chaîne causale persistée requêtable + audit systématique** — n'est offert ensemble par aucun APS du marché. Il est aujourd'hui sous-vendu au profit de promesses (scenario-first, autonomie) que le runtime ne tient pas encore. Recommandation stratégique : vendre ce qui est vrai, corriger ce qui est faux, dans cet ordre.
+
+### Scores par domaine (vs un APS de référence)
+
+| Domaine | Score | Résumé |
+|---|---|---|
+| Demand planning | 2,5/10 | Couche de faits excellente (`demand_history`), couche de prévision sous un APS d'entrée de gamme (forecast plat, historique contaminé) |
+| Supply planning (MRP/DRP) | 3,5/10 | Cœur de netting APICS crédible et golden-masterisé ; périphérie write défaillante ; DRP inexistant au runtime |
+| S&OP / capacité | 3/10 | Design Shipping Plan remarquable sur le papier ; zéro runtime ; RCCP non conforme |
+| What-if / scénarios | 4/10 | Meilleure infrastructure du projet ; mais contre-factuels silencieusement faux hors baseline |
+| Master data | 4/10 | Discipline rare (SCD2, typed columns, staging gouverné) ; non forkable — contradiction frontale avec le North Star |
+| Control tower / autonomie | 3,5/10 | Diagnostic et gouvernance solides ; boucle tronquée aux deux extrémités (pas de scénario en amont, pas d'exécution en aval) |
+
+### Le méta-problème : la duplication
+
+La moitié des découvertes sont des variantes d'un seul défaut structurel : **deux implémentations partout, sans arbitre désigné**. Deux moteurs MRP (~4 % de dérive médiane, parité jamais exécutée en CI), deux consommations de forecast, deux MPS (module `mps/` vs `scripts/mrp_grid.py`), deux vérités de pénurie (les watchers ne lisent pas la table `shortages` du kernel), deux systèmes de scénarios sans pont (PG persistant / Rust éphémère), deux lecteurs d'historique de demande. Règle terrain proposée : le jour où une seconde implémentation d'une capacité apparaît, l'implémentation canonique doit être désignée dans CLAUDE.md (le projet l'a fait pour le MRP via ADR-020 — à généraliser).
+
+---
+
+## Constats vérifiés (contre-vérification adversariale dans le code)
+
+Chaque constat ci-dessous a été soumis à un agent vérificateur chargé de le **réfuter** en fouillant le dépôt. Verdicts : ✅ confirmé, 🟡 partiel (voir nuance).
+
+### Critiques — invalident le pitch scenario-first
+
+| ID | Verdict | Constat |
+|---|---|---|
+| A1 | ✅ | **Le MRP write nette contre le stock baseline dans tout fork** : `_get_initial_on_hand` code en dur `BASELINE = UUID('…0001')` (`engine/mrp/gross_to_net.py:352`, requêtes l.363/372) quel que soit le scénario du run. Un agent qui simule dans un fork obtient un plan silencieusement faux. (= issue #333, confirmée) |
+| A2 | ✅ | **Chaque re-run MRP APICS double-compte la supply** : `cleanup_previous_run` (`engine/mrp/graph_integration.py:352`) n'a **aucun appelant**. Conséquence vicieuse : l'environnement de démo se dégrade avec l'usage (« demo rot »). |
+| A3 | ✅ | **ATP/CTP et RCCP agrègent TOUS les scénarios** — pire que « baseline-only » : `src/ootils_core/atp/` ne contient aucune occurrence de `scenario` ; `api/routers/rccp.py:179-186` n'accepte pas `scenario_id` et sa requête de charge (l.278-295) somme les nœuds supply de tous les scénarios. Un fork qui écrit **contamine les réponses baseline** (bidirectionnel). |
+| A4 | ✅ | **La prévision s'entraîne sur des prévisions** : les deux lecteurs d'historique (`api/routers/forecasting.py:196-228`, `pyramide/repository.py:103-126`) somment `ForecastDemand` + `CustomerOrderDemand` comme « historique », **sans filtre `scenario_id`**, en contournant `demand_history` pourtant livrée (migrations 047-050). Plus les agents forkent, plus l'historique gonfle. (= issue #331, confirmée et aggravée) |
+| A5 | ✅ | **« Scenario-backed recommendations » est faux pour la production** : aucun des 5 watchers (`scripts/agent_*_watcher.py`) ne fork ni n'appelle `/v1/simulate` ; ils calculent sur `core.BASELINE` en dur avec `'L1'` codé en dur. Seul le `demo_agent` (M7) a un chemin scénarisé. `/v1/simulate` **avale les exceptions de propagation** (`simulate.py:242-244`) et renvoie `created` avec delta vide — un agent ne distingue pas « aucune pénurie » de « le calcul a planté ». |
+| A6 | ✅ | **Aucun garde-fou de parité A-vs-B en CI** : `scripts/parity_mrp_engines.py` existe mais n'est référencé par aucun workflow ; ~4,1 % de dérive médiane entre les deux moteurs, non surveillée. La validation « byte-identique 99 765 ordres » était un one-shot de migration (A-avant vs A-après), pas un filet permanent. (= issue #332, confirmée) |
+
+### Majeurs — crédibilité APS
+
+| ID | Verdict | Constat |
+|---|---|---|
+| A7 | ✅ | **Aucune méthode saisonnière implémentée** : `SEASONAL` est déclarée (enum, regex API, CHECK SQL 026/038) mais `forecasting/algorithms.py` ne contient que MA/ES/Croston. Le chemin par défaut sort un forecast **plat** — disqualifiant pour un business piscine à saisonnalité extrême. Le PoC seasonal-naive (`scripts/forecast_poc.py`) existe et est validé sur données réelles. |
+| A8 | ✅ | **Pas de messages de reprogrammation des ordres ouverts** : `_classify_shortage` (`graph_integration.py:614-646`) n'émet jamais DEFER/CANCEL (déclarés en docstring) ; les scheduled receipts sont lus comme supply figée sans comparaison date d'ordre vs date de besoin. Le premier réflexe d'un planificateur (re-dater un PO, gratuit) est impossible. |
+| A9 | ✅ | **Aucun firm planned order** (`grep is_firm|firm_planned` = 0) → aucune stabilité de plan, nervosité maximale à chaque régénération. |
+| A10 | ✅ | **Le master data n'est pas forkable** : `items`, `locations`, `suppliers`, `supplier_items`, `item_planning_params`, `bom_headers/lines` n'ont aucune colonne `scenario_id`. Le what-if n°1 en production (« et si le lead time / la MOQ changeait ? ») est structurellement impossible. |
+| A11 | ✅ | **Aucun moteur DRP** : `distribution_links` / `transportation_lanes` (migration 029) ne sont référencées par aucun `.py` du dépôt — tables mortes, donc aucune recommandation de transfert inter-site possible. Idem `uom_conversions`. |
+| A12 | ✅ | **Réconciliation hiérarchique inexistante en production** : `recon_method` est persisté dans `pyramide_runs` mais aucun moteur ne l'applique ; middle-out = PoC uniquement ; FM_CHRONOS/FM_MOIRAI = stubs retombant sur AUTO_SELECT. |
+| A13 | ✅ | **Cycle de vie scénario incomplet côté API** : `ScenarioManager.diff` (l.497) et `.promote` (l.622) sans endpoint ; `promote()` rejoue les overrides sans détection de divergence de la baseline ; l'invalidation des scénarios frères n'est **même pas loggée** (promesse de docstring). Diff limité à 6 champs stock/pénurie, aucun KPI métier. |
+| A14 | ✅ | **La couche S&OP n'existe pas en code** : aucune table/module S&OP, pas de calendrier de programmes (brique B ADR-019) ; Shipping Plan purement documentaire — et le numéro de migration prévu par le design (`049_shipping_plan.sql`) est **déjà pris** par `049_item_asp.sql`. |
+| A15 | ✅ | **Priorisation financière factice** : `_UNIT_COST_PROXY = Decimal('1')` (`kernel/shortage/detector.py:24`) alors que `items.standard_cost` existe (migration 042 + roll-up). Le tri des pénuries n'est pas en valeur réelle. |
+
+### Nuances issues de la contre-vérification (affirmations corrigées)
+
+| ID | Verdict | Nuance |
+|---|---|---|
+| N1 (C4) | 🟡 | « Pas de backtest rolling-origin » est **partiellement faux** : `pyramide/engines.py:340-365` (`_backtest_score`) EST un rolling-origin à fenêtre expansive (jusqu'à 52 cutoffs, ré-entraînement par cutoff, erreur normalisée type WAPE), utilisé par AUTO_SELECT. Le manque réel : pas de cadre d'accuracy multi-horizon **persisté/exposé**, pas de MASE/WAPE nommés dans la mesure publiée, colonnes CI jamais alimentées, pas de FVA. |
+| N2 (C9) | 🟡 | « Aucune règle de sourcing » est excessif : `loader.py:128-136` ordonne par `is_preferred DESC` pour `best_sup` (valorisation, watchers). Les manques réels : le lead time de **planification** reste `MIN()` tous fournisseurs, `preferred_supplier_id` (override item×location) non lu, pas de split multi-fournisseur. Le pooling item-level est une décision **documentée et transitoire** (ADR-020, cœur paramétrable `(item, location)`), pas une incohérence cachée. |
+| N3 (C10) | 🟡 | « Buckets hebdo codés en dur » ne vaut que pour le cœur consolidé A : le moteur APICS B supporte `day\|week\|month` de bout en bout (`gross_to_net.py:120-168`, `MRPRunConfig.bucket_grain`, exposé via `routers/mrp.py:47`). L'offset lead-time calendaire (sans `kernel/calc/calendar.py`) reste confirmé. |
+| N4 (C15) | 🟡 | Trois sous-points nuancés : le rate limiting global existe (slowapi opt-in `OOTILS_RATE_LIMIT_PER_MIN`, `app.py:87-94`), l'idempotence ingest existe (migration 023), et le `demo_agent` M7 produit bien une recommandation adossée à `/v1/simulate` avec `simulation_scenario_id` persisté. Le fond tient pour les 5 watchers de production. |
+
+---
+
+## Ce qui est réellement bon (et rare)
+
+- **Déterminisme reproductible** : UUID déterministes, seeds persistés, golden-master MRP dérivé à la main (`tests/test_mrp_core_golden.py`) qui a déjà attrapé des bugs réels.
+- **Chaîne causale persistée requêtable** (ADR-004, `/v1/explain`) — le « insight feed » d'un o9 est opaque en comparaison.
+- **Audit systématique** : ledger `agent_runs`, machine d'états DRAFT→APPROVED avec transitions contraintes et `FOR UPDATE`.
+- **Règle booking/shipping matérialisée dans le schéma** : `demand_history` (booked_date primaire, streams regular/warranty, `counts_for_asp`, retours jamais nettés) — plus rigoureux que la moyenne des implémentations SAP terrain.
+- **Consommation de prévision APICS-correcte** : `max(orders, forecast)`, jamais la somme ; demand time fence gelée = commandes seules. Beaucoup de MRP maison ratent exactement ça.
+- **Sandbox Rust** : fork ArcSwap ~1 µs, cycle agent p50 12,45 ms — structurellement la réponse Kinaxis (versionnement in-memory) appliquée au bon sous-problème.
+- **Discipline typed-columns + SCD2 + staging gouverné** sur le master data.
+
+## Non-objectifs assumés (sains pour le positionnement — à documenter en ADR)
+
+- **Pas d'ordonnancement fin / capacité finie** : métier distribution, la contrainte est l'appro, pas la machine.
+- **Pas de solveur d'optimisation** : Kinaxis a bâti sa domination sur la re-simulation heuristique rapide, pas sur un LP. À tracer : les 3 endroits où un solveur deviendra nécessaire (allocation fair-share, lissage capacité, placement shipping plan sous contrainte $) et le critère de bascule.
+
+## Angles métier (pool) non couverts par les designs actuels
+
+1. **Consommation de forecast et Early Buy** : bookings fermes pris 4-6 mois avant expédition ; une consommation `max()` **par bucket hebdo** ne consomme pas le forecast des buckets voisins → double comptage temporel précisément en pré-saison. Il faut une fenêtre de consommation backward/forward (le `forecast_consumer` a une fenêtre, `core.py` n'en a pas).
+2. **Biais saisonnier de l'ASP T12M** : les remises Early Buy tirent l'ASP sous le prix in-season → variance $ du futur Shipping Plan structurellement biaisée par phase. Prévoir un ASP par programme (`order_type`) ou par saison — la granularité de `demand_history` le permet déjà.
+3. **Famine d'allocation** : le greedy strictement priorisé (`kernel/allocation/engine.py`) affame les dealers B en pénurie prolongée — en saison c'est une crise à J+15, pas un raffinement V2.
+4. **Chimie piscine** : péremption / FEFO / lots / hazmat transport — zéro trace dans le schéma (stock utilisable vs stock total dans le netting, rotation FEFO au DRP, colisage hazmat au shipping plan).
+5. **Le goulot réel d'un distributeur saisonnier** est la capacité de réception/stockage des DC en pré-saison (docks, main-d'œuvre, cube), pas la machine — le RCCP orienté fabrication ne pose pas la bonne question.
+6. **Open-to-buy** : le MRP génère des ordres planifiés sans plafond financier ni valorisation cumulée vs budget achat — jumeau indispensable du shipping plan pour un distributeur saisonnier.
+7. **Preuve de valeur impossible aujourd'hui** : pas de snapshots de stock historiques, pas de chaînage recommandation→résultat observé. Un snapshot quotidien (item×location×on_hand) + le chaînage `recommendation_id→outcome` transformerait le ledger d'audit existant en machine à ROI — coût faible, impact commercial majeur.
+8. **MEIO** : ADR-020 décide « SS central poolé (risk pooling) » mais rien ne dit comment dimensionner les buffers par échelon (service level, variabilité demande×LT).
+9. **Nervosité / dampening rules** : sans seuils d'amortissement (re-datage minimal, tolérance quantité), un MRP régénératif piloté par agents en continu produira une tempête de messages inexploitables.
+10. **Supersession côté demande** (chaining item→successeur pour le transfert d'historique au cold-start) — fréquent en équipement piscine (millésimes de pompes/robots).
+11. **Multi-devise / FX** : orgs PPS/PCC = deux devises ; l'agrégation cross-org du shipping plan en $ est impossible sans conversion — absente des 4 questions ouvertes du design (§11).
+12. **Sécurité agent** : un seul token Bearer global, pas de scopes par agent, pas de kill-switch, pas de budgets — exigés par le North Star avant tout pilote où des agents écrivent.
+
+## Observations d'implémentation (pièges terrain)
+
+- **« Démo propre, vraies données cassées »** : ADR-019 admet que `time_span_start` est souvent NULL sur données réelles (casse `_get_historical_demand`), `warehouse_id` reste un TEXT non résolu, l'ingestion réelle est un TSV manuel hors API/staging/**tests**. L'écart entre `seed_demo_data.py` et le chemin de données réel est le risque de pilote dominant.
+- Le vrai champ de bataille face à Kinaxis/o9 n'est pas l'algorithme mais le **temps d'implémentation** : connecteurs, mapping master data, delta-loads réconciliés. C'est le maillon le plus faible (TSV manuel, cap 10 MB, pas de CDC, fondation demande sans tests).
+- La politique de migration « erreur already-exists ⇒ enregistrée comme appliquée » est un piège de dérive de schéma silencieuse entre environnements ; combinée à la collision de numéro 049 déjà constatée, elle plaide pour un check de somme de contrôle du schéma en CI.
+- Les inserts ligne à ligne du moteur APICS (`persist_planned_orders`, `_persist_bucket_records`) sous transactions longues + advisory locks par scénario sont une bombe de contention dès que plusieurs agents planifient en parallèle — le passage en COPY/executemany est une condition de la promesse multi-agents, pas une optimisation.
+- Le réequilibrage inter-DC est LE premier réflexe d'un planificateur distribution : la question tombera à la première session pilote. Réponse honnête à préparer (« gated sur ADR-020 PAS 4 »).
+
+---
+
+## Backlog — chantiers priorisés
+
+> Séquencement recommandé : **arrêter les nouvelles features de planification, faire le sprint correctness d'abord.** Tout usage au-delà de « baseline, premier run » produit aujourd'hui des chiffres faux.
+
+### C0 — Sprint correctness scénarios (P0 — restaurer l'invariant fondateur)
+
+| # | Chantier | Constat | Issue |
+|---|---|---|---|
+| C0.1 | MRP write : on-hand scénarisé | A1 | #333 |
+| C0.2 | Brancher `cleanup_previous_run` (purge des runs APICS) | A2 | #337 |
+| C0.3 | ATP/CTP + RCCP : filtre `scenario_id` | A3 | #338 |
+| C0.4 | `/v1/simulate` : remonter les échecs de propagation (`propagation_status` + freshness) | A5 | #339 |
+| C0.5 | Parité A-vs-B en CI (seuil de dérive) | A6 | #332 |
+| C0.6 | Lecteurs d'historique → `demand_history` (bookings réels, scenario-aware) | A4 | #331 |
+
+### C1 — Fermer la boucle wedge (P0/P1)
+
+| # | Chantier | Constat | Issue |
+|---|---|---|---|
+| C1.1 | Watchers réellement adossés à un fork (delta pénuries dans l'evidence) | A5 | #340 |
+| C1.2 | API recommandations (file/review/approve) + diff/promote avec détection de conflit minimale | A13 | #341 |
+| C1.3 | `standard_cost` dans le severity_score (quick win) | A15 | #342 |
+| C1.4 | Unifier les deux vérités de pénurie (kernel `shortages` vs `mrp_core.first_shortage`) | méta | #343 |
+| C1.5 | Tests d'intégration fondation demande (`demand_history`, `item_asp`, `returns_history`, ingestion) | — | #344 |
+
+### C2 — Profondeur APS (P1)
+
+| # | Chantier | Constat | Issue |
+|---|---|---|---|
+| C2.1 | SeasonalForecaster en production (promouvoir le PoC, méthode SEASONAL déjà déclarée) | A7 | #345 |
+| C2.2 | Messages de reprogrammation des ordres ouverts (reschedule-in/out, DEFER, CANCEL) + Firm Planned Orders | A8, A9 | #346 |
+| C2.3 | Overlay scénarisé des paramètres de planification (`scenario_planning_overrides`, COALESCE dans les loaders) | A10 | #347 |
+| C2.4 | Réconciliation middle-out du PoC à la production (débloquant DRP / ADR-020 PAS 4) | A12 | #348 |
+| C2.5 | Fenêtre de consommation forecast (Early Buy backward/forward) | métier §1 | #349 |
+
+### C3 — Fond de backlog (P2)
+
+Regroupés dans l'issue collective #350 : ASP par programme/saison · allocation fair-share · snapshots stock + chaînage reco→résultat (ROI) · tables mortes (câbler ou documenter `uom_conversions`, `distribution_links`, `transportation_lanes`) · calendrier S&OP (brique B ADR-019) + fix collision migration 049 · effectivité BOM complète (`effective_from`, niveau ligne) + `preferred_supplier_id` · lead time jours ouvrés via calendrier existant · cadre d'accuracy persisté (WAPE/MASE, CI alimentées, FVA) + score de confiance North Star · gouvernance des time fences (`requires_approval` consommé) · dampening rules · purge scénarios archivés / partitionnement · ADR « simulation, pas optimisation » · ADR non-objectifs (scheduling fin) · bill of capacity RCCP · check de somme de contrôle du schéma en CI.
+
+---
+
+*Revue produite le 2026-07-01 par workflow multi-agents (cartographie → évaluation → vérification adversariale → critique de complétude). Les affirmations non vérifiées adversarialement sont signalées comme telles ; toute citation `fichier:ligne` a été produite par lecture directe du code au commit `b752a38`.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 # the next major. Dependabot opens PRs weekly to bump within these ranges.
 # See docs/REVIEW-2026-05.md R4.
 dependencies = [
-    "fastapi ~= 0.128",
+    "fastapi ~= 0.128.0",  # NOT ~= 0.128: that means <1.0 and let CI resolve 0.139 + starlette 1.x (breaking)
     "uvicorn[standard] ~= 0.40",
     "psycopg[binary] ~= 3.3",
     "psycopg-pool ~= 3.3",

--- a/src/ootils_core/api/routers/rccp.py
+++ b/src/ootils_core/api/routers/rccp.py
@@ -9,6 +9,8 @@ Query params:
   from_date   : date début (YYYY-MM-DD), défaut = today
   to_date     : date fin (YYYY-MM-DD), défaut = from_date + 12 semaines
   grain       : day | week | month (défaut : week)
+  scenario_id : UUID de scénario ou 'baseline' (aussi via header X-Scenario-ID),
+                défaut = baseline — la charge est lue dans ce scénario uniquement
 
 Réponse:
   {
@@ -30,13 +32,14 @@ from __future__ import annotations
 import logging
 from datetime import date, timedelta
 from typing import Optional
+from uuid import UUID
 
 import psycopg
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
 from ootils_core.api.auth import require_auth
-from ootils_core.api.dependencies import get_db
+from ootils_core.api.dependencies import get_db, resolve_scenario_id
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1/rccp", tags=["rccp"])
@@ -181,6 +184,7 @@ def get_rccp(
     from_date: date = Query(default=None, description="Début de l'horizon (YYYY-MM-DD). Défaut : today."),
     to_date: date = Query(default=None, description="Fin de l'horizon (YYYY-MM-DD). Défaut : from_date + 84 jours."),
     grain: str = Query(default="week", description="Granularité : day | week | month."),
+    scenario_id: UUID = Depends(resolve_scenario_id),
     db: psycopg.Connection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> RCCPResponse:
@@ -275,6 +279,8 @@ def get_rccp(
 
     # Query: load = SUM of quantities for supply nodes connected to this resource
     # within the date range, aggregated by time_ref (supply date)
+    # Scenario isolation (#338): supply nodes, edges and the Resource node are
+    # all scenario-scoped (deep-copy fork), so every leg of the join is filtered.
     load_rows = db.execute(
         """
         SELECT
@@ -287,11 +293,14 @@ def get_rccp(
           AND e.edge_type = 'consumes_resource'
           AND e.active = TRUE
           AND n.active = TRUE
+          AND n.scenario_id = %s
+          AND e.scenario_id = %s
           AND rn.node_type = 'Resource'
           AND rn.external_id = %s
+          AND rn.scenario_id = %s
           AND n.time_ref BETWEEN %s AND %s
         """,
-        (resource_external_id, from_date, to_date),
+        (scenario_id, scenario_id, resource_external_id, scenario_id, from_date, to_date),
     ).fetchall()
 
     # Build load by date
@@ -369,8 +378,8 @@ def get_rccp(
         )
 
     logger.info(
-        "rccp.get resource=%s from=%s to=%s grain=%s buckets=%d",
-        resource_external_id, from_date, to_date, grain, len(buckets),
+        "rccp.get resource=%s from=%s to=%s grain=%s scenario=%s buckets=%d",
+        resource_external_id, from_date, to_date, grain, scenario_id, len(buckets),
     )
 
     return RCCPResponse(resource=resource_info, buckets=buckets)

--- a/src/ootils_core/api/routers/simulate.py
+++ b/src/ootils_core/api/routers/simulate.py
@@ -4,7 +4,7 @@ POST /v1/simulate — Create a scenario with overrides and return delta.
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import Literal, Optional
 from uuid import UUID
 
 import psycopg
@@ -65,6 +65,16 @@ class SimulateResponse(BaseModel):
     base_scenario_id: UUID
     calc_run_id: Optional[UUID] = None
     nodes_recalculated: int = 0
+    # Outcome of the post-fork recompute (#339):
+    #   'ok'      — propagation ran and the delta below is meaningful
+    #   'failed'  — propagation raised; the delta is NOT meaningful
+    #   'skipped' — propagation never ran (no applied override, or a
+    #               concurrent calc run prevented starting one)
+    propagation_status: Literal["ok", "failed", "skipped"] = "skipped"
+    # Freshness flag for `delta`: True only when propagation succeeded and
+    # the shortage delta was actually computed. Agents must treat an empty
+    # delta with delta_computed=False as "unknown", not "no change".
+    delta_computed: bool = False
     delta: SimulateDelta = SimulateDelta()
 
 
@@ -74,7 +84,14 @@ def create_simulation(
     db: psycopg.Connection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> SimulateResponse:
-    """Create a new scenario with overrides and compute the delta vs base."""
+    """Create a new scenario with overrides and compute the delta vs base.
+
+    Contract (#339): the fork itself is transactional — if it fails we return
+    500. The post-fork recompute is best-effort: when it fails the response
+    is still 201/'created' (the scenario exists and is usable), but
+    ``propagation_status`` and ``delta_computed`` make the "created but not
+    calculated" state explicit instead of masquerading as an empty delta.
+    """
     # Resolve base scenario
     if body.base_scenario_id and body.base_scenario_id.lower() != "baseline":
         try:
@@ -149,6 +166,11 @@ def create_simulation(
     calc_run_id = None
     nodes_recalculated = 0
     delta = SimulateDelta()
+    propagation_status: Literal["ok", "failed", "skipped"] = "skipped"
+    delta_computed = False
+    calc_run = None
+    calc_run_mgr = None
+    calc_run_finished = False
 
     if applied > 0:
         try:
@@ -202,6 +224,7 @@ def create_simulation(
                     engine._propagate(calc_run, all_pi_ids, db)
 
                 engine._finish_run(calc_run, scenario.scenario_id, db)
+                calc_run_finished = True
                 calc_run_id = calc_run.calc_run_id
                 nodes_recalculated = calc_run.nodes_recalculated or 0
 
@@ -238,10 +261,37 @@ def create_simulation(
                     ],
                     net_shortage_change=len(new_ids) - len(resolved_ids),
                 )
+                propagation_status = "ok"
+                delta_computed = True
 
-        except Exception as exc:
-            logger.warning("simulate.propagation_failed scenario=%s: %s", scenario.scenario_id, exc)
-            # Don't fail the simulate call — scenario is created, propagation is best-effort
+        except Exception:
+            # Deliberately NOT an HTTP 500 (#339): the scenario fork succeeded,
+            # only the best-effort recompute failed. The failure is surfaced
+            # explicitly via propagation_status='failed' + delta_computed=False
+            # so agents can distinguish "no new shortages" from "the calc
+            # crashed". Full traceback goes to the server log only — never to
+            # the client.
+            logger.exception(
+                "simulate.propagation_failed scenario=%s", scenario.scenario_id
+            )
+            propagation_status = "failed"
+            delta_computed = False
+            delta = SimulateDelta()  # a partially built delta is not meaningful
+
+            # If the calc run was started but never finished, the scenario's
+            # advisory lock is still held by this pooled connection — release
+            # it (and persist the failure record) or every subsequent
+            # /v1/simulate on this scenario would silently return 'skipped'.
+            if calc_run is not None and not calc_run_finished:
+                try:
+                    calc_run_mgr.fail_calc_run(
+                        calc_run, "simulate propagation failed", db
+                    )
+                except Exception:
+                    logger.exception(
+                        "simulate.fail_calc_run_failed scenario=%s run=%s",
+                        scenario.scenario_id, calc_run.calc_run_id,
+                    )
 
     return SimulateResponse(
         scenario_id=scenario.scenario_id,
@@ -252,5 +302,7 @@ def create_simulation(
         base_scenario_id=base_id,
         calc_run_id=calc_run_id,
         nodes_recalculated=nodes_recalculated,
+        propagation_status=propagation_status,
+        delta_computed=delta_computed,
         delta=delta,
     )

--- a/src/ootils_core/atp/api.py
+++ b/src/ootils_core/atp/api.py
@@ -17,7 +17,7 @@ from fastapi import Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
 from ootils_core.api.auth import require_auth
-from ootils_core.api.dependencies import get_db
+from ootils_core.api.dependencies import get_db, resolve_scenario_id
 from ootils_core.atp.engine import ATPEngine
 from ootils_core.atp.models import ATPBucket, ATPResult
 
@@ -137,6 +137,7 @@ def _extract_shortage_details(result: ATPResult) -> List[ShortageDetail]:
 
 async def check_atp_availability(
     body: ATPCheckRequest,
+    scenario_id: UUID = Depends(resolve_scenario_id),
     db: psycopg.Connection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> ATPCheckResponse:
@@ -171,6 +172,7 @@ async def check_atp_availability(
             quantity=body.quantity,
             request_date=body.requested_date,
             horizon_days=body.horizon_days,
+            scenario_id=scenario_id,
         )
     except Exception as e:
         logger.exception("ATP calculation failed: %s", e)

--- a/src/ootils_core/atp/ctp.py
+++ b/src/ootils_core/atp/ctp.py
@@ -235,51 +235,42 @@ class CTPEngine:
     ) -> List[str]:
         """
         Get list of critical resource external IDs for an item.
-        
-        Critical resources are those that are bottlenecks or have limited capacity.
-        They are defined in item_resource_priority or routing tables.
-        
+
+        Currently: every active resource on the item's active routing
+        (routings → routing_operations → resources, the same join the CRP
+        engine uses). There is no criticality model yet — the historical
+        queries here referenced a table (item_resource_priority) and columns
+        (routing_operations.item_id/location_id/is_bottleneck) that no
+        migration creates, so this method crashed on any migrated DB. A real
+        priority/bottleneck model is future design work (see revue APS
+        2026-07 / issue #350).
+
         Args:
             item_id: The item to check
-            location_id: The location to check
-        
+            location_id: The location to check. Unused for now: routings are
+                item-scoped (no location dimension in migration 028).
+
         Returns:
-            List of resource external IDs
+            List of resource external IDs (deterministic order)
         """
         resources = []
-        
+
         with self._conn.cursor() as cur:
-            # Query item_resource_priority for critical resources (priority <= 2)
             cur.execute("""
-                SELECT r.external_id
-                FROM item_resource_priority irp
-                JOIN resources r ON r.resource_id = irp.resource_id
-                WHERE irp.item_id = %s
-                  AND irp.location_id = %s
-                  AND irp.priority <= 2
-                  AND r.active = TRUE
-                ORDER BY irp.priority
-            """, (item_id, location_id))
-            
+                SELECT DISTINCT r.external_id
+                FROM routings rt
+                JOIN routing_operations ro
+                  ON ro.routing_id = rt.routing_id AND ro.active = TRUE
+                JOIN resources r
+                  ON r.resource_id = ro.resource_id AND r.active = TRUE
+                WHERE rt.item_id = %s
+                  AND rt.active = TRUE
+                ORDER BY r.external_id
+            """, (item_id,))
+
             for row in cur.fetchall():
                 resources.append(row["external_id"])
-        
-        # Fallback: check routing operations for bottleneck resources
-        if not resources:
-            with self._conn.cursor() as cur:
-                cur.execute("""
-                    SELECT DISTINCT r.external_id
-                    FROM routing_operations ro
-                    JOIN resources r ON r.resource_id = ro.resource_id
-                    WHERE ro.item_id = %s
-                      AND ro.location_id = %s
-                      AND ro.is_bottleneck = TRUE
-                      AND r.active = TRUE
-                """, (item_id, location_id))
-                
-                for row in cur.fetchall():
-                    resources.append(row["external_id"])
-        
+
         logger.debug("Found %d critical resources for item=%s", len(resources), item_id)
         return resources
     

--- a/src/ootils_core/atp/ctp.py
+++ b/src/ootils_core/atp/ctp.py
@@ -19,6 +19,7 @@ import psycopg
 
 from ootils_core.atp.engine import ATPEngine
 from ootils_core.atp.models import ATPResult, ATPConfig
+from ootils_core.constants import BASELINE_SCENARIO_ID
 
 logger = logging.getLogger(__name__)
 
@@ -136,10 +137,11 @@ class CTPEngine:
         requested_date: date,
         horizon_days: Optional[int] = None,
         include_capacity: bool = True,
+        scenario_id: Optional[UUID] = None,
     ) -> CTPResult:
         """
         Check CTP (Capable-to-Promise) for an item.
-        
+
         Args:
             item_id: The item to check
             location_id: The location to check
@@ -147,20 +149,22 @@ class CTPEngine:
             requested_date: Date when quantity is needed
             horizon_days: Number of days to look ahead (default: 365)
             include_capacity: Whether to check capacity constraints (default: True)
-        
+            scenario_id: Scenario to read supply/demand/load from (default: baseline)
+
         Returns:
             CTPResult with ATP result + capacity feasibility
         """
         if self._conn is None:
             raise ValueError("Database connection not set. Call engine.connection = conn first.")
-        
+
         horizon_days = horizon_days or 365
-        
+        scenario_id = scenario_id or BASELINE_SCENARIO_ID
+
         logger.debug(
-            "CTP check started: item=%s, location=%s, qty=%s, date=%s, horizon=%s",
-            item_id, location_id, quantity, requested_date, horizon_days,
+            "CTP check started: item=%s, location=%s, qty=%s, date=%s, horizon=%s, scenario=%s",
+            item_id, location_id, quantity, requested_date, horizon_days, scenario_id,
         )
-        
+
         # Step 1: Calculate ATP (material availability)
         atp_result = self._atp_engine.calculate(
             item_id=item_id,
@@ -168,6 +172,7 @@ class CTPEngine:
             quantity=quantity,
             request_date=requested_date,
             horizon_days=horizon_days,
+            scenario_id=scenario_id,
         )
         
         # If no material availability, return early
@@ -206,6 +211,7 @@ class CTPEngine:
             atp_result.available_date or requested_date,
             critical_resources,
             horizon_days,
+            scenario_id,
         )
         
         capacity_feasible = len(violations) == 0
@@ -285,10 +291,11 @@ class CTPEngine:
         available_date: date,
         critical_resources: List[str],
         horizon_days: int,
+        scenario_id: UUID,
     ) -> List[CapacityViolation]:
         """
         Check capacity constraints on critical resources.
-        
+
         Args:
             item_id: The item to check
             location_id: The location to check
@@ -296,18 +303,19 @@ class CTPEngine:
             available_date: Date when material is available
             critical_resources: List of critical resource external IDs
             horizon_days: Number of days to check
-        
+            scenario_id: Scenario to read the existing load from
+
         Returns:
             List of CapacityViolation for any overloaded resources
         """
         violations = []
-        
+
         for resource_external_id in critical_resources:
             resource_violations = self._check_single_resource_capacity(
-                resource_external_id, quantity, available_date, horizon_days,
+                resource_external_id, quantity, available_date, horizon_days, scenario_id,
             )
             violations.extend(resource_violations)
-        
+
         return violations
     
     def _check_single_resource_capacity(
@@ -316,16 +324,18 @@ class CTPEngine:
         quantity: Decimal,
         required_date: date,
         horizon_days: int,
+        scenario_id: UUID,
     ) -> List[CapacityViolation]:
         """
         Check capacity for a single resource.
-        
+
         Args:
             resource_external_id: Resource external ID
             quantity: Quantity requiring capacity
             required_date: Date when capacity is needed
             horizon_days: Days to look ahead
-        
+            scenario_id: Scenario to read the existing load from
+
         Returns:
             List of CapacityViolation (empty if no violations)
         """
@@ -360,7 +370,9 @@ class CTPEngine:
             override_row = cur.fetchone()
             available_capacity = Decimal(str(override_row["capacity"])) if override_row else capacity_per_day
             
-            # Check existing load on that date
+            # Check existing load on that date.
+            # Scenario isolation: supply nodes, edges and the Resource node are
+            # all scenario-scoped (deep-copy fork), so filter every leg of the join.
             cur.execute("""
                 SELECT COALESCE(SUM(n.quantity), 0) AS total_load
                 FROM nodes n
@@ -370,10 +382,13 @@ class CTPEngine:
                   AND e.edge_type = 'consumes_resource'
                   AND e.active = TRUE
                   AND n.active = TRUE
+                  AND n.scenario_id = %s
+                  AND e.scenario_id = %s
                   AND rn.node_type = 'Resource'
                   AND rn.external_id = %s
+                  AND rn.scenario_id = %s
                   AND n.time_ref = %s
-            """, (resource_external_id, required_date))
+            """, (scenario_id, scenario_id, resource_external_id, scenario_id, required_date))
             
             load_row = cur.fetchone()
             existing_load = Decimal(str(load_row["total_load"])) if load_row else Decimal("0")
@@ -403,24 +418,27 @@ class CTPEngine:
         quantity: Decimal,
         start_date: Optional[date] = None,
         max_days: int = 30,
+        scenario_id: Optional[UUID] = None,
     ) -> List[Tuple[date, bool, Dict[str, Any]]]:
         """
         Binary search over dates to find first feasible CTP date.
-        
+
         Args:
             item_id: The item to check
             location_id: The location to check
             quantity: Quantity requested
             start_date: Start date for search (default: today)
             max_days: Maximum days to search (default: 30)
-        
+            scenario_id: Scenario to read supply/demand/load from (default: baseline)
+
         Returns:
             List of (date, feasible, capacity_status) tuples for each tested date
         """
         if self._conn is None:
             raise ValueError("Database connection not set.")
-        
+
         start_date = start_date or date.today()
+        scenario_id = scenario_id or BASELINE_SCENARIO_ID
         results = []
         
         # Binary search approach
@@ -438,6 +456,7 @@ class CTPEngine:
                 quantity=quantity,
                 requested_date=test_date,
                 horizon_days=max_days - mid,
+                scenario_id=scenario_id,
             )
             
             feasible = result.capacity_feasible and result.atp_result.is_fully_available
@@ -464,6 +483,7 @@ class CTPEngine:
                     quantity=quantity,
                     requested_date=test_date,
                     horizon_days=1,
+                    scenario_id=scenario_id,
                 )
                 feasible = result.capacity_feasible and result.atp_result.is_fully_available
                 results.append((test_date, feasible, {

--- a/src/ootils_core/atp/engine.py
+++ b/src/ootils_core/atp/engine.py
@@ -29,6 +29,7 @@ from ootils_core.atp.models import (
     ATPDemand,
     ATPConfig,
 )
+from ootils_core.constants import BASELINE_SCENARIO_ID
 
 logger = logging.getLogger(__name__)
 
@@ -87,17 +88,19 @@ class ATPEngine:
         quantity: Decimal,
         request_date: date,
         horizon_days: Optional[int] = None,
+        scenario_id: Optional[UUID] = None,
     ) -> ATPResult:
         """
         Calculate ATP for an item at a location.
-        
+
         Args:
             item_id: The item to check availability for
             location_id: The location to check availability at
             quantity: Quantity requested
             request_date: Date when quantity is needed
             horizon_days: Number of days to look ahead (default: config.default_horizon_days)
-        
+            scenario_id: Scenario to read supplies/demands from (default: baseline)
+
         Returns:
             ATPResult with available quantity, date, and bucket breakdown
         
@@ -109,20 +112,21 @@ class ATPEngine:
             raise ValueError("Database connection not set. Call engine.connection = conn first.")
         
         start_time = time.perf_counter()
-        
+
         horizon_days = horizon_days or self._config.default_horizon_days
         horizon_end = request_date + timedelta(days=horizon_days)
-        
+        scenario_id = scenario_id or BASELINE_SCENARIO_ID
+
         logger.debug(
-            "ATP calculation started: item=%s, location=%s, qty=%s, date=%s, horizon=%s days",
-            item_id, location_id, quantity, request_date, horizon_days
+            "ATP calculation started: item=%s, location=%s, qty=%s, date=%s, horizon=%s days, scenario=%s",
+            item_id, location_id, quantity, request_date, horizon_days, scenario_id
         )
-        
+
         # Step 1: Fetch supplies (OnHand + PlannedSupply)
-        supplies = self._fetch_supplies(item_id, location_id, request_date, horizon_end)
-        
+        supplies = self._fetch_supplies(item_id, location_id, request_date, horizon_end, scenario_id)
+
         # Step 2: Fetch demands (Customer Orders)
-        demands = self._fetch_demands(item_id, location_id, request_date, horizon_end)
+        demands = self._fetch_demands(item_id, location_id, request_date, horizon_end, scenario_id)
         
         # Step 3: Build daily buckets and calculate cumulative ATP
         buckets = self._calculate_cumulative_atp(
@@ -160,20 +164,22 @@ class ATPEngine:
         location_id: UUID,
         start_date: date,
         end_date: date,
+        scenario_id: UUID,
     ) -> List[ATPSupply]:
         """
         Fetch supply sources from database.
-        
+
         Sources:
         - OnHandSupply: Current on-hand inventory (snapshot at start_date)
         - PlannedSupply: Released MPS/MRP planned supplies (scheduled receipts)
-        
+
         Args:
             item_id: The item to fetch supplies for
             location_id: The location to fetch supplies at
             start_date: Start of horizon
             end_date: End of horizon
-        
+            scenario_id: Scenario to read planned supplies from
+
         Returns:
             List of ATPSupply records, sorted by available_date
         """
@@ -183,7 +189,9 @@ class ATPEngine:
 
         with self._conn.cursor() as cur:
             # Fetch OnHandSupply (snapshot at start_date)
-            # OnHand is treated as available at start_date with highest priority
+            # OnHand is treated as available at start_date with highest priority.
+            # NOTE: on_hand_supply (migration 030) has no scenario_id column —
+            # the physical inventory snapshot is shared across scenarios.
             cur.execute("""
                 SELECT 
                     oh.on_hand_id,
@@ -229,11 +237,12 @@ class ATPEngine:
                 FROM planned_supply ps
                 WHERE ps.item_id = %s
                   AND ps.location_id = %s
+                  AND ps.scenario_id = %s
                   AND ps.due_date >= %s
                   AND ps.due_date < %s
                   AND ps.status IN ('RELEASED', 'APPROVED')
                 ORDER BY ps.due_date, ps.priority
-            """, (item_id, location_id, start_date, end_date))
+            """, (item_id, location_id, scenario_id, start_date, end_date))
             
             for row in cur.fetchall():
                 ps_id, ps_item, ps_loc, qty, due_date, priority = _row_values(
@@ -262,19 +271,21 @@ class ATPEngine:
         location_id: UUID,
         start_date: date,
         end_date: date,
+        scenario_id: UUID,
     ) -> List[ATPDemand]:
         """
         Fetch demand commitments from database.
-        
+
         Sources:
         - CustomerOrderDemand: Committed customer orders
-        
+
         Args:
             item_id: The item to fetch demands for
             location_id: The location to fetch demands at
             start_date: Start of horizon
             end_date: End of horizon
-        
+            scenario_id: Scenario to read demands from
+
         Returns:
             List of ATPDemand records, sorted by demand_date
         """
@@ -296,11 +307,12 @@ class ATPEngine:
                 FROM customer_order_demand cod
                 WHERE cod.item_id = %s
                   AND cod.location_id = %s
+                  AND cod.scenario_id = %s
                   AND cod.requested_date >= %s
                   AND cod.requested_date < %s
                   AND cod.status IN ('CONFIRMED', 'RELEASED')
                 ORDER BY cod.requested_date, cod.priority
-            """, (item_id, location_id, start_date, end_date))
+            """, (item_id, location_id, scenario_id, start_date, end_date))
             
             for row in cur.fetchall():
                 cod_id, cod_item, cod_loc, qty, req_date, priority, is_committed = _row_values(
@@ -464,20 +476,22 @@ class ATPEngine:
         location_id: UUID,
         quantity: Decimal,
         request_date: date,
+        scenario_id: Optional[UUID] = None,
     ) -> bool:
         """
         Quick check if quantity is available on request_date.
-        
+
         Args:
             item_id: The item to check
             location_id: The location to check
             quantity: Quantity needed
             request_date: Date when needed
-        
+            scenario_id: Scenario to check availability in (default: baseline)
+
         Returns:
             True if quantity is available on request_date, False otherwise
         """
-        result = self.calculate(item_id, location_id, quantity, request_date)
+        result = self.calculate(item_id, location_id, quantity, request_date, scenario_id=scenario_id)
         return result.is_fully_available
     
     def get_available_date(
@@ -485,17 +499,19 @@ class ATPEngine:
         item_id: UUID,
         location_id: UUID,
         quantity: Decimal,
+        scenario_id: Optional[UUID] = None,
     ) -> Optional[date]:
         """
         Get the earliest date when quantity will be available.
-        
+
         Args:
             item_id: The item to check
             location_id: The location to check
             quantity: Quantity needed
-        
+            scenario_id: Scenario to check availability in (default: baseline)
+
         Returns:
             Earliest available date, or None if never available in horizon
         """
-        result = self.calculate(item_id, location_id, quantity, date.today())
+        result = self.calculate(item_id, location_id, quantity, date.today(), scenario_id=scenario_id)
         return result.available_date

--- a/src/ootils_core/atp/routers.py
+++ b/src/ootils_core/atp/routers.py
@@ -12,13 +12,14 @@ import logging
 from datetime import date
 from decimal import Decimal
 from typing import List, Optional
+from uuid import UUID
 
 import psycopg
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
 from ootils_core.api.auth import require_auth
-from ootils_core.api.dependencies import get_db
+from ootils_core.api.dependencies import get_db, resolve_scenario_id
 from ootils_core.atp.api import (
     ATPCheckRequest,
     ATPCheckResponse,
@@ -112,18 +113,20 @@ class CTPSimulateResponse(BaseModel):
 )
 async def check_atp(
     body: ATPCheckRequest,
+    scenario_id: UUID = Depends(resolve_scenario_id),
     db: psycopg.Connection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> ATPCheckResponse:
     """
     Check ATP availability for an item at a location.
-    
+
     - **item_id**: Item external ID or UUID
     - **location_id**: Location external ID or UUID
     - **quantity**: Quantity requested
     - **requested_date**: Date when quantity is needed
     - **horizon_days**: Days to look ahead for availability (default: 365)
-    
+    - **scenario_id**: Scenario to read from (query param or X-Scenario-ID header; default: baseline)
+
     Returns:
     - **available**: Whether full quantity is available on requested date
     - **available_date**: Earliest date when full quantity is available
@@ -157,6 +160,7 @@ async def check_atp(
             quantity=body.quantity,
             request_date=body.requested_date,
             horizon_days=body.horizon_days,
+            scenario_id=scenario_id,
         )
     except Exception as e:
         logger.exception("ATP calculation failed: %s", e)
@@ -164,7 +168,7 @@ async def check_atp(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"ATP calculation failed: {str(e)}",
         )
-    
+
     # Import here to avoid circular dependency
     from ootils_core.atp.api import _convert_bucket_to_detail, _extract_shortage_details
     
@@ -199,19 +203,21 @@ async def check_atp(
 )
 async def check_ctp(
     body: CTPCheckRequest,
+    scenario_id: UUID = Depends(resolve_scenario_id),
     db: psycopg.Connection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> CTPCheckResponse:
     """
     Check CTP availability for an item at a location.
-    
+
     - **item_id**: Item external ID or UUID
     - **location_id**: Location external ID or UUID
     - **quantity**: Quantity requested
     - **requested_date**: Date when quantity is needed
     - **horizon_days**: Days to look ahead (default: 365)
     - **include_capacity**: Whether to check capacity constraints (default: True)
-    
+    - **scenario_id**: Scenario to read from (query param or X-Scenario-ID header; default: baseline)
+
     Returns:
     - **available**: Whether full quantity is available on requested date
     - **available_date**: Earliest date when full quantity is available
@@ -245,6 +251,7 @@ async def check_ctp(
             requested_date=body.requested_date,
             horizon_days=body.horizon_days,
             include_capacity=body.include_capacity,
+            scenario_id=scenario_id,
         )
     except Exception as e:
         logger.exception("CTP check failed: %s", e)
@@ -300,6 +307,7 @@ async def check_ctp(
 )
 async def simulate_ctp(
     body: CTPSimulateRequest,
+    scenario_id: UUID = Depends(resolve_scenario_id),
     db: psycopg.Connection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> CTPSimulateResponse:
@@ -315,7 +323,8 @@ async def simulate_ctp(
     - **quantity**: Quantity requested
     - **start_date**: Start date for search (default: today)
     - **max_days**: Maximum days to search (default: 30)
-    
+    - **scenario_id**: Scenario to read from (query param or X-Scenario-ID header; default: baseline)
+
     Returns:
     - **first_feasible_date**: First date when order is fully feasible (or None)
     - **options**: List of tested dates with feasibility status
@@ -345,6 +354,7 @@ async def simulate_ctp(
             quantity=body.quantity,
             start_date=body.start_date,
             max_days=body.max_days,
+            scenario_id=scenario_id,
         )
     except Exception as e:
         logger.exception("CTP simulation failed: %s", e)

--- a/src/ootils_core/engine/mrp/graph_integration.py
+++ b/src/ootils_core/engine/mrp/graph_integration.py
@@ -351,36 +351,60 @@ class GraphIntegration:
 
     def cleanup_previous_run(self, run_id: Optional[UUID] = None):
         """
-        Clean up nodes/edges from a previous MRP run.
+        Deactivate nodes/edges from a previous MRP run (soft delete).
 
         Two modes:
-        - run_id provided: delete only artefacts belonging to that run
-        - run_id is None: delete all PlannedSupply nodes for this scenario
+        - run_id provided: deactivate only artefacts belonging to that run
+        - run_id is None: deactivate ALL active PlannedSupply nodes for this
+          scenario (full-regeneration contract — see below)
+
+        Soft delete (``active = FALSE``) rather than hard DELETE, for two
+        reasons:
+        - FK integrity: ``events.trigger_node_id``, ``explanations`` and
+          ``node_versions`` reference ``nodes(node_id)`` with no ON DELETE
+          clause; every receipt node gets an ``ingestion_complete`` event on
+          persist, so a hard DELETE of a previous run's nodes would raise an
+          FK violation on any re-run.
+        - Auditability: prior-run planned orders stay queryable (with their
+          ``mrp_run_id``) for explanation/audit trails, matching the simple
+          MRP mode's ``clear_existing`` behaviour (api/routers/mrp.py).
+
+        Regeneration contract (run_id=None): an APICS run regenerates the
+        complete planned-supply picture for the scenario, so the purge scope
+        is node_type='PlannedSupply' + scenario_id — deliberately wider than
+        the run's item/location filter. Firm Planned Orders (FPO) do not
+        exist yet (chantier C2.2); once they do, firmed supply must be
+        excluded from this purge.
         """
         if run_id:
-            # Delete edges referencing nodes from this run
+            # Deactivate edges referencing nodes from this run
             self.db.execute(
                 """
-                DELETE FROM edges
-                WHERE from_node_id IN (
+                UPDATE edges SET active = FALSE
+                WHERE active = TRUE
+                  AND (from_node_id IN (
                     SELECT node_id FROM nodes WHERE mrp_run_id = %s
                 ) OR to_node_id IN (
                     SELECT node_id FROM nodes WHERE mrp_run_id = %s
-                )
+                ))
                 """,
                 (run_id, run_id),
             )
-            # Delete nodes from this run
+            # Deactivate nodes from this run
             self.db.execute(
-                "DELETE FROM nodes WHERE mrp_run_id = %s",
+                """
+                UPDATE nodes SET active = FALSE, updated_at = NOW()
+                WHERE mrp_run_id = %s AND active = TRUE
+                """,
                 (run_id,),
             )
         else:
-            # Delete all PlannedSupply nodes for scenario
+            # Deactivate all PlannedSupply nodes for scenario
             self.db.execute(
                 """
-                DELETE FROM edges
-                WHERE from_node_id IN (
+                UPDATE edges SET active = FALSE
+                WHERE active = TRUE
+                  AND (from_node_id IN (
                     SELECT node_id FROM nodes
                     WHERE node_type = 'PlannedSupply'
                     AND scenario_id = %s
@@ -388,18 +412,25 @@ class GraphIntegration:
                     SELECT node_id FROM nodes
                     WHERE node_type = 'PlannedSupply'
                     AND scenario_id = %s
-                )
+                ))
                 """,
                 (self.scenario_id, self.scenario_id),
             )
             self.db.execute(
                 """
-                DELETE FROM nodes
+                UPDATE nodes SET active = FALSE, updated_at = NOW()
                 WHERE node_type = 'PlannedSupply'
                 AND scenario_id = %s
+                AND active = TRUE
                 """,
                 (self.scenario_id,),
             )
+        logger.info(
+            "cleanup_previous_run: deactivated previous %s "
+            "(scenario %s, run_id=%s)",
+            "run artefacts (all node types)" if run_id else "PlannedSupply nodes",
+            self.scenario_id, run_id,
+        )
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/ootils_core/engine/mrp/gross_to_net.py
+++ b/src/ootils_core/engine/mrp/gross_to_net.py
@@ -348,9 +348,7 @@ class GrossToNetCalculator:
     def _get_initial_on_hand(
         self, item_id: UUID, location_id: Optional[UUID]
     ) -> Decimal:
-        """Get current on-hand inventory for item/location from baseline scenario."""
-        BASELINE = UUID("00000000-0000-0000-0000-000000000001")
-
+        """Get current on-hand inventory for item/location in the run's scenario."""
         if location_id:
             row = self.db.execute("""
                 SELECT COALESCE(SUM(quantity), 0) AS qty
@@ -360,7 +358,7 @@ class GrossToNetCalculator:
                   AND location_id = %s
                   AND scenario_id = %s
                   AND active = true
-            """, (item_id, location_id, BASELINE)).fetchone()
+            """, (item_id, location_id, self.scenario_id)).fetchone()
         else:
             row = self.db.execute("""
                 SELECT COALESCE(SUM(quantity), 0) AS qty
@@ -369,7 +367,7 @@ class GrossToNetCalculator:
                   AND item_id = %s
                   AND scenario_id = %s
                   AND active = true
-            """, (item_id, BASELINE)).fetchone()
+            """, (item_id, self.scenario_id)).fetchone()
 
         if row and row["qty"] is not None:
             return Decimal(str(row["qty"]))

--- a/src/ootils_core/engine/mrp/mrp_apics_engine.py
+++ b/src/ootils_core/engine/mrp/mrp_apics_engine.py
@@ -130,6 +130,17 @@ class MrpApicsEngine:
             # 1. Create MRP run record
             self._create_run_record(run_id, config)
 
+            # 1b. Regeneration contract: every APICS run rebuilds the FULL
+            # planned-supply picture for the scenario, so deactivate ALL
+            # previous PlannedSupply nodes/edges first (run_id=None → scenario
+            # scope). Without this, each re-run stacks new PlannedSupply on
+            # top of the previous run's, double-counting planned supply
+            # (issue #337). FPOs don't exist yet (chantier C2.2); when they
+            # do, firmed orders must survive this purge. Runs in the same
+            # transaction as the persist steps below: on failure the except
+            # branch rolls back, restoring the previous plan.
+            self.graph.cleanup_previous_run()
+
             # 2. Calculate or retrieve LLCs
             if config.recalculate_llc:
                 self.llc_calculator.calculate_all()
@@ -278,11 +289,18 @@ class MrpApicsEngine:
             errors.append(str(e))
             elapsed_ms = (time.monotonic() - start_time) * 1000
 
-            # Mark run as failed
+            # Coherence on failure: run() does not re-raise (it returns a
+            # FAILED result), so the caller's commit-on-success path would
+            # otherwise persist the cleanup (1b) and any partial writes.
+            # Roll back to restore the previous planned-supply picture, then
+            # re-record the run as FAILED (the original run record was part
+            # of the rolled-back transaction).
             try:
+                self.db.rollback()
+                self._create_run_record(run_id, config)
                 self._complete_run_record(run_id, "FAILED", elapsed_ms, str(e))
             except Exception:
-                pass
+                logger.exception("Failed to record FAILED status for MRP run %s", run_id)
 
             return MrpRunResult(
                 run_id=run_id,

--- a/tests/integration/test_m6_api_integration.py
+++ b/tests/integration/test_m6_api_integration.py
@@ -466,6 +466,80 @@ class TestPostSimulate:
         finally:
             _cleanup_scenario(seeded_db, scenario_id)
 
+    def test_simulate_no_overrides_propagation_skipped(self, api_client, auth, seeded_db):
+        """
+        #339 — with no applied override, propagation never runs: the response
+        must say so explicitly (propagation_status='skipped', delta_computed
+        False) instead of pretending an empty delta was computed.
+        """
+        name = f"int-skip-sim-{uuid4().hex[:8]}"
+        resp = api_client.post(
+            "/v1/simulate",
+            json={"scenario_name": name},
+            headers=auth,
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        try:
+            assert data["propagation_status"] == "skipped"
+            assert data["delta_computed"] is False
+            assert data["calc_run_id"] is None
+            assert data["delta"]["new_shortages"] == []
+            assert data["delta"]["resolved_shortages"] == []
+        finally:
+            _cleanup_scenario(seeded_db, data["scenario_id"])
+
+    def test_simulate_with_override_propagation_ok(self, api_client, auth, seeded_db):
+        """
+        #339 — when an override is applied and the recompute succeeds, the
+        response carries propagation_status='ok' and delta_computed=True so
+        agents can trust the (possibly empty) shortage delta.
+        """
+        with _conn(seeded_db) as c:
+            row = c.execute(
+                """
+                SELECT node_id FROM nodes
+                WHERE scenario_id = %s
+                  AND node_type IN ('PurchaseOrderSupply', 'CustomerOrderDemand',
+                                    'WorkOrderSupply', 'WorkOrderDemand')
+                  AND quantity IS NOT NULL
+                  AND active = TRUE
+                LIMIT 1
+                """,
+                (BASELINE_SCENARIO_ID,),
+            ).fetchone()
+        if row is None:
+            pytest.skip("Seed produced no overridable supply/demand nodes")
+
+        name = f"int-prop-ok-sim-{uuid4().hex[:8]}"
+        resp = api_client.post(
+            "/v1/simulate",
+            json={
+                "scenario_name": name,
+                "overrides": [
+                    {
+                        "node_id": str(row["node_id"]),
+                        "field_name": "quantity",
+                        "new_value": "500",
+                    }
+                ],
+            },
+            headers=auth,
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        try:
+            assert data["override_count"] == 1
+            assert data["propagation_status"] == "ok"
+            assert data["delta_computed"] is True
+            assert data["calc_run_id"] is not None
+            # Delta is structurally present (content depends on seed dynamics)
+            assert isinstance(data["delta"]["new_shortages"], list)
+            assert isinstance(data["delta"]["resolved_shortages"], list)
+            assert isinstance(data["delta"]["net_shortage_change"], int)
+        finally:
+            _cleanup_scenario(seeded_db, data["scenario_id"])
+
     def test_simulate_all_overrides_fail_returns_422(self, api_client, auth, seeded_db):
         """
         Non-regression #48 (DB-backed half): if every override targets a node

--- a/tests/integration/test_mrp_apics_rerun_integration.py
+++ b/tests/integration/test_mrp_apics_rerun_integration.py
@@ -1,0 +1,204 @@
+# ruff: noqa: F401,F811
+"""Integration tests for APICS MRP re-run cleanup (issue #337).
+
+Before the fix, ``GraphIntegration.cleanup_previous_run`` had no caller, so
+every APICS re-run stacked a fresh set of PlannedSupply nodes on top of the
+previous run's — double-counting planned supply. The engine now deactivates
+all previous PlannedSupply nodes/edges for the scenario at the start of each
+run (full-regeneration contract), so two successive runs must yield an
+identical active planned-supply picture.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import UUID
+
+import psycopg
+import pytest
+from psycopg.rows import dict_row
+
+from .conftest import requires_db, TEST_DB_URL
+from .test_mrp_api import api_client, auth, seeded_db  # noqa: F401
+
+BASELINE_SCENARIO_ID = UUID("00000000-0000-0000-0000-000000000001")
+
+
+@pytest.fixture
+def demand_item_location(seeded_db):  # noqa: F811
+    """Pick an (item, location) pair that actually carries demand.
+
+    The generic ``test_item_location`` fixture picks item and location with
+    two independent ``LIMIT 1`` queries, so the pair may have no demand at
+    all — an MRP run on it would create zero PlannedSupply and the re-run
+    assertions would pass vacuously (0 == 0). Here we select the pair with
+    the largest future demand so run 1 is guaranteed to plan something.
+    """
+    with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+        row = conn.execute(
+            """
+            SELECT i.external_id AS item_ext, i.item_id AS item_uuid,
+                   l.external_id AS loc_ext, l.location_id AS loc_uuid
+            FROM nodes n
+            JOIN items i ON i.item_id = n.item_id
+            JOIN locations l ON l.location_id = n.location_id
+            WHERE n.node_type IN ('CustomerOrderDemand', 'ForecastDemand')
+              AND n.scenario_id = %s
+              AND n.active = TRUE
+            GROUP BY i.external_id, i.item_id, l.external_id, l.location_id
+            ORDER BY SUM(n.quantity) DESC
+            LIMIT 1
+            """,
+            (BASELINE_SCENARIO_ID,),
+        ).fetchone()
+
+    if row is None:
+        pytest.skip("No demand nodes in seeded DB for MRP re-run tests")
+
+    return {
+        "item_id": str(row["item_ext"]),
+        "item_uuid": str(row["item_uuid"]),
+        "location_id": str(row["loc_ext"]),
+        "location_uuid": str(row["loc_uuid"]),
+    }
+
+
+def _active_planned_supply_stats(scenario_id: UUID) -> dict:
+    """Return count and total quantity of ACTIVE PlannedSupply nodes for a scenario."""
+    with psycopg.connect(TEST_DB_URL, row_factory=dict_row) as conn:
+        row = conn.execute(
+            """
+            SELECT COUNT(*) AS cnt, COALESCE(SUM(quantity), 0) AS total_qty
+            FROM nodes
+            WHERE node_type = 'PlannedSupply'
+              AND scenario_id = %s
+              AND active = TRUE
+            """,
+            (scenario_id,),
+        ).fetchone()
+    return {"count": row["cnt"], "total_qty": Decimal(str(row["total_qty"]))}
+
+
+def _active_count_for_run(run_id: UUID) -> int:
+    """Return the number of ACTIVE nodes belonging to a given MRP run."""
+    with psycopg.connect(TEST_DB_URL, row_factory=dict_row) as conn:
+        row = conn.execute(
+            "SELECT COUNT(*) AS cnt FROM nodes WHERE mrp_run_id = %s AND active = TRUE",
+            (run_id,),
+        ).fetchone()
+    return row["cnt"]
+
+
+@requires_db
+def test_apics_rerun_does_not_accumulate_planned_supply(api_client, auth, demand_item_location):
+    """Two successive APICS runs on the same scenario must not double-count.
+
+    The active PlannedSupply node count and total quantity must be identical
+    after the second run, and the first run's nodes must have been
+    deactivated (soft-deleted) by the second run's cleanup.
+    """
+    payload = {
+        "item_id": demand_item_location["item_id"],
+        "location_id": demand_item_location["location_id"],
+        "apics_mode": True,
+        "horizon_days": 90,
+        "bucket_grain": "week",
+        "forecast_strategy": "MAX",
+    }
+
+    # --- First run ---
+    resp1 = api_client.post("/v1/mrp/run", json=payload, headers=auth)
+    assert resp1.status_code == 200, resp1.text
+    data1 = resp1.json()
+    assert data1["status"] == "COMPLETED", data1["errors"]
+    run1_id = UUID(data1["run_id"])
+
+    stats_after_run1 = _active_planned_supply_stats(BASELINE_SCENARIO_ID)
+    # Guard against a vacuous pass: the pair was chosen because it carries
+    # demand, so the first run must actually have planned supply.
+    assert stats_after_run1["count"] > 0, (
+        "First APICS run created no PlannedSupply — the re-run assertions "
+        "below would pass vacuously (0 == 0)"
+    )
+
+    # --- Second run (identical parameters) ---
+    resp2 = api_client.post("/v1/mrp/run", json=payload, headers=auth)
+    assert resp2.status_code == 200, resp2.text
+    data2 = resp2.json()
+    assert data2["status"] == "COMPLETED", data2["errors"]
+    run2_id = UUID(data2["run_id"])
+    assert run2_id != run1_id
+
+    stats_after_run2 = _active_planned_supply_stats(BASELINE_SCENARIO_ID)
+
+    # No accumulation: identical active node count and stable quantity totals.
+    assert stats_after_run2["count"] == stats_after_run1["count"], (
+        f"PlannedSupply nodes accumulated across re-runs: "
+        f"{stats_after_run1['count']} → {stats_after_run2['count']}"
+    )
+    assert stats_after_run2["total_qty"] == stats_after_run1["total_qty"], (
+        f"PlannedSupply total quantity drifted across re-runs: "
+        f"{stats_after_run1['total_qty']} → {stats_after_run2['total_qty']}"
+    )
+
+    # The second run's cleanup must have deactivated the first run's nodes.
+    assert _active_count_for_run(run1_id) == 0, (
+        "First run's PlannedSupply nodes should be inactive after re-run"
+    )
+
+    # The surviving active picture belongs to the second run.
+    assert _active_count_for_run(run2_id) == stats_after_run2["count"]
+
+
+@requires_db
+def test_apics_rerun_purge_is_scenario_scoped(api_client, auth, demand_item_location):
+    """The regeneration purge is scenario-wide, not limited to the run's items.
+
+    A scenario-wide run (deprecated endpoint, no item filter) followed by a
+    single-item run must leave only the second run's nodes active: the
+    cleanup contract purges by node_type='PlannedSupply' + scenario_id,
+    deliberately wider than the run's item/location filter (no FPOs yet —
+    chantier C2.2).
+    """
+    # Run A: scenario-wide (deprecated endpoint takes a raw location UUID)
+    resp_a = api_client.post(
+        "/v1/mrp/apics/run",
+        json={
+            "location_id": demand_item_location["location_uuid"],
+            "horizon_days": 90,
+        },
+        headers=auth,
+    )
+    assert resp_a.status_code == 200, resp_a.text
+    data_a = resp_a.json()
+    assert data_a["status"] == "COMPLETED", data_a["errors"]
+    run_a_id = UUID(data_a["run_id"])
+
+    # Guard against a vacuous pass: the scenario-wide run must have planned
+    # something before we can prove the next run purges it.
+    assert _active_count_for_run(run_a_id) > 0, (
+        "Scenario-wide APICS run created no PlannedSupply — the purge "
+        "assertions below would pass vacuously"
+    )
+
+    # Run B: single item on the unified endpoint
+    resp_b = api_client.post(
+        "/v1/mrp/run",
+        json={
+            "item_id": demand_item_location["item_id"],
+            "location_id": demand_item_location["location_id"],
+            "apics_mode": True,
+            "horizon_days": 90,
+        },
+        headers=auth,
+    )
+    assert resp_b.status_code == 200, resp_b.text
+    data_b = resp_b.json()
+    assert data_b["status"] == "COMPLETED", data_b["errors"]
+    run_b_id = UUID(data_b["run_id"])
+
+    # Only the latest run owns active PlannedSupply nodes.
+    assert _active_count_for_run(run_a_id) == 0, (
+        "Scenario-wide run's nodes should be purged by the following run"
+    )
+    stats = _active_planned_supply_stats(BASELINE_SCENARIO_ID)
+    assert _active_count_for_run(run_b_id) == stats["count"]

--- a/tests/integration/test_mrp_apics_scenario_isolation_integration.py
+++ b/tests/integration/test_mrp_apics_scenario_isolation_integration.py
@@ -1,0 +1,131 @@
+"""
+tests/integration/test_mrp_apics_scenario_isolation_integration.py — Issue #333.
+
+The APICS gross-to-net calculator used to hardcode the baseline scenario UUID
+inside _get_initial_on_hand, so an MRP run inside a scenario fork silently
+netted against *baseline* on-hand — a fork with diverged stock produced a
+wrong (baseline-shaped) plan.
+
+These tests fork the baseline via ScenarioManager, diverge the fork's copied
+OnHandSupply node, and verify that netting reads the fork's stock, not the
+baseline's — and that baseline runs are unchanged.
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from .conftest import requires_db
+
+BASELINE_ID = UUID("00000000-0000-0000-0000-000000000001")
+
+BASELINE_ON_HAND = Decimal("100")
+FORK_ON_HAND = Decimal("5")
+
+
+def _setup_fork_with_divergent_on_hand(conn):
+    """
+    Seed one item/location with baseline on-hand = 100, fork the baseline,
+    then set the fork's copied OnHandSupply quantity to 5.
+
+    Returns (item_id, location_id, fork_scenario_id).
+    """
+    from ootils_core.engine.scenario.manager import ScenarioManager
+
+    item_id = uuid4()
+    location_id = uuid4()
+
+    conn.execute(
+        "INSERT INTO items (item_id, name) VALUES (%s, 'mrp-iso-test-item')",
+        (item_id,),
+    )
+    conn.execute(
+        "INSERT INTO locations (location_id, name) VALUES (%s, 'mrp-iso-test-loc')",
+        (location_id,),
+    )
+    conn.execute(
+        """
+        INSERT INTO nodes (
+            node_id, node_type, scenario_id, item_id, location_id,
+            quantity, time_grain, time_ref, active
+        ) VALUES (%s, 'OnHandSupply', %s, %s, %s, %s, 'exact_date', CURRENT_DATE, TRUE)
+        """,
+        (uuid4(), BASELINE_ID, item_id, location_id, BASELINE_ON_HAND),
+    )
+
+    fork = ScenarioManager().create_scenario(
+        "mrp-apics-isolation-fork", BASELINE_ID, conn
+    )
+
+    # Diverge the fork: the deep-copied OnHandSupply drops from 100 to 5.
+    result = conn.execute(
+        """
+        UPDATE nodes
+        SET quantity = %s, updated_at = NOW()
+        WHERE scenario_id = %s
+          AND node_type = 'OnHandSupply'
+          AND item_id = %s
+          AND location_id = %s
+          AND active = TRUE
+        """,
+        (FORK_ON_HAND, fork.scenario_id, item_id, location_id),
+    )
+    assert result.rowcount == 1, "fork should contain exactly one copied OnHandSupply node"
+
+    return item_id, location_id, fork.scenario_id
+
+
+@requires_db
+def test_initial_on_hand_reads_fork_not_baseline(conn):
+    """_get_initial_on_hand scoped to a fork returns the fork's on-hand."""
+    from ootils_core.engine.mrp import GrossToNetCalculator
+
+    item_id, location_id, fork_id = _setup_fork_with_divergent_on_hand(conn)
+
+    fork_calc = GrossToNetCalculator(conn, fork_id)
+    assert fork_calc._get_initial_on_hand(item_id, location_id) == FORK_ON_HAND
+    # Location-less variant hits the second query branch — same scoping rule.
+    assert fork_calc._get_initial_on_hand(item_id, None) == FORK_ON_HAND
+
+
+@requires_db
+def test_initial_on_hand_baseline_unchanged(conn):
+    """Baseline-scoped calculator still reads baseline stock (regression guard)."""
+    from ootils_core.engine.mrp import GrossToNetCalculator
+
+    item_id, location_id, _fork_id = _setup_fork_with_divergent_on_hand(conn)
+
+    baseline_calc = GrossToNetCalculator(conn, BASELINE_ID)
+    assert baseline_calc._get_initial_on_hand(item_id, location_id) == BASELINE_ON_HAND
+
+
+@requires_db
+def test_netting_in_fork_uses_fork_on_hand(conn):
+    """
+    Full gross-to-net chain inside the fork: 50 units of demand against the
+    fork's on-hand of 5 must produce a net requirement. Against the baseline
+    on-hand of 100 (the pre-fix behaviour) there would be no shortage at all.
+    """
+    from ootils_core.engine.mrp import GrossToNetCalculator
+
+    item_id, location_id, fork_id = _setup_fork_with_divergent_on_hand(conn)
+
+    calc = GrossToNetCalculator(conn, fork_id)
+    buckets = calc.create_time_buckets(date.today(), horizon_days=28, grain="week")
+    demand = Decimal("50")
+
+    records = calc.calculate(
+        item_id=item_id,
+        location_id=location_id,
+        buckets=buckets,
+        planning_params={},  # safety stock defaults to 0
+        consumed_forecast={buckets[0].start: demand},
+        llc=0,
+    )
+
+    first = records[0]
+    # PAB(0) = fork on-hand (5) - demand (50) = -45, NOT baseline 100 - 50 = 50.
+    assert first.projected_on_hand == FORK_ON_HAND - demand
+    assert first.net_requirements == demand - FORK_ON_HAND
+    assert first.has_shortage is True

--- a/tests/integration/test_scenario_isolation_atp_rccp_integration.py
+++ b/tests/integration/test_scenario_isolation_atp_rccp_integration.py
@@ -1,0 +1,460 @@
+"""
+Scenario-isolation integration tests for ATP/CTP and RCCP (#338).
+
+Before the fix, the ATP engine queries on ``planned_supply`` /
+``customer_order_demand`` and the RCCP/CTP load queries on ``nodes`` had no
+``scenario_id`` predicate — a fork that wrote supply/demand contaminated the
+baseline answers (and vice-versa). These tests seed a baseline dataset plus a
+fork scenario with *extra* supplies/demands and assert:
+
+  (a) the baseline response does NOT include the fork rows;
+  (b) the response with ``?scenario_id=<fork>`` (or ``X-Scenario-ID`` header)
+      reflects the fork rows only.
+
+Runs against a real PostgreSQL database (no mocks), on a fresh migrated DB —
+no demo seed needed, every row is created (and cleaned up) locally.
+"""
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+AUTH_HEADERS = {"Authorization": "Bearer integration-test-token"}
+BASELINE_SCENARIO_ID = "00000000-0000-0000-0000-000000000001"
+
+
+# ---------------------------------------------------------------------------
+# Shared module-scoped fixtures (mirror tests/integration/test_atp_api_integration.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def api_client(migrated_db):
+    """Module-scoped FastAPI TestClient bound to the real test DB."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = "integration-test-token"
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+    from fastapi.testclient import TestClient
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="module")
+def auth():
+    return AUTH_HEADERS
+
+
+@pytest.fixture(scope="module")
+def fork_scenario_id(migrated_db) -> str:
+    """Create a fork scenario row (parent = baseline), return its id."""
+    import psycopg
+    from psycopg.rows import dict_row
+
+    scenario_id = uuid4()
+    with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        conn.execute(
+            """
+            INSERT INTO scenarios (scenario_id, name, parent_scenario_id)
+            VALUES (%s, %s, %s::UUID)
+            """,
+            (scenario_id, "atp-rccp-isolation-fork", BASELINE_SCENARIO_ID),
+        )
+        conn.commit()
+    return str(scenario_id)
+
+
+# ---------------------------------------------------------------------------
+# Seeding helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_item_and_location(conn) -> tuple[UUID, UUID]:
+    """Create a unique item + location, return their ids."""
+    item_id = uuid4()
+    location_id = uuid4()
+    conn.execute(
+        "INSERT INTO items (item_id, name) VALUES (%s, %s)",
+        (item_id, f"Iso Test Item {item_id}"),
+    )
+    conn.execute(
+        "INSERT INTO locations (location_id, name) VALUES (%s, %s)",
+        (location_id, f"Iso Test Loc {location_id}"),
+    )
+    return item_id, location_id
+
+
+def _seed_on_hand(conn, *, item_id, location_id, quantity, as_of_date) -> UUID:
+    on_hand_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO on_hand_supply (on_hand_id, item_id, location_id, quantity, as_of_date)
+        VALUES (%s, %s, %s, %s, %s)
+        """,
+        (on_hand_id, item_id, location_id, quantity, as_of_date),
+    )
+    return on_hand_id
+
+
+def _seed_planned_supply(
+    conn, *, item_id, location_id, quantity, due_date, scenario_id=BASELINE_SCENARIO_ID
+) -> UUID:
+    ps_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO planned_supply
+            (planned_supply_id, item_id, location_id, scenario_id, quantity, due_date, status, priority)
+        VALUES (%s, %s, %s, %s::UUID, %s, %s, 'RELEASED', 0)
+        """,
+        (ps_id, item_id, location_id, scenario_id, quantity, due_date),
+    )
+    return ps_id
+
+
+def _seed_demand(
+    conn, *, item_id, location_id, quantity, requested_date, scenario_id=BASELINE_SCENARIO_ID
+) -> UUID:
+    cod_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO customer_order_demand
+            (customer_order_demand_id, item_id, location_id, scenario_id, quantity,
+             requested_date, status, priority, is_committed)
+        VALUES (%s, %s, %s, %s::UUID, %s, %s, 'CONFIRMED', 0, TRUE)
+        """,
+        (cod_id, item_id, location_id, scenario_id, quantity, requested_date),
+    )
+    return cod_id
+
+
+def _teardown_atp_rows(conn, *, item_id, location_id) -> None:
+    """Delete every ATP row written for this item/location."""
+    conn.execute("DELETE FROM customer_order_demand WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM planned_supply WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM on_hand_supply WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM items WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM locations WHERE location_id = %s", (location_id,))
+
+
+def _insert_resource_with_node(conn, *, external_id: str, scenario_id: str) -> dict:
+    """Insert a resources row + a 'Resource' graph node in the given scenario."""
+    resource_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO resources
+            (resource_id, external_id, name, resource_type, capacity_per_day, capacity_unit)
+        VALUES (%s, %s, 'Iso Test Resource', 'machine', 100.0, 'unit')
+        """,
+        (resource_id, external_id),
+    )
+    node_id = _insert_resource_node(conn, external_id=external_id, scenario_id=scenario_id)
+    return {"resource_id": resource_id, "node_id": node_id}
+
+
+def _insert_resource_node(conn, *, external_id: str, scenario_id: str) -> UUID:
+    """Insert only a 'Resource' graph node (fork copy of an existing resource)."""
+    node_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO nodes (node_id, node_type, scenario_id, external_id, active)
+        VALUES (%s, 'Resource', %s::UUID, %s, TRUE)
+        """,
+        (node_id, scenario_id, external_id),
+    )
+    return node_id
+
+
+def _insert_supply_node_with_edge(
+    conn,
+    *,
+    node_type: str,
+    item_id,
+    time_ref: date,
+    quantity: float,
+    resource_node_id,
+    scenario_id: str,
+) -> UUID:
+    """Insert a supply node + consumes_resource edge, both in the given scenario."""
+    node_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO nodes
+            (node_id, node_type, scenario_id, item_id, quantity, time_grain, time_ref, active)
+        VALUES (%s, %s, %s::UUID, %s, %s, 'exact_date', %s, TRUE)
+        """,
+        (node_id, node_type, scenario_id, item_id, quantity, time_ref),
+    )
+    conn.execute(
+        """
+        INSERT INTO edges (edge_id, edge_type, from_node_id, to_node_id, scenario_id, active)
+        VALUES (%s, 'consumes_resource', %s, %s, %s::UUID, TRUE)
+        """,
+        (uuid4(), node_id, resource_node_id, scenario_id),
+    )
+    return node_id
+
+
+def _teardown_rccp_rows(conn, *, external_id: str, item_id, location_id) -> None:
+    """Delete the resource, its graph nodes (all scenarios), edges and supply nodes."""
+    node_rows = conn.execute(
+        "SELECT node_id FROM nodes WHERE node_type = 'Resource' AND external_id = %s",
+        (external_id,),
+    ).fetchall()
+    for nr in node_rows:
+        supply_rows = conn.execute(
+            """
+            SELECT n.node_id FROM nodes n
+            JOIN edges e ON e.from_node_id = n.node_id
+            WHERE e.edge_type = 'consumes_resource' AND e.to_node_id = %s
+            """,
+            (nr["node_id"],),
+        ).fetchall()
+        for sr in supply_rows:
+            conn.execute("DELETE FROM edges WHERE from_node_id = %s", (sr["node_id"],))
+            conn.execute("DELETE FROM nodes WHERE node_id = %s", (sr["node_id"],))
+        conn.execute(
+            "DELETE FROM edges WHERE from_node_id = %s OR to_node_id = %s",
+            (nr["node_id"], nr["node_id"]),
+        )
+        conn.execute("DELETE FROM nodes WHERE node_id = %s", (nr["node_id"],))
+    conn.execute("DELETE FROM resources WHERE external_id = %s", (external_id,))
+    conn.execute("DELETE FROM items WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM locations WHERE location_id = %s", (location_id,))
+
+
+def _stable(body: dict) -> dict:
+    """Strip the timing field so two identical calculations compare equal."""
+    return {k: v for k, v in body.items() if k != "calculation_time_ms"}
+
+
+# ---------------------------------------------------------------------------
+# ATP / CTP — baseline vs fork isolation
+# ---------------------------------------------------------------------------
+
+
+class TestATPScenarioIsolation:
+    """POST /v1/atp/check and /v1/ctp/check must be scenario-scoped."""
+
+    def _seed(self, migrated_db, fork_scenario_id):
+        """Baseline: on_hand 100 + demand 20@D+1. Fork: +supply 50@D+5, +demand 100@D+1."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        today = date.today()
+        with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+            item_id, location_id = _insert_item_and_location(conn)
+            _seed_on_hand(conn, item_id=item_id, location_id=location_id,
+                          quantity=100, as_of_date=today)
+            _seed_demand(conn, item_id=item_id, location_id=location_id,
+                         quantity=20, requested_date=today + timedelta(days=1))
+            # Fork-only rows — must NOT leak into baseline answers
+            _seed_planned_supply(conn, item_id=item_id, location_id=location_id,
+                                 quantity=50, due_date=today + timedelta(days=5),
+                                 scenario_id=fork_scenario_id)
+            _seed_demand(conn, item_id=item_id, location_id=location_id,
+                         quantity=100, requested_date=today + timedelta(days=1),
+                         scenario_id=fork_scenario_id)
+            conn.commit()
+        return item_id, location_id, today
+
+    def test_atp_baseline_ignores_fork_and_fork_sees_own_rows(
+        self, api_client, auth, migrated_db, fork_scenario_id
+    ):
+        import psycopg
+        from psycopg.rows import dict_row
+
+        item_id, location_id, today = self._seed(migrated_db, fork_scenario_id)
+        payload = {
+            "item_id": str(item_id),
+            "location_id": str(location_id),
+            "quantity": 150,
+            "requested_date": today.isoformat(),
+            "horizon_days": 30,
+        }
+        try:
+            # (a) Baseline (no scenario param): on_hand 100 - demand 20 = 80.
+            # The fork's +50 supply and +100 demand must be invisible.
+            resp = api_client.post("/v1/atp/check", json=payload, headers=auth)
+            assert resp.status_code == 200, resp.text
+            baseline = resp.json()
+            assert baseline["available"] is False
+            assert float(baseline["quantity_available"]) == 80.0
+            assert float(baseline["backorder_quantity"]) == 70.0
+
+            # (b) Fork: on_hand 100 (shared snapshot) - fork demand 100 + fork
+            # supply 50 = 50 available at D+5.
+            resp = api_client.post(
+                "/v1/atp/check", json=payload,
+                params={"scenario_id": fork_scenario_id}, headers=auth,
+            )
+            assert resp.status_code == 200, resp.text
+            fork = resp.json()
+            assert fork["available"] is False
+            assert float(fork["quantity_available"]) == 50.0
+            assert float(fork["backorder_quantity"]) == 100.0
+
+            # X-Scenario-ID header is equivalent to the query param
+            # (calculation_time_ms is timing noise — excluded from comparison)
+            resp = api_client.post(
+                "/v1/atp/check", json=payload,
+                headers={**auth, "X-Scenario-ID": fork_scenario_id},
+            )
+            assert resp.status_code == 200, resp.text
+            assert _stable(resp.json()) == _stable(fork)
+
+            # Baseline answer is unchanged after fork reads (no contamination)
+            resp = api_client.post("/v1/atp/check", json=payload, headers=auth)
+            assert resp.status_code == 200, resp.text
+            assert _stable(resp.json()) == _stable(baseline)
+        finally:
+            with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+                _teardown_atp_rows(conn, item_id=item_id, location_id=location_id)
+                conn.commit()
+
+    def test_ctp_check_is_scenario_scoped(
+        self, api_client, auth, migrated_db, fork_scenario_id
+    ):
+        """CTP wraps ATP — same isolation contract on the material side."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        item_id, location_id, today = self._seed(migrated_db, fork_scenario_id)
+        payload = {
+            "item_id": str(item_id),
+            "location_id": str(location_id),
+            "quantity": 150,
+            "requested_date": today.isoformat(),
+            "horizon_days": 30,
+            "include_capacity": True,
+        }
+        try:
+            resp = api_client.post("/v1/ctp/check", json=payload, headers=auth)
+            assert resp.status_code == 200, resp.text
+            assert float(resp.json()["quantity_available"]) == 80.0
+
+            resp = api_client.post(
+                "/v1/ctp/check", json=payload,
+                params={"scenario_id": fork_scenario_id}, headers=auth,
+            )
+            assert resp.status_code == 200, resp.text
+            assert float(resp.json()["quantity_available"]) == 50.0
+        finally:
+            with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+                _teardown_atp_rows(conn, item_id=item_id, location_id=location_id)
+                conn.commit()
+
+    def test_atp_invalid_scenario_id_is_422(self, api_client, auth):
+        payload = {
+            "item_id": str(uuid4()),
+            "location_id": str(uuid4()),
+            "quantity": 1,
+            "requested_date": date.today().isoformat(),
+        }
+        resp = api_client.post(
+            "/v1/atp/check", json=payload,
+            params={"scenario_id": "not-a-uuid"}, headers=auth,
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# RCCP — baseline vs fork isolation
+# ---------------------------------------------------------------------------
+
+
+class TestRCCPScenarioIsolation:
+    """GET /v1/rccp/{resource} load aggregation must be scenario-scoped."""
+
+    def test_rccp_load_baseline_vs_fork(
+        self, api_client, auth, migrated_db, fork_scenario_id
+    ):
+        import psycopg
+        from psycopg.rows import dict_row
+
+        ext = f"RES-ISO-{uuid4().hex[:6]}"
+        load_date = date(2026, 1, 13)
+        with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+            item_id, location_id = _insert_item_and_location(conn)
+            # Baseline: resources row + Resource node + WorkOrderSupply 300
+            ids = _insert_resource_with_node(
+                conn, external_id=ext, scenario_id=BASELINE_SCENARIO_ID
+            )
+            _insert_supply_node_with_edge(
+                conn, node_type="WorkOrderSupply", item_id=item_id,
+                time_ref=load_date, quantity=300.0,
+                resource_node_id=ids["node_id"], scenario_id=BASELINE_SCENARIO_ID,
+            )
+            # Fork: Resource node copy + extra PlannedSupply 400 (fork-only)
+            fork_node_id = _insert_resource_node(
+                conn, external_id=ext, scenario_id=fork_scenario_id
+            )
+            _insert_supply_node_with_edge(
+                conn, node_type="PlannedSupply", item_id=item_id,
+                time_ref=load_date, quantity=400.0,
+                resource_node_id=fork_node_id, scenario_id=fork_scenario_id,
+            )
+            conn.commit()
+
+        params = {
+            "from_date": load_date.isoformat(),
+            "to_date": load_date.isoformat(),
+            "grain": "day",
+        }
+        try:
+            # (a) Baseline: load = 300 only — the fork's 400 must not be summed
+            # (pre-fix this returned 700).
+            resp = api_client.get(f"/v1/rccp/{ext}", params=params, headers=auth)
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["buckets"][0]["load"] == 300.0
+
+            # (b) Fork: load = 400 only (the fork graph is self-contained).
+            resp = api_client.get(
+                f"/v1/rccp/{ext}",
+                params={**params, "scenario_id": fork_scenario_id},
+                headers=auth,
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["buckets"][0]["load"] == 400.0
+
+            # X-Scenario-ID header path
+            resp = api_client.get(
+                f"/v1/rccp/{ext}", params=params,
+                headers={**auth, "X-Scenario-ID": fork_scenario_id},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["buckets"][0]["load"] == 400.0
+        finally:
+            with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+                _teardown_rccp_rows(
+                    conn, external_id=ext, item_id=item_id, location_id=location_id
+                )
+                conn.commit()
+
+    def test_rccp_invalid_scenario_id_is_422(self, api_client, auth):
+        resp = api_client.get(
+            "/v1/rccp/ANY-RES",
+            params={"grain": "day", "scenario_id": "not-a-uuid"},
+            headers=auth,
+        )
+        assert resp.status_code == 422

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -648,6 +648,83 @@ class TestSimulateRouterBranches:
         # The propagation succeeded — calc_run_id should be set
         assert body["calc_run_id"] is not None
         assert body["nodes_recalculated"] == 5
+        # #339 contract: success is reported explicitly
+        assert body["propagation_status"] == "ok"
+        assert body["delta_computed"] is True
+
+    def test_simulate_propagation_failure_surfaced_and_lock_released(self):
+        """simulate.py except branch (#339) — a propagation crash must NOT be
+        swallowed into a 'created'-with-empty-delta response, and the calc
+        run's advisory lock must be released via fail_calc_run."""
+        from ootils_core.engine.scenario.manager import ScenarioManager
+        from ootils_core.models import Scenario
+
+        fake_scenario = Scenario(
+            scenario_id=uuid4(),
+            name="x",
+            parent_scenario_id=UUID("00000000-0000-0000-0000-000000000001"),
+            is_baseline=False,
+            status="active",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        from ootils_core.api.routers import events as events_module
+        from ootils_core.engine.kernel.shortage.detector import ShortageDetector
+        from ootils_core.engine.orchestration.calc_run import CalcRunManager
+        from ootils_core.engine.kernel.graph.dirty import DirtyFlagManager
+
+        calc_run = MagicMock()
+        calc_run.calc_run_id = uuid4()
+        calc_run.nodes_recalculated = 0
+
+        # The propagation engine crashes mid-run (after start_calc_run, before
+        # _finish_run) — the advisory lock is held at that point.
+        fake_engine = MagicMock()
+        fake_engine._propagate.side_effect = RuntimeError("propagation boom")
+
+        pi_node_id = uuid4()
+        conn = _make_db_with_responses([
+            None,  # INSERT events
+            [{"node_id": pi_node_id}],  # SELECT all_pi_nodes
+        ])
+
+        with patch.object(ScenarioManager, "create_scenario", return_value=fake_scenario), \
+             patch.object(ScenarioManager, "apply_override"), \
+             patch.object(ShortageDetector, "get_active_shortages", return_value=[]), \
+             patch.object(CalcRunManager, "start_calc_run", return_value=calc_run), \
+             patch.object(CalcRunManager, "fail_calc_run") as fail_mock, \
+             patch.object(DirtyFlagManager, "mark_dirty"), \
+             patch.object(DirtyFlagManager, "flush_to_postgres"), \
+             patch.object(events_module, "_build_propagation_engine", return_value=fake_engine):
+            client = _make_client(conn)
+            resp = client.post(
+                "/v1/simulate",
+                json={
+                    "scenario_name": "crash-case",
+                    "overrides": [
+                        {
+                            "node_id": str(uuid4()),
+                            "field_name": "quantity",
+                            "new_value": "100",
+                        }
+                    ],
+                },
+                headers=AUTH_HEADERS,
+            )
+
+        # Scenario creation succeeded — not an HTTP error...
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        # ...but the failure is explicit: an agent can tell "no new shortages"
+        # from "the calc crashed".
+        assert body["propagation_status"] == "failed"
+        assert body["delta_computed"] is False
+        assert body["delta"]["new_shortages"] == []
+        assert body["delta"]["resolved_shortages"] == []
+        # The started-but-unfinished calc run was failed → advisory lock released.
+        fail_mock.assert_called_once()
+        assert fail_mock.call_args[0][0] is calc_run
 
 
 # ============================================================================


### PR DESCRIPTION
## Chantier C0 — Sprint correctness scénarios, vague 1

Première vague du sprint correctness issu de la **revue APS 2026-07** (`docs/REVIEW-2026-07-APS.md`, épique #351). Quatre fixes P0 qui restaurent l'invariant scenario-first, chacun passé en revue adversariale.

### Fixes

| Issue | Fix |
|---|---|
| #333 (partiel) | `_get_initial_on_hand` lit `self.scenario_id` au lieu de `BASELINE` en dur — le netting MRP APICS dans un fork utilise l'on-hand du fork. Audit grep : aucun autre chemin de lecture baseline-en-dur dans `engine/mrp/`. **Reste pour la vague 2** : la lecture demande Pyramide (couplée à #331). |
| #337 | `cleanup_previous_run()` appelé en tête de run APICS → plus d'accumulation de PlannedSupply au re-run. Converti en **soft-delete** (`active=FALSE`) : le hard DELETE violait la FK `events.trigger_node_id` dès le 2e run ; aligne aussi sur le pattern `clear_existing` du mode simple et préserve l'audit. Rollback ajouté si le run échoue (sinon la purge était committée sans plan de remplacement). |
| #338 | ATP/CTP + RCCP scénarisés : `resolve_scenario_id` + prédicats `scenario_id` sur toutes les requêtes. Défaut baseline, rétro-compatible. Avant : agrégation de **tous** les scénarios (contamination bidirectionnelle fork↔baseline). |
| #339 | `/v1/simulate` expose `propagation_status` (`ok`/`failed`/`skipped`) + `delta_computed` ; l'échec de propagation est loggé au lieu d'être avalé ; l'advisory lock est relâché via `fail_calc_run` si le run était en cours (sinon les simulate suivants renvoyaient `skipped` en silence). Volontairement PAS un HTTP 500 : le fork a réussi, c'est le recompute best-effort qui a échoué. |

### Tests

- `tests/integration/test_mrp_apics_scenario_isolation_integration.py` (3 tests) — isolation on-hand fork vs baseline, chaîne de netting complète dans le fork.
- `tests/integration/test_mrp_apics_rerun_integration.py` (2 tests) — pas d'accumulation au re-run, purge scenario-scoped ; fixture dédiée choisissant une paire (item, location) portant de la demande + garde anti-test-vide (`count > 0`).
- `tests/integration/test_scenario_isolation_atp_rccp_integration.py` — un fork qui écrit ne change pas les réponses baseline ATP/RCCP.
- `tests/integration/test_m6_api_integration.py` — contrat `propagation_status` en intégration.
- `tests/test_coverage_gaps.py` — branche `failed` de simulate en unitaire (crash de propagation → statut explicite + lock relâché).

Local : ruff OK, 1690 tests unitaires verts. Les tests d'intégration s'exécutent en CI.

### Découvertes en passant

- #352 (nouvelle) : fuites `str(e)` pré-existantes hors carve-out dans `atp/routers.py` et `simulate.py:115`.
- Le fork ne copie pas les tables relationnelles `planned_supply`/`customer_order_demand` → l'ATP dans un fork fraîchement créé voit une supply vide (limite documentée, pas une régression).
- CLAUDE.md est en retard sur la CI : `tests/integration/` est bien exécuté avec un service Postgres.

Closes #337. Closes #338. Closes #339. Ref #333, #351.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
