### PR TITLE
feat(scenario): C1 PR-C — diff/promote en API, détection de conflit, audit de promotion

### DIFF
--- a/src/ootils_core/api/routers/scenarios.py
+++ b/src/ootils_core/api/routers/scenarios.py
@@ -5,32 +5,48 @@
 
 # Scope of each endpoint group
 
-| Endpoint                         | Backend  | Persistence    |
-|----------------------------------|----------|----------------|
-| GET    /v1/scenarios             | PG only  | persistent     |
-| GET    /v1/scenarios/{id}        | PG only  | persistent     |
-| DELETE /v1/scenarios/{id}        | PG+engine| persistent     |
-| POST   /v1/scenarios/sandbox     | engine   | ephemeral (TTL)|
-| GET    /v1/scenarios/sandbox     | engine   | ephemeral      |
-| DELETE /v1/scenarios/sandbox/{id}| engine   | ephemeral      |
+| Endpoint                          | Backend  | Persistence    |
+|-----------------------------------|----------|----------------|
+| GET    /v1/scenarios              | PG only  | persistent     |
+| GET    /v1/scenarios/{id}         | PG only  | persistent     |
+| DELETE /v1/scenarios/{id}         | PG+engine| persistent     |
+| GET    /v1/scenarios/{id}/diff    | PG only  | persistent     |
+| POST   /v1/scenarios/{id}/promote | PG only  | persistent     |
+| POST   /v1/scenarios/sandbox      | engine   | ephemeral (TTL)|
+| GET    /v1/scenarios/sandbox      | engine   | ephemeral      |
+| DELETE /v1/scenarios/sandbox/{id} | engine   | ephemeral      |
 
 Sandbox scenarios live in the engine's RAM (P2.1.a-d), are evicted
 by TTL (default 1 h idle), and never reach Postgres. The persistent
 flavor (Option C "Save as") lands in P2.2.
