### PR TITLE
feat(pyramide): axe A PR3 — réconciliation middle-out déterministe + MinT optionnel, commit feuilles-seulement

### DIFF
--- a/docs/ADR-022-pyramide-reconciliation.md
+++ b/docs/ADR-022-pyramide-reconciliation.md
@@ -1,0 +1,46 @@
+# ADR-022 — Réconciliation hiérarchique Pyramide : middle-out déterministe au cœur, MinT-shrink au bord
+
+**Statut :** Accepté — Pyramide V1 axe A, PR3 (branche `feat/pyramide-a-reconcile`) ; s'appuie sur PR1 (SEASONAL en courbe) et PR2 (migration 053, blocs S creux).
+**Date :** 2026-07-02
+**Contexte mesuré :** `docs/DESIGN-pyramide-forecasting.md` §3-4 (la loi de l'axe A), `pyramide_runs.recon_method` morte depuis la migration 038, `SummingBlock` par bloc (PR2).
+
+---
+
+## Contexte
+
+Le moteur Pyramide savait prévoir une série à la fois (PR1 : courbes saisonnières) et construire la matrice de sommation S par bloc (PR2), mais rien ne les assemblait : pas de désagrégation, pas de cohérence entre niveaux, `recon_method` stockée mais jamais appliquée. Le design (§3-4) impose deux exigences en tension :
+
+- **Cohérence exacte** entre niveaux (`ŷ = S·b̂`) pour que MRP (agrégat) et DRP (feuille) consomment le même plan ;
+- **Déterminisme du cœur** (ADR-003, North Star) alors que la méthode optimale de la littérature (MinT-shrink) est de l'algèbre flottante numpy/BLAS, non garantie bit-à-bit entre environnements.
+
+## Décision
+
+1. **Le chemin garanti est le middle-out par proportions historiques** (`pyramide/hierarchy/reconcile.py:middle_out`) : pur Python `Decimal`, golden-testé, zéro dépendance. Prévision au niveau de réconciliation (paramétrable, défaut = niveau du bloc), désagrégation vers les feuilles par parts historiques calculées sur la fenêtre de lookback (`demand_history`, prédicats métier partagés), agrégation de tous les niveaux via S.
+2. **La cohérence `ŷ = S·b̂` est exacte PAR CONSTRUCTION, pas par vérification** : les courbes feuilles sont calculées d'abord, et *toute* valeur de série (y compris le niveau de réconciliation lui-même) est la somme creuse de ses feuilles. La courbe persistée au niveau de réconciliation est donc re-dérivée des feuilles — elle peut différer de la prévision de base brute par la poussière de division `Decimal` (< 1e-25 relatif), jamais l'inverse.
+3. **Proportions V1 (réponse à la question §4 du design)** : parts = totaux réservés (booking) par feuille sur fenêtre glissante, normalisés par nœud de réconciliation (somme = 1 par construction). **Cold-start = règle du JUMEAU** : une feuille sans historique hérite de la moyenne des poids positifs de ses sœurs (même parent direct) ; sans sœur positive, **zéro naturel** documenté par warning (une feuille structurellement non servie ne doit pas recevoir de demande). Le forecast direct de la feuille par FM puis réconciliation (design §4(c)) est le point d'extension documenté qui remplacera le jumeau. **Non-objectif assumé de cette PR** : les profils de proportions par phase de saison (§4) — les parts V1 sont un scalaire par feuille.
+4. **MinT-shrink est une amélioration OPTIONNELLE au bord stochastique** (`mint_shrink`) : via `hierarchicalforecast` (Nixtla), ajouté à l'extra `[forecast]`, import paresseux + fallback middle-out (pattern `_statsforecast` existant). **La reproductibilité bit-à-bit de MinT n'est PAS garantissable** (algèbre flottante numpy/BLAS) : le résultat est daté, seedé, versionné (`code_version`, `random_seed` de `pyramide_runs`) et re-basé sur les feuilles réconciliées (bornées à 0) puis re-dérivé via S — la cohérence reste exacte quel que soit le backend. Approximations V1 documentées dans le code : alignement positionnel des historiques creux sans dates, fitted in-sample = proxy naïf lag-1 ; en dessous de 8 points alignés, MinT est refusé et le middle-out prend le relais.
+5. **`pyramide_runs.recon_method` devient réelle (migration 054)** : elle porte la méthode **effectivement appliquée** (`middleout`, `mintrace_wls_shrink`), jamais la requête rejetée — un fallback MinT→middle-out persiste `middleout` + warning. Les runs feuilles mono-série portent désormais `none` (défaut honnête). La 054 répare aussi un trou latent de la 038 : `SEASONAL` manquait aux CHECK `pyramide_runs.method` / `pyramide_snapshots.method`.
+6. **Frontière graphe : feuilles seulement.** Les agrégats sont persistés et requêtables dans `forecasts`/`forecast_values` (schéma 053) mais ne sont **jamais** matérialisés en `ForecastDemand` : `commit_run` lève `PyramideAggregateCommitError` (409 côté API). Une demande de nœud agrégat dans le graphe double-compterait ses feuilles en propagation. `pyramide_snapshots` garde son contrat feuille NOT NULL — un snapshot n'existe que pour nourrir le commit graphe.
+7. **Orchestration par bloc** (`pyramide/hierarchy/runner.py:HierarchicalRunner`) : un run = un bloc (nœud racine du `block_level`), scenario-aware (`scenario_id` estampille chaque ligne ; les lectures d'historique restent invariantes par scénario — les actuals ne forkent pas). Les feuilles de S étant des items (demande tous sites, lecteurs PR2), les forecasts feuilles sont adressés à une `leaf_location_id` paramétrable (le site réseau/central dont le graphe consomme le plan ; la ventilation par site est le rôle de la couche DRP, ADR-020). Générique — aucune constante métier.
+
+## Alternatives rejetées
+
+- **MinT comme chemin par défaut.** Rejeté : non reproductible bit-à-bit, opaque pour la gouvernance (pas de parts explicites lisibles par un humain/agent — design §4), et dépendance optionnelle. Le différenciateur d'Ootils est l'explicabilité + la confiance, pas 2 % d'accuracy (design §2).
+- **Vérifier la cohérence a posteriori (tolérance) au lieu de la construire.** Rejeté : une tolérance est un mensonge qui grandit ; la dérivation par S rend l'incohérence impossible plutôt que détectée.
+- **Matérialiser les agrégats dans le graphe.** Rejeté : double comptage en propagation, et le contrat de demande du graphe est (item, location) — même refus argumenté que les watchers écrivains dans `shortages` (ADR-021).
+- **Parts prévues (mix-aware) plutôt qu'historiques.** Différé, pas rejeté : les parts historiques sont stables et lisibles ; le mix-aware est précisément ce que MinT apporte quand on l'active (design §4 « la vraie réponse moderne »).
+
+## Conséquences
+
+- **Positif :** un plan cohérent multi-niveaux requêtable par niveau, avec provenance complète (méthode de base + modèle sélectionné — qui embarque `season_length` quand un modèle saisonnier gagne — + `recon_method` effective + niveau de prévision) ; golden tests verrouillent l'arithmétique du middle-out.
+- **Contrainte assumée :** `leaf_location_id` unique par run — la ventilation multi-sites des feuilles attend la couche DRP ; les profils de proportions par phase de saison restent hors périmètre V1.
+- **À surveiller :** la dérive d'API de `hierarchicalforecast` est absorbée par le fallback (jamais par un crash), mais un environnement `[forecast]` cassé dégraderait silencieusement en middle-out — le warning persiste dans le résultat du run, et `recon_method` dit toujours la vérité.
+
+## Références
+
+- `docs/DESIGN-pyramide-forecasting.md` §3-4 — la spécification de l'axe A.
+- `src/ootils_core/pyramide/hierarchy/reconcile.py` — middle-out + MinT-shrink.
+- `src/ootils_core/pyramide/hierarchy/runner.py` — orchestration par bloc.
+- `src/ootils_core/db/migrations/054_pyramide_recon_method.sql` — recon_method réelle.
+- `docs/ADR-020-mrp-consolidation.md` — la couche DRP qui consommera les feuilles.
+- `docs/ADR-021-shortage-truth.md` — le refus jumeau « un seul écrivain dans le graphe ».

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,10 @@ forecast = [
     "mlforecast ~= 1.0",
     "lightgbm ~= 4.0",
     "pandas ~= 2.3",
+    # Optional MinT-shrink reconciliation backend (Pyramide axis A, PR3).
+    # Lazy-imported by pyramide/hierarchy/reconcile.py with a fallback to
+    # the deterministic middle-out path when absent (ADR-022).
+    "hierarchicalforecast ~= 1.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/src/ootils_core/api/routers/pyramide.py
+++ b/src/ootils_core/api/routers/pyramide.py
@@ -14,6 +14,7 @@ from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db
 from ootils_core.pyramide import PyramideError, PyramideRunConfig, PyramideRunner, SUPPORTED_METHODS
 from ootils_core.pyramide.repository import (
+    PyramideAggregateCommitError,
     commit_run,
     fetch_run_summary,
     fetch_run_values,
@@ -40,7 +41,13 @@ class PyramideRunRequest(BaseModel):
     method_params: dict[str, Any] = Field(default_factory=dict)
     scenario_id: str | None = None
     model_strategy: str = Field(default="stat", pattern="^(auto|stat|ml|fm|hybrid)$")
-    recon_method: str = Field(default="bottomup", pattern="^(mintrace_wls|bottomup|topdown|middleout|none)$")
+    # Single-series leaf endpoint: nothing is reconciled here, so the
+    # ONLY honest value is 'none' (recon_method = method EFFECTIVELY
+    # applied, migration 054 — provenance never lies). Hierarchical block
+    # runs go through HierarchicalRunner, not this endpoint; a client
+    # requesting a reconciliation method here gets a clear 422 instead of
+    # a silently-false provenance row (review PR3).
+    recon_method: str = Field(default="none", pattern="^none$")
     random_seed: int = Field(default=0, ge=0)
     code_version: str = Field(default="local", min_length=1, max_length=64)
 
@@ -53,9 +60,10 @@ class PyramideRunOut(BaseModel):
     # Leaf runs carry (item_id, location_id); aggregate runs (migration
     # 053) carry (hierarchy_id, level, node_code) — the unused side is
     # None. Optional on both sides so an aggregate run never 500s on
-    # response validation.
+    # response validation. snapshot_id is None for aggregate runs
+    # (snapshots are leaf-only — they exist to feed the graph commit).
     run_id: UUID
-    snapshot_id: UUID
+    snapshot_id: UUID | None = None
     forecast_id: UUID
     status: str
     item_id: UUID | None = None
@@ -260,7 +268,13 @@ def commit_pyramide_run(
     db: psycopg.Connection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> PyramideCommitOut:
-    summary = commit_run(db, run_id)
+    try:
+        summary = commit_run(db, run_id)
+    except PyramideAggregateCommitError as exc:
+        # Typed domain-exception carve-out (cf. CLAUDE.md): hand-authored
+        # message containing only UUIDs / hierarchy codes — the client
+        # needs it to understand why an aggregate run is not committable.
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
     if summary is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Pyramide run '{run_id}' not found")
     return PyramideCommitOut(

--- a/src/ootils_core/db/migrations/054_pyramide_recon_method.sql
+++ b/src/ootils_core/db/migrations/054_pyramide_recon_method.sql
@@ -1,0 +1,65 @@
+-- ============================================================
+-- Migration 054 — Pyramide reconciliation provenance (axis A, PR3)
+-- ============================================================
+-- pyramide_runs.recon_method was dead since migration 038 (stored but
+-- never consumed). PR3 makes it REAL: it now carries the reconciliation
+-- method EFFECTIVELY applied by the hierarchy layer
+-- (src/ootils_core/pyramide/hierarchy/reconcile.py):
+--   * 'middleout'            — deterministic middle-out by historical
+--                              proportions (the guaranteed core path);
+--   * 'mintrace_wls_shrink'  — optional MinT with shrinkage covariance
+--                              via hierarchicalforecast (new value);
+--   * 'none'                 — single-series leaf runs (no
+--                              reconciliation applied — the honest
+--                              value for the standalone runner);
+--   * 'mintrace_wls', 'bottomup', 'topdown' stay accepted for
+--     compatibility with rows written since 038.
+--
+-- Also repairs a latent 038 gap: SUPPORTED_METHODS gained 'SEASONAL'
+-- (PR1) and forecasts / forecast_values CHECKs were extended then, but
+-- pyramide_runs.method / pyramide_snapshots.method were not — a leaf
+-- run with method='SEASONAL' would fail its INSERT. The hierarchical
+-- runner persists method into both tables, so the gap is closed here.
+--
+-- Idempotence: DROP CONSTRAINT IF EXISTS + ADD (deterministic
+-- re-create) — a re-run must not fail (repo migration policy).
+-- No JSONB. Typed columns only.
+-- ============================================================
+
+BEGIN;
+
+ALTER TABLE pyramide_runs DROP CONSTRAINT IF EXISTS pyramide_runs_recon_method_check;
+ALTER TABLE pyramide_runs ADD CONSTRAINT pyramide_runs_recon_method_check CHECK (
+    recon_method IN (
+        'mintrace_wls', 'mintrace_wls_shrink',
+        'bottomup', 'topdown', 'middleout', 'none'
+    )
+);
+
+ALTER TABLE pyramide_runs DROP CONSTRAINT IF EXISTS pyramide_runs_method_check;
+ALTER TABLE pyramide_runs ADD CONSTRAINT pyramide_runs_method_check CHECK (
+    method IN (
+        'MA', 'EXP_SMOOTHING', 'CROSTON', 'SEASONAL',
+        'AUTO_SELECT', 'ENSEMBLE_STAT',
+        'STAT_AUTOETS', 'STAT_AUTOARIMA',
+        'ML_LGBM', 'FM_CHRONOS', 'FM_MOIRAI'
+    )
+);
+
+ALTER TABLE pyramide_snapshots DROP CONSTRAINT IF EXISTS pyramide_snapshots_method_check;
+ALTER TABLE pyramide_snapshots ADD CONSTRAINT pyramide_snapshots_method_check CHECK (
+    method IN (
+        'MA', 'EXP_SMOOTHING', 'CROSTON', 'SEASONAL',
+        'AUTO_SELECT', 'ENSEMBLE_STAT',
+        'STAT_AUTOETS', 'STAT_AUTOARIMA',
+        'ML_LGBM', 'FM_CHRONOS', 'FM_MOIRAI'
+    )
+);
+
+COMMENT ON COLUMN pyramide_runs.recon_method IS
+    'Reconciliation method EFFECTIVELY applied to the run (never the '
+    'rejected request): middleout = deterministic core, '
+    'mintrace_wls_shrink = optional MinT edge, none = single-series leaf '
+    'run. Made real by migration 054 (PR3).';
+
+COMMIT;

--- a/src/ootils_core/pyramide/hierarchy/__init__.py
+++ b/src/ootils_core/pyramide/hierarchy/__init__.py
@@ -1,7 +1,9 @@
 """
 Hierarchy layer of Pyramide (axis A) — sparse summing-matrix (S)
 construction over the generic hierarchy registry (migration 047:
-hierarchy / hierarchy_node / item_hierarchy).
+hierarchy / hierarchy_node / item_hierarchy), reconciliation
+(middle-out deterministic core, MinT-shrink optional edge) and the
+block-level orchestration runner.
 
 Blocks are cut at a configurable level of a configurable domain's
 hierarchy (default: one block per root node of the domain's default
@@ -9,6 +11,26 @@ hierarchy), so reconciliation always works on small independent
 matrices instead of one full-hierarchy S.
 """
 
+from .reconcile import (
+    MINT_MIN_INSAMPLE,
+    RECON_MIDDLEOUT,
+    RECON_MINT_SHRINK,
+    SUPPORTED_RECON_METHODS,
+    LeafShare,
+    MintInputs,
+    ReconciledBlock,
+    ReconciliationError,
+    ReconciliationUnavailable,
+    middle_out,
+    mint_shrink,
+    reconcile,
+)
+from .runner import (
+    HierarchicalPersistedSeries,
+    HierarchicalRunConfig,
+    HierarchicalRunner,
+    HierarchicalRunResult,
+)
 from .summing import (
     AGGREGATE,
     LEAF,
@@ -23,10 +45,26 @@ from .summing import (
 __all__ = [
     "AGGREGATE",
     "LEAF",
+    "MINT_MIN_INSAMPLE",
+    "RECON_MIDDLEOUT",
+    "RECON_MINT_SHRINK",
+    "SUPPORTED_RECON_METHODS",
+    "HierarchicalPersistedSeries",
+    "HierarchicalRunConfig",
+    "HierarchicalRunner",
+    "HierarchicalRunResult",
     "HierarchyNodeRow",
+    "LeafShare",
+    "MintInputs",
+    "ReconciledBlock",
+    "ReconciliationError",
+    "ReconciliationUnavailable",
     "SeriesRef",
     "SummingBlock",
     "build_summing_blocks",
     "load_summing_blocks",
+    "middle_out",
+    "mint_shrink",
+    "reconcile",
     "resolve_default_hierarchy_id",
 ]

--- a/src/ootils_core/pyramide/hierarchy/reconcile.py
+++ b/src/ootils_core/pyramide/hierarchy/reconcile.py
@@ -1,0 +1,619 @@
+"""
+Hierarchical forecast reconciliation (Pyramide axis A — PR3).
+
+Two paths, one coherence contract (docs/DESIGN-pyramide-forecasting.md
+§3-4, docs/ADR-022-pyramide-reconciliation.md):
+
+* ``middle_out()`` — **THE guaranteed deterministic path** (pure Python,
+  Decimal arithmetic, golden-testable). Forecast at a configurable
+  reconciliation level, disaggregate to the leaves by historical shares,
+  aggregate every other level through the sparse summing matrix S.
+* ``mint_shrink()`` — **optional improvement** via *hierarchicalforecast*
+  (Nixtla, ``ootils-core[forecast]`` extra). Lazy import + fallback to
+  middle-out (same pattern as ``engines.PyramideForecastEngine`` with
+  statsforecast). MinT is float/numpy linear algebra: deterministic for a
+  fixed environment but NOT bit-for-bit guaranteed across BLAS/numpy
+  builds — it lives on the stochastic edge (seeded, versioned, logged),
+  never in the deterministic core.
+
+Coherence contract
+------------------
+Every result satisfies ``y_hat = S @ b_hat`` EXACTLY by construction:
+leaf curves are computed first and every series value (all levels,
+including the reconciliation level itself) is the sparse-row sum of the
+leaf curves (``SummingBlock.rows``). The persisted reconciliation-level
+curve is therefore re-derived from its leaves; it can differ from the
+raw base forecast by Decimal-division dust (< 1e-25 relative) when the
+shares are not exact decimals — never the other way around.
+
+Proportions (design §4 — V1 answer)
+-----------------------------------
+* Shares = historical booked totals per leaf over a sliding lookback
+  window, normalized within each reconciliation node. The sum of shares
+  per node is 1 up to Decimal quantization: non-terminating divisions
+  (e.g. thirds) leave dust in the last of the 28 significant digits —
+  ~9 orders of magnitude below any business quantity. Coherence of the
+  OUTPUT does not depend on it: every series, including the
+  reconciliation level itself, is re-derived as the sparse sum of the
+  disaggregated leaves (ŷ = S·b̂ exact by construction).
+* Cold start (leaf with zero history): TWIN rule — the leaf inherits the
+  arithmetic mean of the positive weights of its siblings (leaves
+  attached to the SAME direct parent node), then shares are recomputed
+  over the imputed weights. Documented extension point: forecasting the
+  cold leaf directly with a foundation model then reconciling (design
+  §4(c), implementation step 3 of §7) replaces this rule later.
+* Natural zero: a leaf with zero history AND no positive-history twin
+  keeps weight 0 (a structurally-unserved leaf must not receive demand);
+  a warning documents each one.
+* NON-GOAL of this PR (documented): season-phase proportion profiles
+  (shares varying along the season per design §4) — V1 shares are a
+  scalar per leaf over the lookback window.
+
+Genericity: nothing here is domain-specific — blocks come from the
+migration-047 registry via ``summing.py``; no business constant.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Mapping, Sequence
+
+from .summing import AGGREGATE, LEAF, SeriesRef, SummingBlock
+
+logger = logging.getLogger(__name__)
+
+RECON_MIDDLEOUT = "middleout"
+RECON_MINT_SHRINK = "mintrace_wls_shrink"
+SUPPORTED_RECON_METHODS = frozenset({RECON_MIDDLEOUT, RECON_MINT_SHRINK})
+
+# MinT-shrink estimates a residual covariance: below this many aligned
+# in-sample points the shrinkage target dominates and the result is
+# noise — refuse and fall back (documented, deterministic rule).
+MINT_MIN_INSAMPLE = 8
+
+_ZERO = Decimal("0")
+
+
+class ReconciliationError(ValueError):
+    """The inputs cannot produce coherent reconciled curves."""
+
+
+class ReconciliationUnavailable(RuntimeError):
+    """The optional MinT backend (or its aligned inputs) is unavailable.
+
+    Not a data error: the caller is expected to fall back to middle-out
+    (the deterministic path) unless strict mode was requested.
+    """
+
+
+@dataclass(frozen=True)
+class LeafShare:
+    """Explainability record of one leaf's disaggregation share.
+
+    ``weight`` is the historical total actually used (after twin
+    imputation when ``cold_start`` is True); ``share`` = weight / sum of
+    the weights of the same reconciliation node.
+    """
+    leaf: str
+    recon_node: str
+    weight: Decimal
+    share: Decimal
+    cold_start: bool
+
+
+@dataclass(frozen=True)
+class ReconciledBlock:
+    """Coherent forecast curves for every series of one summing block.
+
+    ``series`` mirrors ``SummingBlock.series`` (same order);
+    ``values[i]`` is the horizon curve of ``series[i]``.
+    ``recon_method`` is the method EFFECTIVELY applied ('middleout' or
+    'mintrace_wls_shrink') — a MinT request that fell back reports
+    'middleout' plus a warning, so provenance never lies.
+    ``shares`` is empty on the MinT path (MinT derives its weights from
+    the error covariance, not from explicit proportions — the
+    explainability trade-off documented in design §4).
+    """
+    block_code: str
+    recon_level: str
+    recon_method: str
+    series: tuple[SeriesRef, ...]
+    values: tuple[tuple[Decimal, ...], ...]
+    shares: tuple[LeafShare, ...]
+    warnings: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MintInputs:
+    """Aligned inputs for the optional MinT-shrink path.
+
+    Curves: one base-forecast curve per series (aggregates keyed by
+    node code, leaves by leaf column key), all of the same horizon
+    length. Insample/fitted: aligned tails of the same length k
+    (>= MINT_MIN_INSAMPLE) for EVERY series — MinT estimates a residual
+    covariance, which requires a common observation grid.
+    """
+    aggregate_curves: Mapping[str, Sequence[Decimal]]
+    leaf_curves: Mapping[str, Sequence[Decimal]]
+    aggregate_insample: Mapping[str, Sequence[Decimal]]
+    leaf_insample: Mapping[str, Sequence[Decimal]]
+    aggregate_fitted: Mapping[str, Sequence[Decimal]]
+    leaf_fitted: Mapping[str, Sequence[Decimal]]
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+def reconcile(
+    block: SummingBlock,
+    recon_level: str,
+    base_curves: Mapping[str, Sequence[Decimal]],
+    leaf_history_totals: Mapping[str, Decimal],
+    *,
+    method: str = RECON_MIDDLEOUT,
+    mint_inputs: MintInputs | None = None,
+    strict: bool = False,
+) -> ReconciledBlock:
+    """
+    Reconcile one block with the requested method.
+
+    'middleout' runs the deterministic path directly. 'mintrace_wls_shrink'
+    attempts the optional backend and FALLS BACK to middle-out on any
+    failure (missing dependency, missing aligned inputs, backend error),
+    reporting the effectively-applied method plus a warning — unless
+    ``strict`` is True, in which case the failure is re-raised as a
+    ReconciliationError (mirrors the engine's ``strict_backend``).
+    """
+    if method not in SUPPORTED_RECON_METHODS:
+        raise ReconciliationError(
+            f"unsupported reconciliation method '{method}' "
+            f"(supported: {sorted(SUPPORTED_RECON_METHODS)})"
+        )
+    if method == RECON_MIDDLEOUT:
+        return middle_out(block, recon_level, base_curves, leaf_history_totals)
+
+    try:
+        if mint_inputs is None:
+            raise ReconciliationUnavailable(
+                "MinT inputs not provided (base forecasts + aligned "
+                "insample series for every series of the block)"
+            )
+        return mint_shrink(block, recon_level, mint_inputs)
+    except ReconciliationError:
+        raise  # data errors are never absorbed by the fallback
+    except Exception as exc:
+        if strict:
+            raise ReconciliationError(
+                f"{RECON_MINT_SHRINK} failed in strict mode: {exc}"
+            ) from exc
+        logger.warning(
+            "reconcile: %s unavailable for block '%s'; falling back to "
+            "middle-out: %s",
+            RECON_MINT_SHRINK, block.block_code, exc,
+        )
+        fallback = middle_out(block, recon_level, base_curves, leaf_history_totals)
+        return ReconciledBlock(
+            block_code=fallback.block_code,
+            recon_level=fallback.recon_level,
+            recon_method=fallback.recon_method,  # 'middleout' — effective truth
+            series=fallback.series,
+            values=fallback.values,
+            shares=fallback.shares,
+            warnings=(
+                f"{RECON_MINT_SHRINK} unavailable; fell back to "
+                f"{RECON_MIDDLEOUT}: {exc}",
+                *fallback.warnings,
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Middle-out (deterministic core)
+# ---------------------------------------------------------------------------
+
+
+def middle_out(
+    block: SummingBlock,
+    recon_level: str,
+    base_curves: Mapping[str, Sequence[Decimal]],
+    leaf_history_totals: Mapping[str, Decimal],
+) -> ReconciledBlock:
+    """
+    Deterministic middle-out reconciliation by historical proportions.
+
+    Args:
+        block: sparse summing matrix of the block.
+        recon_level: hierarchy level the base forecasts were made at.
+            Every leaf column must be covered by exactly one node of
+            that level (fails loudly otherwise — pick a higher level).
+        base_curves: node_code -> base forecast curve, one per
+            reconciliation-level node that has leaves; all the same
+            horizon length, values >= 0.
+        leaf_history_totals: leaf column key -> historical booked total
+            over the lookback window (the share numerators). Missing
+            keys count as 0 (a leaf without history — twin rule / natural
+            zero apply, see module docstring).
+    """
+    if not block.leaves:
+        raise ReconciliationError(
+            f"block '{block.block_code}' has no leaf columns — nothing to reconcile"
+        )
+    recon_nodes = _recon_nodes(block, recon_level)
+    node_codes = {ref.key for _, ref in recon_nodes}
+    unknown = set(base_curves) - node_codes
+    if unknown:
+        raise ReconciliationError(
+            f"base curves provided for series {sorted(unknown)} which are "
+            f"not '{recon_level}' nodes of block '{block.block_code}'"
+        )
+
+    horizon = _validated_horizon(base_curves)
+    leaf_code_of = {
+        ref.key: ref.leaf_code for ref in block.series if ref.kind == LEAF
+    }
+
+    leaf_curves: list[tuple[Decimal, ...] | None] = [None] * len(block.leaves)
+    shares: list[LeafShare] = []
+    warnings: list[str] = []
+
+    for i, ref in recon_nodes:
+        cols = block.rows[i]
+        raw_curve = base_curves.get(ref.key)
+        if not cols:
+            if raw_curve is not None and any(_as_decimal(v) != 0 for v in raw_curve):
+                raise ReconciliationError(
+                    f"reconciliation node '{ref.key}' has a non-zero base "
+                    f"forecast but no leaf column to disaggregate to"
+                )
+            continue
+        if raw_curve is None:
+            raise ReconciliationError(
+                f"missing base curve for reconciliation node '{ref.key}' "
+                f"of block '{block.block_code}'"
+            )
+        curve = tuple(_as_decimal(v) for v in raw_curve)
+        if any(v < 0 for v in curve):
+            raise ReconciliationError(
+                f"base curve of node '{ref.key}' contains negative values "
+                "(the engine clamps at 0 — negative input is a caller bug)"
+            )
+
+        weights, cold_cols, node_warnings = _node_weights(
+            ref.key, cols, block, leaf_history_totals, leaf_code_of
+        )
+        total = sum(weights.values(), _ZERO)
+        if total == 0:
+            if any(v != 0 for v in curve):
+                warnings.extend(node_warnings)
+                raise ReconciliationError(
+                    f"node '{ref.key}' has a non-zero base forecast but zero "
+                    "historical weight on every leaf — cannot disaggregate. "
+                    "Cold-start block: forecast the leaves directly (FM "
+                    "extension point, design §4) or extend the lookback."
+                )
+            # All-zero node with an all-zero curve: legitimate quiet branch —
+            # do NOT surface the per-leaf 'natural zero' warnings here (review
+            # PR3): there is nothing to disaggregate, silence is honest.
+            for j in cols:
+                leaf_curves[j] = tuple(_ZERO for _ in range(horizon))
+                shares.append(LeafShare(
+                    leaf=block.leaves[j], recon_node=ref.key,
+                    weight=_ZERO, share=_ZERO, cold_start=False,
+                ))
+            continue
+        warnings.extend(node_warnings)
+
+        for j in cols:
+            share = weights[j] / total
+            leaf_curves[j] = tuple(value * share for value in curve)
+            shares.append(LeafShare(
+                leaf=block.leaves[j], recon_node=ref.key,
+                weight=weights[j], share=share, cold_start=j in cold_cols,
+            ))
+
+    completed = [
+        curve if curve is not None else tuple(_ZERO for _ in range(horizon))
+        for curve in leaf_curves
+    ]
+    values = _series_values_from_leaves(block, completed, horizon)
+    return ReconciledBlock(
+        block_code=block.block_code,
+        recon_level=recon_level,
+        recon_method=RECON_MIDDLEOUT,
+        series=block.series,
+        values=values,
+        shares=tuple(shares),
+        warnings=tuple(warnings),
+    )
+
+
+def _recon_nodes(
+    block: SummingBlock, recon_level: str
+) -> list[tuple[int, SeriesRef]]:
+    """Reconciliation-level nodes + coverage check (fail loudly)."""
+    nodes = [
+        (i, ref)
+        for i, ref in enumerate(block.series)
+        if ref.kind == AGGREGATE and ref.level == recon_level
+    ]
+    if not nodes:
+        raise ReconciliationError(
+            f"block '{block.block_code}' has no aggregate node at level "
+            f"'{recon_level}'"
+        )
+    covered: list[int] = []
+    for i, _ in nodes:
+        covered.extend(block.rows[i])
+    if len(covered) != len(set(covered)):
+        # Impossible in a tree; defensive against a corrupted block.
+        raise ReconciliationError(
+            f"level '{recon_level}' nodes of block '{block.block_code}' "
+            "overlap on leaf columns — corrupted summing block"
+        )
+    missing = set(range(len(block.leaves))) - set(covered)
+    if missing:
+        names = sorted(block.leaves[j] for j in missing)
+        raise ReconciliationError(
+            f"leaves {names} of block '{block.block_code}' are not covered "
+            f"by any '{recon_level}' node (attached above the "
+            "reconciliation level) — pick a higher reconciliation level"
+        )
+    return nodes
+
+
+def _node_weights(
+    node_code: str,
+    cols: Sequence[int],
+    block: SummingBlock,
+    leaf_history_totals: Mapping[str, Decimal],
+    leaf_code_of: Mapping[str, str | None],
+) -> tuple[dict[int, Decimal], set[int], list[str]]:
+    """Historical weights of one node's leaves, with twin imputation."""
+    raw: dict[int, Decimal] = {}
+    for j in cols:
+        weight = _as_decimal(leaf_history_totals.get(block.leaves[j], _ZERO))
+        if weight < 0:
+            raise ReconciliationError(
+                f"leaf '{block.leaves[j]}' has a negative history total "
+                f"({weight}) — shares are only defined on non-negative demand"
+            )
+        raw[j] = weight
+
+    by_parent: dict[str, list[int]] = {}
+    for j in cols:
+        parent = leaf_code_of.get(block.leaves[j]) or ""
+        by_parent.setdefault(parent, []).append(j)
+
+    weights = dict(raw)
+    cold: set[int] = set()
+    warnings: list[str] = []
+    for parent in sorted(by_parent):
+        siblings = by_parent[parent]
+        positive = [raw[j] for j in siblings if raw[j] > 0]
+        for j in siblings:
+            if raw[j] > 0:
+                continue
+            if positive:
+                # TWIN rule: mean of the positive weights of the leaves
+                # sharing the same direct parent node.
+                weights[j] = sum(positive, _ZERO) / Decimal(len(positive))
+                cold.add(j)
+            else:
+                warnings.append(
+                    f"leaf '{block.leaves[j]}' under node '{node_code}' has "
+                    f"no history and no positive-history twin (parent "
+                    f"'{parent}') — natural zero share"
+                )
+    return weights, cold, warnings
+
+
+def _series_values_from_leaves(
+    block: SummingBlock,
+    leaf_curves: Sequence[tuple[Decimal, ...]],
+    horizon: int,
+) -> tuple[tuple[Decimal, ...], ...]:
+    """y_hat = S @ b_hat, exactly, for every series of the block."""
+    return tuple(
+        tuple(
+            sum((leaf_curves[j][t] for j in row), _ZERO)
+            for t in range(horizon)
+        )
+        for row in block.rows
+    )
+
+
+def _validated_horizon(base_curves: Mapping[str, Sequence[Decimal]]) -> int:
+    lengths = {code: len(curve) for code, curve in base_curves.items()}
+    if not lengths:
+        raise ReconciliationError("no base curve provided")
+    distinct = set(lengths.values())
+    if len(distinct) > 1:
+        raise ReconciliationError(
+            f"base curves have inconsistent horizon lengths: {lengths}"
+        )
+    horizon = distinct.pop()
+    if horizon < 1:
+        raise ReconciliationError("base curves must have at least one period")
+    return horizon
+
+
+def _as_decimal(value: Any) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+# ---------------------------------------------------------------------------
+# MinT-shrink (optional stochastic-edge improvement)
+# ---------------------------------------------------------------------------
+
+
+def mint_shrink(
+    block: SummingBlock,
+    recon_level: str,
+    inputs: MintInputs,
+) -> ReconciledBlock:
+    """
+    MinT (Minimum Trace) reconciliation with Ledoit-Wolf-style shrinkage,
+    via *hierarchicalforecast* (Nixtla) — lazy import, optional
+    ``[forecast]`` extra.
+
+    Raises ReconciliationUnavailable when the backend is not installed,
+    the inputs are too short/misaligned, or the backend API rejects the
+    call — the dispatcher falls back to middle-out.
+
+    Reproducibility note (ADR-022): the computation is numpy/BLAS float
+    algebra — stable for a fixed environment (and logged with the run's
+    code_version), but NOT bit-for-bit reproducible across BLAS builds.
+    The output is re-based on the reconciled LEAF values (clamped at 0)
+    and every level is re-derived through S, so the coherence contract
+    ``y_hat = S @ b_hat`` holds exactly whatever the backend returns.
+    """
+    try:
+        import numpy as np
+        import pandas as pd
+        from hierarchicalforecast.core import HierarchicalReconciliation
+        from hierarchicalforecast.methods import MinTrace
+    except ImportError as exc:
+        raise ReconciliationUnavailable(
+            "hierarchicalforecast backend not installed "
+            "(pip install 'ootils-core[forecast]')"
+        ) from exc
+
+    # never used as data, only to satisfy the coverage contract early
+    _recon_nodes(block, recon_level)
+
+    series_ids: list[str] = []
+    curves: list[Sequence[Decimal]] = []
+    insample: list[Sequence[Decimal]] = []
+    fitted: list[Sequence[Decimal]] = []
+    for ref in block.series:
+        if ref.kind == AGGREGATE:
+            sid = f"agg::{ref.key}"
+            curve = inputs.aggregate_curves.get(ref.key)
+            hist = inputs.aggregate_insample.get(ref.key)
+            fit = inputs.aggregate_fitted.get(ref.key)
+        else:
+            sid = f"leaf::{ref.key}"
+            curve = inputs.leaf_curves.get(ref.key)
+            hist = inputs.leaf_insample.get(ref.key)
+            fit = inputs.leaf_fitted.get(ref.key)
+        if curve is None or hist is None or fit is None:
+            raise ReconciliationUnavailable(
+                f"MinT inputs incomplete for series '{ref.key}' "
+                "(base curve + insample + fitted are all required)"
+            )
+        series_ids.append(sid)
+        curves.append(curve)
+        insample.append(hist)
+        fitted.append(fit)
+
+    horizons = {len(c) for c in curves}
+    if len(horizons) != 1:
+        raise ReconciliationUnavailable(
+            f"MinT base curves have inconsistent horizons: {sorted(horizons)}"
+        )
+    horizon = horizons.pop()
+    ks = {len(h) for h in insample} | {len(f) for f in fitted}
+    if len(ks) != 1:
+        raise ReconciliationUnavailable(
+            "MinT insample/fitted series are not aligned to a single length"
+        )
+    k = ks.pop()
+    if k < MINT_MIN_INSAMPLE:
+        raise ReconciliationUnavailable(
+            f"MinT needs >= {MINT_MIN_INSAMPLE} aligned insample points, got {k}"
+        )
+
+    n_series, n_leaves = len(block.series), len(block.leaves)
+    s_matrix = np.zeros((n_series, n_leaves))
+    for i, row in enumerate(block.rows):
+        for j in row:
+            s_matrix[i, j] = 1.0
+    leaf_ids = [f"leaf::{key}" for key in block.leaves]
+    s_df = pd.DataFrame(s_matrix, index=series_ids, columns=leaf_ids)
+
+    # integer ds grid: 1..k insample, k+1..k+horizon forecast
+    y_df = pd.DataFrame({
+        "unique_id": np.repeat(series_ids, k),
+        "ds": np.tile(np.arange(1, k + 1), n_series),
+        "y": [float(v) for hist in insample for v in hist],
+        "base": [float(v) for fit in fitted for v in fit],
+    })
+    y_hat_df = pd.DataFrame({
+        "unique_id": np.repeat(series_ids, horizon),
+        "ds": np.tile(np.arange(k + 1, k + 1 + horizon), n_series),
+        "base": [float(v) for curve in curves for v in curve],
+    })
+
+    hrec = HierarchicalReconciliation(
+        reconcilers=[MinTrace(method="mint_shrink")]
+    )
+    try:
+        try:
+            rec = hrec.reconcile(
+                Y_hat_df=y_hat_df, Y_df=y_df, S=s_df, tags=_tags(block, np)
+            )
+        except TypeError:
+            # older/newer keyword spelling of the S matrix argument
+            rec = hrec.reconcile(
+                Y_hat_df=y_hat_df, Y_df=y_df, S_df=s_df, tags=_tags(block, np)
+            )
+    except Exception as exc:
+        raise ReconciliationUnavailable(
+            f"hierarchicalforecast MinTrace(mint_shrink) failed: {exc}"
+        ) from exc
+
+    rec_columns = [c for c in rec.columns if "MinTrace" in str(c)]
+    if not rec_columns:
+        raise ReconciliationUnavailable(
+            f"no MinTrace column in the reconciled frame (columns: "
+            f"{list(rec.columns)})"
+        )
+    rec_column = rec_columns[0]
+    if "unique_id" not in rec.columns:
+        rec = rec.reset_index()
+
+    # Re-base on the reconciled LEAF values (clamped at 0) and re-derive
+    # every level through S — coherence exact by construction.
+    leaf_curves: list[tuple[Decimal, ...]] = []
+    for leaf_id in leaf_ids:
+        chunk = rec[rec["unique_id"] == leaf_id].sort_values("ds")
+        if len(chunk) != horizon:
+            raise ReconciliationUnavailable(
+                f"reconciled frame misses periods for '{leaf_id}' "
+                f"({len(chunk)} != {horizon})"
+            )
+        leaf_curves.append(tuple(
+            max(Decimal(str(v)), _ZERO) for v in chunk[rec_column].tolist()
+        ))
+
+    values = _series_values_from_leaves(block, leaf_curves, horizon)
+    return ReconciledBlock(
+        block_code=block.block_code,
+        recon_level=recon_level,
+        recon_method=RECON_MINT_SHRINK,
+        series=block.series,
+        values=values,
+        shares=(),  # MinT has no explicit proportions (design §4 trade-off)
+        warnings=(
+            "mintrace_wls_shrink: float linear algebra — deterministic for "
+            "a fixed environment, not bit-for-bit across numpy/BLAS builds "
+            "(ADR-022); leaf values clamped at 0 then re-aggregated "
+            "through S",
+        ),
+    )
+
+
+def _tags(block: SummingBlock, np) -> dict:
+    """hierarchicalforecast tags: series ids grouped by hierarchy level."""
+    tags: dict[str, list[str]] = {}
+    for ref in block.series:
+        if ref.kind == AGGREGATE:
+            tags.setdefault(f"level::{ref.level}", []).append(f"agg::{ref.key}")
+        else:
+            tags.setdefault("level::__leaf__", []).append(f"leaf::{ref.key}")
+    return {name: np.array(ids) for name, ids in tags.items()}

--- a/src/ootils_core/pyramide/hierarchy/runner.py
+++ b/src/ootils_core/pyramide/hierarchy/runner.py
@@ -1,0 +1,485 @@
+"""
+Hierarchical multi-series orchestration (Pyramide axis A — PR3).
+
+For ONE summing block (a root node of the block level, summing.py):
+load S -> read per-series history (reconciliation nodes via
+``get_historical_demand_by_node``, leaf weights via
+``get_historical_demand_totals_by_items``) -> seasonal base forecasts at
+the reconciliation level (PyramideForecastEngine, PR1) -> reconcile
+(reconcile.py: middle-out deterministic core, MinT-shrink optional edge)
+-> persist EVERY level in the forecast tables (migration 053: aggregates
+carry hierarchy_id/level/node_code, leaves carry item/location) with
+full provenance (base method + selected model label, which embeds
+season_length when a seasonal model won + recon_method effectively
+applied + forecast level), seeded/versioned through pyramide_runs.
+
+Graph boundary: aggregates are queryable in the tables and NEVER
+committed to the graph (repository.commit_run guards it); only leaf
+(item, location) runs get pyramide_snapshots and can be materialized as
+ForecastDemand nodes.
+
+Leaf addressing: summing-block leaves are ITEMS (item_hierarchy —
+demand summed across all sites, like every hierarchy reader). The
+persisted leaf forecasts therefore need a demand location:
+``leaf_location_id`` is the location the leaf series are addressed to
+(typically the network/central site whose graph consumes the demand
+plan; the per-site split is the DRP layer's job, ADR-020). Generic —
+callers choose the location, nothing is hardcoded.
+
+Scenario-aware: the run's ``scenario_id`` stamps every persisted row, so
+a fork can hold its own hierarchical forecasts. History readers are
+scenario-invariant by design (actuals do not fork).
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from decimal import Decimal
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+from uuid import UUID
+
+import psycopg
+
+from ..engines import ForecastComputation, PyramideEngineError, PyramideForecastEngine
+from ..models import METHOD_AUTO_SELECT, SUPPORTED_GRANULARITIES, SUPPORTED_METHODS
+from ..repository import (
+    PyramidePersistedRun,
+    get_historical_demand_by_item,
+    get_historical_demand_by_node,
+    get_historical_demand_totals_by_items,
+    persist_series_run,
+)
+from ..runner import PyramideError, bucket_dates
+from .reconcile import (
+    MINT_MIN_INSAMPLE,
+    RECON_MIDDLEOUT,
+    RECON_MINT_SHRINK,
+    SUPPORTED_RECON_METHODS,
+    LeafShare,
+    MintInputs,
+    ReconciledBlock,
+    ReconciliationError,
+    reconcile,
+)
+from .summing import AGGREGATE, SeriesRef, SummingBlock, load_summing_blocks
+
+logger = logging.getLogger(__name__)
+
+_ZERO = Decimal("0")
+
+
+@dataclass(frozen=True)
+class HierarchicalRunConfig:
+    """Configuration of one hierarchical (block-level) forecast run.
+
+    ``recon_level`` defaults to the block level itself (one base forecast
+    at the block root, disaggregated to the leaves); pass a deeper level
+    for a classic middle-out at an intermediate level.
+    """
+    hierarchy_id: str
+    block_code: str
+    leaf_location_id: UUID
+    scenario_id: UUID
+    horizon_start: date
+    horizon_days: int
+    block_level: str | None = None
+    recon_level: str | None = None
+    granularity: str = "daily"
+    method: str = METHOD_AUTO_SELECT
+    method_params: Mapping[str, Any] = field(default_factory=dict)
+    model_strategy: str = "stat"
+    recon_method: str = RECON_MIDDLEOUT
+    lookback_days: int = 365
+    random_seed: int = 0
+    code_version: str = "local"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "method_params", MappingProxyType(dict(self.method_params or {}))
+        )
+
+    @property
+    def horizon_end(self) -> date:
+        return self.horizon_start + timedelta(days=self.horizon_days - 1)
+
+
+@dataclass(frozen=True)
+class HierarchicalPersistedSeries:
+    """One persisted series of a hierarchical run (kind: aggregate|leaf).
+
+    snapshot_id is None for aggregates (leaf-only snapshot contract)."""
+    kind: str
+    key: str
+    level: str | None
+    run_id: UUID
+    forecast_id: UUID
+    snapshot_id: UUID | None
+
+
+@dataclass(frozen=True)
+class HierarchicalRunResult:
+    hierarchy_id: str
+    block_code: str
+    block_level: str
+    recon_level: str
+    recon_method: str  # effectively applied (never the rejected request)
+    horizon_start: date
+    horizon_end: date
+    granularity: str
+    method: str
+    shares: tuple[LeafShare, ...]
+    persisted: tuple[HierarchicalPersistedSeries, ...]
+    warnings: tuple[str, ...]
+
+
+class HierarchicalRunner:
+    """Run a coherent multi-level forecast for one hierarchy block."""
+
+    def __init__(self, forecast_engine: PyramideForecastEngine | None = None) -> None:
+        self._engine = forecast_engine or PyramideForecastEngine()
+
+    def run(
+        self, db: psycopg.Connection, config: HierarchicalRunConfig
+    ) -> HierarchicalRunResult:
+        method = self._validate_config(config)
+        block = self._load_block(db, config)
+        recon_level = config.recon_level or block.block_level
+        dates = bucket_dates(
+            config.horizon_start, config.horizon_days, config.granularity
+        )
+        periods = len(dates)
+        warnings: list[str] = []
+
+        recon_refs = [
+            (i, ref)
+            for i, ref in enumerate(block.series)
+            if ref.kind == AGGREGATE and ref.level == recon_level
+        ]
+        if not recon_refs:
+            raise PyramideError(
+                f"block '{block.block_code}' has no node at reconciliation "
+                f"level '{recon_level}'"
+            )
+
+        base_curves: dict[str, tuple[Decimal, ...]] = {}
+        base_computations: dict[str, ForecastComputation] = {}
+        node_histories: dict[str, list[Decimal]] = {}
+        for i, ref in recon_refs:
+            if not block.rows[i]:
+                continue  # node without leaves: nothing to forecast/split
+            history = get_historical_demand_by_node(
+                db, config.hierarchy_id, ref.key, config.lookback_days
+            )
+            if not history:
+                raise PyramideError(
+                    f"no demand history for reconciliation node '{ref.key}' "
+                    f"(hierarchy '{config.hierarchy_id}') in the "
+                    f"{config.lookback_days}-day lookback window"
+                )
+            computation = self._base_forecast(history, periods, method, config)
+            node_histories[ref.key] = history
+            base_computations[ref.key] = computation
+            base_curves[ref.key] = computation.values
+            warnings.extend(f"{ref.key}: {w}" for w in computation.warnings)
+
+        leaf_totals = get_historical_demand_totals_by_items(
+            db, [UUID(key) for key in block.leaves], config.lookback_days
+        )
+
+        mint_inputs: MintInputs | None = None
+        if config.recon_method == RECON_MINT_SHRINK:
+            mint_inputs, mint_warnings = self._build_mint_inputs(
+                db, block, config, method, periods, base_curves, node_histories
+            )
+            warnings.extend(mint_warnings)
+
+        strict = bool(config.method_params.get("strict_recon"))
+        try:
+            recon = reconcile(
+                block,
+                recon_level,
+                base_curves,
+                leaf_totals,
+                method=config.recon_method,
+                mint_inputs=mint_inputs,
+                strict=strict,
+            )
+        except ReconciliationError as exc:
+            raise PyramideError(str(exc)) from exc
+        warnings.extend(recon.warnings)
+
+        persisted = self._persist(
+            db, block, recon, recon_refs, base_computations,
+            node_histories, config, method, dates,
+        )
+        return HierarchicalRunResult(
+            hierarchy_id=config.hierarchy_id,
+            block_code=block.block_code,
+            block_level=block.block_level,
+            recon_level=recon_level,
+            recon_method=recon.recon_method,
+            horizon_start=config.horizon_start,
+            horizon_end=config.horizon_end,
+            granularity=config.granularity,
+            method=method,
+            shares=recon.shares,
+            persisted=tuple(persisted),
+            warnings=tuple(warnings),
+        )
+
+    # ------------------------------------------------------------------
+    # Steps
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_config(config: HierarchicalRunConfig) -> str:
+        if config.horizon_days < 1:
+            raise PyramideError("horizon_days must be >= 1")
+        if config.lookback_days < 1:
+            raise PyramideError("lookback_days must be >= 1")
+        if config.granularity not in SUPPORTED_GRANULARITIES:
+            raise PyramideError(f"Unsupported granularity: {config.granularity}")
+        method = config.method.upper()
+        if method not in SUPPORTED_METHODS:
+            raise PyramideError(f"Unsupported forecast method: {config.method}")
+        if config.recon_method not in SUPPORTED_RECON_METHODS:
+            raise PyramideError(
+                f"Unsupported reconciliation method: {config.recon_method} "
+                f"(supported: {sorted(SUPPORTED_RECON_METHODS)})"
+            )
+        return method
+
+    @staticmethod
+    def _load_block(
+        db: psycopg.Connection, config: HierarchicalRunConfig
+    ) -> SummingBlock:
+        blocks = load_summing_blocks(
+            db,
+            hierarchy_id=config.hierarchy_id,
+            block_level=config.block_level,
+        )
+        for block in blocks:
+            if block.block_code == config.block_code:
+                return block
+        raise PyramideError(
+            f"block '{config.block_code}' not found at level "
+            f"'{config.block_level or 'root'}' of hierarchy "
+            f"'{config.hierarchy_id}' (blocks: {[b.block_code for b in blocks]})"
+        )
+
+    def _base_forecast(
+        self,
+        history: Sequence[Decimal],
+        periods: int,
+        method: str,
+        config: HierarchicalRunConfig,
+    ) -> ForecastComputation:
+        try:
+            computation = self._engine.forecast(
+                history=list(history),
+                periods=periods,
+                method=method,
+                method_params=config.method_params,
+                model_strategy=config.model_strategy,
+                granularity=config.granularity,
+                horizon_start=config.horizon_start,
+                random_seed=config.random_seed,
+            )
+        except PyramideEngineError as exc:
+            raise PyramideError(str(exc)) from exc
+        # Same clamp as the leaf runner: demand forecasts are >= 0.
+        return ForecastComputation(
+            values=tuple(max(value, _ZERO) for value in computation.values),
+            selected_model=computation.selected_model,
+            value_method=computation.value_method,
+            engine_backend=computation.engine_backend,
+            warnings=computation.warnings,
+        )
+
+    def _build_mint_inputs(
+        self,
+        db: psycopg.Connection,
+        block: SummingBlock,
+        config: HierarchicalRunConfig,
+        method: str,
+        periods: int,
+        recon_curves: Mapping[str, tuple[Decimal, ...]],
+        node_histories: Mapping[str, list[Decimal]],
+    ) -> tuple[MintInputs | None, list[str]]:
+        """
+        Best-effort aligned inputs for the optional MinT path: every
+        series (all aggregate levels + leaves) gets its own history and
+        base forecast; insample tails are aligned to the shortest series.
+
+        Known V1 approximations (documented, ADR-022): histories are
+        sparse date-less series, so alignment is positional (last k
+        points), and the insample "fitted" values are a naive lag-1
+        proxy. If any series is empty or the aligned tail is shorter
+        than MINT_MIN_INSAMPLE, MinT is skipped (None + warning) and the
+        dispatcher falls back to deterministic middle-out.
+        """
+        histories: dict[str, list[Decimal]] = {}
+        for ref in block.series:
+            if ref.kind == AGGREGATE:
+                history = node_histories.get(ref.key)
+                if history is None:
+                    history = get_historical_demand_by_node(
+                        db, config.hierarchy_id, ref.key, config.lookback_days
+                    )
+            else:
+                history = get_historical_demand_by_item(
+                    db, UUID(ref.key), config.lookback_days
+                )
+            if not history:
+                return None, [
+                    f"{RECON_MINT_SHRINK} skipped: series "
+                    f"'{ref.key}' has no history in the lookback window "
+                    "(middle-out fallback)"
+                ]
+            histories[_series_key(ref)] = history
+
+        k = min(len(h) for h in histories.values())
+        if k < MINT_MIN_INSAMPLE:
+            return None, [
+                f"{RECON_MINT_SHRINK} skipped: aligned insample tail is "
+                f"{k} < {MINT_MIN_INSAMPLE} points (middle-out fallback)"
+            ]
+
+        aggregate_curves: dict[str, Sequence[Decimal]] = {}
+        leaf_curves: dict[str, Sequence[Decimal]] = {}
+        aggregate_insample: dict[str, Sequence[Decimal]] = {}
+        leaf_insample: dict[str, Sequence[Decimal]] = {}
+        aggregate_fitted: dict[str, Sequence[Decimal]] = {}
+        leaf_fitted: dict[str, Sequence[Decimal]] = {}
+        for ref in block.series:
+            history = histories[_series_key(ref)]
+            if ref.kind == AGGREGATE and ref.key in recon_curves:
+                curve: Sequence[Decimal] = recon_curves[ref.key]
+            else:
+                curve = self._base_forecast(history, periods, method, config).values
+            tail = tuple(history[-k:])
+            fitted = (tail[0], *tail[:-1])  # naive lag-1 insample proxy
+            if ref.kind == AGGREGATE:
+                aggregate_curves[ref.key] = curve
+                aggregate_insample[ref.key] = tail
+                aggregate_fitted[ref.key] = fitted
+            else:
+                leaf_curves[ref.key] = curve
+                leaf_insample[ref.key] = tail
+                leaf_fitted[ref.key] = fitted
+        return MintInputs(
+            aggregate_curves=aggregate_curves,
+            leaf_curves=leaf_curves,
+            aggregate_insample=aggregate_insample,
+            leaf_insample=leaf_insample,
+            aggregate_fitted=aggregate_fitted,
+            leaf_fitted=leaf_fitted,
+        ), []
+
+    def _persist(
+        self,
+        db: psycopg.Connection,
+        block: SummingBlock,
+        recon: ReconciledBlock,
+        recon_refs: Sequence[tuple[int, SeriesRef]],
+        base_computations: Mapping[str, ForecastComputation],
+        node_histories: Mapping[str, list[Decimal]],
+        config: HierarchicalRunConfig,
+        method: str,
+        dates: Sequence[date],
+    ) -> list[HierarchicalPersistedSeries]:
+        parent_of: dict[str, str] = {}
+        for i, ref in recon_refs:
+            for j in block.rows[i]:
+                parent_of[block.leaves[j]] = ref.key
+
+        recon_backend = f"internal:reconciliation:{recon.recon_method}"
+        persisted: list[HierarchicalPersistedSeries] = []
+        for index, ref in enumerate(block.series):
+            quantities = recon.values[index]
+            if ref.kind == AGGREGATE:
+                computation = base_computations.get(ref.key)
+                if computation is not None:
+                    selected_model = computation.selected_model
+                    engine_backend = computation.engine_backend
+                    value_method = computation.value_method
+                    history_count = len(node_histories[ref.key])
+                else:
+                    # non-reconciliation level: values are S-sums of leaves
+                    selected_model = f"RECON({recon.recon_method}@{recon.recon_level})"
+                    engine_backend = recon_backend
+                    value_method = method
+                    history_count = 0
+                record = persist_series_run(
+                    db,
+                    scenario_id=config.scenario_id,
+                    horizon_start=config.horizon_start,
+                    horizon_end=config.horizon_end,
+                    granularity=config.granularity,
+                    method=method,
+                    model_strategy=config.model_strategy,
+                    recon_method=recon.recon_method,
+                    random_seed=config.random_seed,
+                    code_version=config.code_version,
+                    selected_model=selected_model,
+                    engine_backend=engine_backend,
+                    source_history_count=history_count,
+                    bucket_dates=dates,
+                    quantities=quantities,
+                    value_method=value_method,
+                    hierarchy_id=config.hierarchy_id,
+                    level=ref.level,
+                    node_code=ref.key,
+                )
+            else:
+                recon_node = parent_of.get(ref.key)
+                computation = (
+                    base_computations.get(recon_node) if recon_node else None
+                )
+                base_label = (
+                    computation.selected_model if computation else method
+                )
+                value_method = (
+                    computation.value_method if computation else method
+                )
+                record = persist_series_run(
+                    db,
+                    scenario_id=config.scenario_id,
+                    horizon_start=config.horizon_start,
+                    horizon_end=config.horizon_end,
+                    granularity=config.granularity,
+                    method=method,
+                    model_strategy=config.model_strategy,
+                    recon_method=recon.recon_method,
+                    random_seed=config.random_seed,
+                    code_version=config.code_version,
+                    selected_model=f"{base_label}@{recon_node or recon.recon_level}",
+                    engine_backend=recon_backend,
+                    source_history_count=0,
+                    bucket_dates=dates,
+                    quantities=quantities,
+                    value_method=value_method,
+                    item_id=UUID(ref.key),
+                    location_id=config.leaf_location_id,
+                )
+            persisted.append(_persisted_series(ref, record))
+        return persisted
+
+
+def _series_key(ref: SeriesRef) -> str:
+    return f"{ref.kind}::{ref.key}"
+
+
+def _persisted_series(
+    ref: SeriesRef, record: PyramidePersistedRun
+) -> HierarchicalPersistedSeries:
+    return HierarchicalPersistedSeries(
+        kind=ref.kind,
+        key=ref.key,
+        level=ref.level,
+        run_id=record.run_id,
+        forecast_id=record.forecast_id,
+        snapshot_id=record.snapshot_id,
+    )

--- a/src/ootils_core/pyramide/models.py
+++ b/src/ootils_core/pyramide/models.py
@@ -46,7 +46,12 @@ class PyramideRunConfig:
     method: str = METHOD_AUTO_SELECT
     method_params: Mapping[str, Any] = field(default_factory=dict)
     model_strategy: str = "stat"
-    recon_method: str = "bottomup"
+    # recon_method carries the reconciliation EFFECTIVELY applied
+    # (migration 054). A standalone single-series leaf run reconciles
+    # nothing — 'none' is the honest default. Hierarchical runs are
+    # persisted by pyramide/hierarchy/runner.py with the method the
+    # reconciler actually used ('middleout' / 'mintrace_wls_shrink').
+    recon_method: str = "none"
     random_seed: int = 0
     code_version: str = "local"
 

--- a/src/ootils_core/pyramide/repository.py
+++ b/src/ootils_core/pyramide/repository.py
@@ -5,6 +5,7 @@ import logging
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
+from typing import Sequence
 from uuid import UUID, uuid4
 
 import psycopg
@@ -16,10 +17,23 @@ from .models import PyramideRunResult
 logger = logging.getLogger(__name__)
 
 
+class PyramideAggregateCommitError(ValueError):
+    """Commit requested on an AGGREGATE (hierarchy-node) run.
+
+    Aggregate forecasts are never materialized as graph demand: the graph
+    only carries leaf (item, location) ForecastDemand nodes; aggregates
+    stay queryable in forecasts / forecast_values (migration 053). The
+    router maps this to a 409.
+    """
+
+
 @dataclass(frozen=True)
 class PyramidePersistedRun:
+    # snapshot_id is None for AGGREGATE runs: pyramide_snapshots keeps its
+    # leaf NOT NULL contract (migration 038) — snapshots exist to feed the
+    # graph commit path, which is leaf-only by design.
     run_id: UUID
-    snapshot_id: UUID
+    snapshot_id: UUID | None
     forecast_id: UUID
 
 
@@ -29,10 +43,11 @@ class PyramideRunSummary:
     Leaf runs carry (item_id, location_id); aggregate runs (migration 053)
     carry (hierarchy_id, level, node_code) instead — the unused side is
     None (DB CHECK: leaf XOR aggregate). Consumers must not assume
-    item_id/location_id are set.
+    item_id/location_id are set. snapshot_id is None for aggregate runs
+    (no pyramide_snapshots row — leaf NOT NULL contract of migration 038).
     """
     run_id: UUID
-    snapshot_id: UUID
+    snapshot_id: UUID | None
     forecast_id: UUID
     item_id: UUID | None
     location_id: UUID | None
@@ -291,6 +306,67 @@ def get_historical_demand_by_node(
     return [Decimal(str(row["total_qty"])) for row in rows]
 
 
+def get_historical_demand_by_item(
+    db: psycopg.Connection,
+    item_id: UUID,
+    lookback_days: int,
+) -> list[Decimal]:
+    """
+    Historical demand series for one item across ALL sites: daily booked
+    sums, sorted date ASC, same sparse contract as the other readers
+    (days without demand are absent). Business filters are the shared
+    ``_DEMAND_HISTORY_BUSINESS_PREDICATES``.
+
+    This is the LEAF series of the hierarchy layer: summing-block columns
+    are items (item_hierarchy), site-agnostic — the site split belongs to
+    the reconciliation/DRP layer, exactly like the node reader. No
+    warehouse filter, no graph fallback, no scenario parameter (actuals
+    are scenario-invariant).
+    """
+    rows = db.execute(
+        f"""
+        SELECT dh.booked_date AS demand_date,
+               COALESCE(SUM(dh.ordered_quantity), 0) AS total_qty
+        FROM demand_history dh
+        WHERE dh.item_id = %(item_id)s
+          AND {_DEMAND_HISTORY_BUSINESS_PREDICATES}
+        GROUP BY dh.booked_date
+        ORDER BY dh.booked_date ASC
+        """,
+        {"item_id": item_id, "lookback_days": lookback_days},
+    ).fetchall()
+    return [Decimal(str(row["total_qty"])) for row in rows]
+
+
+def get_historical_demand_totals_by_items(
+    db: psycopg.Connection,
+    item_ids: Sequence[UUID],
+    lookback_days: int,
+) -> dict[str, Decimal]:
+    """
+    Booked totals per item over the lookback window, across ALL sites —
+    the middle-out share numerators (reconcile.py). Keys are stringified
+    item UUIDs (the summing-block leaf column keys). Items with no
+    qualifying row are ABSENT from the dict (callers default them to 0 —
+    the cold-start / natural-zero rules of the reconciler apply).
+
+    Same shared business predicates as every demand-history reader.
+    """
+    if not item_ids:
+        return {}
+    rows = db.execute(
+        f"""
+        SELECT dh.item_id, COALESCE(SUM(dh.ordered_quantity), 0) AS total_qty
+        FROM demand_history dh
+        WHERE dh.item_id = ANY(%(item_ids)s)
+          AND {_DEMAND_HISTORY_BUSINESS_PREDICATES}
+        GROUP BY dh.item_id
+        """,
+        {"item_ids": list(item_ids), "lookback_days": lookback_days},
+    ).fetchall()
+    return {str(row["item_id"]): Decimal(str(row["total_qty"])) for row in rows}
+
+
 def persist_run(db: psycopg.Connection, result: PyramideRunResult) -> PyramidePersistedRun:
     run_id = uuid4()
     snapshot_id = uuid4()
@@ -382,7 +458,135 @@ def persist_run(db: psycopg.Connection, result: PyramideRunResult) -> PyramidePe
     return PyramidePersistedRun(run_id=run_id, snapshot_id=snapshot_id, forecast_id=forecast_id)
 
 
+def persist_series_run(
+    db: psycopg.Connection,
+    *,
+    scenario_id: UUID,
+    horizon_start: date,
+    horizon_end: date,
+    granularity: str,
+    method: str,
+    model_strategy: str,
+    recon_method: str,
+    random_seed: int,
+    code_version: str,
+    selected_model: str,
+    engine_backend: str,
+    source_history_count: int,
+    bucket_dates: Sequence[date],
+    quantities: Sequence[Decimal],
+    value_method: str,
+    item_id: UUID | None = None,
+    location_id: UUID | None = None,
+    hierarchy_id: str | None = None,
+    level: str | None = None,
+    node_code: str | None = None,
+) -> PyramidePersistedRun:
+    """
+    Persist ONE series of a hierarchical run (migration 053): either a
+    LEAF (item_id + location_id) or an AGGREGATE (hierarchy_id + level +
+    node_code) — never both (mirrors the DB CHECK, validated here first
+    so the error is readable).
+
+    Writes forecasts + forecast_values + pyramide_runs for every series;
+    pyramide_snapshots ONLY for leaves. Rationale: snapshots exist to
+    feed the graph commit path (_commit_snapshot_to_demand_nodes), which
+    materializes LEAF ForecastDemand nodes only — aggregates stay
+    queryable in the forecast tables and never enter the graph, so a
+    snapshot row (whose leaf columns are NOT NULL by migration 038)
+    would be meaningless for them.
+
+    ``recon_method`` must be the method EFFECTIVELY applied (the
+    reconciler reports it) — this is what makes the column real.
+    """
+    is_leaf = item_id is not None and location_id is not None
+    is_aggregate = (
+        hierarchy_id is not None and level is not None and node_code is not None
+    )
+    if is_leaf == is_aggregate:
+        raise ValueError(
+            "persist_series_run targets a leaf (item_id + location_id) XOR "
+            "an aggregate (hierarchy_id + level + node_code); got "
+            f"item_id={item_id}, location_id={location_id}, "
+            f"hierarchy_id={hierarchy_id}, level={level}, node_code={node_code}"
+        )
+    if len(bucket_dates) != len(quantities):
+        raise ValueError(
+            f"{len(bucket_dates)} bucket dates but {len(quantities)} quantities"
+        )
+
+    run_id = uuid4()
+    forecast_id = uuid4()
+    db.execute(
+        """
+        INSERT INTO forecasts (
+            forecast_id, item_id, location_id, hierarchy_id, level, node_code,
+            scenario_id, horizon_start, horizon_end, granularity, method
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        """,
+        (
+            forecast_id, item_id, location_id, hierarchy_id, level, node_code,
+            scenario_id, horizon_start, horizon_end, granularity, method,
+        ),
+    )
+    total_quantity = Decimal("0")
+    for bucket_date, quantity in zip(bucket_dates, quantities):
+        total_quantity += quantity
+        db.execute(
+            """
+            INSERT INTO forecast_values (
+                value_id, forecast_id, forecast_date, quantity, method
+            ) VALUES (%s, %s, %s, %s, %s)
+            """,
+            (uuid4(), forecast_id, bucket_date, quantity, value_method),
+        )
+    db.execute(
+        """
+        INSERT INTO pyramide_runs (
+            run_id, forecast_id, item_id, location_id,
+            hierarchy_id, level, node_code, scenario_id,
+            horizon_start, horizon_end, granularity, method,
+            model_strategy, recon_method, random_seed, code_version,
+            selected_model, engine_backend, source_history_count, status,
+            deterministic_artifact
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                  %s, %s, %s, %s, %s, 'generated', 'forecast_values')
+        """,
+        (
+            run_id, forecast_id, item_id, location_id,
+            hierarchy_id, level, node_code, scenario_id,
+            horizon_start, horizon_end, granularity, method,
+            model_strategy, recon_method, random_seed, code_version,
+            selected_model, engine_backend, source_history_count,
+        ),
+    )
+
+    snapshot_id: UUID | None = None
+    if is_leaf:
+        snapshot_id = uuid4()
+        db.execute(
+            """
+            INSERT INTO pyramide_snapshots (
+                snapshot_id, run_id, forecast_id, item_id, location_id,
+                scenario_id, horizon_start, horizon_end, granularity, method,
+                value_count, total_quantity, immutable_artifact
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                      'forecast_values')
+            """,
+            (
+                snapshot_id, run_id, forecast_id, item_id, location_id,
+                scenario_id, horizon_start, horizon_end, granularity, method,
+                len(quantities), total_quantity,
+            ),
+        )
+    return PyramidePersistedRun(
+        run_id=run_id, snapshot_id=snapshot_id, forecast_id=forecast_id
+    )
+
+
 def fetch_run_summary(db: psycopg.Connection, run_id: UUID) -> PyramideRunSummary | None:
+    # LEFT JOIN: aggregate runs (migration 053) have no snapshot — their
+    # value_count/total come straight from the frozen forecast_values.
     row = db.execute(
         """
         SELECT
@@ -393,9 +597,16 @@ def fetch_run_summary(db: psycopg.Connection, run_id: UUID) -> PyramideRunSummar
             pr.code_version, pr.selected_model, pr.engine_backend,
             pr.source_history_count, pr.status,
             pr.deterministic_artifact, pr.created_at, pr.committed_at,
-            ps.value_count, ps.total_quantity
+            COALESCE(ps.value_count, vc.value_count) AS value_count,
+            COALESCE(ps.total_quantity, vc.total_quantity) AS total_quantity
         FROM pyramide_runs pr
-        JOIN pyramide_snapshots ps ON ps.run_id = pr.run_id
+        LEFT JOIN pyramide_snapshots ps ON ps.run_id = pr.run_id
+        LEFT JOIN LATERAL (
+            SELECT COUNT(*)::int AS value_count,
+                   COALESCE(SUM(fv.quantity), 0) AS total_quantity
+            FROM forecast_values fv
+            WHERE fv.forecast_id = pr.forecast_id
+        ) vc ON TRUE
         WHERE pr.run_id = %s
         """,
         (run_id,),
@@ -432,9 +643,26 @@ def fetch_run_values(db: psycopg.Connection, run_id: UUID) -> list[PyramideForec
 
 
 def commit_run(db: psycopg.Connection, run_id: UUID) -> PyramideCommitResult | None:
+    """
+    Materialize a LEAF run's frozen values as ForecastDemand graph nodes.
+
+    LEAVES ONLY: an aggregate (hierarchy-node) run raises
+    PyramideAggregateCommitError — aggregates stay queryable in
+    forecasts/forecast_values and never enter the graph (the graph's
+    demand contract is (item, location); a node-level demand quantity
+    would double-count its leaves in propagation).
+    """
     summary = fetch_run_summary(db, run_id)
     if summary is None:
         return None
+    if summary.node_code is not None:
+        raise PyramideAggregateCommitError(
+            f"Pyramide run '{run_id}' targets aggregate node "
+            f"'{summary.node_code}' (hierarchy '{summary.hierarchy_id}', "
+            f"level '{summary.level}') — aggregate forecasts are never "
+            "materialized as graph demand; commit the block's leaf "
+            "(item, location) runs instead"
+        )
 
     demand_node_count = _commit_snapshot_to_demand_nodes(db, summary)
     db.execute(
@@ -562,6 +790,24 @@ def _snapshot_from_row(row) -> PyramideSnapshotSummary:
 
 
 def _commit_snapshot_to_demand_nodes(db: psycopg.Connection, summary: PyramideRunSummary) -> int:
+    """
+    LEAF-ONLY materialization contract: only leaf (item, location) series
+    ever become ForecastDemand nodes. Aggregate series live exclusively
+    in the forecast tables (migration 053) — pyramide_snapshots keeps its
+    leaf NOT NULL contract (migration 038) precisely because a snapshot's
+    sole purpose is this graph-commit path. commit_run() guards the
+    aggregate case with a typed error before reaching here; this check is
+    the defensive backstop.
+    """
+    if (
+        summary.item_id is None
+        or summary.location_id is None
+        or summary.snapshot_id is None
+    ):
+        raise PyramideAggregateCommitError(
+            f"run '{summary.run_id}' has no leaf (item, location) snapshot — "
+            "only leaf runs are materialized to the graph"
+        )
     _ensure_projection_series_window(
         db=db,
         item_id=summary.item_id,

--- a/src/ootils_core/pyramide/runner.py
+++ b/src/ootils_core/pyramide/runner.py
@@ -20,6 +20,40 @@ class PyramideError(ValueError):
     """Raised when a Pyramide run cannot produce a valid forecast snapshot."""
 
 
+def bucket_dates(horizon_start: date, horizon_days: int, granularity: str) -> tuple[date, ...]:
+    """Forecast bucket start dates for a horizon — the single definition
+    shared by the leaf runner (PyramideRunner) and the hierarchical
+    runner (hierarchy/runner.py), so the two can never bucket a horizon
+    differently."""
+    if granularity == "daily":
+        return tuple(horizon_start + timedelta(days=i) for i in range(horizon_days))
+
+    if granularity == "weekly":
+        periods = ceil(horizon_days / 7)
+        return tuple(horizon_start + timedelta(days=i * 7) for i in range(periods))
+
+    horizon_end = horizon_start + timedelta(days=horizon_days - 1)
+    periods = _monthly_period_count(horizon_start, horizon_end)
+    return tuple(_add_months(horizon_start, i) for i in range(periods))
+
+
+def _monthly_period_count(start: date, end: date) -> int:
+    count = 1
+    cursor = start
+    while _add_months(cursor, 1) <= end:
+        cursor = _add_months(cursor, 1)
+        count += 1
+    return count
+
+
+def _add_months(start: date, months: int) -> date:
+    month_index = start.month - 1 + months
+    year = start.year + month_index // 12
+    month = month_index % 12 + 1
+    day = min(start.day, calendar.monthrange(year, month)[1])
+    return date(year, month, day)
+
+
 class PyramideRunner:
     """Build immutable forecast snapshots from historical demand series."""
 
@@ -83,29 +117,4 @@ class PyramideRunner:
 
     @classmethod
     def _bucket_dates(cls, config: PyramideRunConfig) -> tuple[date, ...]:
-        if config.granularity == "daily":
-            return tuple(config.horizon_start + timedelta(days=i) for i in range(config.horizon_days))
-
-        if config.granularity == "weekly":
-            periods = ceil(config.horizon_days / 7)
-            return tuple(config.horizon_start + timedelta(days=i * 7) for i in range(periods))
-
-        periods = cls._monthly_period_count(config.horizon_start, config.horizon_end)
-        return tuple(cls._add_months(config.horizon_start, i) for i in range(periods))
-
-    @classmethod
-    def _monthly_period_count(cls, start: date, end: date) -> int:
-        count = 1
-        cursor = start
-        while cls._add_months(cursor, 1) <= end:
-            cursor = cls._add_months(cursor, 1)
-            count += 1
-        return count
-
-    @staticmethod
-    def _add_months(start: date, months: int) -> date:
-        month_index = start.month - 1 + months
-        year = start.year + month_index // 12
-        month = month_index % 12 + 1
-        day = min(start.day, calendar.monthrange(year, month)[1])
-        return date(year, month, day)
+        return bucket_dates(config.horizon_start, config.horizon_days, config.granularity)

--- a/tests/integration/test_pyramide_reconcile_integration.py
+++ b/tests/integration/test_pyramide_reconcile_integration.py
@@ -1,0 +1,312 @@
+"""
+Integration tests for Pyramide axis A — PR3 (hierarchical reconciliation
+runner + migration 054) against a real PostgreSQL database (no mocks).
+
+Covered:
+  - full hierarchical run over a synthetic seeded block with KNOWN weekly
+    seasonal patterns per leaf (minimal D6-style generator below):
+    per-level persistence is queryable (aggregates carry
+    hierarchy_id/level/node_code, leaves carry item/location);
+  - coherence: sum(leaf values) == block-root aggregate values per date
+    (tolerance = NUMERIC(18,6) storage rounding);
+  - recon_method persisted on every run of the block == the method
+    EFFECTIVELY applied (migration 054 made the column real);
+  - determinism: two identical runs produce identical stored quantities;
+  - snapshots are leaf-only; commit materializes ONLY leaf series as
+    ForecastDemand nodes; committing an aggregate run raises the typed
+    guard (PyramideAggregateCommitError) and writes nothing;
+  - a MinT request never lies: persisted recon_method equals the
+    effective one whether the optional backend ran or fell back.
+
+Conventions (mirrors test_pyramide_hierarchy_integration.py): the
+function-scoped ``conn`` fixture (rollback teardown) keeps every test
+self-cleaning; every test seeds its OWN registry rows / items (fresh
+codes).
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+BASELINE_SCENARIO_ID = UUID("00000000-0000-0000-0000-000000000001")
+# Anti-flake rule (see test_pyramide_hierarchy_integration.py): seeded
+# history stays at TODAY-4 .. TODAY-59 (strictly past even with a ±1-day
+# client/server date skew); the forecast horizon starts at TODAY+2.
+TODAY = date.today()
+
+# Minimal D6-style synthetic generator: a KNOWN weekly pattern (7-day
+# season) scaled per leaf. 8 full weeks => every weekday appears exactly
+# 8 times, so per-leaf booked totals are amplitude * 14 * 8 and the
+# middle-out shares are exactly 0.5 / 0.3 / 0.2.
+WEEK_PATTERN = (2, 1, 1, 1, 3, 4, 2)  # sum = 14
+AMPLITUDES = {"A1": 10, "A2": 6, "A3": 4}
+HISTORY_DAYS = range(4, 60)  # 56 consecutive days = 8 full weeks
+
+
+def _seed_block(conn, h: str, tag: str):
+    """FAM-<tag> (family) -> PRD-<tag>1 (2 items) + PRD-<tag>2 (1 item)."""
+    conn.execute(
+        """
+        INSERT INTO hierarchy (hierarchy_id, domain, scope, levels, is_default)
+        VALUES (%s, 'product', 'local', %s, FALSE)
+        """,
+        (h, ["family", "product"]),
+    )
+    fam, prd1, prd2 = f"FAM-{tag}", f"PRD-{tag}1", f"PRD-{tag}2"
+    for code, level, parent in [
+        (fam, "family", None),
+        (prd1, "product", fam),
+        (prd2, "product", fam),
+    ]:
+        conn.execute(
+            "INSERT INTO hierarchy_node (hierarchy_id, code, level, parent_code) "
+            "VALUES (%s, %s, %s, %s)",
+            (h, code, level, parent),
+        )
+
+    items: dict[str, UUID] = {}
+    for suffix, leaf_code in [("A1", prd1), ("A2", prd1), ("A3", prd2)]:
+        item_id = uuid4()
+        ext = f"PR3-{tag}-{suffix}"
+        conn.execute(
+            "INSERT INTO items (item_id, name, item_type, uom, status, external_id) "
+            "VALUES (%s, %s, 'finished_good', 'EA', 'active', %s)",
+            (item_id, f"{ext} item", ext),
+        )
+        conn.execute(
+            "INSERT INTO item_hierarchy (item_id, hierarchy_id, leaf_code) "
+            "VALUES (%s, %s, %s)",
+            (item_id, h, leaf_code),
+        )
+        items[suffix] = item_id
+        for back in HISTORY_DAYS:
+            day = TODAY - timedelta(days=back)
+            qty = AMPLITUDES[suffix] * WEEK_PATTERN[day.weekday()]
+            conn.execute(
+                """
+                INSERT INTO demand_history (
+                    item_id, item_code, stream, booked_date,
+                    ordered_quantity, value_ext, counts_for_asp,
+                    fulfillment, order_number
+                ) VALUES (%s, %s, 'regular', %s, %s, 0, FALSE, 'standard', 'PR3')
+                """,
+                (item_id, ext, day, qty),
+            )
+
+    loc_id = uuid4()
+    conn.execute(
+        "INSERT INTO locations (location_id, name, location_type, country, external_id) "
+        "VALUES (%s, %s, 'dc', 'US', %s)",
+        (loc_id, f"PR3-{tag} DC", f"PR3-{tag}-DC"),
+    )
+    return fam, prd1, prd2, items, loc_id
+
+
+def _config(h: str, fam: str, loc_id: UUID, **overrides):
+    from ootils_core.pyramide.hierarchy import HierarchicalRunConfig
+
+    defaults = dict(
+        hierarchy_id=h,
+        block_code=fam,
+        leaf_location_id=loc_id,
+        scenario_id=BASELINE_SCENARIO_ID,
+        horizon_start=TODAY + timedelta(days=2),
+        horizon_days=14,
+        granularity="daily",
+        method="SEASONAL",
+        method_params={"season_length": 7},
+        lookback_days=90,
+    )
+    defaults.update(overrides)
+    return HierarchicalRunConfig(**defaults)
+
+
+def _values_by_forecast(conn, forecast_id: UUID) -> dict[date, Decimal]:
+    rows = conn.execute(
+        "SELECT forecast_date, quantity FROM forecast_values "
+        "WHERE forecast_id = %s ORDER BY forecast_date ASC",
+        (forecast_id,),
+    ).fetchall()
+    return {r["forecast_date"]: Decimal(str(r["quantity"])) for r in rows}
+
+
+class TestHierarchicalRunPersistence:
+    def test_full_run_persists_every_level_coherently(self, conn):
+        from ootils_core.pyramide.hierarchy import HierarchicalRunner
+
+        h = "pr3-h-full"
+        fam, prd1, prd2, items, loc_id = _seed_block(conn, h, "F")
+        result = HierarchicalRunner().run(conn, _config(h, fam, loc_id))
+
+        assert result.recon_method == "middleout"
+        assert result.recon_level == "family"
+        by_key = {p.key: p for p in result.persisted}
+        assert set(by_key) == {fam, prd1, prd2} | {str(i) for i in items.values()}
+
+        # aggregates address hierarchy nodes; leaves address (item, loc)
+        for code, level in [(fam, "family"), (prd1, "product"), (prd2, "product")]:
+            row = conn.execute(
+                "SELECT item_id, location_id, hierarchy_id, level, node_code "
+                "FROM forecasts WHERE forecast_id = %s",
+                (by_key[code].forecast_id,),
+            ).fetchone()
+            assert row["item_id"] is None and row["location_id"] is None
+            assert (row["hierarchy_id"], row["level"], row["node_code"]) == (h, level, code)
+        for item_id in items.values():
+            row = conn.execute(
+                "SELECT item_id, location_id, node_code FROM forecasts "
+                "WHERE forecast_id = %s",
+                (by_key[str(item_id)].forecast_id,),
+            ).fetchone()
+            assert row["item_id"] == item_id
+            assert row["location_id"] == loc_id
+            assert row["node_code"] is None
+
+        # coherence per date: sum(leaves) == family aggregate == sum(products)
+        fam_values = _values_by_forecast(conn, by_key[fam].forecast_id)
+        assert len(fam_values) == 14
+        leaf_sums: dict[date, Decimal] = {}
+        for item_id in items.values():
+            for day, qty in _values_by_forecast(conn, by_key[str(item_id)].forecast_id).items():
+                leaf_sums[day] = leaf_sums.get(day, Decimal("0")) + qty
+        tolerance = Decimal("0.0001")  # NUMERIC(18,6) storage rounding x 3 leaves
+        for day, fam_qty in fam_values.items():
+            assert abs(leaf_sums[day] - fam_qty) <= tolerance, day
+
+        # middle-out shares are exactly the seeded 0.5 / 0.3 / 0.2
+        shares = {s.leaf: s.share for s in result.shares}
+        assert shares[str(items["A1"])] == Decimal("0.5")
+        assert shares[str(items["A2"])] == Decimal("0.3")
+        assert shares[str(items["A3"])] == Decimal("0.2")
+
+        # recon_method is REAL: persisted on every run of the block
+        run_ids = [p.run_id for p in result.persisted]
+        rows = conn.execute(
+            "SELECT run_id, recon_method, method, random_seed, code_version "
+            "FROM pyramide_runs WHERE run_id = ANY(%s)",
+            (run_ids,),
+        ).fetchall()
+        assert len(rows) == 6
+        assert all(r["recon_method"] == "middleout" for r in rows)
+        assert all(r["method"] == "SEASONAL" for r in rows)
+
+        # snapshots are leaf-only
+        snapshot_rows = conn.execute(
+            "SELECT run_id FROM pyramide_snapshots WHERE run_id = ANY(%s)",
+            (run_ids,),
+        ).fetchall()
+        leaf_run_ids = {p.run_id for p in result.persisted if p.kind == "leaf"}
+        assert {r["run_id"] for r in snapshot_rows} == leaf_run_ids
+        assert all(
+            (p.snapshot_id is None) == (p.kind == "aggregate")
+            for p in result.persisted
+        )
+
+    def test_aggregate_run_is_queryable_via_summary(self, conn):
+        from ootils_core.pyramide.hierarchy import HierarchicalRunner
+        from ootils_core.pyramide.repository import fetch_run_summary
+
+        h = "pr3-h-summary"
+        fam, _, _, _, loc_id = _seed_block(conn, h, "S")
+        result = HierarchicalRunner().run(conn, _config(h, fam, loc_id))
+        agg = next(p for p in result.persisted if p.key == fam)
+        summary = fetch_run_summary(conn, agg.run_id)
+        assert summary is not None
+        assert summary.snapshot_id is None
+        assert summary.node_code == fam
+        assert summary.level == "family"
+        assert summary.item_id is None
+        assert summary.value_count == 14
+        assert summary.recon_method == "middleout"
+
+    def test_two_runs_are_deterministic(self, conn):
+        from ootils_core.pyramide.hierarchy import HierarchicalRunner
+
+        h = "pr3-h-determinism"
+        fam, _, _, _, loc_id = _seed_block(conn, h, "D")
+        first = HierarchicalRunner().run(conn, _config(h, fam, loc_id))
+        second = HierarchicalRunner().run(conn, _config(h, fam, loc_id))
+        by_key_first = {p.key: p.forecast_id for p in first.persisted}
+        by_key_second = {p.key: p.forecast_id for p in second.persisted}
+        assert set(by_key_first) == set(by_key_second)
+        for key, forecast_id in by_key_first.items():
+            assert _values_by_forecast(conn, forecast_id) == \
+                _values_by_forecast(conn, by_key_second[key]), key
+
+
+class TestCommitBoundary:
+    def test_commit_materializes_leaves_only(self, conn):
+        from ootils_core.pyramide.hierarchy import HierarchicalRunner
+        from ootils_core.pyramide.repository import (
+            PyramideAggregateCommitError,
+            commit_run,
+        )
+
+        h = "pr3-h-commit"
+        fam, _, _, items, loc_id = _seed_block(conn, h, "C")
+        result = HierarchicalRunner().run(conn, _config(h, fam, loc_id))
+
+        def forecast_demand_count():
+            return conn.execute(
+                "SELECT COUNT(*) AS n FROM nodes "
+                "WHERE node_type = 'ForecastDemand' AND scenario_id = %s "
+                "  AND location_id = %s",
+                (BASELINE_SCENARIO_ID, loc_id),
+            ).fetchone()["n"]
+
+        # the aggregate guard fires BEFORE any write
+        agg = next(p for p in result.persisted if p.kind == "aggregate")
+        with pytest.raises(PyramideAggregateCommitError, match="aggregate"):
+            commit_run(conn, agg.run_id)
+        assert forecast_demand_count() == 0
+        status = conn.execute(
+            "SELECT status FROM pyramide_runs WHERE run_id = %s", (agg.run_id,)
+        ).fetchone()["status"]
+        assert status == "generated"  # aggregate run untouched
+
+        # a leaf run commits normally
+        leaf = next(
+            p for p in result.persisted if p.key == str(items["A1"])
+        )
+        committed = commit_run(conn, leaf.run_id)
+        assert committed is not None
+        assert committed.demand_node_count == 14
+        assert forecast_demand_count() == 14
+        node = conn.execute(
+            "SELECT item_id, location_id FROM nodes "
+            "WHERE node_type = 'ForecastDemand' AND scenario_id = %s "
+            "  AND location_id = %s LIMIT 1",
+            (BASELINE_SCENARIO_ID, loc_id),
+        ).fetchone()
+        assert node["item_id"] == items["A1"]
+
+
+class TestMintProvenanceNeverLies:
+    def test_persisted_recon_method_is_the_effective_one(self, conn):
+        """Request MinT: whether the optional backend runs or falls back,
+        the persisted recon_method equals the effective method reported by
+        the runner, and a fallback leaves an explicit warning."""
+        from ootils_core.pyramide.hierarchy import HierarchicalRunner
+
+        h = "pr3-h-mint"
+        fam, _, _, _, loc_id = _seed_block(conn, h, "M")
+        result = HierarchicalRunner().run(
+            conn,
+            _config(h, fam, loc_id, recon_method="mintrace_wls_shrink"),
+        )
+        assert result.recon_method in {"mintrace_wls_shrink", "middleout"}
+        if result.recon_method == "middleout":
+            assert any("fell back" in w or "skipped" in w for w in result.warnings)
+
+        rows = conn.execute(
+            "SELECT recon_method FROM pyramide_runs WHERE run_id = ANY(%s)",
+            ([p.run_id for p in result.persisted],),
+        ).fetchall()
+        assert {r["recon_method"] for r in rows} == {result.recon_method}

--- a/tests/test_pyramide_hierarchy_reconcile.py
+++ b/tests/test_pyramide_hierarchy_reconcile.py
@@ -1,0 +1,364 @@
+"""
+Pure golden-master tests (no DB, no mocks) for hierarchical
+reconciliation (src/ootils_core/pyramide/hierarchy/reconcile.py) —
+Pyramide axis A, PR3. Pattern: tests/test_mrp_core_golden.py /
+tests/test_seasonal_forecaster_golden.py — tiny hand-computed fixtures
+lock the arithmetic so any deviation fails CI instead of silently
+reshaping a demand plan.
+
+Golden mini-block — hierarchy 'h-recon', levels = (family, product),
+ONE reconciliation node (FAM-X, the block root) and THREE leaves:
+
+    FAM-X (family)            <- reconciliation level (base curve here)
+    ├── PRD-X1 (product)
+    │     ├── item-x1         (history total 50 -> share 0.5)
+    │     └── item-x2         (history total 30 -> share 0.3)
+    └── PRD-X2 (product)
+          └── item-x3         (history total 20 -> share 0.2)
+
+Base curve at FAM-X (known seasonal curve): [200, 50, 100, 50].
+
+Hand-written disaggregation (leaf = share x base, value by value):
+
+    item-x1 (0.5): [100, 25, 50, 25]
+    item-x2 (0.3): [ 60, 15, 30, 15]
+    item-x3 (0.2): [ 40, 10, 20, 10]
+
+Hand-written aggregates (exact sums of their leaves):
+
+    PRD-X1 = x1 + x2      = [160, 40, 80, 40]
+    PRD-X2 = x3           = [ 40, 10, 20, 10]
+    FAM-X  = x1 + x2 + x3 = [200, 50, 100, 50]   (== base exactly)
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from ootils_core.pyramide.hierarchy import (
+    RECON_MIDDLEOUT,
+    RECON_MINT_SHRINK,
+    MintInputs,
+    ReconciliationError,
+    ReconciliationUnavailable,
+    HierarchyNodeRow,
+    build_summing_blocks,
+    middle_out,
+    mint_shrink,
+    reconcile,
+)
+
+H = "h-recon"
+LEVELS = ("family", "product")
+
+NODES = [
+    HierarchyNodeRow(code="FAM-X", level="family", parent_code=None),
+    HierarchyNodeRow(code="PRD-X1", level="product", parent_code="FAM-X"),
+    HierarchyNodeRow(code="PRD-X2", level="product", parent_code="FAM-X"),
+]
+
+MEMBERSHIPS = [
+    ("item-x1", "PRD-X1"),
+    ("item-x2", "PRD-X1"),
+    ("item-x3", "PRD-X2"),
+]
+
+BASE = [Decimal("200"), Decimal("50"), Decimal("100"), Decimal("50")]
+TOTALS = {"item-x1": Decimal("50"), "item-x2": Decimal("30"), "item-x3": Decimal("20")}
+
+# series order (summing.py contract): FAM-X, PRD-X1, PRD-X2, x1, x2, x3
+EXPECTED = {
+    "FAM-X": (Decimal("200"), Decimal("50"), Decimal("100"), Decimal("50")),
+    "PRD-X1": (Decimal("160"), Decimal("40"), Decimal("80"), Decimal("40")),
+    "PRD-X2": (Decimal("40"), Decimal("10"), Decimal("20"), Decimal("10")),
+    "item-x1": (Decimal("100"), Decimal("25"), Decimal("50"), Decimal("25")),
+    "item-x2": (Decimal("60"), Decimal("15"), Decimal("30"), Decimal("15")),
+    "item-x3": (Decimal("40"), Decimal("10"), Decimal("20"), Decimal("10")),
+}
+
+
+def _block(nodes=None, memberships=None):
+    return build_summing_blocks(
+        hierarchy_id=H,
+        levels=LEVELS,
+        nodes=nodes if nodes is not None else NODES,
+        memberships=memberships if memberships is not None else MEMBERSHIPS,
+    )[0]
+
+
+def _by_key(result):
+    return {ref.key: result.values[i] for i, ref in enumerate(result.series)}
+
+
+class TestGoldenMiddleOut:
+    def test_disaggregation_matches_hand_written_values(self):
+        result = middle_out(_block(), "family", {"FAM-X": BASE}, TOTALS)
+        assert result.recon_method == RECON_MIDDLEOUT
+        assert result.recon_level == "family"
+        assert _by_key(result) == EXPECTED
+
+    def test_shares_recorded_for_explainability(self):
+        result = middle_out(_block(), "family", {"FAM-X": BASE}, TOTALS)
+        shares = {s.leaf: s for s in result.shares}
+        assert shares["item-x1"].share == Decimal("0.5")
+        assert shares["item-x2"].share == Decimal("0.3")
+        assert shares["item-x3"].share == Decimal("0.2")
+        assert all(s.recon_node == "FAM-X" for s in result.shares)
+        assert not any(s.cold_start for s in result.shares)
+        # sum of shares = 1 by construction
+        assert sum(s.share for s in result.shares) == Decimal("1")
+
+    def test_coherence_y_equals_s_times_b_value_by_value(self):
+        """y_hat = S . b_hat checked through SummingBlock.multiply for
+        every horizon step — coherence is exact, not within tolerance."""
+        block = _block()
+        result = middle_out(block, "family", {"FAM-X": BASE}, TOTALS)
+        leaf_offset = len(result.series) - len(block.leaves)
+        for t in range(len(BASE)):
+            leaf_vector = [result.values[leaf_offset + j][t] for j in range(len(block.leaves))]
+            assert block.multiply(leaf_vector) == [result.values[i][t] for i in range(len(result.series))]
+
+    def test_aggregates_are_exact_sums(self):
+        values = _by_key(middle_out(_block(), "family", {"FAM-X": BASE}, TOTALS))
+        for t in range(len(BASE)):
+            assert values["PRD-X1"][t] == values["item-x1"][t] + values["item-x2"][t]
+            assert values["PRD-X2"][t] == values["item-x3"][t]
+            assert values["FAM-X"][t] == (
+                values["item-x1"][t] + values["item-x2"][t] + values["item-x3"][t]
+            )
+
+    def test_reconciliation_at_intermediate_level(self):
+        """Middle-out at 'product': one base curve per product node.
+
+        PRD-X1 base [100, 10], leaves x1/x2 weights 50/50 -> [50, 5] each;
+        PRD-X2 base [40, 4] -> x3 [40, 4]; FAM-X = sums = [140, 14].
+        """
+        result = middle_out(
+            _block(),
+            "product",
+            {"PRD-X1": [Decimal("100"), Decimal("10")],
+             "PRD-X2": [Decimal("40"), Decimal("4")]},
+            {"item-x1": Decimal("50"), "item-x2": Decimal("50"),
+             "item-x3": Decimal("7")},
+        )
+        values = _by_key(result)
+        assert values["item-x1"] == (Decimal("50"), Decimal("5"))
+        assert values["item-x2"] == (Decimal("50"), Decimal("5"))
+        assert values["item-x3"] == (Decimal("40"), Decimal("4"))
+        assert values["FAM-X"] == (Decimal("140"), Decimal("14"))
+
+
+class TestColdStartTwin:
+    def test_cold_leaf_inherits_mean_of_sibling_weights(self):
+        """item-x2 has no history; its twin under PRD-X1 (item-x1, weight
+        30) gives it weight 30. item-x3 keeps its own 30. Total 90 ->
+        every leaf gets share 1/3: base [90, 9] -> [30, 3] each."""
+        result = middle_out(
+            _block(),
+            "family",
+            {"FAM-X": [Decimal("90"), Decimal("9")]},
+            {"item-x1": Decimal("30"), "item-x2": Decimal("0"),
+             "item-x3": Decimal("30")},
+        )
+        values = _by_key(result)
+        for leaf in ("item-x1", "item-x2", "item-x3"):
+            assert values[leaf] == (Decimal("30"), Decimal("3"))
+        shares = {s.leaf: s for s in result.shares}
+        assert shares["item-x2"].cold_start is True
+        assert shares["item-x2"].weight == Decimal("30")
+        assert shares["item-x1"].cold_start is False
+        assert shares["item-x3"].cold_start is False
+
+    def test_leaf_without_history_or_twin_is_a_natural_zero(self):
+        """item-x3 is alone under PRD-X2 with no history: no twin -> its
+        share is a documented natural zero and its curve is flat 0; the
+        demand goes entirely to the leaves that have history."""
+        result = middle_out(
+            _block(),
+            "family",
+            {"FAM-X": [Decimal("80")]},
+            {"item-x1": Decimal("50"), "item-x2": Decimal("30")},
+        )
+        values = _by_key(result)
+        assert values["item-x3"] == (Decimal("0"),)
+        assert values["item-x1"] == (Decimal("50"),)
+        assert values["item-x2"] == (Decimal("30"),)
+        assert values["PRD-X2"] == (Decimal("0"),)
+        assert values["FAM-X"] == (Decimal("80"),)
+        assert any("natural zero" in w for w in result.warnings)
+        shares = {s.leaf: s for s in result.shares}
+        assert shares["item-x3"].share == Decimal("0")
+        assert shares["item-x3"].cold_start is False
+
+
+class TestDeterminism:
+    def test_two_runs_are_bit_identical(self):
+        first = middle_out(_block(), "family", {"FAM-X": BASE}, TOTALS)
+        second = middle_out(_block(), "family", {"FAM-X": BASE}, TOTALS)
+        assert first == second
+        assert repr(first) == repr(second)
+
+    def test_totals_dict_order_does_not_matter(self):
+        shuffled = {"item-x3": Decimal("20"), "item-x1": Decimal("50"),
+                    "item-x2": Decimal("30")}
+        assert middle_out(_block(), "family", {"FAM-X": BASE}, shuffled) == \
+            middle_out(_block(), "family", {"FAM-X": BASE}, TOTALS)
+
+
+class TestFailLoudly:
+    def test_unknown_recon_level(self):
+        with pytest.raises(ReconciliationError, match="galaxy"):
+            middle_out(_block(), "galaxy", {"FAM-X": BASE}, TOTALS)
+
+    def test_missing_base_curve(self):
+        with pytest.raises(ReconciliationError, match="PRD-X2"):
+            middle_out(
+                _block(), "product",
+                {"PRD-X1": [Decimal("10")]},
+                TOTALS,
+            )
+
+    def test_base_curve_for_unknown_series(self):
+        with pytest.raises(ReconciliationError, match="NOT-A-NODE"):
+            middle_out(
+                _block(), "family",
+                {"FAM-X": BASE, "NOT-A-NODE": BASE},
+                TOTALS,
+            )
+
+    def test_inconsistent_horizons(self):
+        with pytest.raises(ReconciliationError, match="horizon"):
+            middle_out(
+                _block(), "product",
+                {"PRD-X1": [Decimal("10")], "PRD-X2": [Decimal("1"), Decimal("2")]},
+                TOTALS,
+            )
+
+    def test_leaf_above_recon_level_is_not_covered(self):
+        """An item attached directly to the family node cannot be reached
+        by product-level disaggregation — must fail, not vanish."""
+        memberships = MEMBERSHIPS + [("item-x0", "FAM-X")]
+        with pytest.raises(ReconciliationError, match="item-x0"):
+            middle_out(
+                _block(memberships=memberships), "product",
+                {"PRD-X1": [Decimal("10")], "PRD-X2": [Decimal("5")]},
+                TOTALS,
+            )
+
+    def test_nonzero_base_with_zero_weights_everywhere(self):
+        with pytest.raises(ReconciliationError, match="cannot disaggregate"):
+            middle_out(_block(), "family", {"FAM-X": BASE}, {})
+
+    def test_negative_weight_rejected(self):
+        with pytest.raises(ReconciliationError, match="negative"):
+            middle_out(
+                _block(), "family", {"FAM-X": BASE},
+                {"item-x1": Decimal("-1"), "item-x2": Decimal("3"),
+                 "item-x3": Decimal("2")},
+            )
+
+    def test_negative_base_value_rejected(self):
+        with pytest.raises(ReconciliationError, match="negative"):
+            middle_out(
+                _block(), "family",
+                {"FAM-X": [Decimal("-5"), Decimal("10")]},
+                TOTALS,
+            )
+
+    def test_block_without_leaves(self):
+        with pytest.raises(ReconciliationError, match="no leaf columns"):
+            middle_out(_block(memberships=[]), "family", {"FAM-X": BASE}, {})
+
+    def test_zero_base_with_zero_weights_yields_zero_curves(self):
+        """All-zero base + no history is a legitimate silent block: every
+        curve is 0, no error (nothing to disaggregate)."""
+        result = middle_out(
+            _block(), "family",
+            {"FAM-X": [Decimal("0"), Decimal("0")]},
+            {},
+        )
+        assert all(v == (Decimal("0"), Decimal("0")) for v in result.values)
+
+
+class TestDispatcher:
+    def test_middleout_direct(self):
+        result = reconcile(_block(), "family", {"FAM-X": BASE}, TOTALS)
+        assert result.recon_method == RECON_MIDDLEOUT
+        assert _by_key(result) == EXPECTED
+
+    def test_unsupported_method_fails_loudly(self):
+        with pytest.raises(ReconciliationError, match="unsupported"):
+            reconcile(_block(), "family", {"FAM-X": BASE}, TOTALS,
+                      method="topdown")
+
+    def test_mint_without_inputs_falls_back_to_middleout(self):
+        """The fallback is deterministic (no dependency involved: missing
+        inputs short-circuit before any import) and provenance says the
+        truth: recon_method == 'middleout' + explicit warning."""
+        result = reconcile(
+            _block(), "family", {"FAM-X": BASE}, TOTALS,
+            method=RECON_MINT_SHRINK, mint_inputs=None,
+        )
+        assert result.recon_method == RECON_MIDDLEOUT
+        assert any("fell back" in w for w in result.warnings)
+        assert _by_key(result) == EXPECTED
+
+    def test_mint_strict_raises_instead_of_falling_back(self):
+        with pytest.raises(ReconciliationError, match="strict"):
+            reconcile(
+                _block(), "family", {"FAM-X": BASE}, TOTALS,
+                method=RECON_MINT_SHRINK, mint_inputs=None, strict=True,
+            )
+
+
+class TestMintShrinkOptionalBackend:
+    """Real MinT path — runs only when the optional [forecast] backend is
+    installed; the coherence contract must hold whatever the backend
+    returns (leaves clamped, aggregates re-derived through S)."""
+
+    def _inputs(self, k: int = 12) -> MintInputs:
+        leaf_hist = {
+            "item-x1": [Decimal("10")] * k,
+            "item-x2": [Decimal("6")] * k,
+            "item-x3": [Decimal("4")] * k,
+        }
+        agg_hist = {
+            "PRD-X1": [Decimal("16")] * k,
+            "PRD-X2": [Decimal("4")] * k,
+            "FAM-X": [Decimal("20")] * k,
+        }
+        fitted = lambda hist: (hist[0], *hist[:-1])  # noqa: E731
+        return MintInputs(
+            aggregate_curves={"FAM-X": [Decimal("20")] * 3,
+                              "PRD-X1": [Decimal("16")] * 3,
+                              "PRD-X2": [Decimal("4")] * 3},
+            leaf_curves={"item-x1": [Decimal("10")] * 3,
+                         "item-x2": [Decimal("6")] * 3,
+                         "item-x3": [Decimal("4")] * 3},
+            aggregate_insample=agg_hist,
+            leaf_insample=leaf_hist,
+            aggregate_fitted={c: fitted(h) for c, h in agg_hist.items()},
+            leaf_fitted={c: fitted(h) for c, h in leaf_hist.items()},
+        )
+
+    def test_mint_shrink_produces_coherent_curves(self):
+        pytest.importorskip("hierarchicalforecast")
+        block = _block()
+        try:
+            result = mint_shrink(block, "family", self._inputs())
+        except ReconciliationUnavailable as exc:
+            pytest.skip(f"MinT backend unavailable in this environment: {exc}")
+        assert result.recon_method == RECON_MINT_SHRINK
+        leaf_offset = len(result.series) - len(block.leaves)
+        horizon = len(result.values[0])
+        for t in range(horizon):
+            leaf_vector = [result.values[leaf_offset + j][t] for j in range(len(block.leaves))]
+            assert all(v >= 0 for v in leaf_vector)
+            assert block.multiply(leaf_vector) == [result.values[i][t] for i in range(len(result.series))]
+
+    def test_mint_refuses_short_insample(self):
+        """Whether the backend is installed (length check) or not (lazy
+        import), the failure mode is the same fallback-able exception."""
+        with pytest.raises(ReconciliationUnavailable):
+            mint_shrink(_block(), "family", self._inputs(k=3))


### PR DESCRIPTION
## Pyramide V1 — axe A, PR3 : la réconciliation (spec §3-4, décision D4)

L'assemblage final de l'axe A : les courbes saisonnières (PR1 #361) circulent dans la matrice S (PR2 #362) et en ressortent **cohérentes à tous les niveaux**.

- **`middle_out()` = cœur déterministe garanti** (pur `Decimal`, golden-testé) : parts historiques par fenêtre glissante, **cold-start par produit jumeau**, zéros naturels tracés. **ŷ = S·b̂ exact par construction** — chaque série, y compris le niveau de réconciliation lui-même, est re-dérivée comme somme creuse des feuilles réconciliées.
- **`mint_shrink()` = amélioration optionnelle** (`hierarchicalforecast`, extra `[forecast]`, import paresseux + fallback réel) — bord stochastique documenté (non-reproductibilité BLAS → ADR-022). **La provenance ne ment jamais** : `recon_method` persisté = méthode effective ; un fallback écrit `middleout` + warning ; l'endpoint mono-série refuse toute valeur ≠ `none` (422, fix revue).
- **`HierarchicalRunner`** : bloc → S → historiques par nœud → forecasts saisonniers → réconciliation → **persistance par niveau** (schéma 053), scenario-aware, seedée/versionnée.
- **Commit graphe feuilles-seulement** : garde typée → 409 — les agrégats ne polluent jamais le graphe (pas de double comptage).
- **Migration 054** : `recon_method` cesse d'être une colonne morte + réparation d'un trou latent (CHECK `SEASONAL` manquant depuis la 038).
- **ADR-022** : décisions et alternatives rejetées (MinT par défaut, tolérance a posteriori, agrégats dans le graphe).

25 goldens purs main-calculés (parts 0.5/0.3/0.2 × [200,50,100,50] recalculées par le reviewer) · 5 tests d'intégration D6 (le générateur produit des motifs connus que la réconciliation doit retrouver) · 1841 unitaires ✅ · ruff ✅.

Closes #348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
