### PR TITLE
feat(reco): C1 PR-B — API recommandations, machine d'états partagée, garde humaine L3+

### DIFF
--- a/scripts/recommendation_review.py
+++ b/scripts/recommendation_review.py
@@ -9,11 +9,17 @@ Non-negotiable (strategy doc §13): no external ERP mutation without explicit
 human approval. APPROVED/APPLIED transitions are human (L3/L4) decisions only —
 this tool records them; it does not itself push to any ERP.
 
-State machine:
+State machine (single source of truth:
+src/ootils_core/engine/recommendation/state_machine.py — shared with the
+/v1/recommendations API router):
     DRAFT     → REVIEWED | APPROVED | REJECTED
     REVIEWED  → APPROVED | REJECTED
     APPROVED  → APPLIED  | REJECTED
     EXPIRED / APPLIED / REJECTED = terminal
+
+Schema: tables come from migrations 039 (recommendations) + 040
+(recommendation_transitions) — applied automatically at API startup.
+This tool no longer creates any table itself.
 
 Commands:
     status                                  inbox summary by status × action
@@ -36,28 +42,10 @@ import sys
 
 import psycopg
 
+from ootils_core.engine.recommendation.state_machine import transition_many
+
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger("reco_review")
-
-ALLOWED = {
-    "DRAFT": {"REVIEWED", "APPROVED", "REJECTED"},
-    "REVIEWED": {"APPROVED", "REJECTED"},
-    "APPROVED": {"APPLIED", "REJECTED"},
-}
-
-ENSURE_SCHEMA = """
-CREATE TABLE IF NOT EXISTS recommendation_transitions (
-    transition_id     UUID NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
-    recommendation_id UUID NOT NULL,
-    from_status       TEXT,
-    to_status         TEXT NOT NULL,
-    actor             TEXT NOT NULL,
-    actor_kind        TEXT NOT NULL DEFAULT 'human',
-    reason            TEXT,
-    created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-CREATE INDEX IF NOT EXISTS ix_reco_trans_reco ON recommendation_transitions (recommendation_id, created_at);
-"""
 
 
 def _guard(dsn: str, allow_dev: bool) -> str:
@@ -97,40 +85,21 @@ def cmd_list(conn, action, limit):
 
 
 def _transition(conn, to_status, actor, reason, action, reco_id, allow_dev):
-    """Apply a state transition to a set of recommendations, logging each."""
-    # Select targets + their current status, locking them
-    if reco_id:
-        targets = conn.execute(
-            "SELECT recommendation_id, status FROM recommendations WHERE recommendation_id=%s FOR UPDATE",
-            (reco_id,),
-        ).fetchall()
-    else:
-        # bulk by action; for APPLIED, source must be APPROVED, else DRAFT/REVIEWED
-        src_statuses = ("APPROVED",) if to_status == "APPLIED" else ("DRAFT", "REVIEWED")
-        q = "SELECT recommendation_id, status FROM recommendations WHERE status = ANY(%s)"
-        params = [list(src_statuses)]
-        if action:
-            q += " AND action=%s"
-            params.append(action)
-        q += " FOR UPDATE"
-        targets = conn.execute(q, params).fetchall()
+    """Apply a state transition to a set of recommendations, logging each.
 
-    moved, skipped = 0, 0
-    for rid, cur_status in targets:
-        if to_status not in ALLOWED.get(cur_status, set()):
-            skipped += 1
-            continue
-        conn.execute(
-            "UPDATE recommendations SET status=%s, updated_at=now() WHERE recommendation_id=%s",
-            (to_status, rid),
-        )
-        conn.execute(
-            "INSERT INTO recommendation_transitions (recommendation_id, from_status, to_status, actor, actor_kind, reason) "
-            "VALUES (%s,%s,%s,%s,'human',%s)",
-            (rid, cur_status, to_status, actor, reason),
-        )
-        moved += 1
-    return moved, skipped
+    Delegates to the shared engine state machine (FOR UPDATE locking,
+    validation, audit row) — this CLI is a human tool, so actor_kind is
+    always 'human'.
+    """
+    return transition_many(
+        conn,
+        to_status,
+        actor,
+        actor_kind="human",
+        reason=reason,
+        action=action,
+        recommendation_id=reco_id,
+    )
 
 
 def cmd_history(conn, reco_id):
@@ -169,7 +138,6 @@ def main(argv=None) -> int:
     _guard(args.dsn, args.allow_dev)
 
     with psycopg.connect(args.dsn) as conn:
-        conn.execute(ENSURE_SCHEMA)
         if args.command == "status":
             cmd_status(conn)
         elif args.command == "list":

--- a/src/ootils_core/api/app.py
+++ b/src/ootils_core/api/app.py
@@ -33,7 +33,7 @@ except ImportError:
 
 from ootils_core.api.auth import _expected_token
 from ootils_core.api.dependencies import _get_ootils_db, get_db
-from ootils_core.api.routers import bom, calc, calendars, demo, dq, events, explain, forecasting, ghosts, graph, ingest, issues, mrp, mrp_apics, planning_params, projection, pyramide, rccp, scenarios, simulate, staging
+from ootils_core.api.routers import bom, calc, calendars, demo, dq, events, explain, forecasting, ghosts, graph, ingest, issues, mrp, mrp_apics, planning_params, projection, pyramide, rccp, recommendations, scenarios, simulate, staging
 from ootils_core.api.routers.graph import nodes_router
 from ootils_core.mps import router as mps_router
 from ootils_core.atp import atp_router
@@ -361,6 +361,7 @@ def create_app() -> FastAPI:
     application.include_router(rccp.router)
     application.include_router(ghosts.router)
     application.include_router(planning_params.router)
+    application.include_router(recommendations.router)
     application.include_router(scenarios.router)
     application.include_router(calc.router)
     application.include_router(demo.router)

--- a/src/ootils_core/api/routers/events.py
+++ b/src/ootils_core/api/routers/events.py
@@ -94,7 +94,7 @@ def _build_propagation_engine(db):
     )
 
 