+
+diff/promote (chantier #341b) expose ScenarioManager.diff/.promote:
+promote carries conflict detection (409 + typed conflict list when
+the baseline diverged since the overrides were captured) and the
+Decision Ladder human gate (promote = applying a scenario to the
+baseline = the 'APPLIED' L3+ action class).
 """
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import Literal, Optional
 from uuid import UUID
 
 import psycopg
 from psycopg import sql
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db, BASELINE_SCENARIO_ID
+from ootils_core.engine.recommendation.state_machine import (
+    HumanGateError,
+    enforce_human_gate,
+)
+from ootils_core.engine.scenario.manager import (
+    PromoteConflictError,
+    ScenarioManager,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1/scenarios", tags=["scenarios"])
@@ -154,6 +170,235 @@ def delete_scenario(
             exc,
         )
     logger.info("scenario.archived scenario_id=%s", scenario_id)
+
+
+# ============================================================
+# Diff / promote (persistent, PG) endpoints — chantier #341b
+# ============================================================
+
+
+class ScenarioDiffEntry(BaseModel):
+    diff_id: UUID
+    node_id: UUID
+    field_name: str
+    baseline_value: Optional[str] = None
+    scenario_value: Optional[str] = None
+
+
+class ScenarioDiffResponse(BaseModel):
+    scenario_id: UUID
+    baseline_id: UUID
+    baseline_calc_run_id: UUID
+    scenario_calc_run_id: UUID
+    diffs: list[ScenarioDiffEntry]
+    total: int
+
+
+class PromoteRequest(BaseModel):
+    actor: str = Field(min_length=1, max_length=200, description="Username or agent name")
+    actor_kind: Literal["human", "agent"] = "human"
+    reason: Optional[str] = None
+
+
+class PromoteConflictOut(BaseModel):
+    """One baseline field that diverged since the override captured it."""
+
+    node_id: UUID
+    field_name: str
+    expected: Optional[str] = None  # baseline value at override time
+    actual: Optional[str] = None    # current baseline value
+
+
+class PromoteResponse(BaseModel):
+    promotion_id: UUID
+    scenario_id: UUID
+    promoted_by: str
+    promoted_at: str
+    override_count: int
+    patched_nodes: int
+    siblings_invalidated: int
+    conflict_checked: bool
+    event_id: UUID
+
+
+def _load_scenario_or_404(scenario_id: UUID, db: psycopg.Connection) -> dict:
+    row = db.execute(
+        "SELECT * FROM scenarios WHERE scenario_id = %s", (scenario_id,)
+    ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail=f"Scenario {scenario_id} not found")
+    return row
+
+
+@router.get("/{scenario_id}/diff", response_model=ScenarioDiffResponse)
+def diff_scenario(
+    scenario_id: UUID,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+    baseline_id: UUID = Query(default=BASELINE_SCENARIO_ID),
+) -> ScenarioDiffResponse:
+    """Field-level diff of a scenario vs a baseline (latest completed calc_runs).
+
+    Delegates to ScenarioManager.diff, which persists the entries in
+    scenario_diffs (upsert on the calc_run pair) — re-reading the same pair
+    is idempotent. Agents read this from a fork before proposing a promote.
+    """
+    _load_scenario_or_404(scenario_id, db)
+    _load_scenario_or_404(baseline_id, db)
+
+    manager = ScenarioManager()
+    try:
+        diffs = manager.diff(scenario_id=scenario_id, baseline_id=baseline_id, db=db)
+    except ValueError:
+        # Raised by _latest_calc_run when a scenario has no completed
+        # calc_run. Hand-authored message (never str(exc) in a response).
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"No completed calc_run found for scenario {scenario_id} "
+                f"and/or baseline {baseline_id}. Run a calculation on both "
+                "before requesting a diff."
+            ),
+        )
+
+    if diffs:
+        baseline_calc_run_id = diffs[0].baseline_calc_run_id
+        scenario_calc_run_id = diffs[0].scenario_calc_run_id
+    else:
+        # No differences — still resolve the calc_run pair for the response
+        baseline_calc_run_id = manager._latest_calc_run(baseline_id, db)  # noqa: SLF001
+        scenario_calc_run_id = manager._latest_calc_run(scenario_id, db)  # noqa: SLF001
+
+    return ScenarioDiffResponse(
+        scenario_id=scenario_id,
+        baseline_id=baseline_id,
+        baseline_calc_run_id=baseline_calc_run_id,
+        scenario_calc_run_id=scenario_calc_run_id,
+        diffs=[
+            ScenarioDiffEntry(
+                diff_id=d.diff_id,
+                node_id=d.node_id,
+                field_name=d.field_name,
+                baseline_value=d.baseline_value,
+                scenario_value=d.scenario_value,
+            )
+            for d in diffs
+        ],
+        total=len(diffs),
+    )
+
+
+@router.post("/{scenario_id}/promote", response_model=PromoteResponse)
+def promote_scenario(
+    scenario_id: UUID,
+    body: PromoteRequest,
+    db: psycopg.Connection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> PromoteResponse:
+    """Promote a scenario's overrides onto the baseline (L3+ decision).
+
+    Conflict-safe (ADR-018 P2.2.c): if the baseline diverged since the
+    overrides were captured, the promote aborts with 409 and the typed
+    conflict list — nothing is written. Success writes the
+    scenario_promotions audit row (migration 052) and emits a
+    'scenario_merge' event.
+    """
+    # Decision Ladder gate — promoting IS applying a scenario to the
+    # baseline, i.e. the 'APPLIED' human-only action class. The rule lives
+    # in engine/recommendation/state_machine (single source of truth,
+    # shared with the recommendation router/CLI); this router only maps
+    # HumanGateError to a 403. Transitional until per-token agent scopes
+    # land (#350): actor_kind is self-declared.
+    try:
+        enforce_human_gate("APPLIED", body.actor_kind)
+    except HumanGateError:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Promoting a scenario to baseline is an L3/L4 decision "
+                "reserved to human actors (Decision Ladder, strategy doc §5)."
+            ),
+        )
+
+    if scenario_id == BASELINE_SCENARIO_ID:
+        raise HTTPException(status_code=400, detail="Cannot promote the baseline scenario onto itself")
+    row = _load_scenario_or_404(scenario_id, db)
+    if row["is_baseline"]:
+        raise HTTPException(status_code=400, detail="Cannot promote a baseline scenario")
+    if row["status"] != "active":
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Scenario {scenario_id} has status '{row['status']}'; "
+                "only 'active' scenarios can be promoted."
+            ),
+        )
+
+    manager = ScenarioManager()
+    try:
+        result = manager.promote(scenario_id=scenario_id, db=db, promoted_by=body.actor)
+    except PromoteConflictError as e:
+        # Typed conflict payload built from exception attributes — never
+        # str(exc) in a response. Nothing was written by the manager.
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": (
+                    f"Promote aborted: baseline diverged on {len(e.conflicts)} "
+                    "node field(s) since the overrides were captured. "
+                    "Re-fork or re-apply the overrides, then retry."
+                ),
+                "conflicts": [
+                    PromoteConflictOut(
+                        node_id=c.node_id,
+                        field_name=c.field_name,
+                        expected=c.expected,
+                        actual=c.actual,
+                    ).model_dump(mode="json")
+                    for c in e.conflicts
+                ],
+            },
+        )
+
+    # Audit row (migration 052) — promote had no trail at all before #341b.
+    audit = db.execute(
+        """
+        INSERT INTO scenario_promotions (
+            scenario_id, promoted_by, reason,
+            override_count, conflict_checked, siblings_invalidated
+        ) VALUES (%s, %s, %s, %s, %s, %s)
+        RETURNING promotion_id, promoted_at
+        """,
+        (
+            scenario_id,
+            body.actor,
+            body.reason,
+            result.override_count,
+            result.conflict_checked,
+            result.siblings_invalidated,
+        ),
+    ).fetchone()
+    logger.info(
+        "scenario.promoted scenario_id=%s promotion_id=%s by=%s overrides=%d",
+        scenario_id,
+        audit["promotion_id"],
+        body.actor,
+        result.override_count,
+    )
+
+    return PromoteResponse(
+        promotion_id=audit["promotion_id"],
+        scenario_id=scenario_id,
+        promoted_by=body.actor,
+        promoted_at=audit["promoted_at"].isoformat()
+        if hasattr(audit["promoted_at"], "isoformat")
+        else str(audit["promoted_at"]),
+        override_count=result.override_count,
+        patched_nodes=result.patched_nodes,
+        siblings_invalidated=result.siblings_invalidated,
+        conflict_checked=result.conflict_checked,
+        event_id=result.merge_event_id,
+    )
 
 
 # ============================================================

--- a/src/ootils_core/db/migrations/052_scenario_promotion_audit.sql
+++ b/src/ootils_core/db/migrations/052_scenario_promotion_audit.sql
@@ -1,0 +1,35 @@
+-- ============================================================
+-- Migration 052 — scenario_promotions audit table
+-- ============================================================
+-- Promoting a scenario to baseline is an L3+ decision (Decision
+-- Ladder, strategy doc §5) that patches baseline nodes — until now
+-- it left no audit trail at all. One row per successful promote
+-- (POST /v1/scenarios/{id}/promote, chantier #341b):
+--   who (promoted_by), when (promoted_at), how much (override_count),
+--   whether divergence was checked (conflict_checked — always TRUE for
+--   the API path; column exists so legacy/backfilled rows can say FALSE),
+--   and how many sibling scenarios were logically invalidated.
+--
+-- Typed columns only, no JSONB (per CLAUDE.md carve-out policy).
+-- The promote event itself reuses the existing 'scenario_merge'
+-- event_type (migration 006 CHECK) — no CHECK change needed here.
+-- Conflicting promotes write NOTHING (409 + PromoteConflictError),
+-- so this table records successes only.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS scenario_promotions (
+    promotion_id         UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    scenario_id          UUID        NOT NULL REFERENCES scenarios(scenario_id),
+    promoted_by          TEXT        NOT NULL,           -- human actor (L3+ gate)
+    promoted_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    reason               TEXT,                           -- optional justification
+    override_count       INTEGER     NOT NULL DEFAULT 0, -- overrides replayed on baseline
+    conflict_checked     BOOLEAN     NOT NULL DEFAULT TRUE,
+    siblings_invalidated INTEGER     NOT NULL DEFAULT 0  -- active same-parent scenarios now stale
+);
+
+CREATE INDEX IF NOT EXISTS idx_scenario_promotions_scenario
+    ON scenario_promotions (scenario_id);
+
+CREATE INDEX IF NOT EXISTS idx_scenario_promotions_promoted_at
+    ON scenario_promotions (promoted_at);

--- a/src/ootils_core/db/migrations/052_scenario_promotion_audit.sql
+++ b/src/ootils_core/db/migrations/052_scenario_promotion_audit.sql
@@ -19,7 +19,9 @@
 
 CREATE TABLE IF NOT EXISTS scenario_promotions (
     promotion_id         UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
-    scenario_id          UUID        NOT NULL REFERENCES scenarios(scenario_id),
+    -- ON DELETE RESTRICT: ADR-011 — every FK onto scenarios must block
+    -- hard-deletes (guarded by test_scenario_fk_retention.py).
+    scenario_id          UUID        NOT NULL REFERENCES scenarios(scenario_id) ON DELETE RESTRICT,
     promoted_by          TEXT        NOT NULL,           -- human actor (L3+ gate)
     promoted_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
     reason               TEXT,                           -- optional justification

--- a/src/ootils_core/engine/scenario/manager.py
+++ b/src/ootils_core/engine/scenario/manager.py
@@ -12,6 +12,7 @@ Design principles (per EXPERT-dirty-flags-and-scenarios.md Q4.1–Q4.7):
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID, uuid4
@@ -38,6 +39,51 @@ _DIFF_FIELDS: tuple[str, ...] = (
 
 # Baseline sentinel UUID (matches seed in migration 002)
 _BASELINE_ID = UUID("00000000-0000-0000-0000-000000000001")
+
+
+@dataclass(frozen=True)
+class PromoteConflict:
+    """One field where the baseline diverged since the override captured it.
+
+    `expected` is the baseline value at override time (scenario_overrides.
+    old_value — the scenario node was a verbatim deep-copy of the baseline
+    node, so the value read just before the first override IS the baseline
+    value at fork time). `actual` is the baseline value now. Both are the
+    TEXT serialization used by apply_override (str() of the column value).
+    """
+
+    node_id: UUID  # baseline node id
+    field_name: str
+    expected: Optional[str]
+    actual: Optional[str]
+
+
+class PromoteConflictError(Exception):
+    """
+    Raised by promote() when the baseline diverged from the value captured
+    at override time (ADR-018 P2.2.c: no more blind overlay apply).
+    Nothing has been written when this is raised.
+    """
+
+    def __init__(self, scenario_id: UUID, conflicts: list[PromoteConflict]) -> None:
+        self.scenario_id = scenario_id
+        self.conflicts = conflicts
+        super().__init__(
+            f"Promote of scenario {scenario_id} aborted: baseline diverged on "
+            f"{len(conflicts)} node field(s) since the overrides were captured"
+        )
+
+
+@dataclass(frozen=True)
+class PromoteResult:
+    """Outcome of a successful promote (consumed by the API audit row)."""
+
+    scenario_id: UUID
+    override_count: int
+    patched_nodes: int
+    siblings_invalidated: int
+    merge_event_id: UUID
+    conflict_checked: bool = True
 
 
 class ScenarioManager:
@@ -401,7 +447,12 @@ class ScenarioManager:
         override_id = uuid4()
 
         # 2. Upsert override (one per scenario/node/field)
-        # ON CONFLICT: if a prior override exists, update values.
+        # ON CONFLICT: if a prior override exists, update values — but KEEP
+        # the original old_value: it is the pre-first-override capture that
+        # promote's conflict detection compares against the current baseline
+        # (#341). Overwriting it with EXCLUDED.old_value would store the
+        # scenario's CURRENT value (= the previous override's new_value) and
+        # guarantee a false conflict at promote after any re-override.
         # The PK (override_id) is not changed on conflict — we use our generated UUID
         # for new inserts; existing rows retain their original override_id.
         db.execute(
@@ -412,7 +463,7 @@ class ScenarioManager:
                 applied_at, applied_by
             ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (scenario_id, node_id, field_name) DO UPDATE SET
-                old_value  = EXCLUDED.old_value,
+                old_value  = scenario_overrides.old_value,
                 new_value  = EXCLUDED.new_value,
                 applied_at = EXCLUDED.applied_at,
                 applied_by = EXCLUDED.applied_by
@@ -623,37 +674,53 @@ class ScenarioManager:
         self,
         scenario_id: UUID,
         db: psycopg.Connection,
-    ) -> None:
+        promoted_by: Optional[str] = None,
+    ) -> PromoteResult:
         """
         Promote a scenario to baseline.
 
         Per EXPERT Q4.5 — merge is a first-class event:
-          1. For each node override in the scenario, apply its new_value to
+          1. Conflict detection (ADR-018 P2.2.c): for each override, compare
+             the baseline value captured at override time (scenario_overrides.
+             old_value) with the CURRENT baseline value. Any divergence →
+             PromoteConflictError with the full conflict list, nothing written.
+             A missing baseline node (deleted since the fork) is logged and
+             skipped, matching the historical patch behaviour.
+          2. For each node override in the scenario, apply its new_value to
              the corresponding baseline node (matched by business key).
-          2. Mark the old baseline scenario as 'archived'.
-          3. Create a 'scenario_merge' event.
-          4. Mark all other active variant scenarios as 'stale' (not
-             implemented at schema level yet — logged only for now).
+          3. Mark the promoted scenario as 'archived'.
+          4. Create a 'scenario_merge' event (user_ref = promoted_by).
+          5. Log the logical invalidation of sibling scenarios (same parent,
+             still active): their computed state predates the new baseline.
+             Schema-level 'stale' status is still future work.
 
-        The scenario being promoted retains its own status and nodes.
-        The baseline scenario's nodes are patched with the promoted values.
+        The scenario being promoted retains its own nodes. The baseline
+        scenario's nodes are patched with the promoted values.
+
+        Raises PromoteConflictError before any write if the baseline diverged.
+        Returns a PromoteResult for the caller's audit trail.
         """
-        # 1. Load all overrides for this scenario
+        # 1. Load all overrides for this scenario (old_value = baseline value
+        #    captured at override time — the conflict-detection reference).
         override_rows = db.execute(
             """
-            SELECT node_id, field_name, new_value
+            SELECT node_id, field_name, old_value, new_value
             FROM scenario_overrides
             WHERE scenario_id = %s
             """,
             (scenario_id,),
         ).fetchall()
 
-        # 2. Load nodes from the promoted scenario → build match key → patch baseline
+        # 2. Load nodes from the promoted scenario → build match key
         scenario_nodes = _fetch_nodes_as_dict(scenario_id, db)
         scenario_index = {UUID(str(n["node_id"])): n for n in scenario_nodes}
 
         now = datetime.now(timezone.utc)
-        patched = 0
+
+        # PASS 1 — read-only: resolve baseline targets and detect divergence.
+        # No write happens until the whole overlay is known to be clean.
+        conflicts: list[PromoteConflict] = []
+        patch_plan: list[tuple[UUID, str, str]] = []  # (baseline_node_id, field, new_value)
 
         for ov in override_rows:
             ov_node_id = UUID(str(ov["node_id"]))
@@ -669,11 +736,13 @@ class ScenarioManager:
                 )
                 continue
 
-            # Find the matching baseline node by business key
+            # Find the matching baseline node(s) by business key, reading the
+            # current value of the overridden field for divergence detection.
+            # field_name is whitelisted above (never raw user input in SQL).
             b_key = _node_business_key(s_node)
             b_rows = db.execute(
-                """
-                SELECT node_id FROM nodes
+                f"""
+                SELECT node_id, {field_name} FROM nodes
                 WHERE scenario_id = %s
                   AND node_type = %s
                   AND item_id IS NOT DISTINCT FROM %s
@@ -692,18 +761,55 @@ class ScenarioManager:
                 ),
             ).fetchall()
 
-            for b_row in b_rows:
-                db.execute(
-                    f"""
-                    UPDATE nodes
-                    SET {field_name} = %s,
-                        is_dirty     = TRUE,
-                        updated_at   = %s
-                    WHERE node_id = %s AND scenario_id = %s
-                    """,
-                    (new_value, now, UUID(str(b_row["node_id"])), _BASELINE_ID),
+            if not b_rows:
+                logger.warning(
+                    "promote.skip no active baseline node matches business key "
+                    "for override node_id=%s field=%s",
+                    ov_node_id,
+                    field_name,
                 )
-                patched += 1
+                continue
+
+            expected: Optional[str] = ov["old_value"]
+            for b_row in b_rows:
+                b_node_id = UUID(str(b_row["node_id"]))
+                current = b_row[field_name]
+                actual: Optional[str] = str(current) if current is not None else None
+                if actual != expected:
+                    conflicts.append(
+                        PromoteConflict(
+                            node_id=b_node_id,
+                            field_name=field_name,
+                            expected=expected,
+                            actual=actual,
+                        )
+                    )
+                else:
+                    patch_plan.append((b_node_id, field_name, new_value))
+
+        if conflicts:
+            logger.warning(
+                "promote.conflict scenario=%s conflicts=%d — baseline diverged, "
+                "nothing written",
+                scenario_id,
+                len(conflicts),
+            )
+            raise PromoteConflictError(scenario_id, conflicts)
+
+        # PASS 2 — apply the (clean) overlay to the baseline.
+        patched = 0
+        for b_node_id, field_name, new_value in patch_plan:
+            db.execute(
+                f"""
+                UPDATE nodes
+                SET {field_name} = %s,
+                    is_dirty     = TRUE,
+                    updated_at   = %s
+                WHERE node_id = %s AND scenario_id = %s
+                """,
+                (new_value, now, b_node_id, _BASELINE_ID),
+            )
+            patched += 1
 
         # 3. Archive the promoted scenario
         db.execute(
@@ -723,23 +829,67 @@ class ScenarioManager:
             INSERT INTO events (
                 event_id, event_type, scenario_id,
                 old_text, new_text,
-                processed, source, created_at
-            ) VALUES (%s, 'scenario_merge', %s, %s, %s, FALSE, 'engine', %s)
+                processed, source, user_ref, created_at
+            ) VALUES (%s, 'scenario_merge', %s, %s, %s, FALSE, 'engine', %s, %s)
             """,
             (
                 event_id,
                 _BASELINE_ID,
                 str(scenario_id),   # old_text = source scenario_id
                 "promoted",
+                promoted_by,
                 now,
             ),
         )
 
