### PR TITLE
feat(pyramide): axe A PR2 — schéma multi-niveaux + matrice de sommation S sparse par bloc

### DIFF
--- a/src/ootils_core/api/routers/forecasting.py
+++ b/src/ootils_core/api/routers/forecasting.py
@@ -472,13 +472,18 @@ def get_forecast(
     """
     Retrieve a forecast by ID with all values and adjustments.
     """
-    # 1. Fetch forecast header
+    # 1. Fetch forecast header.
+    # item_id IS NOT NULL: this endpoint's contract is the LEAF
+    # (item, location) forecast — aggregate hierarchy-node rows
+    # (migration 053, nullable item/location) are out of scope here and
+    # must 404 rather than break the ForecastOut model.
     row = db.execute(
         """
         SELECT forecast_id, item_id, location_id, scenario_id,
                horizon_start, horizon_end, granularity, method, created_at
         FROM forecasts
         WHERE forecast_id = %s
+          AND item_id IS NOT NULL
         """,
         (forecast_id,),
     ).fetchone()
@@ -629,8 +634,11 @@ def list_forecasts(
             ) AS has_adjustments
         FROM forecasts f
         LEFT JOIN forecast_values fv ON fv.forecast_id = f.forecast_id
-        WHERE TRUE
+        WHERE f.item_id IS NOT NULL
     """
+    # f.item_id IS NOT NULL: leaf-forecast listing only — aggregate
+    # hierarchy-node forecasts (migration 053) have NULL item/location
+    # and would break the non-optional ForecastSummary fields.
 
     params: list = []
     conditions: list = []

--- a/src/ootils_core/api/routers/pyramide.py
+++ b/src/ootils_core/api/routers/pyramide.py
@@ -50,12 +50,19 @@ class PyramideRunRequest(BaseModel):
 
 
 class PyramideRunOut(BaseModel):
+    # Leaf runs carry (item_id, location_id); aggregate runs (migration
+    # 053) carry (hierarchy_id, level, node_code) — the unused side is
+    # None. Optional on both sides so an aggregate run never 500s on
+    # response validation.
     run_id: UUID
     snapshot_id: UUID
     forecast_id: UUID
     status: str
-    item_id: UUID
-    location_id: UUID
+    item_id: UUID | None = None
+    location_id: UUID | None = None
+    hierarchy_id: str | None = None
+    level: str | None = None
+    node_code: str | None = None
     scenario_id: UUID
     horizon_start: date
     horizon_end: date
@@ -333,6 +340,9 @@ def _run_out(summary) -> PyramideRunOut:
         status=summary.status,
         item_id=summary.item_id,
         location_id=summary.location_id,
+        hierarchy_id=summary.hierarchy_id,
+        level=summary.level,
+        node_code=summary.node_code,
         scenario_id=summary.scenario_id,
         horizon_start=summary.horizon_start,
         horizon_end=summary.horizon_end,

--- a/src/ootils_core/db/migrations/053_pyramide_hierarchical.sql
+++ b/src/ootils_core/db/migrations/053_pyramide_hierarchical.sql
@@ -1,0 +1,130 @@
+-- ============================================================
+-- Migration 053 — Pyramide hierarchical forecasts (axis A, PR2)
+-- ============================================================
+-- Arbitrated design: EXTEND the existing forecast tables (no separate
+-- aggregate-forecast table). A forecasts / pyramide_runs row now targets
+-- either:
+--   * a LEAF      — (item_id, location_id), the historical contract, or
+--   * an AGGREGATE — a node of a registered hierarchy (migration 047):
+--                    (hierarchy_id, level, node_code).
+-- A CHECK constraint enforces "leaf XOR aggregate"; hybrid rows are
+-- impossible at the database level.
+--
+-- Why the same tables?  Aggregate forecasts share the full lifecycle of
+-- leaf forecasts (values, adjustments, runs, snapshots-to-come) and the
+-- reconciliation step (S matrix) needs both in one queryable namespace.
+--
+-- Idempotence notes (repo migration policy: a re-run must not fail):
+--   * ADD COLUMN IF NOT EXISTS            — no-op on re-run.
+--   * ALTER COLUMN ... DROP NOT NULL      — Postgres treats dropping an
+--     absent NOT NULL as a plain no-op (no error raised, any run count).
+--   * DROP CONSTRAINT IF EXISTS + ADD     — deterministic re-create.
+--   * CREATE INDEX IF NOT EXISTS          — no-op on re-run.
+--
+-- Existing leaf rows satisfy the new CHECK trivially (item_id and
+-- location_id are populated; hierarchy_id / level / node_code are
+-- freshly added, hence NULL): no backfill needed.
+-- No JSONB. Typed columns only.
+--
+-- NOTE — hierarchy_id is TEXT, not UUID: it references
+-- hierarchy(hierarchy_id), whose primary key is TEXT (migration 047).
+-- ============================================================
+
+BEGIN;
+
+-- ============================================================
+-- 1. forecasts — aggregate-node addressing
+-- ============================================================
+
+ALTER TABLE forecasts
+    ADD COLUMN IF NOT EXISTS hierarchy_id TEXT
+        REFERENCES hierarchy(hierarchy_id) ON DELETE RESTRICT;
+ALTER TABLE forecasts ADD COLUMN IF NOT EXISTS level     TEXT;
+ALTER TABLE forecasts ADD COLUMN IF NOT EXISTS node_code TEXT;
+
+-- Leaf columns become nullable: an aggregate forecast has no item/location.
+ALTER TABLE forecasts ALTER COLUMN item_id     DROP NOT NULL;
+ALTER TABLE forecasts ALTER COLUMN location_id DROP NOT NULL;
+
+-- Leaf XOR aggregate (exact arbitrated predicate).
+-- Leaf branch pins ALL aggregate columns to NULL: an orphan hierarchy_id
+-- on a leaf row would be silently ignored by the composite FK below
+-- (MATCH SIMPLE skips the check when node_code is NULL), so the CHECK
+-- must forbid it. Aggregate branch requires level too. "level is the
+-- actual level of node_code in the registry" stays an application-layer
+-- invariant (a CHECK cannot subquery hierarchy_node).
+ALTER TABLE forecasts DROP CONSTRAINT IF EXISTS chk_forecasts_leaf_xor_aggregate;
+ALTER TABLE forecasts ADD CONSTRAINT chk_forecasts_leaf_xor_aggregate CHECK (
+    (item_id IS NOT NULL AND location_id IS NOT NULL
+     AND hierarchy_id IS NULL AND level IS NULL AND node_code IS NULL)
+    OR
+    (node_code IS NOT NULL AND hierarchy_id IS NOT NULL AND level IS NOT NULL
+     AND item_id IS NULL AND location_id IS NULL)
+);
+
+-- The referenced aggregate node must exist in the hierarchy registry.
+-- MATCH SIMPLE (default): leaf rows (node_code NULL) are not checked.
+ALTER TABLE forecasts DROP CONSTRAINT IF EXISTS fk_forecasts_hierarchy_node;
+ALTER TABLE forecasts ADD CONSTRAINT fk_forecasts_hierarchy_node
+    FOREIGN KEY (hierarchy_id, node_code)
+    REFERENCES hierarchy_node (hierarchy_id, code)
+    ON DELETE RESTRICT;
+
+-- Aggregate lookups: "forecasts for node X of hierarchy H at level L".
+CREATE INDEX IF NOT EXISTS idx_forecasts_hierarchy_node
+    ON forecasts (hierarchy_id, level, node_code)
+    WHERE node_code IS NOT NULL;
+
+COMMENT ON COLUMN forecasts.hierarchy_id IS
+    'Aggregate forecasts only: hierarchy this forecast''s node belongs to '
+    '(migration 047 registry). NULL on leaf (item, location) forecasts.';
+COMMENT ON COLUMN forecasts.level IS
+    'Aggregate forecasts only: level name of node_code within the hierarchy '
+    '(e.g. one of hierarchy.levels). NULL on leaf forecasts.';
+COMMENT ON COLUMN forecasts.node_code IS
+    'Aggregate forecasts only: hierarchy_node.code this forecast targets. '
+    'CHECK chk_forecasts_leaf_xor_aggregate enforces leaf XOR aggregate.';
+
+-- ============================================================
+-- 2. pyramide_runs — a run can target an aggregate node too
+-- ============================================================
+
+ALTER TABLE pyramide_runs
+    ADD COLUMN IF NOT EXISTS hierarchy_id TEXT
+        REFERENCES hierarchy(hierarchy_id) ON DELETE RESTRICT;
+ALTER TABLE pyramide_runs ADD COLUMN IF NOT EXISTS level     TEXT;
+ALTER TABLE pyramide_runs ADD COLUMN IF NOT EXISTS node_code TEXT;
+
+ALTER TABLE pyramide_runs ALTER COLUMN item_id     DROP NOT NULL;
+ALTER TABLE pyramide_runs ALTER COLUMN location_id DROP NOT NULL;
+
+-- Same tightened predicate as forecasts (see the comment there): leaf
+-- rows carry no aggregate column at all, aggregate rows require level.
+ALTER TABLE pyramide_runs DROP CONSTRAINT IF EXISTS chk_pyramide_runs_leaf_xor_aggregate;
+ALTER TABLE pyramide_runs ADD CONSTRAINT chk_pyramide_runs_leaf_xor_aggregate CHECK (
+    (item_id IS NOT NULL AND location_id IS NOT NULL
+     AND hierarchy_id IS NULL AND level IS NULL AND node_code IS NULL)
+    OR
+    (node_code IS NOT NULL AND hierarchy_id IS NOT NULL AND level IS NOT NULL
+     AND item_id IS NULL AND location_id IS NULL)
+);
+
+ALTER TABLE pyramide_runs DROP CONSTRAINT IF EXISTS fk_pyramide_runs_hierarchy_node;
+ALTER TABLE pyramide_runs ADD CONSTRAINT fk_pyramide_runs_hierarchy_node
+    FOREIGN KEY (hierarchy_id, node_code)
+    REFERENCES hierarchy_node (hierarchy_id, code)
+    ON DELETE RESTRICT;
+
+CREATE INDEX IF NOT EXISTS idx_pyramide_runs_hierarchy_node
+    ON pyramide_runs (hierarchy_id, level, node_code)
+    WHERE node_code IS NOT NULL;
+
+COMMENT ON COLUMN pyramide_runs.hierarchy_id IS
+    'Aggregate runs only: hierarchy of the target node. NULL on leaf runs.';
+COMMENT ON COLUMN pyramide_runs.level IS
+    'Aggregate runs only: level name of node_code. NULL on leaf runs.';
+COMMENT ON COLUMN pyramide_runs.node_code IS
+    'Aggregate runs only: hierarchy_node.code the run forecasts. '
+    'CHECK chk_pyramide_runs_leaf_xor_aggregate enforces leaf XOR aggregate.';
+
+COMMIT;

--- a/src/ootils_core/pyramide/hierarchy/__init__.py
+++ b/src/ootils_core/pyramide/hierarchy/__init__.py
@@ -1,0 +1,32 @@
+"""
+Hierarchy layer of Pyramide (axis A) — sparse summing-matrix (S)
+construction over the generic hierarchy registry (migration 047:
+hierarchy / hierarchy_node / item_hierarchy).
+
+Blocks are cut at a configurable level of a configurable domain's
+hierarchy (default: one block per root node of the domain's default
+hierarchy), so reconciliation always works on small independent
+matrices instead of one full-hierarchy S.
+"""
+
+from .summing import (
+    AGGREGATE,
+    LEAF,
+    HierarchyNodeRow,
+    SeriesRef,
+    SummingBlock,
+    build_summing_blocks,
+    load_summing_blocks,
+    resolve_default_hierarchy_id,
+)
+
+__all__ = [
+    "AGGREGATE",
+    "LEAF",
+    "HierarchyNodeRow",
+    "SeriesRef",
+    "SummingBlock",
+    "build_summing_blocks",
+    "load_summing_blocks",
+    "resolve_default_hierarchy_id",
+]

--- a/src/ootils_core/pyramide/hierarchy/summing.py
+++ b/src/ootils_core/pyramide/hierarchy/summing.py
@@ -1,0 +1,392 @@
+"""
+Sparse summing-matrix (S) construction for hierarchical forecast
+reconciliation (Pyramide axis A).
+
+For a hierarchy block, the summing matrix S encodes ``y = S @ b``: every
+series (aggregate node at any level, plus the leaf series themselves) is
+a sum of leaf series. Reconciliation methods (bottom-up, middle-out,
+MinT, ...) all consume S; this module only *builds* it.
+
+Blocks
+------
+S is never built for the whole hierarchy at once (scale wall — see
+docs/DESIGN-pyramide-forecasting.md §3): the hierarchy is cut into
+independent BLOCKS, one per node of a configurable ``block_level``
+(default: the ROOT level, ``hierarchy.levels[0]``). Each block covers
+the node's whole subtree and the items attached to it.
+
+Sparse representation
+---------------------
+scipy is not a project dependency (pyproject: core deps are fastapi /
+psycopg / pydantic; the optional ``forecast`` extra has pandas but no
+scipy), so S uses a pure-Python sparse row encoding: every row is the
+sorted tuple of leaf column indices it sums (all coefficients of a
+summing matrix are 0/1). Per-block sizes make this comfortable.
+
+Determinism
+-----------
+Every ordering is explicit (sorted node codes, sorted (leaf_code,
+item_id) for leaves, hierarchy level order for aggregate rows), so the
+same inputs always produce byte-identical blocks, whatever the input
+row order. No randomness.
+
+Genericity
+----------
+Nothing here is domain-specific: hierarchies come from the registry
+tables of migration 047 (``hierarchy`` / ``hierarchy_node`` /
+``item_hierarchy``), with the domain and block level as parameters.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Iterable, Sequence
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+# SeriesRef.kind values
+AGGREGATE = "aggregate"
+LEAF = "leaf"
+
+
+@dataclass(frozen=True)
+class HierarchyNodeRow:
+    """One row of ``hierarchy_node`` (pure-Python mirror)."""
+    code: str
+    level: str
+    parent_code: str | None
+
+
+@dataclass(frozen=True)
+class SeriesRef:
+    """
+    One row of a block's summing matrix.
+
+    kind='aggregate' → key is a hierarchy_node.code, level its level name.
+    kind='leaf'      → key is the item identifier (stringified item_id),
+                       level is None, leaf_code the node the item hangs from.
+    """
+    kind: str
+    key: str
+    level: str | None = None
+    leaf_code: str | None = None
+
+
+@dataclass(frozen=True)
+class SummingBlock:
+    """
+    The sparse summing matrix S of one hierarchy block.
+
+    ``series`` are the rows of S (aggregates first — hierarchy level
+    order, then code order — then the leaf identity rows). ``leaves``
+    are the columns (item identifiers, ordered by (leaf_code, item)).
+    ``rows[i]`` is the sorted tuple of column indices summed by series
+    ``series[i]`` — i.e. S[i, j] = 1 iff j in rows[i].
+    """
+    hierarchy_id: str
+    block_code: str
+    block_level: str
+    series: tuple[SeriesRef, ...]
+    leaves: tuple[str, ...]
+    rows: tuple[tuple[int, ...], ...]
+
+    def multiply(self, base: Sequence) -> list:
+        """
+        Compute ``y = S @ base``: one output value per series, from one
+        input value per leaf column (any additive type: Decimal, int,
+        float). Empty rows (aggregate node with no items) yield 0.
+        """
+        if len(base) != len(self.leaves):
+            raise ValueError(
+                f"base vector has {len(base)} entries, block "
+                f"'{self.block_code}' has {len(self.leaves)} leaf columns"
+            )
+        return [sum((base[j] for j in row), Decimal(0) if _is_decimal(base) else 0)
+                for row in self.rows]
+
+
+def _is_decimal(base: Sequence) -> bool:
+    return bool(base) and isinstance(base[0], Decimal)
+
+
+# ---------------------------------------------------------------------------
+# Pure construction (unit-testable without a database)
+# ---------------------------------------------------------------------------
+
+
+def build_summing_blocks(
+    hierarchy_id: str,
+    levels: Sequence[str],
+    nodes: Iterable[HierarchyNodeRow],
+    memberships: Iterable[tuple[str, str]],
+    block_level: str | None = None,
+) -> list[SummingBlock]:
+    """
+    Build one sparse S per node of ``block_level`` (default: the root
+    level ``levels[0]``).
+
+    Args:
+        hierarchy_id: registry id (traceability only — no lookup here).
+        levels:       ordered level names, root → leaf (hierarchy.levels).
+        nodes:        hierarchy_node rows of this hierarchy.
+        memberships:  (item_key, leaf_code) pairs — item_hierarchy rows
+                      of this hierarchy; item_key is any stable string
+                      identifier (stringified item_id UUID from the DB).
+        block_level:  level name whose nodes each get their own block.
+
+    Returns blocks sorted by block_code. Fails loudly on: unknown
+    block_level, node level not in ``levels``, duplicate node code,
+    a parent_code pointing at an unknown node, parent cycles, or a
+    membership pointing at an unknown node.
+    """
+    levels = list(levels)
+    if not levels:
+        raise ValueError(f"hierarchy '{hierarchy_id}' declares no levels")
+    if block_level is None:
+        block_level = levels[0]
+    if block_level not in levels:
+        raise ValueError(
+            f"block_level '{block_level}' is not a level of hierarchy "
+            f"'{hierarchy_id}' (levels: {levels})"
+        )
+    level_rank = {name: i for i, name in enumerate(levels)}
+
+    by_code: dict[str, HierarchyNodeRow] = {}
+    for node in nodes:
+        if node.code in by_code:
+            raise ValueError(
+                f"duplicate node code '{node.code}' in hierarchy '{hierarchy_id}'"
+            )
+        if node.level not in level_rank:
+            raise ValueError(
+                f"node '{node.code}' has level '{node.level}' which is not "
+                f"declared by hierarchy '{hierarchy_id}' (levels: {levels})"
+            )
+        by_code[node.code] = node
+
+    children: dict[str, list[str]] = {}
+    for node in by_code.values():
+        if node.parent_code is not None:
+            if node.parent_code not in by_code:
+                # An orphan node is unreachable from every block root and
+                # would silently vanish from all blocks (its demand with
+                # it) — same fail-loudly rule as orphan memberships.
+                raise ValueError(
+                    f"node '{node.code}' has parent_code "
+                    f"'{node.parent_code}' which does not exist in "
+                    f"hierarchy '{hierarchy_id}'"
+                )
+            children.setdefault(node.parent_code, []).append(node.code)
+    for kids in children.values():
+        kids.sort()
+
+    # item columns attached directly to each node (via leaf membership)
+    items_by_node: dict[str, list[str]] = {}
+    seen_items: set[str] = set()
+    for item_key, leaf_code in memberships:
+        if leaf_code not in by_code:
+            raise ValueError(
+                f"item '{item_key}' is attached to unknown node "
+                f"'{leaf_code}' in hierarchy '{hierarchy_id}'"
+            )
+        if item_key in seen_items:
+            # item_hierarchy's PK (item_id, hierarchy_id) makes this
+            # impossible from the DB path; guard the pure path anyway
+            # (a duplicated column would silently double-count demand).
+            raise ValueError(
+                f"item '{item_key}' appears twice in hierarchy "
+                f"'{hierarchy_id}' memberships"
+            )
+        seen_items.add(item_key)
+        items_by_node.setdefault(leaf_code, []).append(item_key)
+    for item_keys in items_by_node.values():
+        item_keys.sort()
+
+    block_roots = sorted(
+        code for code, node in by_code.items() if node.level == block_level
+    )
+
+    blocks: list[SummingBlock] = []
+    for root in block_roots:
+        blocks.append(
+            _build_block(
+                hierarchy_id, root, block_level, by_code, children,
+                items_by_node, level_rank,
+            )
+        )
+    return blocks
+
+
+def _subtree_codes(
+    root: str,
+    children: dict[str, list[str]],
+    hierarchy_id: str,
+) -> list[str]:
+    """Deterministic DFS of the subtree; fails loudly on parent cycles."""
+    seen: set[str] = set()
+    order: list[str] = []
+    stack = [root]
+    while stack:
+        code = stack.pop()
+        if code in seen:
+            raise ValueError(
+                f"parent_code cycle detected at node '{code}' in "
+                f"hierarchy '{hierarchy_id}'"
+            )
+        seen.add(code)
+        order.append(code)
+        # push reversed so children pop in sorted order
+        stack.extend(reversed(children.get(code, [])))
+    return order
+
+
+def _build_block(
+    hierarchy_id: str,
+    root: str,
+    block_level: str,
+    by_code: dict[str, HierarchyNodeRow],
+    children: dict[str, list[str]],
+    items_by_node: dict[str, list[str]],
+    level_rank: dict[str, int],
+) -> SummingBlock:
+    subtree = _subtree_codes(root, children, hierarchy_id)
+    subtree_set = set(subtree)
+
+    # Columns: leaf items of the subtree, ordered by (leaf_code, item).
+    leaf_pairs = sorted(
+        (leaf_code, item_key)
+        for leaf_code in subtree_set & items_by_node.keys()
+        for item_key in items_by_node[leaf_code]
+    )
+    leaves = tuple(item_key for _, item_key in leaf_pairs)
+    col_of = {item_key: j for j, (_, item_key) in enumerate(leaf_pairs)}
+    leaf_code_of = {item_key: leaf_code for leaf_code, item_key in leaf_pairs}
+
+    # Columns summed by each node = its own items + its children's, bottom-up.
+    cols_by_node: dict[str, frozenset[int]] = {}
+    for code in reversed(subtree):  # DFS order reversed → children first
+        cols: set[int] = {
+            col_of[item_key] for item_key in items_by_node.get(code, [])
+        }
+        for child in children.get(code, []):
+            cols |= cols_by_node[child]
+        cols_by_node[code] = frozenset(cols)
+
+    # Rows: aggregates in (level rank, code) order, then leaf identities.
+    aggregate_codes = sorted(
+        subtree, key=lambda c: (level_rank[by_code[c].level], c)
+    )
+    series: list[SeriesRef] = []
+    rows: list[tuple[int, ...]] = []
+    for code in aggregate_codes:
+        series.append(
+            SeriesRef(kind=AGGREGATE, key=code, level=by_code[code].level)
+        )
+        rows.append(tuple(sorted(cols_by_node[code])))
+    for j, item_key in enumerate(leaves):
+        series.append(
+            SeriesRef(kind=LEAF, key=item_key, leaf_code=leaf_code_of[item_key])
+        )
+        rows.append((j,))
+
+    return SummingBlock(
+        hierarchy_id=hierarchy_id,
+        block_code=root,
+        block_level=block_level,
+        series=tuple(series),
+        leaves=leaves,
+        rows=tuple(rows),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Database loaders (thin wrappers over the pure builder)
+# ---------------------------------------------------------------------------
+
+
+def resolve_default_hierarchy_id(db: psycopg.Connection, domain: str) -> str:
+    """
+    The is_default hierarchy of a domain (migration 047 registry).
+    Fails loudly if the domain has zero or several defaults — the
+    application layer owns is_default uniqueness, so ambiguity is a
+    data-quality error, not something to resolve silently.
+    """
+    rows = db.execute(
+        """
+        SELECT hierarchy_id FROM hierarchy
+        WHERE domain = %s AND is_default
+        ORDER BY hierarchy_id ASC
+        """,
+        (domain,),
+    ).fetchall()
+    if not rows:
+        raise ValueError(f"no default hierarchy registered for domain '{domain}'")
+    if len(rows) > 1:
+        ids = [r["hierarchy_id"] for r in rows]
+        raise ValueError(
+            f"domain '{domain}' has {len(rows)} default hierarchies "
+            f"({ids}); expected exactly one"
+        )
+    return rows[0]["hierarchy_id"]
+
+
+def load_summing_blocks(
+    db: psycopg.Connection,
+    hierarchy_id: str | None = None,
+    domain: str | None = None,
+    block_level: str | None = None,
+) -> list[SummingBlock]:
+    """
+    Load hierarchy_node + item_hierarchy (migration 047) and build the
+    per-block sparse summing matrices.
+
+    Pass either ``hierarchy_id`` explicitly, or ``domain`` to use the
+    domain's default hierarchy. ``block_level`` defaults to the root
+    level of the hierarchy (one block per root node).
+    """
+    if hierarchy_id is None:
+        if domain is None:
+            raise ValueError("provide hierarchy_id or domain")
+        hierarchy_id = resolve_default_hierarchy_id(db, domain)
+
+    hierarchy_row = db.execute(
+        "SELECT levels FROM hierarchy WHERE hierarchy_id = %s",
+        (hierarchy_id,),
+    ).fetchone()
+    if hierarchy_row is None:
+        raise ValueError(f"hierarchy '{hierarchy_id}' not found")
+
+    node_rows = db.execute(
+        """
+        SELECT code, level, parent_code
+        FROM hierarchy_node
+        WHERE hierarchy_id = %s
+        ORDER BY code ASC
+        """,
+        (hierarchy_id,),
+    ).fetchall()
+    membership_rows = db.execute(
+        """
+        SELECT item_id, leaf_code
+        FROM item_hierarchy
+        WHERE hierarchy_id = %s
+        ORDER BY leaf_code ASC, item_id ASC
+        """,
+        (hierarchy_id,),
+    ).fetchall()
+
+    return build_summing_blocks(
+        hierarchy_id=hierarchy_id,
+        levels=hierarchy_row["levels"],
+        nodes=[
+            HierarchyNodeRow(
+                code=r["code"], level=r["level"], parent_code=r["parent_code"]
+            )
+            for r in node_rows
+        ],
+        memberships=[(str(r["item_id"]), r["leaf_code"]) for r in membership_rows],
+        block_level=block_level,
+    )

--- a/src/ootils_core/pyramide/repository.py
+++ b/src/ootils_core/pyramide/repository.py
@@ -25,11 +25,20 @@ class PyramidePersistedRun:
 
 @dataclass(frozen=True)
 class PyramideRunSummary:
+    """
+    Leaf runs carry (item_id, location_id); aggregate runs (migration 053)
+    carry (hierarchy_id, level, node_code) instead — the unused side is
+    None (DB CHECK: leaf XOR aggregate). Consumers must not assume
+    item_id/location_id are set.
+    """
     run_id: UUID
     snapshot_id: UUID
     forecast_id: UUID
-    item_id: UUID
-    location_id: UUID
+    item_id: UUID | None
+    location_id: UUID | None
+    hierarchy_id: str | None
+    level: str | None
+    node_code: str | None
     scenario_id: UUID
     horizon_start: date
     horizon_end: date
@@ -103,6 +112,24 @@ def resolve_scenario_uuid(scenario_id: str | None) -> UUID:
     return UUID(scenario_id)
 
 
+# Shared business predicates of the demand-history training signal.
+# Single definition consumed by BOTH readers (leaf pair and hierarchy
+# node) so the business rules can never drift apart:
+#   - stream='regular' only (warranty is a separate forecast),
+#   - inter-entity flows excluded (PPS→PCC double-count, migration 048),
+#   - strict past (today is a partial day),
+#   - bounded lookback window.
+# Uses the named placeholder %(lookback_days)s — callers pass params as a
+# dict.
+_DEMAND_HISTORY_BUSINESS_PREDICATES = """
+              dh.stream = 'regular'
+              AND (dh.fulfillment IS NULL OR dh.fulfillment <> 'inter_entity')
+              AND dh.booked_date IS NOT NULL
+              AND dh.booked_date < CURRENT_DATE
+              AND dh.booked_date >= CURRENT_DATE - (%(lookback_days)s::int * INTERVAL '1 day')
+"""
+
+
 def get_historical_demand(
     db: psycopg.Connection,
     item_id: UUID,
@@ -144,21 +171,21 @@ def get_historical_demand(
 
     if warehouse_external_id is not None:
         rows = db.execute(
-            """
+            f"""
             SELECT dh.booked_date AS demand_date,
                    COALESCE(SUM(dh.ordered_quantity), 0) AS total_qty
             FROM demand_history dh
-            WHERE dh.item_id = %s
-              AND dh.warehouse_id = %s
-              AND dh.stream = 'regular'
-              AND (dh.fulfillment IS NULL OR dh.fulfillment <> 'inter_entity')
-              AND dh.booked_date IS NOT NULL
-              AND dh.booked_date < CURRENT_DATE
-              AND dh.booked_date >= CURRENT_DATE - (%s::int * INTERVAL '1 day')
+            WHERE dh.item_id = %(item_id)s
+              AND dh.warehouse_id = %(warehouse_id)s
+              AND {_DEMAND_HISTORY_BUSINESS_PREDICATES}
             GROUP BY dh.booked_date
             ORDER BY dh.booked_date ASC
             """,
-            (item_id, warehouse_external_id, lookback_days),
+            {
+                "item_id": item_id,
+                "warehouse_id": warehouse_external_id,
+                "lookback_days": lookback_days,
+            },
         ).fetchall()
         if rows:
             return [Decimal(str(row["total_qty"])) for row in rows]
@@ -186,6 +213,80 @@ def get_historical_demand(
         ORDER BY 1 ASC
         """,
         (scenario_id, item_id, location_id, lookback_days),
+    ).fetchall()
+    return [Decimal(str(row["total_qty"])) for row in rows]
+
+
+def get_historical_demand_by_node(
+    db: psycopg.Connection,
+    hierarchy_id: str,
+    node_code: str,
+    lookback_days: int,
+) -> list[Decimal]:
+    """
+    Historical demand series AGGREGATED at a hierarchy node: daily booked
+    sums over every item attached (via item_hierarchy) to the node's
+    subtree, sorted date ASC. Same sparse contract as
+    ``get_historical_demand`` (days without demand are absent).
+
+    Business filters are the shared ``_DEMAND_HISTORY_BUSINESS_PREDICATES``
+    — identical to the leaf reader by construction: stream='regular' only,
+    inter-entity excluded, strict past, bounded lookback.
+
+    Scope differences vs the leaf reader, by design:
+      - ALL sites: an aggregate node's series sums demand across DCs
+        (site-level split is the reconciliation/DRP layer's job), so
+        there is no warehouse filter. Rows with NULL/unmatched
+        warehouse_id therefore DO count here.
+      - No degraded graph-node fallback: aggregate nodes have no
+        CustomerOrderDemand equivalent; an empty series is an empty
+        series.
+      - demand_history is scenario-invariant (actuals), so there is no
+        scenario parameter at all.
+
+    Fails loudly (ValueError) if the node does not exist in the
+    hierarchy — silence here would be indistinguishable from "no demand".
+    """
+    exists = db.execute(
+        "SELECT 1 AS ok FROM hierarchy_node WHERE hierarchy_id = %s AND code = %s",
+        (hierarchy_id, node_code),
+    ).fetchone()
+    if exists is None:
+        raise ValueError(
+            f"node '{node_code}' not found in hierarchy '{hierarchy_id}'"
+        )
+
+    rows = db.execute(
+        f"""
+        WITH RECURSIVE subtree AS (
+            SELECT code
+            FROM hierarchy_node
+            WHERE hierarchy_id = %(hierarchy_id)s AND code = %(node_code)s
+            UNION
+            -- UNION (not UNION ALL): hierarchy_node has no self-FK, so a
+            -- bad parent_code cycle must terminate instead of recursing
+            -- forever; dedup guarantees termination.
+            SELECT hn.code
+            FROM hierarchy_node hn
+            JOIN subtree st ON hn.parent_code = st.code
+            WHERE hn.hierarchy_id = %(hierarchy_id)s
+        )
+        SELECT dh.booked_date AS demand_date,
+               COALESCE(SUM(dh.ordered_quantity), 0) AS total_qty
+        FROM demand_history dh
+        JOIN item_hierarchy ih
+          ON ih.item_id = dh.item_id
+         AND ih.hierarchy_id = %(hierarchy_id)s
+        JOIN subtree st ON st.code = ih.leaf_code
+        WHERE {_DEMAND_HISTORY_BUSINESS_PREDICATES}
+        GROUP BY dh.booked_date
+        ORDER BY dh.booked_date ASC
+        """,
+        {
+            "hierarchy_id": hierarchy_id,
+            "node_code": node_code,
+            "lookback_days": lookback_days,
+        },
     ).fetchall()
     return [Decimal(str(row["total_qty"])) for row in rows]
 
@@ -286,6 +387,7 @@ def fetch_run_summary(db: psycopg.Connection, run_id: UUID) -> PyramideRunSummar
         """
         SELECT
             pr.run_id, ps.snapshot_id, pr.forecast_id, pr.item_id, pr.location_id,
+            pr.hierarchy_id, pr.level, pr.node_code,
             pr.scenario_id, pr.horizon_start, pr.horizon_end, pr.granularity,
             pr.method, pr.model_strategy, pr.recon_method, pr.random_seed,
             pr.code_version, pr.selected_model, pr.engine_backend,
@@ -417,6 +519,9 @@ def _summary_from_row(row) -> PyramideRunSummary:
         forecast_id=row["forecast_id"],
         item_id=row["item_id"],
         location_id=row["location_id"],
+        hierarchy_id=row["hierarchy_id"],
+        level=row["level"],
+        node_code=row["node_code"],
         scenario_id=row["scenario_id"],
         horizon_start=row["horizon_start"],
         horizon_end=row["horizon_end"],

--- a/tests/integration/test_pyramide_hierarchy_integration.py
+++ b/tests/integration/test_pyramide_hierarchy_integration.py
@@ -1,0 +1,579 @@
+"""
+Integration tests for Pyramide axis A — PR2 (migration 053 + hierarchy
+readers) against a real PostgreSQL database (no mocks).
+
+Covered:
+  - migration 053 applies (nullable leaf columns + aggregate-node columns
+    on forecasts / pyramide_runs);
+  - the leaf-XOR-aggregate CHECK accepts leaf rows and aggregate rows,
+    and rejects hybrid rows;
+  - repository.get_historical_demand_by_node aggregates demand_history
+    over the node's subtree with the SAME business filters as the leaf
+    reader (shared predicate fragment);
+  - the leaf list endpoint keeps working with aggregate rows present
+    (WHERE item_id IS NOT NULL guard);
+  - load_summing_blocks builds S from real 047 registry rows.
+
+Conventions (mirrors test_demand_foundation_integration.py): module-scoped
+migrated_db, autocommit _db_conn for seeding/teardown, every test creates
+its OWN registry rows / items (fresh codes) and cleans up in a finally
+block.
+"""
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+BASELINE_SCENARIO_ID = UUID("00000000-0000-0000-0000-000000000001")
+# The demand-history predicates compare booked_date to the SERVER's
+# CURRENT_DATE, while TODAY is the client's date.today() — the two can
+# differ by a day around midnight or across timezones. Anti-flake rule
+# for every seeded row: strict-past rows at TODAY-2 or earlier, future
+# rows at TODAY+2 or later; never TODAY / TODAY±1 on an assertion edge.
+TODAY = date.today()
+
+
+# ---------------------------------------------------------------------------
+# Helpers — DB access, hierarchy seeding, teardown
+# ---------------------------------------------------------------------------
+
+
+def _db_conn(dsn):
+    import psycopg
+    from psycopg.rows import dict_row
+    return psycopg.connect(dsn, row_factory=dict_row, autocommit=True)
+
+
+def _create_item(conn, ext_id: str) -> UUID:
+    item_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO items (item_id, name, item_type, uom, status, external_id)
+        VALUES (%s, %s, 'finished_good', 'EA', 'active', %s)
+        """,
+        (item_id, f"{ext_id} test item", ext_id),
+    )
+    return item_id
+
+
+def _create_location(conn, ext_id: str) -> UUID:
+    loc_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO locations (location_id, name, location_type, country, external_id)
+        VALUES (%s, %s, 'dc', 'US', %s)
+        """,
+        (loc_id, f"{ext_id} test DC", ext_id),
+    )
+    return loc_id
+
+
+def _seed_hierarchy(conn, hierarchy_id: str, *, is_default: bool = False):
+    """Two-level registry: FAM-* (family) -> PRD-* (product), per module
+    docstring of tests/test_pyramide_hierarchy_summing.py."""
+    conn.execute(
+        """
+        INSERT INTO hierarchy (hierarchy_id, domain, scope, levels, is_default)
+        VALUES (%s, 'product', 'local', %s, %s)
+        """,
+        (hierarchy_id, ["family", "product"], is_default),
+    )
+    for code, level, parent in [
+        ("FAM-A", "family", None),
+        ("PRD-A1", "product", "FAM-A"),
+        ("PRD-A2", "product", "FAM-A"),
+        ("FAM-B", "family", None),
+        ("PRD-B1", "product", "FAM-B"),
+    ]:
+        conn.execute(
+            """
+            INSERT INTO hierarchy_node (hierarchy_id, code, level, parent_code)
+            VALUES (%s, %s, %s, %s)
+            """,
+            (hierarchy_id, code, level, parent),
+        )
+
+
+def _attach_item(conn, item_id: UUID, hierarchy_id: str, leaf_code: str):
+    conn.execute(
+        """
+        INSERT INTO item_hierarchy (item_id, hierarchy_id, leaf_code)
+        VALUES (%s, %s, %s)
+        """,
+        (item_id, hierarchy_id, leaf_code),
+    )
+
+
+def _insert_dh(
+    conn,
+    item_id: UUID,
+    item_code: str,
+    booked_date: date,
+    qty,
+    *,
+    stream: str = "regular",
+    fulfillment: str | None = "standard",
+    warehouse_id: str | None = None,
+):
+    conn.execute(
+        """
+        INSERT INTO demand_history (
+            item_id, item_code, stream, booked_date,
+            ordered_quantity, value_ext, counts_for_asp,
+            warehouse_id, fulfillment, order_number
+        ) VALUES (%s, %s, %s, %s, %s, 0, FALSE, %s, %s, 'TEST-PH')
+        """,
+        (item_id, item_code, stream, booked_date, qty, warehouse_id, fulfillment),
+    )
+
+
+def _insert_leaf_forecast(conn, item_id: UUID, location_id: UUID) -> UUID:
+    forecast_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO forecasts (
+            forecast_id, item_id, location_id, scenario_id,
+            horizon_start, horizon_end, granularity, method
+        ) VALUES (%s, %s, %s, %s, %s, %s, 'daily', 'MA')
+        """,
+        (forecast_id, item_id, location_id, BASELINE_SCENARIO_ID,
+         TODAY, TODAY + timedelta(days=6)),
+    )
+    return forecast_id
+
+
+def _insert_aggregate_forecast(conn, hierarchy_id: str, node_code: str,
+                               level: str) -> UUID:
+    forecast_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO forecasts (
+            forecast_id, hierarchy_id, level, node_code, scenario_id,
+            horizon_start, horizon_end, granularity, method
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, 'monthly', 'MA')
+        """,
+        (forecast_id, hierarchy_id, level, node_code, BASELINE_SCENARIO_ID,
+         TODAY, TODAY + timedelta(days=29)),
+    )
+    return forecast_id
+
+
+def _cleanup_hierarchy(conn, hierarchy_id: str, item_ids, location_ids=()):
+    """FK teardown order: runs -> forecasts -> facts -> memberships ->
+    nodes -> hierarchy -> items/locations (RESTRICT everywhere)."""
+    conn.execute(
+        "DELETE FROM pyramide_runs WHERE hierarchy_id = %s", (hierarchy_id,)
+    )
+    conn.execute(
+        "DELETE FROM forecast_values WHERE forecast_id IN "
+        "(SELECT forecast_id FROM forecasts WHERE hierarchy_id = %s)",
+        (hierarchy_id,),
+    )
+    conn.execute("DELETE FROM forecasts WHERE hierarchy_id = %s", (hierarchy_id,))
+    for item_id in item_ids:
+        conn.execute("DELETE FROM pyramide_runs WHERE item_id = %s", (item_id,))
+        conn.execute(
+            "DELETE FROM forecast_values WHERE forecast_id IN "
+            "(SELECT forecast_id FROM forecasts WHERE item_id = %s)",
+            (item_id,),
+        )
+        conn.execute("DELETE FROM forecasts WHERE item_id = %s", (item_id,))
+        conn.execute("DELETE FROM demand_history WHERE item_id = %s", (item_id,))
+        conn.execute("DELETE FROM item_hierarchy WHERE item_id = %s", (item_id,))
+        conn.execute("DELETE FROM items WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM hierarchy_node WHERE hierarchy_id = %s", (hierarchy_id,))
+    conn.execute("DELETE FROM hierarchy WHERE hierarchy_id = %s", (hierarchy_id,))
+    for loc_id in location_ids:
+        conn.execute("DELETE FROM locations WHERE location_id = %s", (loc_id,))
+
+
+# ---------------------------------------------------------------------------
+# (1) Migration 053 — schema shape
+# ---------------------------------------------------------------------------
+
+
+class TestMigration053Applied:
+    def test_columns_added_and_leaf_columns_nullable(self, migrated_db):
+        with _db_conn(migrated_db) as conn:
+            rows = conn.execute(
+                """
+                SELECT table_name, column_name, is_nullable
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name IN ('forecasts', 'pyramide_runs')
+                  AND column_name IN
+                      ('item_id', 'location_id', 'hierarchy_id', 'level', 'node_code')
+                """
+            ).fetchall()
+        shape = {(r["table_name"], r["column_name"]): r["is_nullable"] for r in rows}
+        for table in ("forecasts", "pyramide_runs"):
+            for column in ("item_id", "location_id", "hierarchy_id",
+                           "level", "node_code"):
+                assert shape.get((table, column)) == "YES", (
+                    f"{table}.{column} missing or NOT NULL"
+                )
+
+    def test_check_constraints_present(self, migrated_db):
+        with _db_conn(migrated_db) as conn:
+            rows = conn.execute(
+                """
+                SELECT conname FROM pg_constraint
+                WHERE conname IN (
+                    'chk_forecasts_leaf_xor_aggregate',
+                    'chk_pyramide_runs_leaf_xor_aggregate',
+                    'fk_forecasts_hierarchy_node',
+                    'fk_pyramide_runs_hierarchy_node'
+                )
+                """
+            ).fetchall()
+        assert {r["conname"] for r in rows} == {
+            "chk_forecasts_leaf_xor_aggregate",
+            "chk_pyramide_runs_leaf_xor_aggregate",
+            "fk_forecasts_hierarchy_node",
+            "fk_pyramide_runs_hierarchy_node",
+        }
+
+
+# ---------------------------------------------------------------------------
+# (2) CHECK leaf XOR aggregate
+# ---------------------------------------------------------------------------
+
+
+class TestLeafXorAggregateCheck:
+    def test_accepts_leaf_and_aggregate_rows(self, migrated_db):
+        h = "ph-h-check-ok"
+        with _db_conn(migrated_db) as conn:
+            _seed_hierarchy(conn, h)
+            item_id = _create_item(conn, "PH-CK-ITEM")
+            loc_id = _create_location(conn, "PH-CK-LOC")
+            try:
+                leaf_fid = _insert_leaf_forecast(conn, item_id, loc_id)
+                agg_fid = _insert_aggregate_forecast(conn, h, "FAM-A", "family")
+
+                rows = conn.execute(
+                    "SELECT forecast_id, item_id, node_code FROM forecasts "
+                    "WHERE forecast_id IN (%s, %s) ORDER BY node_code NULLS FIRST",
+                    (leaf_fid, agg_fid),
+                ).fetchall()
+                assert len(rows) == 2
+                assert rows[0]["item_id"] == item_id and rows[0]["node_code"] is None
+                assert rows[1]["item_id"] is None and rows[1]["node_code"] == "FAM-A"
+
+                # An aggregate pyramide_run on the aggregate forecast
+                conn.execute(
+                    """
+                    INSERT INTO pyramide_runs (
+                        forecast_id, hierarchy_id, level, node_code, scenario_id,
+                        horizon_start, horizon_end, granularity, method,
+                        source_history_count
+                    ) VALUES (%s, %s, 'family', 'FAM-A', %s, %s, %s,
+                              'monthly', 'MA', 0)
+                    """,
+                    (agg_fid, h, BASELINE_SCENARIO_ID,
+                     TODAY, TODAY + timedelta(days=29)),
+                )
+                run = conn.execute(
+                    "SELECT item_id, location_id, node_code FROM pyramide_runs "
+                    "WHERE forecast_id = %s",
+                    (agg_fid,),
+                ).fetchone()
+                assert run["item_id"] is None
+                assert run["location_id"] is None
+                assert run["node_code"] == "FAM-A"
+            finally:
+                _cleanup_hierarchy(conn, h, [item_id], [loc_id])
+
+    def test_rejects_hybrid_and_orphan_rows(self, migrated_db):
+        import psycopg
+        h = "ph-h-check-ko"
+        with _db_conn(migrated_db) as conn:
+            _seed_hierarchy(conn, h)
+            item_id = _create_item(conn, "PH-KO-ITEM")
+            loc_id = _create_location(conn, "PH-KO-LOC")
+            try:
+                # hybrid: leaf pair AND a node_code
+                with pytest.raises(psycopg.errors.CheckViolation):
+                    conn.execute(
+                        """
+                        INSERT INTO forecasts (
+                            forecast_id, item_id, location_id,
+                            hierarchy_id, level, node_code, scenario_id,
+                            horizon_start, horizon_end, granularity, method
+                        ) VALUES (%s, %s, %s, %s, 'family', 'FAM-A', %s,
+                                  %s, %s, 'daily', 'MA')
+                        """,
+                        (uuid4(), item_id, loc_id, h, BASELINE_SCENARIO_ID,
+                         TODAY, TODAY + timedelta(days=6)),
+                    )
+                # leaf carrying an orphan hierarchy_id (the composite FK
+                # is MATCH SIMPLE and skips node_code-NULL rows, so the
+                # CHECK must catch this)
+                with pytest.raises(psycopg.errors.CheckViolation):
+                    conn.execute(
+                        """
+                        INSERT INTO forecasts (
+                            forecast_id, item_id, location_id, hierarchy_id,
+                            scenario_id, horizon_start, horizon_end,
+                            granularity, method
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, 'daily', 'MA')
+                        """,
+                        (uuid4(), item_id, loc_id, h, BASELINE_SCENARIO_ID,
+                         TODAY, TODAY + timedelta(days=6)),
+                    )
+                # aggregate without level
+                with pytest.raises(psycopg.errors.CheckViolation):
+                    conn.execute(
+                        """
+                        INSERT INTO forecasts (
+                            forecast_id, hierarchy_id, node_code, scenario_id,
+                            horizon_start, horizon_end, granularity, method
+                        ) VALUES (%s, %s, 'FAM-A', %s, %s, %s, 'daily', 'MA')
+                        """,
+                        (uuid4(), h, BASELINE_SCENARIO_ID,
+                         TODAY, TODAY + timedelta(days=6)),
+                    )
+                # aggregate without hierarchy_id
+                with pytest.raises(psycopg.errors.CheckViolation):
+                    conn.execute(
+                        """
+                        INSERT INTO forecasts (
+                            forecast_id, node_code, scenario_id,
+                            horizon_start, horizon_end, granularity, method
+                        ) VALUES (%s, 'FAM-A', %s, %s, %s, 'daily', 'MA')
+                        """,
+                        (uuid4(), BASELINE_SCENARIO_ID,
+                         TODAY, TODAY + timedelta(days=6)),
+                    )
+                # neither leaf nor aggregate
+                with pytest.raises(psycopg.errors.CheckViolation):
+                    conn.execute(
+                        """
+                        INSERT INTO forecasts (
+                            forecast_id, scenario_id,
+                            horizon_start, horizon_end, granularity, method
+                        ) VALUES (%s, %s, %s, %s, 'daily', 'MA')
+                        """,
+                        (uuid4(), BASELINE_SCENARIO_ID,
+                         TODAY, TODAY + timedelta(days=6)),
+                    )
+                # aggregate pointing at a node absent from the registry
+                with pytest.raises(psycopg.errors.ForeignKeyViolation):
+                    conn.execute(
+                        """
+                        INSERT INTO forecasts (
+                            forecast_id, hierarchy_id, level, node_code,
+                            scenario_id, horizon_start, horizon_end,
+                            granularity, method
+                        ) VALUES (%s, %s, 'family', 'NO-SUCH-NODE', %s,
+                                  %s, %s, 'daily', 'MA')
+                        """,
+                        (uuid4(), h, BASELINE_SCENARIO_ID,
+                         TODAY, TODAY + timedelta(days=6)),
+                    )
+            finally:
+                _cleanup_hierarchy(conn, h, [item_id], [loc_id])
+
+
+# ---------------------------------------------------------------------------
+# (3) get_historical_demand_by_node — subtree aggregation + business filters
+# ---------------------------------------------------------------------------
+
+
+class TestHistoricalDemandByNode:
+    def test_node_read_equals_sum_of_subtree_leaves(self, migrated_db):
+        """FAM-A subtree = items under PRD-A1 + PRD-A2, across ALL DCs;
+        FAM-B's item and business-filtered rows never leak in."""
+        from ootils_core.pyramide.repository import get_historical_demand_by_node
+
+        h = "ph-h-reader"
+        # d2 at TODAY-3 (not -1/-2): stays strictly past AND outside a
+        # 1-day server window even with a ±1-day client/server date skew.
+        d1, d2 = TODAY - timedelta(days=4), TODAY - timedelta(days=3)
+        with _db_conn(migrated_db) as conn:
+            _seed_hierarchy(conn, h)
+            item_a1 = _create_item(conn, "PH-RD-A1")
+            item_a2 = _create_item(conn, "PH-RD-A2")
+            item_b1 = _create_item(conn, "PH-RD-B1")
+            _attach_item(conn, item_a1, h, "PRD-A1")
+            _attach_item(conn, item_a2, h, "PRD-A2")
+            _attach_item(conn, item_b1, h, "PRD-B1")
+
+            # counted (day d1): a1=10 (DC-1), a2=4 (DC-2 — cross-site sum)
+            _insert_dh(conn, item_a1, "PH-RD-A1", d1, 10, warehouse_id="DC-1")
+            _insert_dh(conn, item_a2, "PH-RD-A2", d1, 4, warehouse_id="DC-2")
+            # counted (day d2): a1=6, NULL warehouse counts at node level
+            _insert_dh(conn, item_a1, "PH-RD-A1", d2, 6, warehouse_id=None)
+            # excluded: other family, warranty, inter-entity, and
+            # non-past rows (TODAY+2/+3: still >= server CURRENT_DATE
+            # even with a ±1-day client/server skew)
+            _insert_dh(conn, item_b1, "PH-RD-B1", d1, 100)
+            _insert_dh(conn, item_a1, "PH-RD-A1", d1, 100, stream="warranty")
+            _insert_dh(conn, item_a1, "PH-RD-A1", d1, 100,
+                       fulfillment="inter_entity")
+            _insert_dh(conn, item_a1, "PH-RD-A1", TODAY + timedelta(days=2), 100)
+            _insert_dh(conn, item_a1, "PH-RD-A1", TODAY + timedelta(days=3), 100)
+            try:
+                fam_a = get_historical_demand_by_node(
+                    conn, hierarchy_id=h, node_code="FAM-A", lookback_days=30
+                )
+                assert fam_a == [Decimal("14"), Decimal("6")]
+
+                # mid-level node: only its own subtree
+                prd_a2 = get_historical_demand_by_node(
+                    conn, hierarchy_id=h, node_code="PRD-A2", lookback_days=30
+                )
+                assert prd_a2 == [Decimal("4")]
+
+                # lookback bound: a 1-day window sees nothing (window =
+                # server yesterday only; d2 is 3 days back, outside even
+                # with a ±1-day client/server date skew)
+                assert get_historical_demand_by_node(
+                    conn, hierarchy_id=h, node_code="FAM-A", lookback_days=1
+                ) == []
+            finally:
+                _cleanup_hierarchy(conn, h, [item_a1, item_a2, item_b1])
+
+    def test_unknown_node_fails_loudly(self, migrated_db):
+        from ootils_core.pyramide.repository import get_historical_demand_by_node
+
+        h = "ph-h-reader-ko"
+        with _db_conn(migrated_db) as conn:
+            _seed_hierarchy(conn, h)
+            try:
+                with pytest.raises(ValueError, match="NO-SUCH-NODE"):
+                    get_historical_demand_by_node(
+                        conn, hierarchy_id=h, node_code="NO-SUCH-NODE",
+                        lookback_days=30,
+                    )
+            finally:
+                _cleanup_hierarchy(conn, h, [])
+
+    def test_leaf_reader_contract_intact(self, migrated_db):
+        """get_historical_demand (leaf pair) still filters per site and
+        keeps its exact series contract after the predicate factoring."""
+        from ootils_core.pyramide.repository import get_historical_demand
+
+        with _db_conn(migrated_db) as conn:
+            item_id = _create_item(conn, "PH-LEAF-ITEM")
+            loc_id = _create_location(conn, "PH-LEAF-LOC")
+            _insert_dh(conn, item_id, "PH-LEAF-ITEM", TODAY - timedelta(days=4),
+                       7, warehouse_id="PH-LEAF-LOC")
+            # other DC and NULL DC leave the per-site series (unchanged
+            # rule); dates kept at TODAY-3/-2, comfortably strict-past
+            _insert_dh(conn, item_id, "PH-LEAF-ITEM", TODAY - timedelta(days=3),
+                       100, warehouse_id="OTHER-DC")
+            _insert_dh(conn, item_id, "PH-LEAF-ITEM", TODAY - timedelta(days=2),
+                       100, warehouse_id=None)
+            try:
+                series = get_historical_demand(
+                    db=conn, item_id=item_id, location_id=loc_id,
+                    lookback_days=30,
+                )
+                assert series == [Decimal("7")]
+            finally:
+                conn.execute(
+                    "DELETE FROM demand_history WHERE item_id = %s", (item_id,)
+                )
+                conn.execute("DELETE FROM items WHERE item_id = %s", (item_id,))
+                conn.execute(
+                    "DELETE FROM locations WHERE location_id = %s", (loc_id,)
+                )
+
+
+# ---------------------------------------------------------------------------
+# (4) Summing blocks from real registry rows
+# ---------------------------------------------------------------------------
+
+
+class TestSummingBlocksFromDb:
+    def test_load_summing_blocks_matches_registry(self, migrated_db):
+        from ootils_core.pyramide.hierarchy import load_summing_blocks
+
+        h = "ph-h-blocks"
+        with _db_conn(migrated_db) as conn:
+            _seed_hierarchy(conn, h, is_default=True)
+            item_a1 = _create_item(conn, "PH-BK-A1")
+            item_a2 = _create_item(conn, "PH-BK-A2")
+            item_b1 = _create_item(conn, "PH-BK-B1")
+            _attach_item(conn, item_a1, h, "PRD-A1")
+            _attach_item(conn, item_a2, h, "PRD-A2")
+            _attach_item(conn, item_b1, h, "PRD-B1")
+            try:
+                blocks = load_summing_blocks(conn, hierarchy_id=h)
+                assert [b.block_code for b in blocks] == ["FAM-A", "FAM-B"]
+
+                block_a = blocks[0]
+                # columns ordered by (leaf_code, item): PRD-A1 < PRD-A2
+                assert block_a.leaves == (str(item_a1), str(item_a2))
+                # FAM-A row sums both columns; y = S.b holds
+                assert block_a.rows[0] == (0, 1)
+                y = block_a.multiply([Decimal("2"), Decimal("3")])
+                assert y[0] == Decimal("5")
+
+                # default-hierarchy resolution path (domain parameter)
+                by_domain = load_summing_blocks(conn, domain="product")
+                assert by_domain == blocks
+            finally:
+                _cleanup_hierarchy(conn, h, [item_a1, item_a2, item_b1])
+
+
+# ---------------------------------------------------------------------------
+# (5) Leaf API endpoints ignore aggregate rows
+# ---------------------------------------------------------------------------
+
+
+class TestLeafEndpointsIgnoreAggregates:
+    def test_list_forecasts_excludes_aggregate_rows(self, migrated_db):
+        h = "ph-h-api"
+        os.environ["DATABASE_URL"] = migrated_db
+        os.environ["OOTILS_API_TOKEN"] = "integration-test-token"
+
+        from fastapi.testclient import TestClient
+        from ootils_core.api.app import create_app
+        from ootils_core.api.dependencies import get_db
+        from ootils_core.db.connection import OotilsDB
+
+        app = create_app()
+
+        def override_db():
+            db = OotilsDB(migrated_db)
+            with db.conn() as c:
+                yield c
+
+        app.dependency_overrides[get_db] = override_db
+        auth = {"Authorization": "Bearer integration-test-token"}
+
+        with _db_conn(migrated_db) as conn:
+            _seed_hierarchy(conn, h)
+            item_id = _create_item(conn, "PH-API-ITEM")
+            loc_id = _create_location(conn, "PH-API-LOC")
+            leaf_fid = _insert_leaf_forecast(conn, item_id, loc_id)
+            agg_fid = _insert_aggregate_forecast(conn, h, "FAM-A", "family")
+        try:
+            with TestClient(app) as client:
+                # list: the aggregate row is filtered out, no 500
+                resp = client.get("/v1/demand/forecast", headers=auth)
+                assert resp.status_code == 200, resp.text
+                ids = {f["forecast_id"] for f in resp.json()["forecasts"]}
+                assert str(leaf_fid) in ids
+                assert str(agg_fid) not in ids
+
+                # get by id: leaf OK, aggregate 404s on the LEAF endpoint
+                assert client.get(
+                    f"/v1/demand/forecast/{leaf_fid}", headers=auth
+                ).status_code == 200
+                assert client.get(
+                    f"/v1/demand/forecast/{agg_fid}", headers=auth
+                ).status_code == 404
+        finally:
+            app.dependency_overrides.clear()
+            with _db_conn(migrated_db) as conn:
+                _cleanup_hierarchy(conn, h, [item_id], [loc_id])

--- a/tests/test_pyramide_hierarchy_summing.py
+++ b/tests/test_pyramide_hierarchy_summing.py
@@ -1,0 +1,270 @@
+"""
+Pure unit tests (no DB) for the sparse summing-matrix builder
+(src/ootils_core/pyramide/hierarchy/summing.py) — Pyramide axis A.
+
+Golden fixture — hierarchy 'h-test', levels = (family, product),
+2 families x 3 items each, drawn out:
+
+    FAM-A (family)                      FAM-B (family)
+    ├── PRD-A1 (product)                ├── PRD-B1 (product)
+    │     ├── item-a1                   │     └── item-b1
+    │     └── item-a2                   └── PRD-B2 (product)
+    └── PRD-A2 (product)                      ├── item-b2
+          └── item-a3                         └── item-b3
+
+Expected S for block FAM-A (columns = [item-a1, item-a2, item-a3],
+ordered by (leaf_code, item); rows = aggregates in (level, code) order,
+then leaf identities), written by hand:
+
+                 a1  a2  a3
+    FAM-A      [  1   1   1 ]     -> row (0, 1, 2)
+    PRD-A1     [  1   1   0 ]     -> row (0, 1)
+    PRD-A2     [  0   0   1 ]     -> row (2,)
+    item-a1    [  1   0   0 ]     -> row (0,)
+    item-a2    [  0   1   0 ]     -> row (1,)
+    item-a3    [  0   0   1 ]     -> row (2,)
+
+Expected S for block FAM-B (columns = [item-b1, item-b2, item-b3]):
+
+                 b1  b2  b3
+    FAM-B      [  1   1   1 ]     -> row (0, 1, 2)
+    PRD-B1     [  1   0   0 ]     -> row (0,)
+    PRD-B2     [  0   1   1 ]     -> row (1, 2)
+    item-b1    [  1   0   0 ]     -> row (0,)
+    item-b2    [  0   1   0 ]     -> row (1,)
+    item-b3    [  0   0   1 ]     -> row (2,)
+"""
+from __future__ import annotations
+
+import random
+from decimal import Decimal
+
+import pytest
+
+from ootils_core.pyramide.hierarchy import (
+    AGGREGATE,
+    LEAF,
+    HierarchyNodeRow,
+    build_summing_blocks,
+)
+
+H = "h-test"
+LEVELS = ("family", "product")
+
+NODES = [
+    HierarchyNodeRow(code="FAM-A", level="family", parent_code=None),
+    HierarchyNodeRow(code="PRD-A1", level="product", parent_code="FAM-A"),
+    HierarchyNodeRow(code="PRD-A2", level="product", parent_code="FAM-A"),
+    HierarchyNodeRow(code="FAM-B", level="family", parent_code=None),
+    HierarchyNodeRow(code="PRD-B1", level="product", parent_code="FAM-B"),
+    HierarchyNodeRow(code="PRD-B2", level="product", parent_code="FAM-B"),
+]
+
+MEMBERSHIPS = [
+    ("item-a1", "PRD-A1"),
+    ("item-a2", "PRD-A1"),
+    ("item-a3", "PRD-A2"),
+    ("item-b1", "PRD-B1"),
+    ("item-b2", "PRD-B2"),
+    ("item-b3", "PRD-B2"),
+]
+
+
+def _blocks(**kwargs):
+    return build_summing_blocks(
+        hierarchy_id=H, levels=LEVELS, nodes=NODES, memberships=MEMBERSHIPS,
+        **kwargs,
+    )
+
+
+class TestGoldenS:
+    def test_two_blocks_sorted_by_code(self):
+        blocks = _blocks()
+        assert [b.block_code for b in blocks] == ["FAM-A", "FAM-B"]
+        assert all(b.hierarchy_id == H for b in blocks)
+        assert all(b.block_level == "family" for b in blocks)
+
+    def test_block_a_matches_hand_written_s(self):
+        block_a = _blocks()[0]
+        assert block_a.leaves == ("item-a1", "item-a2", "item-a3")
+        assert [(s.kind, s.key) for s in block_a.series] == [
+            (AGGREGATE, "FAM-A"),
+            (AGGREGATE, "PRD-A1"),
+            (AGGREGATE, "PRD-A2"),
+            (LEAF, "item-a1"),
+            (LEAF, "item-a2"),
+            (LEAF, "item-a3"),
+        ]
+        assert block_a.rows == (
+            (0, 1, 2),   # FAM-A
+            (0, 1),      # PRD-A1
+            (2,),        # PRD-A2
+            (0,),        # item-a1
+            (1,),        # item-a2
+            (2,),        # item-a3
+        )
+        # aggregate rows carry their level; leaf rows their leaf_code
+        assert block_a.series[0].level == "family"
+        assert block_a.series[1].level == "product"
+        assert block_a.series[3].level is None
+        assert block_a.series[3].leaf_code == "PRD-A1"
+        assert block_a.series[5].leaf_code == "PRD-A2"
+
+    def test_block_b_matches_hand_written_s(self):
+        block_b = _blocks()[1]
+        assert block_b.leaves == ("item-b1", "item-b2", "item-b3")
+        assert block_b.rows == (
+            (0, 1, 2),   # FAM-B
+            (0,),        # PRD-B1
+            (1, 2),      # PRD-B2
+            (0,),        # item-b1
+            (1,),        # item-b2
+            (2,),        # item-b3
+        )
+
+    def test_y_equals_s_times_b(self):
+        """y = S . b, checked against hand-computed values."""
+        block_a = _blocks()[0]
+        b = [Decimal("3"), Decimal("5"), Decimal("7")]
+        y = block_a.multiply(b)
+        assert y == [
+            Decimal("15"),  # FAM-A  = 3 + 5 + 7
+            Decimal("8"),   # PRD-A1 = 3 + 5
+            Decimal("7"),   # PRD-A2 = 7
+            Decimal("3"),   # item-a1
+            Decimal("5"),   # item-a2
+            Decimal("7"),   # item-a3
+        ]
+
+    def test_multiply_rejects_wrong_base_length(self):
+        block_a = _blocks()[0]
+        with pytest.raises(ValueError, match="leaf columns"):
+            block_a.multiply([Decimal("1"), Decimal("2")])
+
+
+class TestDeterminism:
+    def test_input_order_does_not_change_output(self):
+        """Same rows, shuffled — byte-identical blocks (explicit sorts)."""
+        reference = _blocks()
+        rng = random.Random(42)
+        for _ in range(5):
+            nodes = list(NODES)
+            memberships = list(MEMBERSHIPS)
+            rng.shuffle(nodes)
+            rng.shuffle(memberships)
+            shuffled = build_summing_blocks(
+                hierarchy_id=H, levels=LEVELS,
+                nodes=nodes, memberships=memberships,
+            )
+            assert shuffled == reference
+
+
+class TestBlockLevelParameter:
+    def test_blocks_at_product_level(self):
+        """Generic cut level: one block per product node."""
+        blocks = _blocks(block_level="product")
+        assert [b.block_code for b in blocks] == [
+            "PRD-A1", "PRD-A2", "PRD-B1", "PRD-B2",
+        ]
+        prd_a1 = blocks[0]
+        assert prd_a1.block_level == "product"
+        assert prd_a1.leaves == ("item-a1", "item-a2")
+        # aggregate row for the block root, then leaf identities
+        assert prd_a1.rows == ((0, 1), (0,), (1,))
+
+    def test_unknown_block_level_fails_loudly(self):
+        with pytest.raises(ValueError, match="block_level"):
+            _blocks(block_level="galaxy")
+
+
+class TestFailLoudly:
+    def test_unknown_node_level_raises(self):
+        nodes = NODES + [
+            HierarchyNodeRow(code="X-1", level="galaxy", parent_code=None)
+        ]
+        with pytest.raises(ValueError, match="galaxy"):
+            build_summing_blocks(
+                hierarchy_id=H, levels=LEVELS, nodes=nodes,
+                memberships=MEMBERSHIPS,
+            )
+
+    def test_duplicate_node_code_raises(self):
+        nodes = NODES + [
+            HierarchyNodeRow(code="FAM-A", level="family", parent_code=None)
+        ]
+        with pytest.raises(ValueError, match="duplicate"):
+            build_summing_blocks(
+                hierarchy_id=H, levels=LEVELS, nodes=nodes,
+                memberships=MEMBERSHIPS,
+            )
+
+    def test_unknown_parent_code_raises(self):
+        """A node whose parent_code targets a nonexistent code must raise
+        (it would otherwise silently drop out of every block)."""
+        nodes = NODES + [
+            HierarchyNodeRow(code="PRD-X1", level="product",
+                             parent_code="FAM-GHOST")
+        ]
+        with pytest.raises(ValueError, match="PRD-X1.*FAM-GHOST"):
+            build_summing_blocks(
+                hierarchy_id=H, levels=LEVELS, nodes=nodes,
+                memberships=MEMBERSHIPS,
+            )
+
+    def test_membership_on_unknown_node_raises(self):
+        memberships = MEMBERSHIPS + [("item-x", "PRD-Z9")]
+        with pytest.raises(ValueError, match="PRD-Z9"):
+            build_summing_blocks(
+                hierarchy_id=H, levels=LEVELS, nodes=NODES,
+                memberships=memberships,
+            )
+
+    def test_parent_cycle_raises(self):
+        nodes = [
+            HierarchyNodeRow(code="FAM-C", level="family", parent_code=None),
+            HierarchyNodeRow(code="P-1", level="product", parent_code="P-2"),
+            HierarchyNodeRow(code="P-2", level="product", parent_code="P-1"),
+        ]
+        # The cycle is unreachable from FAM-C, so cut blocks at 'product'
+        # to walk into it.
+        with pytest.raises(ValueError, match="cycle"):
+            build_summing_blocks(
+                hierarchy_id=H, levels=LEVELS, nodes=nodes, memberships=[],
+                block_level="product",
+            )
+
+    def test_empty_levels_raises(self):
+        with pytest.raises(ValueError, match="levels"):
+            build_summing_blocks(
+                hierarchy_id=H, levels=[], nodes=NODES, memberships=MEMBERSHIPS,
+            )
+
+
+class TestEdgeShapes:
+    def test_node_without_items_gets_empty_row(self):
+        """An aggregate node with no attached items sums nothing (row = ())
+        and multiply() yields 0 for it — never an error."""
+        nodes = NODES + [
+            HierarchyNodeRow(code="PRD-A3", level="product", parent_code="FAM-A")
+        ]
+        block_a = build_summing_blocks(
+            hierarchy_id=H, levels=LEVELS, nodes=nodes, memberships=MEMBERSHIPS,
+        )[0]
+        idx = [s.key for s in block_a.series].index("PRD-A3")
+        assert block_a.rows[idx] == ()
+        y = block_a.multiply([Decimal("3"), Decimal("5"), Decimal("7")])
+        assert y[idx] == Decimal("0")
+
+    def test_items_on_intermediate_node_are_summed_too(self):
+        """Membership may point at ANY node (generic hierarchies): items
+        attached to an intermediate node count in that node and above."""
+        memberships = MEMBERSHIPS + [("item-a0", "FAM-A")]
+        block_a = build_summing_blocks(
+            hierarchy_id=H, levels=LEVELS, nodes=NODES, memberships=memberships,
+        )[0]
+        # columns ordered by (leaf_code, item): FAM-A < PRD-A1 < PRD-A2
+        assert block_a.leaves == ("item-a0", "item-a1", "item-a2", "item-a3")
+        fam_row = block_a.rows[[s.key for s in block_a.series].index("FAM-A")]
+        assert fam_row == (0, 1, 2, 3)
+        prd_a1_row = block_a.rows[[s.key for s in block_a.series].index("PRD-A1")]
+        assert prd_a1_row == (1, 2)


### PR DESCRIPTION
## Pyramide V1 — axe A, PR2 : forecasts par niveau + matrice S sparse par bloc (spec §3)

Structure porteuse de la réconciliation hiérarchique (la PR3 MinT s'y branche). Arbitrage pilote appliqué : **extension des tables existantes** (source unique), pas de table séparée.

- **Migration 053** : `forecasts`/`pyramide_runs` portent le niveau (`hierarchy_id` TEXT — la PK réelle de la 047, `level`, `node_code`), `item_id`/`location_id` nullable, **CHECK feuille-XOR-agrégat étanche** (resserré post-revue : une feuille ne peut plus porter un `hierarchy_id` orphelin, un agrégat doit avoir un `level`), FK composite vers `hierarchy_node`, index partiels. Idempotente.
- **`pyramide/hierarchy/summing.py`** : matrice **S sparse pure-Python** (scipy absent des deps), **par bloc** = un S par nœud du niveau paramétrable de la hiérarchie `is_default` d'un domaine — 100 % générique, ordres de tri explicites (déterminisme sous shuffle testé sur 5 permutations). **Fail-loudly complet** (niveau inconnu, code dupliqué, cycle, membership orpheline, parent inexistant — resserré post-revue).
- **`get_historical_demand_by_node`** : lecture `demand_history` agrégée au sous-arbre d'un nœud (CTE récursive), **prédicats métier factorisés** avec le lecteur feuille (aucune duplication possible), contrat feuille intact.
- **Gardes anti-double-comptage** : les endpoints feuilles filtrent `item_id IS NOT NULL` (le risque n°1 de ce choix de schéma, pointé au reviewer) ; `PyramideRunSummary`/`PyramideRunOut` en Optional (plus de 500 latent sur les runs d'agrégat).

Différé documenté : API de lecture des forecasts d'agrégat (PR3), garde adjust/delete sur agrégats, `pyramide_snapshots` (commit d'agrégats = chantier réconciliation).

Golden S écrite à la main (2 familles × 3 items, `y = S·b` vérifié coefficient par coefficient par le reviewer) · 1780 unitaires ✅ (+16) · 9 tests d'intégration (CI) · ruff ✅.

Ref #348 (la partie réconciliation MinT arrive en PR3, qui fermera l'issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
