### PR TITLE
fix(ci): pin fastapi 0.128.x — starlette 1.3 casse l'énumération des routes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 # the next major. Dependabot opens PRs weekly to bump within these ranges.
 # See docs/REVIEW-2026-05.md R4.
 dependencies = [
-    "fastapi ~= 0.128",
+    "fastapi ~= 0.128.0",  # NOT ~= 0.128: that means <1.0 and let CI resolve 0.139 + starlette 1.x (breaking)
     "uvicorn[standard] ~= 0.40",
     "psycopg[binary] ~= 3.3",
     "psycopg-pool ~= 3.3",


### PR DESCRIPTION
## Problème

La CI de toute branche échoue depuis la sortie de fastapi 0.139 : le pin `fastapi ~= 0.128` ne fige que le **premier segment** (PEP 440 : `>=0.128, <1.0`), donc l'install CI a résolu **fastapi 0.139.0 + starlette 1.3.1**. Starlette 1.x introduit `_IncludedRouter`, qui casse l'énumération des routes : les ~14 tests « router registered in app » trouvent 0 routes (`'_IncludedRouter' object has no attribute 'path'`).

Observé sur la CI de #353 (échec identique attendu sur n'importe quelle branche, y compris main — le dernier run CI de main date d'avant la release fastapi 0.139).

## Fix

`fastapi ~= 0.128.0` → autorise les patchs 0.128.x seulement ; fastapi 0.128.x borne starlette à `<0.51.0`, ce qui restaure la pile testée localement (0.128.0 / 0.50.0).

## À surveiller (hors scope, même famille de risque)

Les autres pins 0.x à deux segments (`uvicorn ~= 0.40`, `slowapi ~= 0.1`, `httpx ~= 0.28`, `python-multipart ~= 0.0.20`) ont la même sémantique piégée : un bump mineur 0.x est souvent cassant. À traiter via l'item « check de somme de contrôle / hygiène deps » du fond de backlog #350 si souhaité.

⚠️ À merger en priorité : débloque la CI de #353 (chantier C0 vague 1) et des branches suivantes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