+        # 5. Sibling invalidation — the baseline just moved under their feet,
+        #    so every still-active scenario forked from the same parent now
+        #    holds computed results that predate the new baseline. Logged as
+        #    a logical invalidation (schema-level 'stale' status: future work).
+        siblings_invalidated = 0
+        parent_row = db.execute(
+            "SELECT parent_scenario_id FROM scenarios WHERE scenario_id = %s",
+            (scenario_id,),
+        ).fetchone()
+        if parent_row is not None and parent_row["parent_scenario_id"] is not None:
+            sibling_rows = db.execute(
+                """
+                SELECT scenario_id, name FROM scenarios
+                WHERE parent_scenario_id = %s
+                  AND scenario_id <> %s
+                  AND status = 'active'
+                  AND is_baseline = FALSE
+                """,
+                (parent_row["parent_scenario_id"], scenario_id),
+            ).fetchall()
+            for sib in sibling_rows:
+                logger.warning(
+                    "promote.sibling_invalidated scenario_id=%s name=%r — computed "
+                    "state predates baseline changes from promoted scenario %s; "
+                    "re-run a calculation before trusting its results",
+                    sib["scenario_id"],
+                    sib["name"],
+                    scenario_id,
+                )
+            siblings_invalidated = len(sibling_rows)
+
         logger.info(
-            "promote.complete scenario=%s patched_nodes=%d merge_event=%s",
+            "promote.complete scenario=%s overrides=%d patched_nodes=%d "
+            "siblings_invalidated=%d merge_event=%s by=%s",
             scenario_id,
+            len(override_rows),
             patched,
+            siblings_invalidated,
             event_id,
+            promoted_by,
+        )
+        return PromoteResult(
+            scenario_id=scenario_id,
+            override_count=len(override_rows),
+            patched_nodes=patched,
+            siblings_invalidated=siblings_invalidated,
+            merge_event_id=event_id,
+            conflict_checked=True,
         )
 
 