-# Must stay in sync with events.event_type CHECK constraint in migrations 002 + 006.
+# Must stay in sync with events.event_type CHECK constraint in migrations 002 + 006 + 051.
 # Any new event type requires both a DB migration (ALTER TABLE ... ADD CONSTRAINT)
 # and an addition here.
 VALID_EVENT_TYPES = {
@@ -112,6 +112,8 @@ VALID_EVENT_TYPES = {
     "test_event",
     # From migration 006 CHECK constraint extension
     "scenario_merge",
+    # From migration 051 CHECK constraint extension (recommendation governance)
+    "recommendation_transition",
 }
 
 

--- a/src/ootils_core/api/routers/recommendations.py
+++ b/src/ootils_core/api/routers/recommendations.py
@@ -1,0 +1,353 @@
+"""
+/v1/recommendations — read + govern agent recommendations (chantier #341a).
+
+The agent fleet writes L1 DRAFT recommendations (migration 039); humans
+review, approve, reject, and mark them applied. This router exposes:
+
+  GET  /v1/recommendations                 list (scenario-scoped, paginated)
+  GET  /v1/recommendations/{id}            detail + evidence + audit trail
+  POST /v1/recommendations/{id}/transition governed status change
+
+The state machine lives in engine/recommendation/state_machine.py — the
+single source of truth shared with the CLI control room
+(scripts/recommendation_review.py). This router never re-implements the
+transition rules.
+
+Every applied transition emits a 'recommendation_transition' event
+(migration 051) so agents can stream governance changes (Streamable
+principle) instead of polling.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date
+from decimal import Decimal
+from typing import Any, List, Literal, Optional
+from uuid import UUID, uuid4
+
+import psycopg
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+
+from ootils_core.api.auth import require_auth
+from ootils_core.api.dependencies import get_db, resolve_scenario_id
+from ootils_core.engine.recommendation.state_machine import (
+    ALLOWED_TRANSITIONS,
+    HumanGateError,
+    InvalidTransitionError,
+    RecommendationNotFoundError,
+    transition_one,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/v1/recommendations", tags=["recommendations"])
+
+# Keep in sync with the CHECK constraints in migration 039.
+VALID_STATUSES = frozenset(ALLOWED_TRANSITIONS)
+VALID_ACTIONS = frozenset({"EXPEDITE", "ORDER_RUSH", "ORDER_NOW"})
+
+# Decision Ladder guard (strategy doc §5): APPROVED and APPLIED are L3/L4
+# decisions — humans only. The rule itself lives in the state machine
+# (state_machine.HUMAN_ONLY_TARGETS / enforce_human_gate) so every consumer
+# — this router, the CLI, any future in-process caller — hits the same gate;
+# the router only maps HumanGateError to a 403. Transitional until per-token
+# agent scopes land (#350): actor_kind is self-declared, and once token
+# scopes exist an agent token will be structurally unable to claim 'human'.
+
+
+# ---------------------------------------------------------------------------
+# Response / request models
+# ---------------------------------------------------------------------------
+
+
+class RecommendationOut(BaseModel):
+    recommendation_id: UUID
+    agent_name: str
+    agent_run_id: UUID
+    scenario_id: UUID
+    item_id: UUID
+    item_external_id: str
+    shortage_date: date
+    deficit_qty: Decimal
+    recommended_qty: Decimal
+    estimated_cost: Optional[Decimal] = None
+    currency: Optional[str] = None
+    supplier_id: Optional[UUID] = None
+    supplier_external_id: Optional[str] = None
+    lead_time_days: Optional[int] = None
+    runway_days: Optional[int] = None
+    margin_days: Optional[int] = None
+    action: str
+    decision_level: str
+    status: str
+    confidence: str
+    created_at: str
+    updated_at: str
+
+
+class RecommendationsListResponse(BaseModel):
+    recommendations: List[RecommendationOut]
+    total: int
+    limit: int
+    offset: int
+
+
+class TransitionRecord(BaseModel):
+    transition_id: UUID
+    from_status: Optional[str] = None
+    to_status: str
+    actor: str
+    actor_kind: str
+    reason: Optional[str] = None
+    created_at: str
+
+
+class RecommendationDetailOut(RecommendationOut):
+    # JSONB carve-out payload (migration 039): forensic evidence trail —
+    # unbounded diagnostic shape, surfaced verbatim for explainability.
+    evidence: Optional[Any] = None
+    transitions: List[TransitionRecord] = []
+
+
+class TransitionRequest(BaseModel):
+    to_status: Literal["DRAFT", "REVIEWED", "APPROVED", "REJECTED", "APPLIED", "EXPIRED"]
+    actor: str = Field(min_length=1, max_length=200, description="Username or agent name")
+    actor_kind: Literal["human", "agent"] = "human"
+    reason: Optional[str] = None
+
+
+class TransitionResponse(BaseModel):
+    recommendation_id: UUID
+    transition_id: UUID
+    scenario_id: UUID
+    from_status: str
+    to_status: str
+    actor: str
+    actor_kind: str
+    event_id: UUID
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iso(value: Any) -> str:
+    return value.isoformat() if hasattr(value, "isoformat") else str(value)
+
+
+def _to_out(row: dict) -> RecommendationOut:
+    return RecommendationOut(
+        recommendation_id=row["recommendation_id"],
+        agent_name=row["agent_name"],
+        agent_run_id=row["agent_run_id"],
+        scenario_id=row["scenario_id"],
+        item_id=row["item_id"],
+        item_external_id=row["item_external_id"],
+        shortage_date=row["shortage_date"],
+        deficit_qty=row["deficit_qty"],
+        recommended_qty=row["recommended_qty"],
+        estimated_cost=row.get("estimated_cost"),
+        currency=row.get("currency"),
+        supplier_id=row.get("supplier_id"),
+        supplier_external_id=row.get("supplier_external_id"),
+        lead_time_days=row.get("lead_time_days"),
+        runway_days=row.get("runway_days"),
+        margin_days=row.get("margin_days"),
+        action=row["action"],
+        decision_level=row["decision_level"],
+        status=row["status"],
+        confidence=row["confidence"],
+        created_at=_iso(row["created_at"]),
+        updated_at=_iso(row["updated_at"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=RecommendationsListResponse)
+def list_recommendations(
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+    scenario_id: UUID = Depends(resolve_scenario_id),
+    status_filter: Optional[str] = Query(default=None, alias="status"),
+    action: Optional[str] = Query(default=None),
+    agent_name: Optional[str] = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> RecommendationsListResponse:
+    """List recommendations for a scenario (baseline by default), newest first."""
+    if status_filter is not None and status_filter not in VALID_STATUSES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Unknown status '{status_filter}'. Valid: {sorted(VALID_STATUSES)}",
+        )
+    if action is not None and action not in VALID_ACTIONS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Unknown action '{action}'. Valid: {sorted(VALID_ACTIONS)}",
+        )
+
+    conditions = ["scenario_id = %s"]
+    params: list = [scenario_id]
+    if status_filter is not None:
+        conditions.append("status = %s")
+        params.append(status_filter)
+    if action is not None:
+        conditions.append("action = %s")
+        params.append(action)
+    if agent_name is not None:
+        conditions.append("agent_name = %s")
+        params.append(agent_name)
+    where_clause = "WHERE " + " AND ".join(conditions)
+
+    count_row = db.execute(
+        f"SELECT COUNT(*) AS total FROM recommendations {where_clause}",  # noqa: S608 — static columns, parameterized values
+        params,
+    ).fetchone()
+    total = int(count_row["total"]) if count_row else 0
+
+    rows = db.execute(
+        f"""
+        SELECT * FROM recommendations
+        {where_clause}
+        ORDER BY created_at DESC, recommendation_id
+        LIMIT %s OFFSET %s
+        """,  # noqa: S608
+        params + [limit, offset],
+    ).fetchall()
+
+    return RecommendationsListResponse(
+        recommendations=[_to_out(r) for r in rows],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/{recommendation_id}", response_model=RecommendationDetailOut)
+def get_recommendation(
+    recommendation_id: UUID,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> RecommendationDetailOut:
+    """Recommendation detail: evidence trail (explainability) + full transition history."""
+    row = db.execute(
+        "SELECT * FROM recommendations WHERE recommendation_id = %s",
+        (recommendation_id,),
+    ).fetchone()
+    if not row:
+        raise HTTPException(
+            status_code=404, detail=f"Recommendation {recommendation_id} not found"
+        )
+
+    transitions = db.execute(
+        """
+        SELECT transition_id, from_status, to_status, actor, actor_kind, reason, created_at
+        FROM recommendation_transitions
+        WHERE recommendation_id = %s
+        ORDER BY created_at, transition_id
+        """,
+        (recommendation_id,),
+    ).fetchall()
+
+    base = _to_out(row)
+    return RecommendationDetailOut(
+        **base.model_dump(),
+        evidence=row.get("evidence"),
+        transitions=[
+            TransitionRecord(
+                transition_id=t["transition_id"],
+                from_status=t.get("from_status"),
+                to_status=t["to_status"],
+                actor=t["actor"],
+                actor_kind=t["actor_kind"],
+                reason=t.get("reason"),
+                created_at=_iso(t["created_at"]),
+            )
+            for t in transitions
+        ],
+    )
+
+
+@router.post("/{recommendation_id}/transition", response_model=TransitionResponse)
+def transition_recommendation(
+    recommendation_id: UUID,
+    body: TransitionRequest,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> TransitionResponse:
+    """Apply a governed state-machine transition to one recommendation."""
+    try:
+        result = transition_one(
+            db,
+            recommendation_id,
+            body.to_status,
+            body.actor,
+            actor_kind=body.actor_kind,
+            reason=body.reason,
+        )
+    except HumanGateError as e:
+        # Decision Ladder gate — enforced by the state machine itself (single
+        # source of truth); the router only maps it to HTTP. Transitional
+        # until per-token agent scopes land (#350): actor_kind is
+        # self-declared.
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"Transition to '{e.to_status}' is an L3/L4 decision reserved to "
+                "human actors (Decision Ladder, strategy doc §5). Agents may move "
+                "recommendations to REVIEWED or REJECTED only."
+            ),
+        )
+    except RecommendationNotFoundError:
+        raise HTTPException(
+            status_code=404, detail=f"Recommendation {recommendation_id} not found"
+        )
+    except InvalidTransitionError as e:
+        # Hand-authored message from typed attributes (never str(exc)):
+        # statuses come from the DB CHECK constraint + the Literal-validated body.
+        allowed = ", ".join(sorted(e.allowed)) if e.allowed else "none (terminal status)"
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Invalid transition {e.from_status} -> {e.to_status} for "
+                f"recommendation {recommendation_id}. Allowed from {e.from_status}: {allowed}."
+            ),
+        )
+
+    # Streamable principle: emit a governance event so agents can subscribe
+    # to recommendation state changes. Typed delta columns, no trigger node
+    # (a recommendation is not a graph node — no propagation intended).
+    event_id = uuid4()
+    db.execute(
+        """
+        INSERT INTO events (
+            event_id, event_type, scenario_id,
+            field_changed, old_text, new_text,
+            processed, source, user_ref, created_at
+        ) VALUES (%s, 'recommendation_transition', %s, 'status', %s, %s, FALSE, 'api', %s, now())
+        """,
+        (event_id, result.scenario_id, result.from_status, result.to_status, body.actor),
+    )
+    logger.info(
+        "recommendation.transition.event event_id=%s reco=%s %s->%s",
+        event_id,
+        recommendation_id,
+        result.from_status,
+        result.to_status,
+    )
+
+    return TransitionResponse(
+        recommendation_id=recommendation_id,
+        transition_id=result.transition_id,
+        scenario_id=result.scenario_id,
+        from_status=result.from_status,
+        to_status=result.to_status,
+        actor=result.actor,
+        actor_kind=result.actor_kind,
+        event_id=event_id,
+    )

--- a/src/ootils_core/db/migrations/051_recommendation_transition_event.sql
+++ b/src/ootils_core/db/migrations/051_recommendation_transition_event.sql
@@ -1,0 +1,25 @@
+-- ============================================================
+-- Migration 051 — events.event_type += 'recommendation_transition'
+-- ============================================================
+-- The recommendation governance API (POST /v1/recommendations/{id}/
+-- transition, chantier #341a) emits one event per state-machine
+-- transition so agents can subscribe to governance changes instead
+-- of polling (Streamable principle). The event carries the delta in
+-- typed columns: field_changed='status', old_text=from_status,
+-- new_text=to_status, user_ref=actor.
+--
+-- Keep this list in sync with VALID_EVENT_TYPES in
+-- src/ootils_core/api/routers/events.py (migrations 002 + 006 + 051).
+-- ============================================================
+
+ALTER TABLE events DROP CONSTRAINT IF EXISTS events_event_type_check;
+ALTER TABLE events ADD CONSTRAINT events_event_type_check
+    CHECK (event_type IN (
+        'supply_date_changed', 'supply_qty_changed',
+        'demand_qty_changed', 'onhand_updated',
+        'policy_changed', 'structure_changed',
+        'scenario_created', 'calc_triggered',
+        'ingestion_complete', 'po_date_changed',
+        'test_event', 'scenario_merge',
+        'recommendation_transition'
+    ));

--- a/src/ootils_core/engine/recommendation/__init__.py
+++ b/src/ootils_core/engine/recommendation/__init__.py
@@ -1,0 +1,26 @@
+"""Recommendation governance — state machine for the agent recommendation lifecycle."""
+from .state_machine import (
+    ALLOWED_TRANSITIONS,
+    TERMINAL_STATUSES,
+    InvalidTransitionError,
+    RecommendationNotFoundError,
+    TransitionResult,
+    allowed_targets,
+    is_valid_transition,
+    transition_many,
+    transition_one,
+    validate_transition,
+)
+
+__all__ = [
+    "ALLOWED_TRANSITIONS",
+    "TERMINAL_STATUSES",
+    "InvalidTransitionError",
+    "RecommendationNotFoundError",
+    "TransitionResult",
+    "allowed_targets",
+    "is_valid_transition",
+    "transition_many",
+    "transition_one",
+    "validate_transition",
+]

--- a/src/ootils_core/engine/recommendation/state_machine.py
+++ b/src/ootils_core/engine/recommendation/state_machine.py
@@ -1,0 +1,264 @@
+"""
+state_machine.py — Recommendation lifecycle state machine (single source of truth).
+
+The agent fleet produces L1 DRAFT recommendations (migration 039); every status
+change is audited in recommendation_transitions (migration 040). This module
+owns the transition rules and the transactional write path (row lock + status
+update + audit row) so that every consumer — the CLI control room
+(scripts/recommendation_review.py) and the REST API
+(api/routers/recommendations.py) — enforces the exact same machine.
+Do NOT duplicate these rules elsewhere.
+
+State machine:
+    DRAFT     → REVIEWED | APPROVED | REJECTED
+    REVIEWED  → APPROVED | REJECTED
+    APPROVED  → APPLIED  | REJECTED
+    APPLIED / REJECTED / EXPIRED = terminal (no outbound transitions)
+
+EXPIRED is reached outside this machine: the watcher agents supersede stale
+DRAFT rows directly when they re-run (see scripts/agent_shortage_watcher.py).
+Requesting a transition *to* EXPIRED through this module is therefore invalid.
+
+Locking: both write paths SELECT ... FOR UPDATE the target rows, so two
+concurrent transitions on the same recommendation serialize and the loser
+re-reads a status for which the transition may no longer be valid.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+import psycopg
+from psycopg.rows import dict_row
+
+logger = logging.getLogger(__name__)
+
+# Transition rules — keep in sync with the recommendations.status CHECK
+# constraint (migration 039). Terminal statuses map to an empty set.
+ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
+    "DRAFT": frozenset({"REVIEWED", "APPROVED", "REJECTED"}),
+    "REVIEWED": frozenset({"APPROVED", "REJECTED"}),
+    "APPROVED": frozenset({"APPLIED", "REJECTED"}),
+    "APPLIED": frozenset(),
+    "REJECTED": frozenset(),
+    "EXPIRED": frozenset(),
+}
+
+TERMINAL_STATUSES: frozenset[str] = frozenset(
+    status for status, targets in ALLOWED_TRANSITIONS.items() if not targets
+)
+
+# Decision Ladder gate (North Star L3+): approving or applying a
+# recommendation is a human decision. Enforced HERE — the single source of
+# truth of the machine — so no in-process caller (router, CLI, future
+# watcher/orchestrator import) can bypass it. actor_kind is self-declared
+# until per-token agent scopes land (#350); this gate is the transitional
+# floor, not the final authentication story.
+HUMAN_ONLY_TARGETS: frozenset[str] = frozenset({"APPROVED", "APPLIED"})
+
+
+class RecommendationNotFoundError(Exception):
+    """Raised when the target recommendation_id does not exist."""
+
+    def __init__(self, recommendation_id: UUID) -> None:
+        self.recommendation_id = recommendation_id
+        super().__init__(f"Recommendation {recommendation_id} not found")
+
+
+class InvalidTransitionError(Exception):
+    """Raised when a requested transition violates the state machine."""
+
+    def __init__(self, from_status: str, to_status: str) -> None:
+        self.from_status = from_status
+        self.to_status = to_status
+        self.allowed = allowed_targets(from_status)
+        allowed_s = ", ".join(sorted(self.allowed)) if self.allowed else "none (terminal status)"
+        super().__init__(
+            f"Invalid transition {from_status} -> {to_status}; "
+            f"allowed from {from_status}: {allowed_s}"
+        )
+
+
+class HumanGateError(Exception):
+    """Raised when a non-human actor requests a human-only transition (L3+)."""
+
+    def __init__(self, to_status: str, actor_kind: str) -> None:
+        self.to_status = to_status
+        self.actor_kind = actor_kind
+        super().__init__(
+            f"Transition to {to_status} requires a human actor "
+            f"(Decision Ladder L3+); got actor_kind={actor_kind!r}"
+        )
+
+
+def enforce_human_gate(to_status: str, actor_kind: str) -> None:
+    """Raise HumanGateError if `to_status` is human-only and the actor is not."""
+    if to_status in HUMAN_ONLY_TARGETS and actor_kind != "human":
+        raise HumanGateError(to_status, actor_kind)
+
+
+def allowed_targets(from_status: str) -> frozenset[str]:
+    """Return the set of statuses reachable from `from_status` (empty if terminal/unknown)."""
+    return ALLOWED_TRANSITIONS.get(from_status, frozenset())
+
+
+def is_valid_transition(from_status: str, to_status: str) -> bool:
+    """True if the state machine allows `from_status` → `to_status`."""
+    return to_status in allowed_targets(from_status)
+
+
+def validate_transition(from_status: str, to_status: str) -> None:
+    """Raise InvalidTransitionError if the transition is not allowed."""
+    if not is_valid_transition(from_status, to_status):
+        raise InvalidTransitionError(from_status, to_status)
+
+
+@dataclass(frozen=True)
+class TransitionResult:
+    """Outcome of a successfully applied transition (audit row included)."""
+
+    transition_id: UUID
+    recommendation_id: UUID
+    scenario_id: UUID
+    from_status: str
+    to_status: str
+    actor: str
+    actor_kind: str
+    reason: Optional[str]
+    created_at: datetime
+
+
+def transition_one(
+    conn: psycopg.Connection,
+    recommendation_id: UUID,
+    to_status: str,
+    actor: str,
+    *,
+    actor_kind: str = "human",
+    reason: Optional[str] = None,
+) -> TransitionResult:
+    """
+    Apply a single validated transition: lock the row (FOR UPDATE), validate
+    against the machine, update recommendations.status, insert the audit row.
+
+    Raises RecommendationNotFoundError / InvalidTransitionError /
+    HumanGateError. The caller owns the transaction (commit/rollback) —
+    this function only writes.
+    """
+    enforce_human_gate(to_status, actor_kind)
+    # Per-cursor dict_row so this works on any connection row factory
+    # (the CLI uses default tuple rows; the API uses dict_row).
+    with conn.cursor(row_factory=dict_row) as cur:
+        row = cur.execute(
+            "SELECT status, scenario_id FROM recommendations "
+            "WHERE recommendation_id = %s FOR UPDATE",
+            (recommendation_id,),
+        ).fetchone()
+        if row is None:
+            raise RecommendationNotFoundError(recommendation_id)
+        from_status = row["status"]
+        validate_transition(from_status, to_status)
+
+        cur.execute(
+            "UPDATE recommendations SET status = %s, updated_at = now() "
+            "WHERE recommendation_id = %s",
+            (to_status, recommendation_id),
+        )
+        audit = cur.execute(
+            "INSERT INTO recommendation_transitions "
+            "(recommendation_id, from_status, to_status, actor, actor_kind, reason) "
+            "VALUES (%s, %s, %s, %s, %s, %s) "
+            "RETURNING transition_id, created_at",
+            (recommendation_id, from_status, to_status, actor, actor_kind, reason),
+        ).fetchone()
+
+    logger.info(
+        "recommendation.transition reco=%s %s->%s actor=%s kind=%s",
+        recommendation_id,
+        from_status,
+        to_status,
+        actor,
+        actor_kind,
+    )
+    return TransitionResult(
+        transition_id=audit["transition_id"],
+        recommendation_id=recommendation_id,
+        scenario_id=row["scenario_id"],
+        from_status=from_status,
+        to_status=to_status,
+        actor=actor,
+        actor_kind=actor_kind,
+        reason=reason,
+        created_at=audit["created_at"],
+    )
+
+
+def transition_many(
+    conn: psycopg.Connection,
+    to_status: str,
+    actor: str,
+    *,
+    actor_kind: str = "human",
+    reason: Optional[str] = None,
+    action: Optional[str] = None,
+    recommendation_id: Optional[UUID | str] = None,
+) -> tuple[int, int]:
+    """
+    Bulk transition with CLI semantics: rows whose current status does not
+    allow `to_status` are *skipped* (counted), not raised. Targets are either
+    a single recommendation_id or all rows in the plausible source statuses
+    (APPROVED for APPLIED, DRAFT/REVIEWED otherwise), optionally filtered by
+    action class. All targets are locked FOR UPDATE before any write.
+
+    Returns (moved, skipped). The caller owns the transaction.
+    Raises HumanGateError for human-only targets with a non-human actor.
+    """
+    enforce_human_gate(to_status, actor_kind)
+    with conn.cursor(row_factory=dict_row) as cur:
+        if recommendation_id:
+            targets = cur.execute(
+                "SELECT recommendation_id, status FROM recommendations "
+                "WHERE recommendation_id = %s FOR UPDATE",
+                (recommendation_id,),
+            ).fetchall()
+        else:
+            src_statuses = ("APPROVED",) if to_status == "APPLIED" else ("DRAFT", "REVIEWED")
+            q = "SELECT recommendation_id, status FROM recommendations WHERE status = ANY(%s)"
+            params: list = [list(src_statuses)]
+            if action:
+                q += " AND action = %s"
+                params.append(action)
+            q += " FOR UPDATE"
+            targets = cur.execute(q, params).fetchall()
+
+        moved, skipped = 0, 0
+        for row in targets:
+            rid, cur_status = row["recommendation_id"], row["status"]
+            if not is_valid_transition(cur_status, to_status):
+                skipped += 1
+                continue
+            cur.execute(
+                "UPDATE recommendations SET status = %s, updated_at = now() "
+                "WHERE recommendation_id = %s",
+                (to_status, rid),
+            )
+            cur.execute(
+                "INSERT INTO recommendation_transitions "
+                "(recommendation_id, from_status, to_status, actor, actor_kind, reason) "
+                "VALUES (%s, %s, %s, %s, %s, %s)",
+                (rid, cur_status, to_status, actor, actor_kind, reason),
+            )
+            moved += 1
+
+    logger.info(
+        "recommendation.transition_many to=%s actor=%s kind=%s moved=%d skipped=%d",
+        to_status,
+        actor,
+        actor_kind,
+        moved,
+        skipped,
+    )
+    return moved, skipped

