### PR TITLE
feat(forecast): Pyramide axe A PR1 — saisonnalité native déterministe (courbes, season_length paramétrable)

### DIFF
--- a/src/ootils_core/api/routers/forecasting.py
+++ b/src/ootils_core/api/routers/forecasting.py
@@ -24,7 +24,7 @@ from uuid import UUID, uuid4
 
 import psycopg
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID, get_db
@@ -58,6 +58,20 @@ class ForecastGenerateRequest(BaseModel):
         if v > 365:
             raise ValueError("horizon_days cannot exceed 365")
         return v
+
+    @model_validator(mode="after")
+    def validate_seasonal_params(self) -> "ForecastGenerateRequest":
+        # SEASONAL has no default cycle length: it depends on the data
+        # granularity (e.g. 7 daily, 12 monthly, 52 weekly) and must be chosen
+        # explicitly. Fail at validation time (422, before any DB access).
+        if self.method == "SEASONAL":
+            season_length = (self.method_params or {}).get("season_length")
+            if not isinstance(season_length, int) or isinstance(season_length, bool) or season_length < 2:
+                raise ValueError(
+                    "method SEASONAL requires method_params.season_length (integer >= 2, "
+                    "e.g. 7 daily, 12 monthly, 52 weekly)"
+                )
+        return self
 
 
 class ForecastAdjustRequest(BaseModel):
@@ -369,6 +383,20 @@ def generate_forecast(
             detail="Forecast generation failed",
         )
 
+    # 4b. SEASONAL opt-in: the persisted values follow the seasonal CURVE
+    # (level x indices) instead of repeating a single value. Default methods
+    # (MA, EXP_SMOOTHING, CROSTON) keep the historical flat behaviour. When
+    # the history covers < 2 full cycles, the engine falls back to a flat
+    # level and records it in forecast_result.parameters/warnings.
+    seasonal_series: Optional[List[Decimal]] = None
+    if forecast_result.parameters.get("seasonal_applied"):
+        seasonal_series = engine.forecast_series(
+            item_history=historical_demand,
+            method=body.method,
+            params=body.method_params or {},
+            periods=body.horizon_days,
+        )
+
     # 5. Create forecast header
     forecast_id = uuid4()
     horizon_start = date.today() + timedelta(days=1)