--- a/tests/integration/test_scenario_promote_integration.py
+++ b/tests/integration/test_scenario_promote_integration.py
@@ -1,0 +1,491 @@
+"""
+Integration tests for GET /v1/scenarios/{id}/diff and
+POST /v1/scenarios/{id}/promote against a real PostgreSQL database
+(no mocks) — chantier #341b.
+
+Covers:
+  - promote without conflict: 200, baseline patched, scenario archived,
+    scenario_promotions audit row (migration 052), scenario_merge event
+  - promote with a diverged baseline: 409 + typed conflict list, and
+    NOTHING written (no patch, no archive, no audit row, no event)
+  - Decision Ladder guard: promote is L3+ → 403 for actor_kind='agent'
+  - promote guards: baseline (400), unknown scenario (404), non-active (409)
+  - sibling invalidation count reported on success
+  - diff endpoint: exposes scenario_diffs entries; 409 when no calc_run
+
+Rows are inserted directly (items, nodes, scenarios, scenario_overrides,
+calc_runs) — the baseline scenario is seeded by migration 002.
+"""
+from __future__ import annotations
+
+import os
+from datetime import date
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+AUTH_HEADERS = {"Authorization": "Bearer integration-test-token"}
+BASELINE = "00000000-0000-0000-0000-000000000001"
+DAY = date(2026, 8, 1)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror tests/integration/test_recommendations_api_integration.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def api_client(migrated_db):
+    """Module-scoped FastAPI TestClient bound to the real test DB."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = "integration-test-token"
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+    from fastapi.testclient import TestClient
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="module")
+def auth():
+    return AUTH_HEADERS
+
+
+# ---------------------------------------------------------------------------
+# Helpers — direct DB access for setup/teardown
+# ---------------------------------------------------------------------------
+
+
+def _db_conn(dsn):
+    import psycopg
+    from psycopg.rows import dict_row
+    return psycopg.connect(dsn, row_factory=dict_row, autocommit=True)
+
+
+def _insert_node(
+    conn,
+    *,
+    scenario_id: str,
+    item_id: str,
+    quantity="100",
+    closing_stock=None,
+) -> str:
+    """Insert an active PurchaseOrderSupply node; returns node_id.
+
+    Business key for cross-scenario matching:
+    (node_type, item_id, location_id=NULL, time_span_start, bucket_sequence).
+    """
+    node_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO nodes (
+            node_id, node_type, scenario_id, item_id,
+            quantity, time_grain, time_ref,
+            time_span_start, bucket_sequence,
+            closing_stock, active
+        ) VALUES (%s, 'PurchaseOrderSupply', %s, %s, %s, 'day', %s, %s, 0, %s, TRUE)
+        """,
+        (node_id, scenario_id, item_id, quantity, DAY, DAY, closing_stock),
+    )
+    return str(node_id)
+
+
+def _insert_calc_run(conn, scenario_id: str) -> str:
+    calc_run_id = uuid4()
+    conn.execute(
+        "INSERT INTO calc_runs (calc_run_id, scenario_id, status, started_at, completed_at) "
+        "VALUES (%s, %s, 'completed', now(), now())",
+        (calc_run_id, scenario_id),
+    )
+    return str(calc_run_id)
+
+
+class _Fixture:
+    """A baseline node + a forked scenario carrying one 'quantity' override."""
+
+    def __init__(self, dsn):
+        self.dsn = dsn
+        self.item_id = str(uuid4())
+        self.scenario_id = str(uuid4())
+        with _db_conn(dsn) as conn:
+            conn.execute(
+                "INSERT INTO items (item_id, name) VALUES (%s, %s)",
+                (self.item_id, f"ITEM-{self.item_id[:8]}"),
+            )
+            conn.execute(
+                "INSERT INTO scenarios (scenario_id, name, parent_scenario_id, is_baseline, status) "
+                "VALUES (%s, %s, %s, FALSE, 'active')",
+                (self.scenario_id, f"fork-{self.scenario_id[:8]}", BASELINE),
+            )
+            self.baseline_node_id = _insert_node(
+                conn, scenario_id=BASELINE, item_id=self.item_id, quantity="100"
+            )
+            # Deep-copy twin in the scenario, then apply_override semantics:
+            # old_value = value read from the (still pristine) copy = the
+            # baseline value at fork time; node carries new_value afterwards.
+            self.scenario_node_id = _insert_node(
+                conn, scenario_id=self.scenario_id, item_id=self.item_id, quantity="150"
+            )
+            conn.execute(
+                "INSERT INTO scenario_overrides "
+                "(scenario_id, node_id, field_name, old_value, new_value, applied_by) "
+                "VALUES (%s, %s, 'quantity', '100', '150', 'ngoineau')",
+                (self.scenario_id, self.scenario_node_id),
+            )
+
+    def add_sibling(self) -> str:
+        sibling_id = str(uuid4())
+        with _db_conn(self.dsn) as conn:
+            conn.execute(
+                "INSERT INTO scenarios (scenario_id, name, parent_scenario_id, is_baseline, status) "
+                "VALUES (%s, %s, %s, FALSE, 'active')",
+                (sibling_id, f"sibling-{sibling_id[:8]}", BASELINE),
+            )
+        return sibling_id
+
+    def diverge_baseline(self, new_quantity: str) -> None:
+        with _db_conn(self.dsn) as conn:
+            conn.execute(
+                "UPDATE nodes SET quantity = %s WHERE node_id = %s",
+                (new_quantity, self.baseline_node_id),
+            )
+
+    def baseline_quantity(self) -> Decimal:
+        with _db_conn(self.dsn) as conn:
+            row = conn.execute(
+                "SELECT quantity FROM nodes WHERE node_id = %s",
+                (self.baseline_node_id,),
+            ).fetchone()
+        return row["quantity"]
+
+    def scenario_status(self) -> str:
+        with _db_conn(self.dsn) as conn:
+            row = conn.execute(
+                "SELECT status FROM scenarios WHERE scenario_id = %s",
+                (self.scenario_id,),
+            ).fetchone()
+        return row["status"]
+
+    def promotion_rows(self) -> list[dict]:
+        with _db_conn(self.dsn) as conn:
+            return conn.execute(
+                "SELECT * FROM scenario_promotions WHERE scenario_id = %s",
+                (self.scenario_id,),
+            ).fetchall()
+
+    def merge_events(self) -> list[dict]:
+        with _db_conn(self.dsn) as conn:
+            return conn.execute(
+                "SELECT * FROM events WHERE event_type = 'scenario_merge' AND old_text = %s",
+                (self.scenario_id,),
+            ).fetchall()
+
+    def cleanup(self, extra_scenarios: list[str] | None = None) -> None:
+        scenario_ids = [self.scenario_id] + (extra_scenarios or [])
+        with _db_conn(self.dsn) as conn:
+            conn.execute(
+                "DELETE FROM scenario_diffs WHERE scenario_id = ANY(%s::uuid[])",
+                (scenario_ids,),
+            )
+            conn.execute(
+                "DELETE FROM scenario_promotions WHERE scenario_id = ANY(%s::uuid[])",
+                (scenario_ids,),
+            )
+            conn.execute(
+                "DELETE FROM scenario_overrides WHERE scenario_id = ANY(%s::uuid[])",
+                (scenario_ids,),
+            )
+            conn.execute(
+                "DELETE FROM events WHERE event_type = 'scenario_merge' AND old_text = ANY(%s)",
+                (scenario_ids,),
+            )
+            conn.execute(
+                "DELETE FROM calc_runs WHERE scenario_id = ANY(%s::uuid[]) OR scenario_id = %s",
+                (scenario_ids, BASELINE),
+            )
+            conn.execute("DELETE FROM nodes WHERE item_id = %s", (self.item_id,))
+            conn.execute(
+                "DELETE FROM scenarios WHERE scenario_id = ANY(%s::uuid[])",
+                (scenario_ids,),
+            )
+            conn.execute("DELETE FROM items WHERE item_id = %s", (self.item_id,))
+
+
+@pytest.fixture
+def fx(migrated_db):
+    fixture = _Fixture(migrated_db)
+    extra: list[str] = []
+    fixture._extra = extra  # collected sibling ids for cleanup
+    yield fixture
+    fixture.cleanup(extra_scenarios=extra)
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/scenarios/{id}/promote — success path
+# ---------------------------------------------------------------------------
+
+
+class TestPromoteSuccess:
+    def test_promote_requires_auth(self, api_client, fx):
+        resp = api_client.post(
+            f"/v1/scenarios/{fx.scenario_id}/promote",
+            json={"actor": "ngoineau", "actor_kind": "human"},
+        )
+        assert resp.status_code in (401, 403)
+
+    def test_re_override_does_not_false_conflict_at_promote(
+        self, api_client, auth, fx, migrated_db
+    ):
+        """Regression guard for the old_value upsert (#341 part 2 review):
+        a SECOND apply_override on the same (scenario, node, field) must
+        preserve the ORIGINAL baseline capture in old_value. Before the fix,
+        ON CONFLICT overwrote old_value with the scenario's current value
+        (= the first override's new_value), so any re-overridden field was
+        a guaranteed false 409 at promote."""
+        from uuid import UUID as _UUID
+
+        from ootils_core.engine.scenario.manager import ScenarioManager
+
+        manager = ScenarioManager()
+        with _db_conn(migrated_db) as conn:
+            # Two real apply_override calls — the path that owns the upsert.
+            for new_value in ("160", "175"):
+                manager.apply_override(
+                    scenario_id=_UUID(fx.scenario_id),
+                    node_id=_UUID(fx.scenario_node_id),
+                    field_name="quantity",
+                    new_value=new_value,
+                    applied_by="test-double-override",
+                    db=conn,
+                )
+            row = conn.execute(
+                "SELECT old_value, new_value FROM scenario_overrides "
+                "WHERE scenario_id = %s AND node_id = %s AND field_name = 'quantity'",
+                (fx.scenario_id, fx.scenario_node_id),
+            ).fetchone()
+            # old_value must still be the FORK-TIME baseline capture (150 was
+            # the scenario copy's pristine value in this fixture — see
+            # _Fixture: the direct-INSERT override row uses 100; apply_override
+            # reads the node's current value on first call).
+            assert row["new_value"] == "175"
+
+        resp = api_client.post(
+            f"/v1/scenarios/{fx.scenario_id}/promote",
+            json={"actor": "ngoineau", "actor_kind": "human", "reason": "re-override"},
+            headers=auth,
+        )
+        assert resp.status_code == 200, (
+            f"re-overridden field must not false-conflict at promote: {resp.text}"
+        )
+
+    def test_promote_patches_baseline_audits_and_emits_event(
+        self, api_client, auth, fx
+    ):
+        resp = api_client.post(
+            f"/v1/scenarios/{fx.scenario_id}/promote",
+            json={"actor": "ngoineau", "actor_kind": "human", "reason": "Q3 plan"},
+            headers=auth,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["scenario_id"] == fx.scenario_id
+        assert data["promoted_by"] == "ngoineau"
+        assert data["override_count"] == 1
+        assert data["patched_nodes"] == 1
+        assert data["conflict_checked"] is True
+
+        # Baseline node carries the promoted value
+        assert fx.baseline_quantity() == Decimal("150")
+        # Promoted scenario archived
+        assert fx.scenario_status() == "archived"
+
+        # Audit row (migration 052)
+        promos = fx.promotion_rows()
+        assert len(promos) == 1
+        assert promos[0]["promotion_id"] == UUID(data["promotion_id"])
+        assert promos[0]["promoted_by"] == "ngoineau"
+        assert promos[0]["reason"] == "Q3 plan"
+        assert promos[0]["override_count"] == 1
+        assert promos[0]["conflict_checked"] is True
+
+        # scenario_merge event, attributed to the actor
+        events = fx.merge_events()
+        assert len(events) == 1
+        assert str(events[0]["event_id"]) == data["event_id"]
+        assert events[0]["user_ref"] == "ngoineau"
+        assert events[0]["new_text"] == "promoted"
+
+    def test_promote_reports_sibling_invalidation(self, api_client, auth, fx):
+        sibling_id = fx.add_sibling()
+        fx._extra.append(sibling_id)
+
+        resp = api_client.post(
+            f"/v1/scenarios/{fx.scenario_id}/promote",
+            json={"actor": "ngoineau", "actor_kind": "human"},
+            headers=auth,
+        )
+        assert resp.status_code == 200, resp.text
+        # >= 1, not == 1: the sibling query counts EVERY active child of the
+        # same parent (baseline), so scenarios leaked by other modules of the
+        # same session would inflate the count — the contract here is "OUR
+        # sibling was counted", not "we are alone in the database".
+        assert resp.json()["siblings_invalidated"] >= 1
+        promos = fx.promotion_rows()
+        assert promos[0]["siblings_invalidated"] >= 1
+        assert promos[0]["siblings_invalidated"] == resp.json()["siblings_invalidated"]
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/scenarios/{id}/promote — conflict path (nothing written)
+# ---------------------------------------------------------------------------
+
+
+class TestPromoteConflict:
+    def test_diverged_baseline_is_409_with_typed_conflicts(
+        self, api_client, auth, fx
+    ):
+        fx.diverge_baseline("999")  # baseline moved since the override captured '100'
+
+        resp = api_client.post(
+            f"/v1/scenarios/{fx.scenario_id}/promote",
+            json={"actor": "ngoineau", "actor_kind": "human"},
+            headers=auth,
+        )
+        assert resp.status_code == 409, resp.text
+        detail = resp.json()["detail"]
+        assert "diverged" in detail["message"]
+        conflicts = detail["conflicts"]
+        assert len(conflicts) == 1
+        assert conflicts[0]["node_id"] == fx.baseline_node_id
+        assert conflicts[0]["field_name"] == "quantity"
+        assert conflicts[0]["expected"] == "100"
+        assert conflicts[0]["actual"] == "999"
+
+        # NOTHING was written
+        assert fx.baseline_quantity() == Decimal("999")  # untouched
+        assert fx.scenario_status() == "active"          # not archived
+        assert fx.promotion_rows() == []                 # no audit row
+        assert fx.merge_events() == []                   # no event
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/scenarios/{id}/promote — guards
+# ---------------------------------------------------------------------------
+
+
+class TestPromoteGuards:
+    def test_agent_cannot_promote(self, api_client, auth, fx):
+        """Decision Ladder guard: promote is L3+ → human-only (403 for agents)."""
+        resp = api_client.post(
+            f"/v1/scenarios/{fx.scenario_id}/promote",
+            json={"actor": "shortage_watcher", "actor_kind": "agent"},
+            headers=auth,
+        )
+        assert resp.status_code == 403, resp.text
+        assert "human" in resp.json()["detail"].lower()
+        # Nothing written
+        assert fx.scenario_status() == "active"
+        assert fx.promotion_rows() == []
+
+    def test_promote_baseline_is_400(self, api_client, auth):
+        resp = api_client.post(
+            f"/v1/scenarios/{BASELINE}/promote",
+            json={"actor": "ngoineau", "actor_kind": "human"},
+            headers=auth,
+        )
+        assert resp.status_code == 400
+
+    def test_promote_unknown_scenario_is_404(self, api_client, auth):
+        resp = api_client.post(
+            f"/v1/scenarios/{uuid4()}/promote",
+            json={"actor": "ngoineau", "actor_kind": "human"},
+            headers=auth,
+        )
+        assert resp.status_code == 404
+
+    def test_promote_archived_scenario_is_409(self, api_client, auth, fx):
+        with _db_conn(fx.dsn) as conn:
+            conn.execute(
+                "UPDATE scenarios SET status = 'archived' WHERE scenario_id = %s",
+                (fx.scenario_id,),
+            )
+        resp = api_client.post(
+            f"/v1/scenarios/{fx.scenario_id}/promote",
+            json={"actor": "ngoineau", "actor_kind": "human"},
+            headers=auth,
+        )
+        assert resp.status_code == 409
+        assert "active" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/scenarios/{id}/diff
+# ---------------------------------------------------------------------------
+
+
+class TestDiffEndpoint:
+    def test_diff_exposes_scenario_diff_entries(self, api_client, auth, fx, migrated_db):
+        # Make a computed field differ (diff compares _DIFF_FIELDS, not quantity)
+        with _db_conn(migrated_db) as conn:
+            conn.execute(
+                "UPDATE nodes SET closing_stock = 10 WHERE node_id = %s",
+                (fx.baseline_node_id,),
+            )
+            conn.execute(
+                "UPDATE nodes SET closing_stock = 42 WHERE node_id = %s",
+                (fx.scenario_node_id,),
+            )
+            _insert_calc_run(conn, BASELINE)
+            _insert_calc_run(conn, fx.scenario_id)
+
+        resp = api_client.get(
+            f"/v1/scenarios/{fx.scenario_id}/diff", headers=auth
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["scenario_id"] == fx.scenario_id
+        assert data["baseline_id"] == BASELINE
+        assert data["total"] == len(data["diffs"]) >= 1
+
+        closing = [d for d in data["diffs"] if d["field_name"] == "closing_stock"]
+        assert len(closing) == 1
+        assert Decimal(closing[0]["baseline_value"]) == Decimal("10")
+        assert Decimal(closing[0]["scenario_value"]) == Decimal("42")
+
+        # Entries are persisted in scenario_diffs (upsert per calc_run pair)
+        with _db_conn(migrated_db) as conn:
+            rows = conn.execute(
+                "SELECT field_name FROM scenario_diffs WHERE scenario_id = %s",
+                (fx.scenario_id,),
+            ).fetchall()
+        assert "closing_stock" in {r["field_name"] for r in rows}
+
+    def test_diff_without_calc_run_is_409(self, api_client, auth, fx):
+        resp = api_client.get(
+            f"/v1/scenarios/{fx.scenario_id}/diff", headers=auth
+        )
+        assert resp.status_code == 409, resp.text
+        assert "calc_run" in resp.json()["detail"]
+
+    def test_diff_unknown_scenario_is_404(self, api_client, auth):
+        resp = api_client.get(f"/v1/scenarios/{uuid4()}/diff", headers=auth)
+        assert resp.status_code == 404

--- a/tests/integration/test_scenario_promote_integration.py
+++ b/tests/integration/test_scenario_promote_integration.py
@@ -218,6 +218,14 @@ class _Fixture:
                 "DELETE FROM events WHERE event_type = 'scenario_merge' AND old_text = ANY(%s)",
                 (scenario_ids,),
             )
+            # Real apply_override calls (test_re_override_...) emit
+            # policy_changed events whose trigger_node_id references our
+            # nodes — purge them before the nodes or the FK blocks teardown.
+            conn.execute(
+                "DELETE FROM events WHERE trigger_node_id IN "
+                "(SELECT node_id FROM nodes WHERE item_id = %s)",
+                (self.item_id,),
+            )
             conn.execute(
                 "DELETE FROM calc_runs WHERE scenario_id = ANY(%s::uuid[]) OR scenario_id = %s",
                 (scenario_ids, BASELINE),

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -1507,17 +1507,20 @@ class TestScenarioManagerGaps:
         override_present = {
             "node_id": ov_node_id_present,
             "field_name": "quantity",
+            "old_value": None,  # captured baseline value (conflict check, #341b)
             "new_value": "100",
         }
         override_missing = {
             "node_id": ov_node_id_missing,
             "field_name": "quantity",
+            "old_value": None,
             "new_value": "200",
         }
 
         db = MagicMock()
         # fetchall sequence: overrides, scenario_nodes, baseline matches (1 per present override)
-        baseline_row = {"node_id": uuid4()}
+        # 'quantity' None matches the override's old_value → no conflict.
+        baseline_row = {"node_id": uuid4(), "quantity": None}
         fetchall_responses = [
             [override_present, override_missing],  # overrides
             [scenario_node],                        # scenario nodes

--- a/tests/test_m5_scenarios.py
+++ b/tests/test_m5_scenarios.py
@@ -475,14 +475,21 @@ class TestPromote:
         self,
         override_rows: list[dict],
         scenario_nodes: list[dict],
+        baseline_field_value=None,
     ) -> MagicMock:
         db = MagicMock()
 
         # fetchall sequence:
         #   1st → override rows, 2nd → scenario nodes,
-        #   3rd onward → baseline node matches (one per override)
+        #   3rd onward → baseline node matches (one per override).
+        # fetchone → None (parent lookup → sibling logging skipped).
+        # baseline_field_value: current baseline value of the overridden
+        # field — promote compares it to scenario_overrides.old_value for
+        # conflict detection (#341b).
         baseline_node_row = MagicMock()
-        baseline_node_row.__getitem__ = lambda self, k: _uuid(999) if k == "node_id" else None
+        baseline_node_row.__getitem__ = (
+            lambda self, k: _uuid(999) if k == "node_id" else baseline_field_value
+        )
 
         fetchall_side_effects = (
             [override_rows, scenario_nodes]
@@ -493,8 +500,7 @@ class TestPromote:
 
         return db
 
-    def test_archives_scenario_on_promote(self):
-        """promote() should UPDATE scenarios.status = 'archived'."""
+    def _make_scenario_node_and_override(self) -> tuple[dict, dict]:
         scenario_node = make_node_row(
             node_id=_uuid(50),
             scenario_id=self.SCENARIO_ID,
@@ -506,18 +512,58 @@ class TestPromote:
         override = {
             "node_id": _uuid(50),
             "field_name": "quantity",
+            "old_value": None,  # baseline value captured at override time
             "new_value": "200",
         }
+        return scenario_node, override
+
+    def test_archives_scenario_on_promote(self):
+        """promote() should UPDATE scenarios.status = 'archived'."""
+        scenario_node, override = self._make_scenario_node_and_override()
 
         db = self._make_db_for_promote([override], [scenario_node])
         manager = ScenarioManager()
-        manager.promote(scenario_id=self.SCENARIO_ID, db=db)
+        result = manager.promote(scenario_id=self.SCENARIO_ID, db=db)
 
         archive_calls = [
             c for c in db.execute.call_args_list
             if "archived" in str(c) and "UPDATE scenarios" in str(c)
         ]
         assert len(archive_calls) >= 1
+        assert result.override_count == 1
+        assert result.patched_nodes == 1
+        assert result.conflict_checked is True
+
+    def test_promote_conflict_raises_before_any_write(self):
+        """Baseline diverged since the override captured it →
+        PromoteConflictError with the typed conflict list, and no
+        UPDATE/INSERT issued (ADR-018 P2.2.c)."""
+        from ootils_core.engine.scenario.manager import PromoteConflictError
+
+        scenario_node, override = self._make_scenario_node_and_override()
+        override["old_value"] = "100"  # captured baseline value
+
+        # Current baseline value differs → conflict
+        db = self._make_db_for_promote(
+            [override], [scenario_node], baseline_field_value="999"
+        )
+        manager = ScenarioManager()
+        with pytest.raises(PromoteConflictError) as exc_info:
+            manager.promote(scenario_id=self.SCENARIO_ID, db=db)
+
+        conflicts = exc_info.value.conflicts
+        assert len(conflicts) == 1
+        assert conflicts[0].field_name == "quantity"
+        assert conflicts[0].expected == "100"
+        assert conflicts[0].actual == "999"
+        assert conflicts[0].node_id == _uuid(999)
+
+        # Nothing written: no UPDATE nodes, no archive, no merge event
+        writes = [
+            c for c in db.execute.call_args_list
+            if "UPDATE" in str(c) or "INSERT" in str(c)
+        ]
+        assert writes == []
 
     def test_creates_scenario_merge_event(self):
         """promote() should insert a scenario_merge event."""


### PR DESCRIPTION
## Chantier C1 — PR-C : diff/promote en API avec détection de conflit (#341, partie 2/2)

Clôt #341 (la partie 1 — API recommandations — est mergée via #357). Épique #351.

### Contenu

- **`promote` conflict-safe** : détection de conflit AVANT toute écriture — la valeur baseline capturée à l'override (`scenario_overrides.old_value`, migration 006, aucune évolution de schéma) est comparée à la valeur baseline actuelle → `PromoteConflictError` typée (node, field, expected, actual) → **409 à payload typé**, transaction intacte (testé : aucune écriture). Fini le « merge aveugle » d'ADR-018 P2.2.c.
- **Fix débusqué par la revue adversariale** : `apply_override` rasait `old_value` au re-override (la capture devenait la valeur courante du fork) → faux conflit garanti au promote après double override. `ON CONFLICT` préserve désormais la capture d'origine + test dédié.
- **Invalidation des frères réellement loggée et comptée** (la promesse de docstring est enfin tenue) + **audit `scenario_promotions`** (migration 052, colonnes typées).
- **Endpoints** `GET /v1/scenarios/{id}/diff` et `POST /v1/scenarios/{id}/promote` — garde humaine Decision Ladder **réutilisée** du `state_machine` (promote = L3+, aucune duplication de la règle), 403 agent.

### Réserves documentées

TOCTOU entre les 2 passes de promote (pas de lock — démo-scale, noté pour la prod) · `actor_kind` auto-déclaré (transitoire, #350) · faux conflit possible sur champ recalculé entre fork et premier override (documenté en docstring).

### Tests

12 intégration (conflit 409 sans écriture, re-override sans faux conflit, garde humaine, audit, frères, diff) · suite unitaire 1744 ✅ · ruff ✅ · rebasée sur main post-merge #356/#357.

Closes #341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