--- a/tests/integration/test_recommendations_api_integration.py
+++ b/tests/integration/test_recommendations_api_integration.py
@@ -1,0 +1,455 @@
+"""
+Integration tests for the /v1/recommendations router against a real
+PostgreSQL database (no mocks) — chantier #341a.
+
+Covers:
+  - list pagination + filters (status/action/agent_name) + scenario scoping
+  - detail with evidence + transition history
+  - state-machine transitions: valid (200), invalid (409, allowed list in
+    the message), unknown recommendation (404)
+  - Decision Ladder guard: APPROVED/APPLIED require actor_kind='human' (403)
+  - Streamable principle: each transition emits a 'recommendation_transition'
+    event row (migration 051)
+  - CLI/API share one machine: transition rows written by the API satisfy
+    the migration 040 FK + actor_kind CHECK
+
+Rows are inserted directly (agent_runs + recommendations) — no seed script
+needed; the baseline scenario is seeded by migration 002.
+"""
+from __future__ import annotations
+
+import os
+from uuid import UUID, uuid4
+
+import pytest
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+AUTH_HEADERS = {"Authorization": "Bearer integration-test-token"}
+BASELINE = "00000000-0000-0000-0000-000000000001"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror tests/integration/test_forecasting_api_integration.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def api_client(migrated_db):
+    """Module-scoped FastAPI TestClient bound to the real test DB."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = "integration-test-token"
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+    from fastapi.testclient import TestClient
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="module")
+def auth():
+    return AUTH_HEADERS
+
+
+# ---------------------------------------------------------------------------
+# Helpers — direct DB access for setup/teardown
+# ---------------------------------------------------------------------------
+
+
+def _db_conn(dsn):
+    import psycopg
+    from psycopg.rows import dict_row
+    return psycopg.connect(dsn, row_factory=dict_row, autocommit=True)
+
+
+def _insert_recommendation(
+    dsn,
+    *,
+    scenario_id: str = BASELINE,
+    status: str = "DRAFT",
+    action: str = "EXPEDITE",
+    agent_name: str = "shortage_watcher",
+    evidence: str | None = None,
+) -> tuple[str, str]:
+    """Insert an agent_run + one recommendation; return (reco_id, run_id)."""
+    run_id = uuid4()
+    reco_id = uuid4()
+    with _db_conn(dsn) as conn:
+        conn.execute(
+            "INSERT INTO agent_runs (agent_run_id, agent_name, scenario_id, status) "
+            "VALUES (%s, %s, %s, 'COMPLETED')",
+            (run_id, agent_name, scenario_id),
+        )
+        conn.execute(
+            """
+            INSERT INTO recommendations (
+                recommendation_id, agent_name, agent_run_id, scenario_id,
+                item_id, item_external_id, shortage_date,
+                deficit_qty, recommended_qty, estimated_cost, currency,
+                lead_time_days, runway_days, margin_days,
+                action, status, confidence, evidence
+            ) VALUES (
+                %s, %s, %s, %s,
+                %s, 'PUMP-01', '2026-08-15',
+                100, 120, 4800, 'EUR',
+                14, 30, 16,
+                %s, %s, 'HIGH', %s
+            )
+            """,
+            (reco_id, agent_name, run_id, scenario_id, uuid4(), action, status, evidence),
+        )
+    return str(reco_id), str(run_id)
+
+
+def _cleanup(dsn, reco_ids: list[str], run_ids: list[str]):
+    with _db_conn(dsn) as conn:
+        if reco_ids:
+            conn.execute(
+                "DELETE FROM recommendation_transitions WHERE recommendation_id = ANY(%s::uuid[])",
+                (reco_ids,),
+            )
+            conn.execute(
+                "DELETE FROM recommendations WHERE recommendation_id = ANY(%s::uuid[])",
+                (reco_ids,),
+            )
+        if run_ids:
+            conn.execute(
+                "DELETE FROM agent_runs WHERE agent_run_id = ANY(%s::uuid[])",
+                (run_ids,),
+            )
+        conn.execute("DELETE FROM events WHERE event_type = 'recommendation_transition'")
+
+
+@pytest.fixture
+def tracker(migrated_db):
+    """Collects created ids and cleans them up after each test."""
+    created = {"recos": [], "runs": []}
+
+    def _make(**kwargs) -> str:
+        reco_id, run_id = _insert_recommendation(migrated_db, **kwargs)
+        created["recos"].append(reco_id)
+        created["runs"].append(run_id)
+        return reco_id
+
+    yield _make
+    _cleanup(migrated_db, created["recos"], created["runs"])
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/recommendations — list, pagination, filters, scenario scoping
+# ---------------------------------------------------------------------------
+
+
+class TestListRecommendations:
+    def test_list_requires_auth(self, api_client):
+        resp = api_client.get("/v1/recommendations")
+        assert resp.status_code in (401, 403)
+
+    def test_list_defaults_to_baseline_scenario(self, api_client, auth, tracker):
+        reco_id = tracker()
+        other_scenario_reco = tracker(scenario_id=str(uuid4()))
+
+        resp = api_client.get("/v1/recommendations", headers=auth)
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        ids = [r["recommendation_id"] for r in data["recommendations"]]
+        assert reco_id in ids
+        assert other_scenario_reco not in ids  # scenario-scoped by default
+        for r in data["recommendations"]:
+            assert r["scenario_id"] == BASELINE
+
+    def test_list_filters_by_scenario_id(self, api_client, auth, tracker):
+        fork_id = str(uuid4())
+        fork_reco = tracker(scenario_id=fork_id)
+        baseline_reco = tracker()
+
+        resp = api_client.get(
+            f"/v1/recommendations?scenario_id={fork_id}", headers=auth
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        ids = [r["recommendation_id"] for r in data["recommendations"]]
+        assert fork_reco in ids
+        assert baseline_reco not in ids
+        assert data["total"] == 1
+
+    def test_list_pagination(self, api_client, auth, tracker):
+        scenario = str(uuid4())  # isolated scenario so totals are deterministic
+        for _ in range(3):
+            tracker(scenario_id=scenario)
+
+        page1 = api_client.get(
+            f"/v1/recommendations?scenario_id={scenario}&limit=2&offset=0",
+            headers=auth,
+        ).json()
+        page2 = api_client.get(
+            f"/v1/recommendations?scenario_id={scenario}&limit=2&offset=2",
+            headers=auth,
+        ).json()
+        assert page1["total"] == 3 and page2["total"] == 3
+        assert len(page1["recommendations"]) == 2
+        assert len(page2["recommendations"]) == 1
+        all_ids = {
+            r["recommendation_id"]
+            for r in page1["recommendations"] + page2["recommendations"]
+        }
+        assert len(all_ids) == 3  # no overlap between pages
+
+    def test_list_filters_status_action_agent(self, api_client, auth, tracker):
+        scenario = str(uuid4())
+        draft = tracker(scenario_id=scenario, status="DRAFT", action="EXPEDITE")
+        approved = tracker(
+            scenario_id=scenario, status="APPROVED", action="ORDER_NOW",
+            agent_name="material_watcher",
+        )
+
+        by_status = api_client.get(
+            f"/v1/recommendations?scenario_id={scenario}&status=APPROVED",
+            headers=auth,
+        ).json()
+        assert [r["recommendation_id"] for r in by_status["recommendations"]] == [approved]
+
+        by_action = api_client.get(
+            f"/v1/recommendations?scenario_id={scenario}&action=EXPEDITE",
+            headers=auth,
+        ).json()
+        assert [r["recommendation_id"] for r in by_action["recommendations"]] == [draft]
+
+        by_agent = api_client.get(
+            f"/v1/recommendations?scenario_id={scenario}&agent_name=material_watcher",
+            headers=auth,
+        ).json()
+        assert [r["recommendation_id"] for r in by_agent["recommendations"]] == [approved]
+
+    def test_list_rejects_unknown_status_and_action(self, api_client, auth):
+        assert (
+            api_client.get("/v1/recommendations?status=BOGUS", headers=auth).status_code
+            == 422
+        )
+        assert (
+            api_client.get("/v1/recommendations?action=BOGUS", headers=auth).status_code
+            == 422
+        )
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/recommendations/{id} — detail
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecommendation:
+    def test_detail_not_found(self, api_client, auth):
+        resp = api_client.get(f"/v1/recommendations/{uuid4()}", headers=auth)
+        assert resp.status_code == 404
+
+    def test_detail_includes_evidence_and_history(self, api_client, auth, tracker):
+        reco_id = tracker(evidence='{"deficit": 100, "reason": "supplier late"}')
+
+        # Produce one transition so history is non-empty
+        t = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={"to_status": "REVIEWED", "actor": "ngoineau", "actor_kind": "human"},
+            headers=auth,
+        )
+        assert t.status_code == 200, t.text
+
+        resp = api_client.get(f"/v1/recommendations/{reco_id}", headers=auth)
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["recommendation_id"] == reco_id
+        assert data["evidence"] == {"deficit": 100, "reason": "supplier late"}
+        assert len(data["transitions"]) == 1
+        trans = data["transitions"][0]
+        assert trans["from_status"] == "DRAFT"
+        assert trans["to_status"] == "REVIEWED"
+        assert trans["actor"] == "ngoineau"
+        assert trans["actor_kind"] == "human"
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/recommendations/{id}/transition — state machine + guards + event
+# ---------------------------------------------------------------------------
+
+
+class TestTransitionEndpoint:
+    def test_valid_transition_updates_status_and_audits(
+        self, api_client, auth, tracker, migrated_db
+    ):
+        reco_id = tracker()
+        resp = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={
+                "to_status": "REVIEWED",
+                "actor": "shortage_watcher",
+                "actor_kind": "agent",
+                "reason": "auto-triage",
+            },
+            headers=auth,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["from_status"] == "DRAFT"
+        assert data["to_status"] == "REVIEWED"
+        assert UUID(data["transition_id"])
+        assert UUID(data["event_id"])
+
+        with _db_conn(migrated_db) as conn:
+            row = conn.execute(
+                "SELECT status FROM recommendations WHERE recommendation_id = %s",
+                (reco_id,),
+            ).fetchone()
+            assert row["status"] == "REVIEWED"
+            audit = conn.execute(
+                "SELECT from_status, to_status, actor, actor_kind, reason "
+                "FROM recommendation_transitions WHERE recommendation_id = %s",
+                (reco_id,),
+            ).fetchall()
+            assert len(audit) == 1
+            assert audit[0]["actor_kind"] == "agent"
+            assert audit[0]["reason"] == "auto-triage"
+
+    def test_invalid_transition_is_409_with_allowed_list(self, api_client, auth, tracker):
+        reco_id = tracker()  # DRAFT
+        resp = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={"to_status": "APPLIED", "actor": "ngoineau", "actor_kind": "human"},
+            headers=auth,
+        )
+        assert resp.status_code == 409, resp.text
+        detail = resp.json()["detail"]
+        # Hand-authored message lists what IS allowed from DRAFT
+        assert "DRAFT" in detail and "APPLIED" in detail
+        for allowed in ("APPROVED", "REJECTED", "REVIEWED"):
+            assert allowed in detail
+
+    def test_terminal_status_is_409(self, api_client, auth, tracker):
+        reco_id = tracker(status="REJECTED")
+        resp = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={"to_status": "APPROVED", "actor": "ngoineau", "actor_kind": "human"},
+            headers=auth,
+        )
+        assert resp.status_code == 409
+        assert "terminal" in resp.json()["detail"]
+
+    def test_transition_unknown_recommendation_is_404(self, api_client, auth):
+        resp = api_client.post(
+            f"/v1/recommendations/{uuid4()}/transition",
+            json={"to_status": "REVIEWED", "actor": "ngoineau", "actor_kind": "human"},
+            headers=auth,
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.parametrize("target", ["APPROVED", "APPLIED"])
+    def test_agent_cannot_approve_or_apply(self, api_client, auth, tracker, target):
+        """Decision Ladder guard: L3/L4 targets are human-only (403 for agents)."""
+        status = "APPROVED" if target == "APPLIED" else "DRAFT"
+        reco_id = tracker(status=status)
+        resp = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={"to_status": target, "actor": "shortage_watcher", "actor_kind": "agent"},
+            headers=auth,
+        )
+        assert resp.status_code == 403, resp.text
+        assert "human" in resp.json()["detail"].lower()
+
+    def test_human_can_approve(self, api_client, auth, tracker, migrated_db):
+        reco_id = tracker()
+        resp = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={
+                "to_status": "APPROVED",
+                "actor": "ngoineau",
+                "actor_kind": "human",
+                "reason": "Q3 ramp",
+            },
+            headers=auth,
+        )
+        assert resp.status_code == 200, resp.text
+        with _db_conn(migrated_db) as conn:
+            row = conn.execute(
+                "SELECT status FROM recommendations WHERE recommendation_id = %s",
+                (reco_id,),
+            ).fetchone()
+            assert row["status"] == "APPROVED"
+
+    def test_transition_emits_event(self, api_client, auth, tracker, migrated_db):
+        """Streamable principle: one 'recommendation_transition' event per transition."""
+        reco_id = tracker()
+        resp = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={"to_status": "REVIEWED", "actor": "ngoineau", "actor_kind": "human"},
+            headers=auth,
+        )
+        assert resp.status_code == 200, resp.text
+        event_id = resp.json()["event_id"]
+
+        with _db_conn(migrated_db) as conn:
+            ev = conn.execute(
+                "SELECT event_type, scenario_id, field_changed, old_text, new_text, "
+                "source, user_ref FROM events WHERE event_id = %s",
+                (event_id,),
+            ).fetchone()
+        assert ev is not None
+        assert ev["event_type"] == "recommendation_transition"
+        assert str(ev["scenario_id"]) == BASELINE
+        assert ev["field_changed"] == "status"
+        assert ev["old_text"] == "DRAFT"
+        assert ev["new_text"] == "REVIEWED"
+        assert ev["source"] == "api"
+        assert ev["user_ref"] == "ngoineau"
+
+        # Event is also visible on the read path agents use
+        listed = api_client.get(
+            "/v1/events?event_type=recommendation_transition", headers=auth
+        )
+        assert listed.status_code == 200
+        assert event_id in [e["event_id"] for e in listed.json()["events"]]
+
+    def test_full_lifecycle_history(self, api_client, auth, tracker):
+        """DRAFT → REVIEWED → APPROVED → APPLIED, then terminal (409)."""
+        reco_id = tracker()
+        steps = [
+            ("REVIEWED", "agent", "shortage_watcher"),
+            ("APPROVED", "human", "ngoineau"),
+            ("APPLIED", "human", "ngoineau"),
+        ]
+        for to_status, kind, actor in steps:
+            resp = api_client.post(
+                f"/v1/recommendations/{reco_id}/transition",
+                json={"to_status": to_status, "actor": actor, "actor_kind": kind},
+                headers=auth,
+            )
+            assert resp.status_code == 200, resp.text
+
+        # Terminal now
+        resp = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={"to_status": "REJECTED", "actor": "ngoineau", "actor_kind": "human"},
+            headers=auth,
+        )
+        assert resp.status_code == 409
+
+        detail = api_client.get(f"/v1/recommendations/{reco_id}", headers=auth).json()
+        assert detail["status"] == "APPLIED"
+        assert [t["to_status"] for t in detail["transitions"]] == [
+            "REVIEWED",
+            "APPROVED",
+            "APPLIED",
+        ]

--- a/tests/test_llc_calculator.py
+++ b/tests/test_llc_calculator.py
@@ -497,7 +497,12 @@ class TestPerformance:
         assert result.llc_map[fg] == 0
         # All components at LLC 1
         assert len(result.items_by_llc[1]) == 5000
-        assert elapsed_ms < 100, f"Wide BOM took {elapsed_ms:.1f}ms"
+        # Algorithmic-explosion guard, NOT a benchmark: pure-Python BFS on
+        # 5000 edges runs in ~10ms locally but CI runners are noisy/shared
+        # (measured 106-133ms on slow runners — flaked twice on unrelated
+        # PRs). 500ms still catches an accidental O(n^2) regression
+        # (~seconds at this size) without gambling on runner weather.
+        assert elapsed_ms < 500, f"Wide BOM took {elapsed_ms:.1f}ms"
 
 
 # ─────────────────────────────────────────────────────────────

--- a/tests/test_recommendation_state_machine.py
+++ b/tests/test_recommendation_state_machine.py
@@ -1,0 +1,133 @@
+"""
+Pure unit tests for the recommendation state machine
+(src/ootils_core/engine/recommendation/state_machine.py).
+
+Only the transition-rule layer is tested here — no DB. The transactional
+write paths (transition_one / transition_many) are covered by
+tests/integration/test_recommendations_api_integration.py against real
+Postgres.
+"""
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from ootils_core.engine.recommendation.state_machine import (
+    ALLOWED_TRANSITIONS,
+    HUMAN_ONLY_TARGETS,
+    TERMINAL_STATUSES,
+    HumanGateError,
+    InvalidTransitionError,
+    RecommendationNotFoundError,
+    allowed_targets,
+    enforce_human_gate,
+    is_valid_transition,
+    validate_transition,
+)
+
+# All statuses of the migration 039 CHECK constraint
+ALL_STATUSES = {"DRAFT", "REVIEWED", "APPROVED", "REJECTED", "APPLIED", "EXPIRED"}
+
+
+class TestHumanGate:
+    """Decision Ladder L3+ gate — lives in the ENGINE, not just the router,
+    so no in-process caller (future watcher, orchestrator import) can move a
+    recommendation to APPROVED/APPLIED with a non-human actor."""
+
+    def test_human_only_targets(self):
+        assert HUMAN_ONLY_TARGETS == {"APPROVED", "APPLIED"}
+
+    @pytest.mark.parametrize("to_status", sorted(HUMAN_ONLY_TARGETS))
+    def test_agent_blocked_on_human_only_targets(self, to_status):
+        with pytest.raises(HumanGateError) as exc:
+            enforce_human_gate(to_status, "agent")
+        assert to_status in str(exc.value)
+        assert "agent" in str(exc.value)
+
+    @pytest.mark.parametrize("to_status", sorted(HUMAN_ONLY_TARGETS))
+    def test_human_passes_human_only_targets(self, to_status):
+        enforce_human_gate(to_status, "human")  # must not raise
+
+    @pytest.mark.parametrize("to_status", ["REVIEWED", "REJECTED"])
+    def test_agent_allowed_on_non_gated_targets(self, to_status):
+        enforce_human_gate(to_status, "agent")  # must not raise
+
+
+class TestTransitionRules:
+    def test_machine_covers_every_status(self):
+        assert set(ALLOWED_TRANSITIONS) == ALL_STATUSES
+
+    def test_terminal_statuses(self):
+        assert TERMINAL_STATUSES == {"APPLIED", "REJECTED", "EXPIRED"}
+
+    @pytest.mark.parametrize(
+        "frm,to",
+        [
+            ("DRAFT", "REVIEWED"),
+            ("DRAFT", "APPROVED"),
+            ("DRAFT", "REJECTED"),
+            ("REVIEWED", "APPROVED"),
+            ("REVIEWED", "REJECTED"),
+            ("APPROVED", "APPLIED"),
+            ("APPROVED", "REJECTED"),
+        ],
+    )
+    def test_valid_transitions(self, frm, to):
+        assert is_valid_transition(frm, to)
+        validate_transition(frm, to)  # must not raise
+
+    @pytest.mark.parametrize(
+        "frm,to",
+        [
+            ("DRAFT", "APPLIED"),        # cannot skip approval
+            ("DRAFT", "EXPIRED"),        # EXPIRED set by watcher supersede, not the machine
+            ("DRAFT", "DRAFT"),          # self-loop
+            ("REVIEWED", "APPLIED"),
+            ("REVIEWED", "DRAFT"),       # no backwards move
+            ("APPROVED", "REVIEWED"),
+            ("APPROVED", "DRAFT"),
+        ],
+    )
+    def test_invalid_transitions(self, frm, to):
+        assert not is_valid_transition(frm, to)
+        with pytest.raises(InvalidTransitionError):
+            validate_transition(frm, to)
+
+    @pytest.mark.parametrize("terminal", sorted(TERMINAL_STATUSES))
+    @pytest.mark.parametrize("to", sorted(ALL_STATUSES))
+    def test_terminal_statuses_have_no_outbound(self, terminal, to):
+        assert not is_valid_transition(terminal, to)
+
+    def test_unknown_status_has_no_targets(self):
+        assert allowed_targets("NO_SUCH_STATUS") == frozenset()
+        assert not is_valid_transition("NO_SUCH_STATUS", "APPROVED")
+
+    def test_unknown_target_is_invalid(self):
+        assert not is_valid_transition("DRAFT", "NO_SUCH_STATUS")
+        with pytest.raises(InvalidTransitionError):
+            validate_transition("DRAFT", "NO_SUCH_STATUS")
+
+
+class TestErrorPayloads:
+    def test_invalid_transition_error_attributes(self):
+        with pytest.raises(InvalidTransitionError) as exc_info:
+            validate_transition("APPROVED", "REVIEWED")
+        err = exc_info.value
+        assert err.from_status == "APPROVED"
+        assert err.to_status == "REVIEWED"
+        assert err.allowed == frozenset({"APPLIED", "REJECTED"})
+        # message lists the allowed targets for actionability
+        assert "APPLIED" in str(err) and "REJECTED" in str(err)
+
+    def test_invalid_transition_error_from_terminal(self):
+        with pytest.raises(InvalidTransitionError) as exc_info:
+            validate_transition("REJECTED", "APPROVED")
+        assert exc_info.value.allowed == frozenset()
+        assert "terminal" in str(exc_info.value)
+
+    def test_not_found_error_carries_id(self):
+        rid = uuid4()
+        err = RecommendationNotFoundError(rid)
+        assert err.recommendation_id == rid
+        assert str(rid) in str(err)


### PR DESCRIPTION
## Chantier C1 — PR-B : la boucle recommandation pilotable en API (#341, partie 1/2)

Deuxième PR du chantier C1 (épique #351). La partie 2 (endpoints diff/promote avec détection de conflit) suit en PR-C.

### Contenu

- **Machine d'états extraite** en `engine/recommendation/state_machine.py` — source unique consommée par le CLI ET le router. Le CLI ne recrée plus sa propre table (`ENSURE_SCHEMA` supprimé — doublon divergent de la migration 040 débusqué par l'architecte), comportement inchangé.
- **Garde Decision Ladder ancrée dans la machine** : `APPROVED`/`APPLIED` = humain uniquement (`HumanGateError`), inviolable par tout appelant in-process ; le router mappe vers 403. ⚠️ **Arbitrage transitoire assumé** : `actor_kind` auto-déclaré jusqu'aux scopes par token (#350) — recommandation architecte, à re-valider au chantier sécurité.
- **Router `/v1/recommendations`** : liste paginée scenario-scopée, détail avec evidence + historique, transition gouvernée (409 rédigé à la main listant les transitions autorisées).
- **Événement `recommendation_transition`** émis à chaque transition (migration 051) — principe Streamable. Limite documentée : pas encore de référence à la reco dans l'événement (une reco n'est pas un node) — à compléter au chantier streaming.

### Tests

46 unitaires machine d'états (dont la garde humaine niveau moteur — ajout post-revue) · 17 intégration API (403 agent→APPROVED, 409, pagination, filtre scénario, événement). Suite complète : 1743 ✅, ruff ✅.

Ref #341 (partie 1 — ne pas fermer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