@@ -395,7 +423,7 @@ def generate_forecast(
         value_id = uuid4()
 
         # Use the forecast value (for non-daily granularity, this is a simplification)
-        quantity = forecast_result.forecast_value
+        quantity = seasonal_series[day_offset] if seasonal_series is not None else forecast_result.forecast_value
 
         db.execute(
             """
@@ -426,7 +454,10 @@ def generate_forecast(
 
     metadata = ForecastMetadata(
         method=body.method,
-        method_params=body.method_params,
+        # Effective engine parameters carry the provenance (e.g. season_length
+        # + seasonal_applied for SEASONAL, auto-calibrated alpha/window) in the
+        # existing method_params field — no new column, no JSONB.
+        method_params=forecast_result.parameters or body.method_params,
         generated_at=date.today(),
         horizon_days=body.horizon_days,
         granularity=body.granularity,

--- a/src/ootils_core/forecasting/__init__.py
+++ b/src/ootils_core/forecasting/__init__.py
@@ -1,8 +1,8 @@
 """
 Forecasting module for Ootils Core.
 
-Provides statistical forecasting algorithms (MA, ES, Croston) via a unified
-ForecastingEngine service interface.
+Provides statistical forecasting algorithms (MA, ES, Croston, Seasonal) via a
+unified ForecastingEngine service interface.
 """
 
 from .engine import ForecastingEngine, ForecastMethod, ForecastResult, AccuracyMetrics
@@ -11,6 +11,7 @@ from .algorithms import (
     MovingAverageForecaster,
     ExponentialSmoothingForecaster,
     CrostonForecaster,
+    SeasonalForecaster,
     ForecastingError,
     create_forecaster,
 )
@@ -24,6 +25,7 @@ __all__ = [
     "MovingAverageForecaster",
     "ExponentialSmoothingForecaster",
     "CrostonForecaster",
+    "SeasonalForecaster",
     "ForecastingError",
     "create_forecaster",
 ]

--- a/src/ootils_core/forecasting/algorithms.py
+++ b/src/ootils_core/forecasting/algorithms.py
@@ -1,10 +1,11 @@
 """
 Statistical forecasting algorithms for demand planning.
 
-Implements three classical forecasting algorithms:
+Implements four classical forecasting algorithms:
 1. Moving Average (moyenne mobile)
 2. Exponential Smoothing (lissage exponentiel)
 3. Croston (pour demande intermittente)
+4. Seasonal (décomposition par indices saisonniers, courbe multi-périodes)
 
 Conforme aux spécifications APICS CPIM/CSCP pour le Demand Planning.
 """
@@ -366,6 +367,172 @@ class CrostonForecaster(Forecaster):
         return f"CrostonForecaster(min_demand_threshold={self.min_demand_threshold})"
 
 
+class SeasonalForecaster(Forecaster):
+    """
+    Décomposition saisonnière multiplicative classique (indices saisonniers).
+
+    Déterministe, pur Python, sans dépendance. La longueur de cycle est
+    paramétrable (ex. 7 quotidien, 12 mensuel, 52 hebdomadaire).
+
+    Algorithm:
+    1. Conserver les k derniers cycles COMPLETS (k = n // season_length),
+       alignés sur la FIN de l'historique — la phase du prochain point est
+       ainsi connue même si l'historique commence en milieu de cycle.
+    2. Indice de la position p = moyenne des valeurs observées à la position p
+       / moyenne globale des cycles complets. Les indices moyennent 1.0 par
+       construction. Série constante → indices tous égaux à 1.0.
+    3. Niveau = moyenne du dernier cycle complet désaisonnalisé
+       (valeur / indice de sa position).
+    4. Prévision de la période future h = niveau × indice[(h-1) % season_length].
+
+    Requiert >= 2 cycles complets d'historique (sinon ForecastingError) : avec
+    un seul cycle, indices et bruit sont indiscernables. Le fallback plat est
+    de la responsabilité de l'appelant (cf. ForecastingEngine.generate, qui le
+    documente dans la provenance).
+
+    ⚠️ Ne pas utiliser sur demande intermittente (beaucoup de zéros) : les
+    indices y capturent la position aléatoire des transactions, pas une
+    saison — Croston reste le bon modèle (et reste plat par design).
+
+    Args:
+        season_length: Nombre de périodes par cycle saisonnier (>= 2).
+
+    Performance: O(n) en temps, O(season_length) en mémoire.
+    """
+
+    def __init__(self, season_length: int):
+        """
+        Initialiser le forecaster saisonnier.
+
+        Args:
+            season_length: Longueur du cycle saisonnier (>= 2)
+
+        Raises:
+            ValueError: Si season_length < 2
+        """
+        if not isinstance(season_length, int) or season_length < 2:
+            raise ValueError(f"season_length doit être un entier >= 2, reçu: {season_length}")
+
+        self.season_length = season_length
+        logger.debug(f"SeasonalForecaster initialisé avec season_length={season_length}")
+
+    def _fit(self, historical_data: List[Union[Decimal, float, int]]) -> tuple:
+        """
+        Ajuster (niveau, indices) sur les cycles complets de l'historique.
+
+        Returns:
+            tuple[float, list[float]]: (niveau désaisonnalisé, indices par position)
+
+        Raises:
+            ForecastingError: Si l'historique couvre moins de 2 cycles complets.
+        """
+        self.validate_historical_data(historical_data, min_length=2 * self.season_length)
+
+        data = [float(value) for value in historical_data]
+        cycle_count = len(data) // self.season_length
+        # Cycles complets alignés sur la fin : la position 0 est la position
+        # du premier point conservé, et le point suivant l'historique tombe
+        # exactement en position 0 (longueur conservée = multiple du cycle).
+        trimmed = data[len(data) - cycle_count * self.season_length:]
+
+        grand_mean = sum(trimmed) / len(trimmed)
+        if grand_mean <= 0:
+            # Série nulle (ou de somme <= 0) : aucun profil exploitable,
+            # indices neutres — la prévision retombe sur le niveau seul.
+            indices = [1.0] * self.season_length
+        else:
+            indices = []
+            for position in range(self.season_length):
+                position_values = [trimmed[j] for j in range(position, len(trimmed), self.season_length)]
+                indices.append((sum(position_values) / len(position_values)) / grand_mean)
+
+        # Niveau = moyenne du dernier cycle désaisonnalisé. Les positions
+        # d'indice nul (demande toujours nulle à cette position) sont exclues
+        # de la moyenne : leur prévision est structurellement 0.
+        deseasonalized = [
+            trimmed[j] / indices[j % self.season_length]
+            for j in range(len(trimmed) - self.season_length, len(trimmed))
+            if indices[j % self.season_length] > 0
+        ]
+        level = sum(deseasonalized) / len(deseasonalized) if deseasonalized else 0.0
+
+        return level, indices
+
+    def seasonal_indices(self, historical_data: List[Union[Decimal, float, int]]) -> List[Decimal]:
+        """
+        Retourner les indices saisonniers ajustés (un par position du cycle).
+
+        Args:
+            historical_data: Données historiques (>= 2 cycles complets)
+
+        Returns:
+            List[Decimal]: season_length indices, de moyenne 1.0
+        """
+        _, indices = self._fit(historical_data)
+        return [Decimal(str(index)) for index in indices]
+
+    def forecast(self, historical_data: List[Union[Decimal, float, int]]) -> Decimal:
+        """
+        Calculer la prévision de la période suivante (niveau × indice).
+
+        Exemple (season_length=4):
+            historical_data = [200, 50, 100, 50, 200, 50, 100, 50]
+            → moyenne globale = 100 ; indices = [2.0, 0.5, 1.0, 0.5]
+            → niveau (dernier cycle désaisonnalisé) = 100
+            → prochaine période en position 0 → forecast = 100 × 2.0 = 200
+
+        Args:
+            historical_data: Données historiques (>= 2 cycles complets)
+
+        Returns:
+            Decimal: Prévision pour la période suivante
+        """
+        return self.forecast_curve(historical_data, periods=1)[0]
+
+    def forecast_curve(
+        self,
+        historical_data: List[Union[Decimal, float, int]],
+        periods: int,
+    ) -> List[Decimal]:
+        """
+        Calculer la COURBE de prévision sur plusieurs périodes.
+
+        Chaque période future h (1-indexée) reçoit
+        niveau × indice[(h-1) % season_length] — le profil saisonnier se
+        répète sur l'horizon.
+
+        Args:
+            historical_data: Données historiques (>= 2 cycles complets)
+            periods: Nombre de périodes à prévoir (>= 1)
+
+        Returns:
+            List[Decimal]: periods prévisions (la courbe saisonnière)
+
+        Raises:
+            ValueError: Si periods < 1
+            ForecastingError: Si l'historique couvre moins de 2 cycles complets
+        """
+        if periods < 1:
+            raise ValueError(f"periods doit être >= 1, reçu: {periods}")
+
+        level, indices = self._fit(historical_data)
+        curve = [
+            Decimal(str(level * indices[(h - 1) % self.season_length]))
+            for h in range(1, periods + 1)
+        ]
+
+        logger.debug(
+            f"SeasonalForecaster: {len(historical_data)} valeurs historiques, "
+            f"season_length={self.season_length}, level={level}, "
+            f"curve[0]={curve[0]}"
+        )
+
+        return curve
+
+    def __repr__(self) -> str:
+        return f"SeasonalForecaster(season_length={self.season_length})"
+
+
 # ─────────────────────────────────────────────────────────────
 # Fonctions utilitaires
 # ─────────────────────────────────────────────────────────────
@@ -375,7 +542,7 @@ def create_forecaster(model_type: str, **kwargs) -> Forecaster:
     Factory function pour créer un forecaster par type.
     
     Args:
-        model_type: Type de modèle ('moving_average', 'exponential_smoothing', 'croston')
+        model_type: Type de modèle ('moving_average', 'exponential_smoothing', 'croston', 'seasonal')
         **kwargs: Paramètres spécifiques au modèle
     
     Returns:
@@ -395,9 +562,17 @@ def create_forecaster(model_type: str, **kwargs) -> Forecaster:
     elif model_type == 'croston':
         threshold = kwargs.get('min_demand_threshold', 0.0)
         return CrostonForecaster(min_demand_threshold=threshold)
-    
+
+    elif model_type == 'seasonal':
+        # Pas de défaut : la longueur du cycle dépend de la granularité des
+        # données (7 quotidien, 12 mensuel, 52 hebdomadaire) — l'appelant choisit.
+        season_length = kwargs.get('season_length')
+        if season_length is None:
+            raise ValueError("Le modèle 'seasonal' requiert le paramètre season_length (entier >= 2)")
+        return SeasonalForecaster(season_length=season_length)
+
     else:
         raise ValueError(
             f"Type de modèle inconnu: '{model_type}'. "
-            f"Disponible: 'moving_average', 'exponential_smoothing', 'croston'"
+            f"Disponible: 'moving_average', 'exponential_smoothing', 'croston', 'seasonal'"
         )

--- a/src/ootils_core/forecasting/engine.py
+++ b/src/ootils_core/forecasting/engine.py
@@ -18,6 +18,7 @@ from .algorithms import (
     ForecastingError,
     Forecaster,
     MovingAverageForecaster,
+    SeasonalForecaster,
 )
 
 logger = logging.getLogger(__name__)
@@ -104,11 +105,13 @@ class ForecastingEngine:
         
         Args:
             item_history: Historique des quantités (chronologique, plus récent en dernier).
-            method: Méthode de forecasting (MA, EXP_SMOOTHING, CROSTON).
+            method: Méthode de forecasting (MA, EXP_SMOOTHING, CROSTON, SEASONAL).
             params: Paramètres spécifiques à la méthode:
                     - MA: {"window": int}
                     - EXP_SMOOTHING: {"alpha": float, "auto_calibrate": bool}
                     - CROSTON: {"min_demand_threshold": float}
+                    - SEASONAL: {"season_length": int} (obligatoire, >= 2 —
+                      ex. 7 quotidien, 12 mensuel, 52 hebdomadaire)
             actuals: Valeurs réelles pour calcul des métriques d'accuracy (optionnel).
                     Si fourni, doit être de même longueur que les prévisions testées.
         
@@ -144,9 +147,29 @@ class ForecastingEngine:
                 params["window"] = self._calibrate_window(item_history)
                 warnings.append(f"Window auto-calibré: {params['window']}")
         
+        # SEASONAL : valider le paramètre de cycle et décider saisonnier vs
+        # fallback plat. Le fallback est DOCUMENTÉ (warning + provenance dans
+        # parameters), jamais silencieux.
+        seasonal_fallback = False
+        season_length: Optional[int] = None
+        if method == ForecastMethod.SEASONAL:
+            season_length = self._validate_season_length(params)
+            if len(item_history) < 2 * season_length:
+                # Moins de 2 cycles complets : les indices seraient du bruit.
+                # Niveau plat (MA sur au plus un cycle), tracé en provenance.
+                seasonal_fallback = True
+                fallback_window = min(len(item_history), season_length)
+                warnings.append(
+                    f"SEASONAL fallback: {len(item_history)} point(s) d'historique < "
+                    f"2 cycles complets ({2 * season_length}); niveau plat MA(window={fallback_window})"
+                )
+
         # Créer le forecaster approprié
-        forecaster = self._create_forecaster(method, params)
-        
+        if seasonal_fallback:
+            forecaster: Forecaster = MovingAverageForecaster(window_size=fallback_window)
+        else:
+            forecaster = self._create_forecaster(method, params)
+
         # Générer la prévision
         forecast_value = forecaster.forecast(item_history)
         
@@ -166,11 +189,18 @@ class ForecastingEngine:
             }
         
         # Construire le résultat
+        # Provenance saisonnière portée par le champ parameters existant :
+        # season_length effectif + saisonnier-ou-fallback (pas de JSONB nouveau).
+        parameters = params.copy()
+        if method == ForecastMethod.SEASONAL:
+            parameters["season_length"] = season_length
+            parameters["seasonal_applied"] = not seasonal_fallback
+
         result = ForecastResult(
             method=method,
             forecast_value=forecast_value,
             metrics=metrics,
-            parameters=params.copy(),
+            parameters=parameters,
             historical_count=len(item_history),
             warnings=warnings,
         )
@@ -195,12 +225,43 @@ class ForecastingEngine:
         elif method == ForecastMethod.CROSTON:
             threshold = params.get("min_demand_threshold", 0.0)
             return CrostonForecaster(min_demand_threshold=threshold)
-        
+
+        elif method == ForecastMethod.SEASONAL:
+            season_length = self._validate_season_length(params)
+            return SeasonalForecaster(season_length=season_length)
+
         else:
             raise ForecastingError(
                 f"Méthode de forecasting inconnue: '{method}'. "
-                f"Disponible: {ForecastMethod.MA}, {ForecastMethod.EXP_SMOOTHING}, {ForecastMethod.CROSTON}"
+                f"Disponible: {ForecastMethod.MA}, {ForecastMethod.EXP_SMOOTHING}, "
+                f"{ForecastMethod.CROSTON}, {ForecastMethod.SEASONAL}"
             )
+
+    @staticmethod
+    def _validate_season_length(params: Dict[str, Any]) -> int:
+        """
+        Valider le paramètre season_length de la méthode SEASONAL.
+
+        Obligatoire et sans défaut : la longueur du cycle dépend de la
+        granularité des données (ex. 7 quotidien, 12 mensuel, 52 hebdomadaire)
+        et doit être choisie explicitement par l'appelant.
+
+        Raises:
+            ForecastingError: Si absent, non entier, ou < 2.
+        """
+        raw = params.get("season_length")
+        # Strictement un entier (pas de bool, pas de coercition de 7.9 ni de
+        # "52") — aligné sur le validateur API (routers/forecasting.py).
+        if not isinstance(raw, int) or isinstance(raw, bool):
+            raise ForecastingError(
+                "SEASONAL requiert params['season_length'] (entier >= 2, "
+                f"ex. 7 quotidien, 12 mensuel, 52 hebdomadaire); reçu: {raw!r}"
+            )
+        if raw < 2:
+            raise ForecastingError(
+                f"season_length doit être >= 2, reçu: {raw}"
+            )
+        return raw
     
     def _calibrate_alpha(self, historical_data: List[Union[Decimal, float, int]]) -> float:
         """
@@ -399,13 +460,26 @@ class ForecastingEngine:
         
         Returns:
             Liste des prévisions pour chaque période future.
-        
+
         Note:
             Pour MA et ES, la prévision est constante sur toutes les périodes.
-            Pour Croston, idem (modèle sans tendance).
+            Pour Croston, idem — PLAT PAR DESIGN : sur demande intermittente,
+            projeter des indices saisonniers revient à extrapoler la position
+            aléatoire des transactions, pas une saison.
+            Pour SEASONAL (opt-in via method + season_length), la série est une
+            COURBE niveau × indices ; si l'historique couvre moins de 2 cycles
+            complets, generate() retombe sur un niveau plat (documenté dans la
+            provenance) et la série est constante.
         """
+        params = params or {}
+
         # Générer la prévision de base
         result = self.generate(item_history, method, params)
-        
-        # Répéter pour le nombre de périodes demandé
+
+        # Chemin saisonnier opt-in : la courbe répète le profil sur l'horizon.
+        if method == ForecastMethod.SEASONAL and result.parameters.get("seasonal_applied"):
+            forecaster = SeasonalForecaster(season_length=int(result.parameters["season_length"]))
+            return forecaster.forecast_curve(item_history, periods)
+
+        # Répéter pour le nombre de périodes demandé (comportement plat historique)
         return [result.forecast_value] * periods

--- a/src/ootils_core/pyramide/engines.py
+++ b/src/ootils_core/pyramide/engines.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
@@ -18,7 +19,12 @@ from .models import (
 )
 
 
-BASE_METHODS = frozenset({ForecastMethod.MA, ForecastMethod.EXP_SMOOTHING, ForecastMethod.CROSTON})
+logger = logging.getLogger(__name__)
+
+
+BASE_METHODS = frozenset(
+    {ForecastMethod.MA, ForecastMethod.EXP_SMOOTHING, ForecastMethod.CROSTON, ForecastMethod.SEASONAL}
+)
 EXTERNAL_METHODS = frozenset(
     {METHOD_STAT_AUTOETS, METHOD_STAT_AUTOARIMA, METHOD_ML_LGBM, METHOD_FM_CHRONOS, METHOD_FM_MOIRAI}
 )
@@ -72,6 +78,11 @@ class PyramideForecastEngine:
 
         method = method.upper()
         params = dict(method_params)
+        # Longueur de cycle saisonnier : paramétrable, sinon dérivée de la
+        # granularité (7 quotidien, 52 hebdo, 12 mensuel). Résolue une fois ici
+        # pour que SEASONAL direct, les candidats AUTO_SELECT/ENSEMBLE et les
+        # backends externes partagent la même valeur.
+        params.setdefault("season_length", _default_season_length(granularity))
         if method in BASE_METHODS:
             return self._classical(history, periods, method, params)
         if method == METHOD_AUTO_SELECT:
@@ -115,9 +126,23 @@ class PyramideForecastEngine:
         except ForecastingError as exc:
             raise PyramideEngineError(str(exc)) from exc
 
-        value = max(result.forecast_value, Decimal("0"))
+        if method == ForecastMethod.SEASONAL and result.parameters.get("seasonal_applied"):
+            # Courbe saisonnière déterministe (niveau × indices). Si l'historique
+            # couvre < 2 cycles complets, generate() est déjà retombé sur un
+            # niveau plat et l'a documenté dans result.warnings.
+            series = self._forecasting_engine.forecast_series(
+                item_history=list(history),
+                method=method,
+                params=dict(params),
+                periods=periods,
+            )
+            values = tuple(max(value, Decimal("0")) for value in series)
+        else:
+            value = max(result.forecast_value, Decimal("0"))
+            values = tuple(value for _ in range(periods))
+
         return ForecastComputation(
-            values=tuple(value for _ in range(periods)),
+            values=values,
             selected_model=self._label(method, params),
             value_method=method,
             engine_backend="internal:classical",
@@ -133,7 +158,7 @@ class PyramideForecastEngine:
         candidates = self._candidate_specs(history, params)
         scored = []
         for candidate in candidates:
-            score = self._backtest_score(history, candidate)
+            score = self._backtest_score(history, candidate, horizon=periods)
             if score is not None:
                 scored.append((score, candidate))
 
@@ -162,25 +187,35 @@ class PyramideForecastEngine:
         params: Mapping[str, Any],
     ) -> ForecastComputation:
         candidates = self._candidate_specs(history, params)
-        forecasts: list[tuple[Decimal, float, _Candidate]] = []
+        forecasts: list[tuple[tuple[Decimal, ...], float, _Candidate]] = []
         for candidate in candidates:
             try:
-                computed = self._classical(history, 1, candidate.method, candidate.params)
+                computed = self._classical(history, periods, candidate.method, candidate.params)
             except PyramideEngineError:
                 continue
-            score = self._backtest_score(history, candidate)
-            weight = 1.0 / max(score or 1.0, 0.0001)
-            forecasts.append((computed.values[0], weight, candidate))
+            score = self._backtest_score(history, candidate, horizon=periods)
+            # score is None = pas de backtest possible → poids neutre 1.0.
+            # Un score PARFAIT de 0.0 est falsy mais doit recevoir le poids
+            # plafond (1/0.0001), pas le poids neutre : ne pas utiliser `or`.
+            weight = 1.0 if score is None else 1.0 / max(score, 0.0001)
+            forecasts.append((computed.values, weight, candidate))
 
         if not forecasts:
             return self._auto_select(history, periods, params)
 
+        # Mélange pondéré pas-à-pas : les candidats plats contribuent une
+        # constante, un candidat saisonnier contribue sa courbe.
         total_weight = sum(weight for _, weight, _ in forecasts)
-        blended = sum(float(value) * weight for value, weight, _ in forecasts) / total_weight
-        value = max(Decimal(str(blended)), Decimal("0"))
+        values = tuple(
+            max(
+                Decimal(str(sum(float(curve[step]) * weight for curve, weight, _ in forecasts) / total_weight)),
+                Decimal("0"),
+            )
+            for step in range(periods)
+        )
         model_names = ",".join(candidate.label for _, _, candidate in forecasts)
         return ForecastComputation(
-            values=tuple(value for _ in range(periods)),
+            values=values,
             selected_model=METHOD_ENSEMBLE_STAT,
             value_method=METHOD_ENSEMBLE_STAT,
             engine_backend="internal:ensemble_stat",
@@ -306,11 +341,23 @@ class PyramideForecastEngine:
         )
 
     def _candidate_specs(self, history: Sequence[Decimal], params: Mapping[str, Any]) -> list[_Candidate]:
+        # method_params est un dict libre côté router : toute valeur illisible
+        # écarte simplement le candidat concerné (ou retombe sur le défaut),
+        # tracée en debug — jamais d'exception depuis cette méthode.
         windows = params.get("ma_windows", [3, 6, 12])
+        if not isinstance(windows, (list, tuple)):
+            logger.debug("ma_windows illisible (%r); défaut [3, 6, 12]", windows)
+            windows = [3, 6, 12]
         alphas = params.get("exp_alphas", [0.2, 0.5, 0.8])
+        if not isinstance(alphas, (list, tuple)):
+            logger.debug("exp_alphas illisible (%r); défaut [0.2, 0.5, 0.8]", alphas)
+            alphas = [0.2, 0.5, 0.8]
         candidates: list[_Candidate] = []
         for window in windows:
-            window_int = int(window)
+            window_int = _as_int(window)
+            if window_int is None or window_int < 1:
+                logger.debug("ma_windows: fenêtre illisible (%r); candidat MA ignoré", window)
+                continue
             if len(history) >= window_int:
                 candidates.append(
                     _Candidate(
@@ -320,45 +367,98 @@ class PyramideForecastEngine:
                     )
                 )
         for alpha in alphas:
+            alpha_float = _as_float(alpha)
+            if alpha_float is None or not 0 < alpha_float <= 1:
+                logger.debug("exp_alphas: alpha illisible (%r); candidat EXP_SMOOTHING ignoré", alpha)
+                continue
             candidates.append(
                 _Candidate(
                     method=ForecastMethod.EXP_SMOOTHING,
-                    params={"alpha": float(alpha)},
-                    label=f"EXP_SMOOTHING(alpha={float(alpha):.2f})",
+                    params={"alpha": alpha_float},
+                    label=f"EXP_SMOOTHING(alpha={alpha_float:.2f})",
                 )
             )
-        if self._zero_ratio(history) >= float(params.get("croston_zero_ratio", 0.2)):
+        # Candidat saisonnier : uniquement si l'historique couvre >= 2 cycles
+        # complets ET que la série n'est pas intermittente — projeter des
+        # indices saisonniers sur une demande intermittente extrapole la
+        # position aléatoire des transactions, pas une saison (Croston reste
+        # le modèle plat adapté, par design).
+        season_length = _as_int(params.get("season_length", 0))
+        if season_length is None:
+            logger.debug(
+                "season_length illisible (%r); candidat SEASONAL non proposé",
+                params.get("season_length"),
+            )
+            season_length = 0
+        zero_ratio_threshold = _as_float(params.get("croston_zero_ratio", 0.2))
+        if zero_ratio_threshold is None:
+            logger.debug(
+                "croston_zero_ratio illisible (%r); défaut 0.2",
+                params.get("croston_zero_ratio"),
+            )
+            zero_ratio_threshold = 0.2
+        intermittent = self._zero_ratio(history) >= zero_ratio_threshold
+        if season_length >= 2 and len(history) >= 2 * season_length and not intermittent:
+            candidates.append(
+                _Candidate(
+                    method=ForecastMethod.SEASONAL,
+                    params={"season_length": season_length},
+                    label=f"SEASONAL(season_length={season_length})",
+                )
+            )
+        if intermittent:
+            threshold = _as_float(params.get("min_demand_threshold", 0.0))
+            if threshold is None:
+                logger.debug(
+                    "min_demand_threshold illisible (%r); défaut 0.0",
+                    params.get("min_demand_threshold"),
+                )
+                threshold = 0.0
             candidates.append(
                 _Candidate(
                     method=ForecastMethod.CROSTON,
-                    params={"min_demand_threshold": float(params.get("min_demand_threshold", 0.0))},
+                    params={"min_demand_threshold": threshold},
                     label="CROSTON",
                 )
             )
         return candidates
 
-    def _backtest_score(self, history: Sequence[Decimal], candidate: _Candidate) -> float | None:
+    def _backtest_score(self, history: Sequence[Decimal], candidate: _Candidate, horizon: int = 1) -> float | None:
+        """Rolling-origin backtest sur des COURBES : à chaque origine, le
+        candidat prévoit jusqu'à `horizon` pas comparés aux réels suivants —
+        l'erreur porte sur les h pas, pas sur une valeur unique (un modèle plat
+        contribue la même valeur à chaque pas, un saisonnier sa courbe)."""
         if len(history) < 3:
             return None
+
+        horizon = max(1, horizon)
+        seasonal_min_train = 0
+        if candidate.method == ForecastMethod.SEASONAL:
+            # Ne scorer le candidat saisonnier que sur les origines où il
+            # tourne vraiment (>= 2 cycles complets) : sinon son score
+            # mesurerait le fallback plat, pas le modèle saisonnier.
+            seasonal_min_train = 2 * int(candidate.params.get("season_length", 0))
 
         errors = []
         tail_start = max(1, len(history) - 52)
         for index in range(tail_start, len(history)):
             train = list(history[:index])
-            actual = history[index]
-            if not train:
+            if not train or len(train) < seasonal_min_train:
                 continue
+            actual_window = list(history[index:index + horizon])
             try:
-                result = self._forecasting_engine.generate(
+                series = self._forecasting_engine.forecast_series(
                     item_history=train,
                     method=candidate.method,
                     params=dict(candidate.params),
+                    periods=len(actual_window),
                 )
             except (ForecastingError, ValueError):
                 continue
-            forecast = max(result.forecast_value, Decimal("0"))
-            denom = max(abs(actual), Decimal("1"))
-            errors.append(float(abs(actual - forecast) / denom))
+            for actual, raw_forecast in zip(actual_window, series):
+                forecast = max(raw_forecast, Decimal("0"))
+                denom = max(abs(actual), Decimal("1"))
+                errors.append(float(abs(actual - forecast) / denom))
 
         if not errors:
             return None
@@ -379,7 +479,25 @@ class PyramideForecastEngine:
             return f"EXP_SMOOTHING(alpha={float(params.get('alpha', 0.3)):.2f})"
         if method == ForecastMethod.CROSTON:
             return "CROSTON"
+        if method == ForecastMethod.SEASONAL:
+            return f"SEASONAL(season_length={int(params.get('season_length', 0))})"
         return method
+
+
+def _as_int(value: Any) -> int | None:
+    """Coercition tolérante d'un paramètre libre : None si illisible."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_float(value: Any) -> float | None:
+    """Coercition tolérante d'un paramètre libre : None si illisible."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _freq_for_granularity(granularity: str) -> str:

--- a/src/ootils_core/pyramide/models.py
+++ b/src/ootils_core/pyramide/models.py
@@ -22,6 +22,7 @@ SUPPORTED_METHODS = frozenset(
         ForecastMethod.MA,
         ForecastMethod.EXP_SMOOTHING,
         ForecastMethod.CROSTON,
+        ForecastMethod.SEASONAL,
         METHOD_AUTO_SELECT,
         METHOD_ENSEMBLE_STAT,
         METHOD_STAT_AUTOETS,

--- a/tests/test_forecasting_algorithms.py
+++ b/tests/test_forecasting_algorithms.py
@@ -5,6 +5,8 @@ Tests cover:
 - Moving Average (MA) forecaster
 - Exponential Smoothing (ES) forecaster
 - Croston forecaster (intermittent demand)
+- Seasonal forecaster (seasonal index decomposition — golden battery in
+  tests/test_seasonal_forecaster_golden.py)
 - ForecastingEngine service
 - Accuracy metrics (MAPE, Bias, Tracking Signal)
 - Auto-calibration of parameters
@@ -21,6 +23,7 @@ from ootils_core.forecasting import (
     ForecastMethod,
     ForecastingError,
     MovingAverageForecaster,
+    SeasonalForecaster,
     create_forecaster,
 )
 
@@ -200,6 +203,66 @@ class TestCrostonForecaster:
 
 
 # ─────────────────────────────────────────────────────────────
+# Seasonal Tests (seasonal index decomposition)
+# ─────────────────────────────────────────────────────────────
+# The full hand-computed golden battery lives in
+# tests/test_seasonal_forecaster_golden.py — these are the API-shape basics.
+
+
+class TestSeasonalForecaster:
+    """Tests for Seasonal decomposition algorithm."""
+
+    def test_seasonal_recovers_known_indices(self):
+        """Seasonal indices on a 2-position cycle.
+
+        historical = [150, 50, 150, 50], season_length = 2
+        grand mean = 100 → indices = [1.5, 0.5]
+        level = mean([150/1.5, 50/0.5]) = 100 → next forecast = 100 * 1.5 = 150
+        """
+        forecaster = SeasonalForecaster(season_length=2)
+        historical = [150, 50, 150, 50]
+
+        assert forecaster.seasonal_indices(historical) == [Decimal("1.5"), Decimal("0.5")]
+        assert forecaster.forecast(historical) == Decimal("150")
+
+    def test_seasonal_curve_repeats_profile(self):
+        """forecast_curve projects level x index over the horizon."""
+        forecaster = SeasonalForecaster(season_length=2)
+        historical = [150, 50, 150, 50]
+
+        curve = forecaster.forecast_curve(historical, periods=4)
+
+        assert curve == [Decimal("150"), Decimal("50"), Decimal("150"), Decimal("50")]
+
+    def test_seasonal_insufficient_history(self):
+        """Fewer than 2 complete cycles → ForecastingError (no silent guess)."""
+        forecaster = SeasonalForecaster(season_length=4)
+
+        with pytest.raises(ForecastingError):
+            forecaster.forecast([100, 120, 110])
+
+    def test_seasonal_invalid_season_length(self):
+        """Seasonal should reject season_length < 2."""
+        with pytest.raises(ValueError):
+            SeasonalForecaster(season_length=1)
+
+        with pytest.raises(ValueError):
+            SeasonalForecaster(season_length=-3)
+
+    def test_seasonal_invalid_periods(self):
+        """forecast_curve should reject periods < 1."""
+        forecaster = SeasonalForecaster(season_length=2)
+
+        with pytest.raises(ValueError):
+            forecaster.forecast_curve([150, 50, 150, 50], periods=0)
+
+    def test_seasonal_repr(self):
+        """Seasonal string representation."""
+        forecaster = SeasonalForecaster(season_length=12)
+        assert "season_length=12" in repr(forecaster)
+
+
+# ─────────────────────────────────────────────────────────────
 # Factory Function Tests
 # ─────────────────────────────────────────────────────────────
 
@@ -226,6 +289,18 @@ class TestCreateForecaster:
         
         assert isinstance(forecaster, CrostonForecaster)
         assert forecaster.min_demand_threshold == 1.0
+
+    def test_create_seasonal_forecaster(self):
+        """Create Seasonal forecaster via factory."""
+        forecaster = create_forecaster('seasonal', season_length=52)
+
+        assert isinstance(forecaster, SeasonalForecaster)
+        assert forecaster.season_length == 52
+
+    def test_create_seasonal_requires_season_length(self):
+        """Seasonal factory has no default cycle length."""
+        with pytest.raises(ValueError):
+            create_forecaster('seasonal')
 
     def test_create_unknown_method(self):
         """Factory should reject unknown method."""
@@ -364,6 +439,62 @@ class TestForecastingEngine:
         assert len(series) == 5
         # All periods should have same forecast (flat forecast)
         assert all(v == series[0] for v in series)
+
+    def test_engine_generate_seasonal(self):
+        """Engine generate with SEASONAL method (>= 2 complete cycles)."""
+        engine = ForecastingEngine()
+        historical = [150, 50, 150, 50]
+
+        result = engine.generate(
+            item_history=historical,
+            method=ForecastMethod.SEASONAL,
+            params={"season_length": 2}
+        )
+
+        assert result.method == ForecastMethod.SEASONAL
+        assert result.forecast_value == Decimal("150")
+        assert result.parameters["season_length"] == 2
+        assert result.parameters["seasonal_applied"] is True
+
+    def test_engine_seasonal_requires_season_length(self):
+        """SEASONAL without season_length → ForecastingError (no default)."""
+        engine = ForecastingEngine()
+
+        with pytest.raises(ForecastingError):
+            engine.generate(
+                item_history=[150, 50, 150, 50],
+                method=ForecastMethod.SEASONAL
+            )
+
+    def test_engine_forecast_series_seasonal_curve(self):
+        """forecast_series with SEASONAL returns a curve, not a repeated value."""
+        engine = ForecastingEngine()
+        historical = [150, 50, 150, 50]
+
+        series = engine.forecast_series(
+            item_history=historical,
+            method=ForecastMethod.SEASONAL,
+            params={"season_length": 2},
+            periods=4
+        )
+
+        assert series == [Decimal("150"), Decimal("50"), Decimal("150"), Decimal("50")]
+
+    def test_engine_seasonal_fallback_below_two_cycles(self):
+        """SEASONAL on < 2 complete cycles falls back flat, with provenance."""
+        engine = ForecastingEngine()
+        historical = [150, 50, 150]  # 3 points < 2 * season_length
+
+        result = engine.generate(
+            item_history=historical,
+            method=ForecastMethod.SEASONAL,
+            params={"season_length": 2}
+        )
+
+        assert result.parameters["seasonal_applied"] is False
+        assert any("fallback" in w for w in result.warnings)
+        # Flat level = MA(window=min(3, 2)=2) on last 2 points = (50+150)/2
+        assert result.forecast_value == Decimal("100")
 
 
 # ─────────────────────────────────────────────────────────────

--- a/tests/test_forecasting_api.py
+++ b/tests/test_forecasting_api.py
@@ -123,6 +123,35 @@ class TestGenerateForecastValidation:
         )
         assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
+    def test_generate_forecast_seasonal_missing_season_length(self):
+        """SEASONAL without method_params.season_length → 422 before any DB call."""
+        client = _make_client_no_db()
+        resp = client.post(
+            "/v1/demand/forecast/generate",
+            json={
+                "item_id": "ITEM-001",
+                "location_id": "LOC-001",
+                "method": "SEASONAL",
+            },
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_generate_forecast_seasonal_invalid_season_length(self):
+        """SEASONAL with season_length < 2 → 422 before any DB call."""
+        client = _make_client_no_db()
+        resp = client.post(
+            "/v1/demand/forecast/generate",
+            json={
+                "item_id": "ITEM-001",
+                "location_id": "LOC-001",
+                "method": "SEASONAL",
+                "method_params": {"season_length": 1},
+            },
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
 
 # ─────────────────────────────────────────────────────────────
 # GET /v1/demand/forecast/{forecast_id} — validation

--- a/tests/test_pyramide_api.py
+++ b/tests/test_pyramide_api.py
@@ -37,13 +37,14 @@ def _make_client_no_db() -> TestClient:
 
 
 def test_create_pyramide_run_rejects_unsupported_method_before_db():
+    # SEASONAL is a supported method now — use a genuinely unknown name.
     client = _make_client_no_db()
     response = client.post(
         "/v1/forecast/runs",
         json={
             "item_id": "ITEM-001",
             "location_id": "LOC-001",
-            "method": "SEASONAL",
+            "method": "NOT_A_METHOD",
         },
         headers=AUTH_HEADERS,
     )

--- a/tests/test_pyramide_runner.py
+++ b/tests/test_pyramide_runner.py
@@ -58,9 +58,10 @@ def test_pyramide_runner_builds_weekly_buckets():
 
 
 def test_pyramide_runner_rejects_unknown_method():
+    # SEASONAL is a real method now — use a genuinely unknown name.
     with pytest.raises(PyramideError):
         PyramideRunner().run(
-            _config(method="SEASONAL"),
+            _config(method="NOT_A_METHOD"),
             [Decimal("10"), Decimal("20"), Decimal("30")],
         )
 
@@ -85,3 +86,97 @@ def test_pyramide_runner_external_backend_falls_back_without_optional_dependency
 
     assert result.engine_backend == "internal:auto_select"
     assert any("FM_CHRONOS" in warning for warning in result.warnings)
+
+
+# Two full cycles of a season_length=4 profile: grand mean 100,
+# hand-computed indices [2.0, 0.5, 1.0, 0.5], deseasonalized level 100
+# (full derivation in tests/test_seasonal_forecaster_golden.py).
+SEASONAL_HISTORY = [Decimal(v) for v in (200, 50, 100, 50, 200, 50, 100, 50)]
+
+
+def test_pyramide_runner_seasonal_builds_a_curve():
+    """SEASONAL emits a CURVE (level x indices), not a repeated value."""
+    result = PyramideRunner().run(
+        _config(method="SEASONAL", method_params={"season_length": 4}, horizon_days=6),
+        SEASONAL_HISTORY,
+    )
+
+    assert [value.quantity for value in result.values] == [
+        Decimal("200"), Decimal("50"), Decimal("100"), Decimal("50"), Decimal("200"), Decimal("50"),
+    ]
+    assert result.selected_model == "SEASONAL(season_length=4)"
+    assert result.engine_backend == "internal:classical"
+    assert all(value.method == "SEASONAL" for value in result.values)
+
+
+def test_pyramide_runner_seasonal_falls_back_flat_below_two_cycles():
+    """< 2 complete cycles: flat values + documented fallback in provenance."""
+    result = PyramideRunner().run(
+        _config(method="SEASONAL", method_params={"season_length": 4}, horizon_days=4),
+        SEASONAL_HISTORY[:6],
+    )
+
+    quantities = [value.quantity for value in result.values]
+    assert all(quantity == quantities[0] for quantity in quantities)
+    assert any("fallback" in warning for warning in result.warnings)
+
+
+def test_pyramide_runner_auto_select_seasonal_candidate_wins_on_seasonal_series():
+    """On a strongly seasonal series (3 perfect cycles), the SEASONAL candidate
+    backtests at zero error over the h-step curves and beats the flat models."""
+    history = SEASONAL_HISTORY + SEASONAL_HISTORY[:4]  # 3 full cycles
+    result = PyramideRunner().run(
+        _config(method="AUTO_SELECT", method_params={"season_length": 4}, horizon_days=4),
+        history,
+    )
+
+    assert result.selected_model == "SEASONAL(season_length=4)"
+    assert result.engine_backend == "internal:auto_select"
+    assert [value.quantity for value in result.values] == [
+        Decimal("200"), Decimal("50"), Decimal("100"), Decimal("50"),
+    ]
+
+
+def test_pyramide_runner_auto_select_tolerates_non_numeric_season_length():
+    """method_params is a free-form dict on the router side: a non-numeric
+    season_length must never raise — the SEASONAL candidate is simply not
+    proposed and the run completes on the flat models."""
+    result = PyramideRunner().run(
+        _config(method="AUTO_SELECT", method_params={"season_length": "n/a"}),
+        [Decimal("10"), Decimal("12"), Decimal("14"), Decimal("16"), Decimal("18"), Decimal("20")],
+    )
+
+    assert not result.selected_model.startswith("SEASONAL")
+    assert result.engine_backend == "internal:auto_select"
+
+
+def test_pyramide_runner_ensemble_perfect_candidate_dominates():
+    """A candidate with a PERFECT backtest score of 0.0 (falsy!) must get the
+    capped weight 1/0.0001, not the neutral weight 1.0: on 3 perfect seasonal
+    cycles the SEASONAL candidate dominates the blend and the ensemble curve
+    lands (numerically) on the seasonal curve."""
+    history = SEASONAL_HISTORY + SEASONAL_HISTORY[:4]  # 3 full cycles
+    result = PyramideRunner().run(
+        _config(method="ENSEMBLE_STAT", method_params={"season_length": 4}, horizon_days=4),
+        history,
+    )
+
+    assert result.engine_backend == "internal:ensemble_stat"
+    assert any("SEASONAL(season_length=4)" in warning for warning in result.warnings)
+    expected = [Decimal("200"), Decimal("50"), Decimal("100"), Decimal("50")]
+    for value, target in zip(result.values, expected):
+        assert abs(value.quantity - target) < Decimal("1")
+
+
+def test_pyramide_runner_auto_select_skips_seasonal_on_intermittent_series():
+    """Intermittent demand never gets a SEASONAL candidate (indices would
+    capture the random position of transactions): the forecast stays flat."""
+    history = [Decimal(v) for v in (0, 0, 100, 0, 0, 0, 90, 0, 0, 0, 110, 0)]
+    result = PyramideRunner().run(
+        _config(method="AUTO_SELECT", method_params={"season_length": 4}, horizon_days=4),
+        history,
+    )
+
+    assert not result.selected_model.startswith("SEASONAL")
+    quantities = [value.quantity for value in result.values]
+    assert all(quantity == quantities[0] for quantity in quantities)

--- a/tests/test_seasonal_forecaster_golden.py
+++ b/tests/test_seasonal_forecaster_golden.py
@@ -1,0 +1,243 @@
+"""
+Golden-master for the SEASONAL forecasting path (Pyramide V1 axe A — PR1).
+
+The default forecast path used to emit a REPEATED VALUE; SEASONAL now emits a
+CURVE (level x seasonal indices). This file locks the math on tiny
+hand-computed series so any future change that deviates from the documented
+arithmetic fails CI instead of silently reshaping a demand plan
+(pattern: tests/test_mrp_core_golden.py).
+
+Reference dataset (season_length=4, two full cycles):
+
+    history          = [200, 50, 100, 50, 200, 50, 100, 50]
+
+    grand mean       = 800 / 8 = 100
+    position means   = [200, 50, 100, 50]
+    seasonal indices = [2.0, 0.5, 1.0, 0.5]   (mean exactly 1.0)
+    deseasonalized   = [100] * 8              (perfectly periodic)
+    level            = 100
+    next period      = cycle position 0 -> 100 * 2.0 = 200
+    6-period curve   = [200, 50, 100, 50, 200, 50]
+
+All algorithms are pure Python and deterministic — no DB, no mocks.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from ootils_core.forecasting import (
+    ForecastingEngine,
+    ForecastingError,
+    ForecastMethod,
+    SeasonalForecaster,
+    create_forecaster,
+)
+
+
+HISTORY = [200, 50, 100, 50, 200, 50, 100, 50]
+INDICES = [Decimal("2"), Decimal("0.5"), Decimal("1"), Decimal("0.5")]
+CURVE_6 = [Decimal("200"), Decimal("50"), Decimal("100"), Decimal("50"), Decimal("200"), Decimal("50")]
+
+
+# ───────────────────────── SeasonalForecaster (pure algorithm) ─────────────────────────
+
+
+def test_indices_recovered_exactly():
+    """Indices on the reference dataset are exactly [2.0, 0.5, 1.0, 0.5]."""
+    forecaster = SeasonalForecaster(season_length=4)
+    assert forecaster.seasonal_indices(HISTORY) == INDICES
+
+
+def test_forecast_curve_is_level_times_indices():
+    """Projected curve = level (100) x index of each future position."""
+    forecaster = SeasonalForecaster(season_length=4)
+    assert forecaster.forecast_curve(HISTORY, periods=6) == CURVE_6
+    # forecast() = first point of the curve
+    assert forecaster.forecast(HISTORY) == Decimal("200")
+
+
+def test_noisy_cycles_average_out():
+    """Two noisy cycles whose position means still land on the known indices.
+
+    history        = [190, 55, 95, 60, 210, 45, 105, 40]
+    grand mean     = 800 / 8 = 100
+    position means = [(190+210)/2, (55+45)/2, (95+105)/2, (60+40)/2]
+                   = [200, 50, 100, 50] -> indices [2.0, 0.5, 1.0, 0.5]
+    level          = mean of LAST cycle deseasonalized
+                   = mean([210/2.0, 45/0.5, 105/1.0, 40/0.5])
+                   = mean([105, 90, 105, 80]) = 95
+    curve(4)       = [95*2.0, 95*0.5, 95*1.0, 95*0.5] = [190, 47.5, 95, 47.5]
+    """
+    history = [190, 55, 95, 60, 210, 45, 105, 40]
+    forecaster = SeasonalForecaster(season_length=4)
+
+    assert forecaster.seasonal_indices(history) == INDICES
+    assert forecaster.forecast_curve(history, periods=4) == [
+        Decimal("190"),
+        Decimal("47.5"),
+        Decimal("95"),
+        Decimal("47.5"),
+    ]
+
+
+def test_end_alignment_with_partial_leading_cycle():
+    """A partial leading cycle is dropped: only the last k complete cycles
+    (aligned to the END of the history) drive indices and phase — the 9-point
+    series [50] + reference history forecasts exactly like the reference."""
+    history = [50, *HISTORY]
+    forecaster = SeasonalForecaster(season_length=4)
+
+    assert forecaster.seasonal_indices(history) == INDICES
+    assert forecaster.forecast_curve(history, periods=6) == CURVE_6
+
+
+def test_constant_series_yields_unit_indices():
+    """Constant series -> all indices exactly 1.0, forecast = the constant."""
+    forecaster = SeasonalForecaster(season_length=4)
+    history = [100] * 8
+
+    assert forecaster.seasonal_indices(history) == [Decimal("1")] * 4
+    assert forecaster.forecast_curve(history, periods=5) == [Decimal("100")] * 5
+
+
+def test_all_zero_series_forecasts_zero():
+    """All-zero series: neutral indices (no exploitable profile), level 0."""
+    forecaster = SeasonalForecaster(season_length=4)
+    history = [0] * 8
+
+    assert forecaster.seasonal_indices(history) == [Decimal("1")] * 4
+    assert forecaster.forecast_curve(history, periods=3) == [Decimal("0")] * 3
+
+
+def test_less_than_two_cycles_raises():
+    """< 2 complete cycles: indices would be noise — the algorithm refuses
+    (the flat fallback is the ENGINE's responsibility, with provenance)."""
+    forecaster = SeasonalForecaster(season_length=4)
+
+    with pytest.raises(ForecastingError):
+        forecaster.forecast(HISTORY[:7])
+
+
+def test_season_length_validation():
+    with pytest.raises(ValueError):
+        SeasonalForecaster(season_length=1)
+    with pytest.raises(ValueError):
+        SeasonalForecaster(season_length=0)
+
+
+def test_factory_creates_seasonal_forecaster():
+    forecaster = create_forecaster("seasonal", season_length=12)
+    assert isinstance(forecaster, SeasonalForecaster)
+    assert forecaster.season_length == 12
+
+    # No default cycle length: the caller must choose one.
+    with pytest.raises(ValueError):
+        create_forecaster("seasonal")
+
+
+# ───────────────────────── ForecastingEngine SEASONAL path ─────────────────────────
+
+
+def test_engine_seasonal_generate_carries_provenance():
+    """generate(SEASONAL) succeeds with >= 2 cycles and stamps the provenance
+    (season_length + seasonal_applied) in the existing parameters field."""
+    engine = ForecastingEngine()
+    result = engine.generate(
+        item_history=HISTORY,
+        method=ForecastMethod.SEASONAL,
+        params={"season_length": 4},
+    )
+
+    assert result.forecast_value == Decimal("200")
+    assert result.parameters["season_length"] == 4
+    assert result.parameters["seasonal_applied"] is True
+    assert result.warnings == []
+
+
+def test_engine_forecast_series_returns_the_curve():
+    """forecast_series(SEASONAL) returns the CURVE, not a repeated value."""
+    engine = ForecastingEngine()
+    series = engine.forecast_series(
+        item_history=HISTORY,
+        method=ForecastMethod.SEASONAL,
+        params={"season_length": 4},
+        periods=6,
+    )
+
+    assert series == CURVE_6
+
+
+def test_engine_seasonal_fallback_is_flat_and_documented():
+    """< 2 complete cycles: documented flat fallback, never silent.
+
+    history = [10, 20, 30, 40, 50, 60] with season_length=4 (needs 8 points)
+    -> flat MA(window=min(6, 4)=4) on the last 4 points = (30+40+50+60)/4 = 45
+    """
+    engine = ForecastingEngine()
+    history = [10, 20, 30, 40, 50, 60]
+
+    result = engine.generate(
+        item_history=history,
+        method=ForecastMethod.SEASONAL,
+        params={"season_length": 4},
+    )
+
+    assert result.forecast_value == Decimal("45")
+    assert result.parameters["seasonal_applied"] is False
+    assert any("fallback" in warning for warning in result.warnings)
+
+    # The series stays flat on the fallback path
+    series = engine.forecast_series(
+        item_history=history,
+        method=ForecastMethod.SEASONAL,
+        params={"season_length": 4},
+        periods=3,
+    )
+    assert series == [Decimal("45")] * 3
+
+
+def test_engine_seasonal_requires_season_length():
+    """season_length is mandatory (no business-specific default)."""
+    engine = ForecastingEngine()
+
+    with pytest.raises(ForecastingError):
+        engine.generate(item_history=HISTORY, method=ForecastMethod.SEASONAL)
+    with pytest.raises(ForecastingError):
+        engine.generate(
+            item_history=HISTORY,
+            method=ForecastMethod.SEASONAL,
+            params={"season_length": 1},
+        )
+
+
+def test_engine_seasonal_rejects_non_integer_season_length():
+    """Strictly an int — no coercion of 7.9 / "52" / bool (aligned with the
+    strict API validator in routers/forecasting.py)."""
+    engine = ForecastingEngine()
+
+    for bad in (7.9, "52", True, None, [4]):
+        with pytest.raises(ForecastingError):
+            engine.generate(
+                item_history=HISTORY,
+                method=ForecastMethod.SEASONAL,
+                params={"season_length": bad},
+            )
+
+
+def test_croston_series_stays_flat_on_intermittent_demand():
+    """Croston remains FLAT by design: on intermittent demand, projecting
+    seasonal indices would extrapolate the random position of transactions,
+    not a season."""
+    engine = ForecastingEngine()
+    history = [0, 0, 100, 0, 0, 150, 0, 0, 0, 200]
+
+    series = engine.forecast_series(
+        item_history=history,
+        method=ForecastMethod.CROSTON,
+        periods=6,
+    )
+
+    assert len(series) == 6
+    assert all(value == series[0] for value in series)


### PR DESCRIPTION
## Pyramide V1 — axe A, PR1 : saisonnalité native (spec `DESIGN-pyramide-forecasting.md` §2.A, §7.1)

Le chemin de prévision par défaut sortait **une valeur répétée** (trou n°1 de la spec). Il sort désormais une **courbe saisonnière déterministe**.

- `SeasonalForecaster` : décomposition par indices saisonniers, pur Python, zéro dépendance, `season_length` **paramétrable** — **générique tout business** (aucune constante pilote). ≥ 2 cycles complets requis, sinon **fallback plat tracé en provenance** (jamais silencieux). Croston reste plat par design (l'intermittent n'a pas de saison, documenté).
- Branché partout : `ForecastingEngine` (opt-in, défaut inchangé pour les appelants existants), Pyramide (candidat SEASONAL dans AUTO_SELECT/ENSEMBLE — le backtest rolling-origin évalue désormais des **courbes multi-horizon**, conforme spec §D), API (`422` clair si `season_length` manquant).
- **Golden calculé à la main** (cycle 4 : indices [2.0, 0.5, 1.0, 0.5], niveau 100 → courbe [200,50,100,50,…]) — arithmétique revérifiée par le reviewer adversarial.
- Post-revue : parse défensif de tout `method_params` libre (aucun 500 possible), validateur strict, et **fix d'un bug pré-existant** : un candidat au backtest parfait (0.0, falsy) était sous-pondéré dans l'ensemble (`score or 1.0`).

Changements observables assumés (documentés) : le backtest AUTO_SELECT est multi-horizon (les sélections peuvent changer — voulu par la spec) ; `metadata.method_params` = paramètres **effectifs** (provenance).

1801 tests unitaires ✅ · ruff ✅.

Closes #345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
