### PR TITLE
feat(pyramide): axe A PR4 — harnais de bench réconciliation, anti-fuite prouvé mécaniquement

### DIFF
--- a/scripts/bench_reconciliation.py
+++ b/scripts/bench_reconciliation.py
@@ -1,0 +1,141 @@
+"""
+bench_reconciliation.py — reconciliation bench CLI (Pyramide axis A, design §8).
+
+Thin CLI over ``ootils_core.pyramide.hierarchy.bench.run_reconciliation_bench``:
+for each summing block of the domain's default hierarchy, replays a forecast
+as of ``cutoff = today - holdout_days`` (train strictly before the cutoff,
+never CURRENT_DATE-bounded — the anti-leak split lives in the module) and
+scores every requested reconciliation method plus the uniform 'base'
+comparator against the demand that actually booked in the holdout window.
+
+**Read-only**: the bench only SELECTs (windowed demand_history reads +
+hierarchy registry); reconciliation and scoring are in-memory Python. Like
+scripts/bench_mrp.py, this harness forces a read-only transaction as a
+belt-and-braces guard, so it is safe against a loaded/pilote DB.
+
+Output: one table row per (block, level, method) with WAPE / MASE / bias /
+n_series / n_obs, then the per-block verdict (method with the minimal
+leaf-level WAPE; '(cannot rank)' when no leaf WAPE is defined), then any
+skip/fallback warnings.
+
+Usage:
+    DATABASE_URL=postgresql://ootils:ootils@host:5432/ootils_pilote_test \
+        python scripts/bench_reconciliation.py --domain product \
+            --methods middleout,mintrace_wls_shrink --holdout-days 28
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import psycopg
+from psycopg.rows import dict_row
+
+from ootils_core.pyramide.hierarchy.bench import (
+    BenchReport,
+    run_reconciliation_bench,
+)
+
+
+def _fmt(value, width: int = 9, digits: int = 4) -> str:
+    """Fixed-width numeric cell; '-' for the accuracy module's None sentinel."""
+    if value is None:
+        return "-".rjust(width)
+    return f"{value:.{digits}f}".rjust(width)
+
+
+def print_report(report: BenchReport) -> None:
+    print(
+        f"=== Reconciliation bench -- domain={report.domain} "
+        f"cutoff={report.cutoff.isoformat()} horizon={report.horizon}d "
+        f"holdout={report.holdout_days}d lookback={report.lookback_days}d ===\n"
+    )
+    if not report.rows:
+        print("(no rows -- every block was skipped, see warnings)")
+    else:
+        header = (
+            f"{'block':<20}{'level':<14}{'method':<22}"
+            f"{'WAPE':>9}{'MASE':>9}{'bias':>9}{'series':>8}{'n_obs':>8}"
+        )
+        print(header)
+        print("-" * len(header))
+        for block, level, method, wape, mase, bias, n_series, n_obs in (
+            report.to_rows()
+        ):
+            print(
+                f"{block:<20}{level:<14}{method:<22}"
+                f"{_fmt(wape)}{_fmt(mase)}{_fmt(bias)}"
+                f"{n_series:>8d}{n_obs:>8d}"
+            )
+
+    print("\n--- verdicts (minimal leaf-level WAPE per block) ---")
+    verdicts = report.verdicts()
+    if not verdicts:
+        print("(no block benched)")
+    for block in sorted(verdicts):
+        winner = verdicts[block] or "(cannot rank: no defined leaf WAPE)"
+        print(f"  {block:<20} -> {winner}")
+
+    if report.warnings:
+        print(f"\n--- warnings ({len(report.warnings)}) ---")
+        for warning in report.warnings:
+            print(f"  ! {warning}")
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    p.add_argument("--domain", required=True,
+                   help="hierarchy domain (uses the domain's default hierarchy)")
+    p.add_argument("--block-level", default=None,
+                   help="level defining the blocks (default: hierarchy root)")
+    p.add_argument("--recon-level", default=None,
+                   help="reconciliation level (default: the block level)")
+    p.add_argument("--lookback-days", type=int, default=365)
+    p.add_argument("--horizon", type=int, default=28)
+    p.add_argument("--holdout-days", type=int, default=28)
+    p.add_argument("--methods", default="middleout",
+                   help="comma-separated reconciliation methods "
+                        "('base' is always benched implicitly)")
+    p.add_argument("--blocks", default=None,
+                   help="comma-separated block codes (default: every block)")
+    args = p.parse_args(argv)
+    if not args.dsn:
+        print("ERROR: set DATABASE_URL or pass --dsn", file=sys.stderr)
+        return 2
+
+    methods = [m.strip() for m in args.methods.split(",") if m.strip()]
+    blocks = None
+    if args.blocks:
+        blocks = [b.strip() for b in args.blocks.split(",") if b.strip()]
+
+    with psycopg.connect(args.dsn, row_factory=dict_row) as conn:
+        # Belt-and-braces: the bench only reads, but make it impossible to
+        # write — protects a loaded/pilote DB from any accidental mutation.
+        # COMMIT right after the SETs: in psycopg3 (non-autocommit) the first
+        # execute() opens the very transaction the SETs run in, and
+        # default_transaction_read_only only applies to SUBSEQUENT
+        # transactions — without this commit the guard would be decorative
+        # for the whole bench run (review PR4).
+        conn.execute("SET statement_timeout = '120s'")
+        conn.execute("SET default_transaction_read_only = on")
+        conn.commit()
+        report = run_reconciliation_bench(
+            conn,
+            domain=args.domain,
+            block_level=args.block_level,
+            recon_level=args.recon_level,
+            lookback_days=args.lookback_days,
+            horizon=args.horizon,
+            holdout_days=args.holdout_days,
+            methods=methods,
+            block_codes=blocks,
+        )
+
+    print_report(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/forecast_reconcile_poc.py
+++ b/scripts/forecast_reconcile_poc.py
@@ -1,6 +1,13 @@
 """
 forecast_reconcile_poc.py — does middle-out beat bottom-up? (Pyramide axis A).
 
+PREUVE HISTORIQUE — conservée telle quelle. La thèse validée ici a été
+promue en module produit ``src/ootils_core/pyramide/hierarchy/bench.py``
+(harnais de bench réconciliation, split train/holdout explicite anti-fuite,
+scoring wape/mase/bias via ``pyramide/accuracy.py``) + CLI
+``scripts/bench_reconciliation.py``. Utiliser ceux-là pour tout nouveau
+bench ; ce PoC reste comme trace de la décision (numpy/pandas, ad hoc).
+
 Tests the core thesis of the Pyramide forecasting design on real demand_history:
 forecasting at the clean AGGREGATE level (gen_group) and disaggregating to SKUs
 via historical share beats forecasting each noisy SKU series directly.

--- a/src/ootils_core/pyramide/hierarchy/bench.py
+++ b/src/ootils_core/pyramide/hierarchy/bench.py
@@ -1,0 +1,754 @@
+"""
+Reconciliation bench (Pyramide axis A — design §8): which reconciliation
+method wins, per block, on real held-out demand.
+
+The pilot decides on numbers, not vibes: for each summing block the bench
+replays a forecast **as of a past cutoff** and scores every candidate
+reconciliation method against the demand that actually booked afterwards.
+
+Temporal split — EXPLICIT, never CURRENT_DATE
+---------------------------------------------
+``cutoff = today - holdout_days``. TRAIN is ``demand_history`` STRICTLY
+before the cutoff (bounded by ``lookback_days``); EVAL is
+``[cutoff, cutoff + horizon)``. The SQL here composes the shared
+``_DEMAND_HISTORY_STREAM_PREDICATES`` of ``pyramide/repository.py`` (the
+pure business rules: stream='regular', inter-entity excluded, booked_date
+present) with an explicit parameterized window — reusing the runtime
+readers' CURRENT_DATE-bounded predicates would leak holdout days into
+training, which is exactly the bug this split exists to prevent.
+
+What is compared
+----------------
+Per block and per requested method (``reconcile()`` does the work — the
+bench adds ZERO reconciliation logic), plus the ``'base'`` comparator:
+
+* ``'base'`` = the un-reconciled recon-level forecasts. Leaf-level base
+  curves are a documented NAIVE UNIFORM disaggregation (each leaf under a
+  recon node receives ``curve / n_leaves``): the engine only forecasts at
+  the reconciliation level, so no per-leaf base forecast exists — uniform
+  split is the honest "no reconciliation intelligence" floor.
+
+Scores come from ``ootils_core.pyramide.accuracy`` (wape / mase / bias) —
+zero local metric formulas — at three levels: leaves (pooled), the
+reconciliation level (pooled over its nodes) and the block root. MASE is
+the per-series mean of the defined values (None-safe: series whose train
+history is constant/short contribute nothing, per the accuracy contract).
+
+Verdict: per block, the method with the minimal LEAF-level WAPE (None
+WAPEs excluded; ties broken by method name — deterministic).
+
+Strategies
+----------
+``'exact'`` is the only implemented strategy (single item hierarchy).
+``'two_stage'`` (item x geography) raises ``NotImplementedError``: it is
+gated on the geo hierarchy leg, which does not exist yet. Strategy
+validation happens BEFORE any DB access, so the gate is testable without
+a database.
+
+Genericity: hierarchy/domain/levels all come from the migration-047
+registry — no business constant anywhere in this module.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Mapping, Sequence
+from uuid import UUID
+
+import psycopg
+
+from ..accuracy import bias as accuracy_bias
+from ..accuracy import mase as accuracy_mase
+from ..accuracy import wape as accuracy_wape
+from ..engines import PyramideEngineError, PyramideForecastEngine
+from ..models import METHOD_AUTO_SELECT
+from ..repository import _DEMAND_HISTORY_STREAM_PREDICATES
+from .reconcile import (
+    MINT_MIN_INSAMPLE,
+    RECON_MINT_SHRINK,
+    SUPPORTED_RECON_METHODS,
+    MintInputs,
+    ReconciliationError,
+    reconcile,
+)
+from .summing import AGGREGATE, LEAF, SummingBlock, load_summing_blocks
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "LEVEL_LEAF",
+    "LEVEL_ROOT",
+    "METHOD_BASE",
+    "STRATEGY_EXACT",
+    "STRATEGY_TWO_STAGE",
+    "BenchReport",
+    "BenchRow",
+    "build_bench_report",
+    "compute_bench_row",
+    "run_reconciliation_bench",
+]
+
+_ZERO = Decimal("0")
+
+METHOD_BASE = "base"
+
+LEVEL_LEAF = "leaf"
+LEVEL_ROOT = "root"
+# Display/sort rank: root first, intermediate (recon) levels, leaves last.
+_LEVEL_RANK = {LEVEL_ROOT: 0, LEVEL_LEAF: 2}
+
+STRATEGY_EXACT = "exact"
+STRATEGY_TWO_STAGE = "two_stage"
+
+
+# ---------------------------------------------------------------------------
+# Report structures (pure — unit-testable without a database)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BenchRow:
+    """One scored (block, level, method) cell of the bench.
+
+    ``wape``/``mase`` follow the accuracy module's None sentinel (metric
+    undefined on this data — e.g. zero actual demand in the eval window);
+    ``bias`` is None only when the row scored zero observations, which
+    the bench never emits itself (defensive for hand-built rows).
+    """
+
+    block: str
+    level: str
+    method: str
+    wape: Decimal | None
+    mase: Decimal | None
+    bias: Decimal | None
+    n_series: int
+    n_obs: int
+
+
+@dataclass(frozen=True)
+class BenchReport:
+    """Deterministic bench result: sorted rows + None-safe verdicts."""
+
+    domain: str
+    cutoff: date
+    horizon: int
+    holdout_days: int
+    lookback_days: int
+    rows: tuple[BenchRow, ...]
+    warnings: tuple[str, ...] = ()
+
+    def verdicts(self) -> dict[str, str | None]:
+        """Per block: the method with the minimal leaf-level WAPE.
+
+        None-safe: rows whose WAPE is None (undefined metric) never win;
+        a block with no defined leaf WAPE at all gets verdict ``None``
+        ("cannot rank" — never a silent arbitrary winner). Ties break on
+        the method name — deterministic.
+        """
+        out: dict[str, str | None] = {}
+        best: dict[str, tuple[Decimal, str]] = {}
+        for row in self.rows:
+            out.setdefault(row.block, None)
+            if row.level != LEVEL_LEAF or row.wape is None:
+                continue
+            key = (row.wape, row.method)
+            if row.block not in best or key < best[row.block]:
+                best[row.block] = key
+        for block, (_, method) in best.items():
+            out[block] = method
+        return out
+
+    def to_rows(self) -> list[tuple]:
+        """Plain tuples for tabular display, in the report's sort order."""
+        return [
+            (
+                row.block,
+                row.level,
+                row.method,
+                row.wape,
+                row.mase,
+                row.bias,
+                row.n_series,
+                row.n_obs,
+            )
+            for row in self.rows
+        ]
+
+
+def build_bench_report(
+    rows: Sequence[BenchRow],
+    *,
+    domain: str,
+    cutoff: date,
+    horizon: int,
+    holdout_days: int,
+    lookback_days: int,
+    warnings: Sequence[str] = (),
+) -> BenchReport:
+    """Assemble a report with deterministic row order.
+
+    Sort key: block, then level rank (root -> intermediate -> leaves),
+    then level name, then method — same inputs, byte-identical report.
+    """
+    ordered = tuple(
+        sorted(
+            rows,
+            key=lambda r: (r.block, _LEVEL_RANK.get(r.level, 1), r.level, r.method),
+        )
+    )
+    return BenchReport(
+        domain=domain,
+        cutoff=cutoff,
+        horizon=horizon,
+        holdout_days=holdout_days,
+        lookback_days=lookback_days,
+        rows=ordered,
+        warnings=tuple(warnings),
+    )
+
+
+def compute_bench_row(
+    *,
+    block: str,
+    level: str,
+    method: str,
+    actual_curves: Sequence[Sequence[Decimal]],
+    forecast_curves: Sequence[Sequence[Decimal]],
+    insamples: Sequence[Sequence[Decimal]],
+) -> BenchRow:
+    """Score one (block, level, method) cell — pure, golden-testable.
+
+    WAPE and bias are POOLED over every (series, period) pair of the
+    level (volume-weighted, the business-facing aggregation). MASE is the
+    mean of the per-series values (each series scaled by its OWN train
+    history, per the accuracy contract); series whose MASE is undefined
+    (constant/short insample) are excluded, and the row's MASE is None
+    when no series qualifies. Every formula lives in
+    ``ootils_core.pyramide.accuracy`` — nothing metric-shaped here.
+    """
+    if not actual_curves:
+        raise ValueError("actual_curves must not be empty")
+    if not (len(actual_curves) == len(forecast_curves) == len(insamples)):
+        raise ValueError(
+            "actual_curves, forecast_curves and insamples must align "
+            f"({len(actual_curves)}, {len(forecast_curves)}, {len(insamples)})"
+        )
+    pooled_actuals: list[Decimal] = []
+    pooled_forecasts: list[Decimal] = []
+    mase_values: list[Decimal] = []
+    for actuals, forecasts, insample in zip(
+        actual_curves, forecast_curves, insamples
+    ):
+        if len(actuals) != len(forecasts):
+            raise ValueError(
+                f"series curves must have the same length "
+                f"({len(actuals)} != {len(forecasts)})"
+            )
+        pooled_actuals.extend(actuals)
+        pooled_forecasts.extend(forecasts)
+        series_mase = accuracy_mase(actuals, forecasts, insample)
+        if series_mase is not None:
+            mase_values.append(series_mase)
+    mase_value: Decimal | None = None
+    if mase_values:
+        mase_value = sum(mase_values, _ZERO) / Decimal(len(mase_values))
+    return BenchRow(
+        block=block,
+        level=level,
+        method=method,
+        wape=accuracy_wape(pooled_actuals, pooled_forecasts),
+        mase=mase_value,
+        bias=accuracy_bias(pooled_actuals, pooled_forecasts),
+        n_series=len(actual_curves),
+        n_obs=len(pooled_actuals),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bench runner (DB-backed)
+# ---------------------------------------------------------------------------
+
+
+def run_reconciliation_bench(
+    db: psycopg.Connection,
+    *,
+    domain: str,
+    block_level: str | None = None,
+    recon_level: str | None = None,
+    lookback_days: int = 365,
+    horizon: int = 28,
+    holdout_days: int = 28,
+    methods: Sequence[str] = ("middleout",),
+    strategy: str = STRATEGY_EXACT,
+    block_codes: Sequence[str] | None = None,
+    forecast_engine: PyramideForecastEngine | None = None,
+    today: date | None = None,
+) -> BenchReport:
+    """Run the reconciliation bench on the domain's default hierarchy.
+
+    For every block (optionally restricted to ``block_codes``): train
+    strictly before ``cutoff = today - holdout_days`` (lookback-bounded),
+    forecast+reconcile over ``horizon`` days from the cutoff with each
+    requested method, score against the booked actuals of
+    ``[cutoff, cutoff + horizon)`` — plus the ``'base'`` comparator (see
+    module docstring for its naive-uniform leaf floor).
+
+    ``today`` exists for deterministic replays (defaults to the wall
+    clock — a bench is an operator tool, not a core calculation).
+
+    A block that cannot be benched (no node at the recon level, no
+    training history, engine failure) is SKIPPED with a warning — one
+    cold block must not kill the whole scoreboard; the warning is the
+    fail-loudly trace.
+
+    Raises:
+        NotImplementedError: ``strategy='two_stage'`` (gated on the geo
+            hierarchy leg — validated before any DB access).
+        ValueError: unknown strategy/method, non-positive windows, or
+            ``block_codes`` naming blocks the hierarchy does not have.
+    """
+    _validate_bench_params(
+        strategy=strategy,
+        horizon=horizon,
+        holdout_days=holdout_days,
+        lookback_days=lookback_days,
+        methods=methods,
+    )
+    engine = forecast_engine or PyramideForecastEngine()
+    cutoff = (today or date.today()) - timedelta(days=holdout_days)
+
+    blocks = load_summing_blocks(db, domain=domain, block_level=block_level)
+    if block_codes is not None:
+        wanted = set(block_codes)
+        blocks = [b for b in blocks if b.block_code in wanted]
+        missing = wanted - {b.block_code for b in blocks}
+        if missing:
+            raise ValueError(
+                f"blocks {sorted(missing)} not found at level "
+                f"'{block_level or 'root'}' of domain '{domain}'"
+            )
+
+    rows: list[BenchRow] = []
+    warnings: list[str] = []
+    for block in blocks:
+        if not block.leaves:
+            warnings.append(
+                f"block '{block.block_code}': no leaf column — skipped"
+            )
+            continue
+        block_rows, block_warnings = _bench_block(
+            db,
+            block,
+            recon_level or block.block_level,
+            engine,
+            cutoff=cutoff,
+            horizon=horizon,
+            lookback_days=lookback_days,
+            methods=tuple(methods),
+        )
+        rows.extend(block_rows)
+        warnings.extend(block_warnings)
+
+    return build_bench_report(
+        rows,
+        domain=domain,
+        cutoff=cutoff,
+        horizon=horizon,
+        holdout_days=holdout_days,
+        lookback_days=lookback_days,
+        warnings=warnings,
+    )
+
+
+def _validate_bench_params(
+    *,
+    strategy: str,
+    horizon: int,
+    holdout_days: int,
+    lookback_days: int,
+    methods: Sequence[str],
+) -> None:
+    """Parameter gate — runs BEFORE any DB access (testable without one)."""
+    if strategy == STRATEGY_TWO_STAGE:
+        raise NotImplementedError("two_stage: gated on the geo hierarchy")
+    if strategy != STRATEGY_EXACT:
+        raise ValueError(
+            f"unknown bench strategy '{strategy}' "
+            f"(supported: ['{STRATEGY_EXACT}'; '{STRATEGY_TWO_STAGE}' is gated])"
+        )
+    if horizon < 1:
+        raise ValueError(f"horizon must be >= 1 (got {horizon})")
+    if holdout_days < 1:
+        raise ValueError(f"holdout_days must be >= 1 (got {holdout_days})")
+    if horizon > holdout_days:
+        # The eval window [cutoff, cutoff+horizon) would overflow past the
+        # held-out actuals: _dense_curve would fill those days with phantom
+        # zeros and penalise EVERY method with fake misses (review PR4).
+        # Fail loudly instead of benching against the void.
+        raise ValueError(
+            f"horizon ({horizon}) must be <= holdout_days ({holdout_days}) — "
+            "the eval window cannot extend past the held-out actuals"
+        )
+    if lookback_days < 1:
+        raise ValueError(f"lookback_days must be >= 1 (got {lookback_days})")
+    if not methods:
+        raise ValueError("methods must not be empty")
+    unknown = set(methods) - SUPPORTED_RECON_METHODS
+    if unknown:
+        raise ValueError(
+            f"unsupported reconciliation methods {sorted(unknown)} "
+            f"(supported: {sorted(SUPPORTED_RECON_METHODS)}; "
+            f"'{METHOD_BASE}' is always benched implicitly)"
+        )
+
+
+def _bench_block(
+    db: psycopg.Connection,
+    block: SummingBlock,
+    recon_level: str,
+    engine: PyramideForecastEngine,
+    *,
+    cutoff: date,
+    horizon: int,
+    lookback_days: int,
+    methods: tuple[str, ...],
+) -> tuple[list[BenchRow], list[str]]:
+    """Score one block: train before cutoff, evaluate on the holdout."""
+    warnings: list[str] = []
+    recon_refs = [
+        (i, ref)
+        for i, ref in enumerate(block.series)
+        if ref.kind == AGGREGATE and ref.level == recon_level
+    ]
+    if not recon_refs:
+        return [], [
+            f"block '{block.block_code}': no node at reconciliation level "
+            f"'{recon_level}' — skipped"
+        ]
+
+    train = _load_daily_by_item(
+        db,
+        block.leaves,
+        start=cutoff - timedelta(days=lookback_days),
+        stop=cutoff,
+    )
+    holdout = _load_daily_by_item(
+        db, block.leaves, start=cutoff, stop=cutoff + timedelta(days=horizon)
+    )
+    leaf_totals = {
+        key: sum(by_date.values(), _ZERO) for key, by_date in train.items()
+    }
+    leaf_actuals = [
+        _dense_curve(holdout.get(leaf, {}), cutoff, horizon)
+        for leaf in block.leaves
+    ]
+    leaf_insamples = [
+        _sparse_series(train.get(leaf, {})) for leaf in block.leaves
+    ]
+
+    # Base forecasts at the reconciliation level, on TRAIN data only.
+    base_curves: dict[str, tuple[Decimal, ...]] = {}
+    node_insample: dict[str, list[Decimal]] = {}
+    for i, ref in recon_refs:
+        if not block.rows[i]:
+            continue  # node without leaves: nothing to forecast or score
+        series = _sparse_sum(train, [block.leaves[j] for j in block.rows[i]])
+        if not series:
+            return [], [
+                f"block '{block.block_code}': node '{ref.key}' has no "
+                f"training history before {cutoff.isoformat()} — skipped"
+            ]
+        node_insample[ref.key] = series
+        try:
+            base_curves[ref.key] = _clamped_forecast(
+                engine, series, horizon, cutoff
+            )
+        except PyramideEngineError as exc:
+            return [], [
+                f"block '{block.block_code}': base forecast failed for node "
+                f"'{ref.key}': {exc} — skipped"
+            ]
+
+    mint_inputs: MintInputs | None = None
+    if RECON_MINT_SHRINK in methods:
+        mint_inputs, mint_warnings = _bench_mint_inputs(
+            block, base_curves, train, node_insample, engine, cutoff, horizon
+        )
+        warnings.extend(
+            f"block '{block.block_code}': {w}" for w in mint_warnings
+        )
+
+    root_index = next(
+        i
+        for i, ref in enumerate(block.series)
+        if ref.kind == AGGREGATE and ref.key == block.block_code
+    )
+    recon_indices = {i for i, _ in recon_refs}
+    scored_refs = [(i, ref) for i, ref in recon_refs if block.rows[i]]
+
+    rows: list[BenchRow] = []
+
+    def _score_levels(
+        method: str,
+        leaf_forecasts: Sequence[Sequence[Decimal]],
+        node_forecasts: Mapping[str, Sequence[Decimal]],
+        root_forecast: Sequence[Decimal],
+    ) -> None:
+        rows.append(compute_bench_row(
+            block=block.block_code, level=LEVEL_LEAF, method=method,
+            actual_curves=leaf_actuals, forecast_curves=leaf_forecasts,
+            insamples=leaf_insamples,
+        ))
+        if scored_refs:
+            rows.append(compute_bench_row(
+                block=block.block_code, level=recon_level, method=method,
+                actual_curves=[
+                    _pointwise_sum(
+                        [leaf_actuals[j] for j in block.rows[i]], horizon
+                    )
+                    for i, _ in scored_refs
+                ],
+                forecast_curves=[
+                    node_forecasts[ref.key] for _, ref in scored_refs
+                ],
+                insamples=[node_insample[ref.key] for _, ref in scored_refs],
+            ))
+        if root_index not in recon_indices:
+            # Root row only when the root is not itself the recon level
+            # (otherwise it duplicates the recon-level row exactly).
+            rows.append(compute_bench_row(
+                block=block.block_code, level=LEVEL_ROOT, method=method,
+                actual_curves=[_pointwise_sum(leaf_actuals, horizon)],
+                forecast_curves=[root_forecast],
+                insamples=[_sparse_sum(train, block.leaves)],
+            ))
+
+    for method in methods:
+        try:
+            recon = reconcile(
+                block,
+                recon_level,
+                base_curves,
+                leaf_totals,
+                method=method,
+                mint_inputs=(
+                    mint_inputs if method == RECON_MINT_SHRINK else None
+                ),
+            )
+        except ReconciliationError as exc:
+            warnings.append(
+                f"block '{block.block_code}': method '{method}' failed: "
+                f"{exc} — no rows for this method"
+            )
+            continue
+        if recon.recon_method != method:
+            warnings.append(
+                f"block '{block.block_code}': method '{method}' fell back "
+                f"to '{recon.recon_method}' — its rows score the fallback"
+            )
+        leaf_forecasts = [
+            recon.values[i]
+            for i, ref in enumerate(block.series)
+            if ref.kind == LEAF
+        ]
+        _score_levels(
+            method,
+            leaf_forecasts,
+            {ref.key: recon.values[i] for i, ref in scored_refs},
+            recon.values[root_index],
+        )
+
+    # 'base' comparator: un-reconciled node curves; leaf floor = naive
+    # UNIFORM disaggregation (documented in the module docstring). Leaves
+    # not under any populated recon node keep a zero curve.
+    base_leaf: list[Sequence[Decimal]] = [
+        tuple(_ZERO for _ in range(horizon)) for _ in block.leaves
+    ]
+    for i, ref in scored_refs:
+        n = Decimal(len(block.rows[i]))
+        for j in block.rows[i]:
+            base_leaf[j] = tuple(v / n for v in base_curves[ref.key])
+    _score_levels(
+        METHOD_BASE,
+        base_leaf,
+        base_curves,
+        _pointwise_sum(list(base_curves.values()), horizon),
+    )
+    return rows, warnings
+
+
+def _bench_mint_inputs(
+    block: SummingBlock,
+    base_curves: Mapping[str, tuple[Decimal, ...]],
+    train: Mapping[str, dict[date, Decimal]],
+    node_insample: Mapping[str, list[Decimal]],
+    engine: PyramideForecastEngine,
+    cutoff: date,
+    horizon: int,
+) -> tuple[MintInputs | None, list[str]]:
+    """In-memory MinT inputs from the TRAIN split (no extra DB reads).
+
+    Same V1 approximations as the runner (ADR-022): positional alignment
+    of sparse series tails, naive lag-1 fitted proxy. Any empty series or
+    a tail shorter than MINT_MIN_INSAMPLE skips MinT (the dispatcher then
+    falls back to middle-out, and the bench warns).
+    """
+    histories: list[tuple[object, list[Decimal]]] = []
+    for i, ref in enumerate(block.series):
+        if ref.kind == AGGREGATE:
+            series = node_insample.get(ref.key) or _sparse_sum(
+                train, [block.leaves[j] for j in block.rows[i]]
+            )
+        else:
+            series = _sparse_series(train.get(ref.key, {}))
+        if not series:
+            return None, [
+                f"{RECON_MINT_SHRINK} skipped: series '{ref.key}' has no "
+                "training history (middle-out fallback)"
+            ]
+        histories.append((ref, series))
+
+    k = min(len(series) for _, series in histories)
+    if k < MINT_MIN_INSAMPLE:
+        return None, [
+            f"{RECON_MINT_SHRINK} skipped: aligned insample tail is {k} < "
+            f"{MINT_MIN_INSAMPLE} points (middle-out fallback)"
+        ]
+
+    aggregate_curves: dict[str, Sequence[Decimal]] = {}
+    leaf_curves: dict[str, Sequence[Decimal]] = {}
+    aggregate_insample: dict[str, Sequence[Decimal]] = {}
+    leaf_insample: dict[str, Sequence[Decimal]] = {}
+    aggregate_fitted: dict[str, Sequence[Decimal]] = {}
+    leaf_fitted: dict[str, Sequence[Decimal]] = {}
+    for ref, series in histories:
+        if ref.kind == AGGREGATE and ref.key in base_curves:
+            curve: Sequence[Decimal] = base_curves[ref.key]
+        else:
+            try:
+                curve = _clamped_forecast(engine, series, horizon, cutoff)
+            except PyramideEngineError as exc:
+                return None, [
+                    f"{RECON_MINT_SHRINK} skipped: base forecast failed "
+                    f"for series '{ref.key}': {exc} (middle-out fallback)"
+                ]
+        tail = tuple(series[-k:])
+        fitted = (tail[0], *tail[:-1])  # naive lag-1 insample proxy
+        if ref.kind == AGGREGATE:
+            aggregate_curves[ref.key] = curve
+            aggregate_insample[ref.key] = tail
+            aggregate_fitted[ref.key] = fitted
+        else:
+            leaf_curves[ref.key] = curve
+            leaf_insample[ref.key] = tail
+            leaf_fitted[ref.key] = fitted
+    return MintInputs(
+        aggregate_curves=aggregate_curves,
+        leaf_curves=leaf_curves,
+        aggregate_insample=aggregate_insample,
+        leaf_insample=leaf_insample,
+        aggregate_fitted=aggregate_fitted,
+        leaf_fitted=leaf_fitted,
+    ), []
+
+
+# ---------------------------------------------------------------------------
+# Windowed history readers + series helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_daily_by_item(
+    db: psycopg.Connection,
+    leaves: Sequence[str],
+    *,
+    start: date,
+    stop: date,
+) -> dict[str, dict[date, Decimal]]:
+    """Daily booked sums per item over an EXPLICIT [start, stop) window.
+
+    Composes the shared stream predicates (business rules) with the
+    bench's parameterized window — this is the anti-leak read path: the
+    same query serves the TRAIN split (stop = cutoff) and the EVAL split
+    (start = cutoff), so the two can never overlap by construction.
+    Cross-site sums, like every hierarchy reader (the site split is the
+    DRP layer's job); demand_history is scenario-invariant (actuals).
+    """
+    rows = db.execute(
+        f"""
+        SELECT dh.item_id,
+               dh.booked_date AS demand_date,
+               COALESCE(SUM(dh.ordered_quantity), 0) AS total_qty
+        FROM demand_history dh
+        WHERE dh.item_id = ANY(%(item_ids)s)
+          AND {_DEMAND_HISTORY_STREAM_PREDICATES}
+          AND dh.booked_date >= %(start)s
+          AND dh.booked_date < %(stop)s
+        GROUP BY dh.item_id, dh.booked_date
+        ORDER BY dh.item_id ASC, dh.booked_date ASC
+        """,
+        {"item_ids": [UUID(key) for key in leaves], "start": start, "stop": stop},
+    ).fetchall()
+    out: dict[str, dict[date, Decimal]] = {}
+    for row in rows:
+        out.setdefault(str(row["item_id"]), {})[row["demand_date"]] = Decimal(
+            str(row["total_qty"])
+        )
+    return out
+
+
+def _sparse_series(by_date: Mapping[date, Decimal]) -> list[Decimal]:
+    """Sparse daily series, date ASC — the engines' history contract."""
+    return [by_date[d] for d in sorted(by_date)]
+
+
+def _sparse_sum(
+    train: Mapping[str, dict[date, Decimal]], leaf_keys: Sequence[str]
+) -> list[Decimal]:
+    """Aggregate sparse series: per-date sums over the given leaves."""
+    merged: dict[date, Decimal] = {}
+    for key in leaf_keys:
+        for day, qty in train.get(key, {}).items():
+            merged[day] = merged.get(day, _ZERO) + qty
+    return _sparse_series(merged)
+
+
+def _dense_curve(
+    by_date: Mapping[date, Decimal], start: date, horizon: int
+) -> tuple[Decimal, ...]:
+    """DENSE daily actuals over the eval window: a day without booking IS
+    zero demand (unlike the sparse training contract — the forecast made
+    a claim for every day of the horizon, so every day is scored)."""
+    return tuple(
+        by_date.get(start + timedelta(days=t), _ZERO) for t in range(horizon)
+    )
+
+
+def _pointwise_sum(
+    curves: Sequence[Sequence[Decimal]], horizon: int
+) -> tuple[Decimal, ...]:
+    return tuple(
+        sum((curve[t] for curve in curves), _ZERO) for t in range(horizon)
+    )
+
+
+def _clamped_forecast(
+    engine: PyramideForecastEngine,
+    history: Sequence[Decimal],
+    horizon: int,
+    cutoff: date,
+) -> tuple[Decimal, ...]:
+    """Base forecast on the TRAIN slice, clamped at 0 (same as runners)."""
+    computation = engine.forecast(
+        history=list(history),
+        periods=horizon,
+        method=METHOD_AUTO_SELECT,
+        method_params={},
+        model_strategy="stat",
+        granularity="daily",
+        horizon_start=cutoff,
+        random_seed=0,
+    )
+    return tuple(max(value, _ZERO) for value in computation.values)

--- a/src/ootils_core/pyramide/repository.py
+++ b/src/ootils_core/pyramide/repository.py
@@ -127,19 +127,30 @@ def resolve_scenario_uuid(scenario_id: str | None) -> UUID:
     return UUID(scenario_id)
 
 
-# Shared business predicates of the demand-history training signal.
-# Single definition consumed by BOTH readers (leaf pair and hierarchy
-# node) so the business rules can never drift apart:
+# Shared business predicates of the demand-history training signal,
+# split in two layers so they can never drift apart across consumers:
+#
+# _DEMAND_HISTORY_STREAM_PREDICATES — the pure business rules:
 #   - stream='regular' only (warranty is a separate forecast),
 #   - inter-entity flows excluded (PPS→PCC double-count, migration 048),
-#   - strict past (today is a partial day),
-#   - bounded lookback window.
-# Uses the named placeholder %(lookback_days)s — callers pass params as a
-# dict.
-_DEMAND_HISTORY_BUSINESS_PREDICATES = """
+#   - booked_date present (forecast-on-booking signal).
+#   Consumed directly by the reconciliation bench (hierarchy/bench.py),
+#   which needs the SAME rules over an EXPLICIT historical window
+#   (train/holdout split at a past cutoff — CURRENT_DATE bounds would
+#   leak holdout data into training).
+#
+# _DEMAND_HISTORY_BUSINESS_PREDICATES — the rules PLUS the live window
+#   (strict past because today is a partial day, bounded lookback).
+#   Single definition consumed by every runtime reader (leaf pair,
+#   hierarchy node, per-item, totals). Uses the named placeholder
+#   %(lookback_days)s — callers pass params as a dict.
+_DEMAND_HISTORY_STREAM_PREDICATES = """
               dh.stream = 'regular'
               AND (dh.fulfillment IS NULL OR dh.fulfillment <> 'inter_entity')
               AND dh.booked_date IS NOT NULL
+"""
+
+_DEMAND_HISTORY_BUSINESS_PREDICATES = _DEMAND_HISTORY_STREAM_PREDICATES + """
               AND dh.booked_date < CURRENT_DATE
               AND dh.booked_date >= CURRENT_DATE - (%(lookback_days)s::int * INTERVAL '1 day')
 """

--- a/tests/integration/test_reconciliation_bench_integration.py
+++ b/tests/integration/test_reconciliation_bench_integration.py
@@ -1,0 +1,231 @@
+"""
+Integration tests for the reconciliation bench (Pyramide axis A, design §8)
+against a real PostgreSQL database (no mocks).
+
+Covered:
+  - the bench runs end-to-end on one seeded block (synthetic KNOWN weekly
+    patterns, same D6-style generator as
+    test_pyramide_reconcile_integration.py, but with a history long enough
+    to carve out a holdout window) and produces FINITE wape/mase/bias for
+    'middleout' at all three levels (leaf, recon level, block root);
+  - determinism: two identical calls (fixed ``today``) return equal
+    BenchReports and the same non-None verdict;
+  - anti-leak: a demand line inserted INSIDE the holdout window (on the
+    cutoff day itself — the boundary belongs to EVAL) does NOT change the
+    training histories fed to the forecast engine (hence not the
+    forecasts), only the actuals/metrics. Verified with a recording
+    subclass of the REAL engine (instrumentation, not a mock: the real
+    compute runs).
+
+Conventions (mirrors test_pyramide_reconcile_integration.py): the
+function-scoped ``conn`` fixture (rollback teardown) keeps every test
+self-cleaning; every test seeds its OWN registry rows / items. Dates are
+FIXED (the bench never uses CURRENT_DATE and takes an explicit ``today``),
+so there is no wall-clock flakiness at all.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from ootils_core.pyramide.engines import PyramideForecastEngine
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+# Fully fixed clock: the bench takes an explicit `today` and its read path
+# composes the stream predicates with a parameterized window (never
+# CURRENT_DATE), so seeding at fixed past dates is exactly the production
+# replay situation.
+FIXED_TODAY = date(2026, 3, 2)
+HOLDOUT_DAYS = 28
+HORIZON = 28
+LOOKBACK_DAYS = 120
+CUTOFF = FIXED_TODAY - timedelta(days=HOLDOUT_DAYS)
+
+# D6-style synthetic generator (same pattern as
+# test_pyramide_reconcile_integration.py): a KNOWN weekly pattern scaled
+# per leaf. 12 train weeks + 4 holdout weeks of the SAME pattern, so every
+# method has both a learnable signal and non-zero holdout actuals.
+WEEK_PATTERN = (2, 1, 1, 1, 3, 4, 2)
+AMPLITUDES = {"A1": 10, "A2": 6, "A3": 4}
+TRAIN_DAYS = 84   # 12 full weeks strictly before the cutoff
+SEEDED_DAYS = range(1, TRAIN_DAYS + HOLDOUT_DAYS + 1)  # FIXED_TODAY-1 .. cutoff-84
+
+
+def _seed_block(conn, h: str, tag: str):
+    """FAM-<tag> (family, root) -> PRD-<tag>1 (2 items) + PRD-<tag>2 (1 item).
+
+    The hierarchy is registered as the domain default (the bench resolves
+    by domain); any pre-existing 'product' default is unset INSIDE the
+    test transaction — the conn fixture's rollback restores it.
+    """
+    conn.execute("UPDATE hierarchy SET is_default = FALSE WHERE domain = 'product'")
+    conn.execute(
+        """
+        INSERT INTO hierarchy (hierarchy_id, domain, scope, levels, is_default)
+        VALUES (%s, 'product', 'local', %s, TRUE)
+        """,
+        (h, ["family", "product"]),
+    )
+    fam, prd1, prd2 = f"FAM-{tag}", f"PRD-{tag}1", f"PRD-{tag}2"
+    for code, level, parent in [
+        (fam, "family", None),
+        (prd1, "product", fam),
+        (prd2, "product", fam),
+    ]:
+        conn.execute(
+            "INSERT INTO hierarchy_node (hierarchy_id, code, level, parent_code) "
+            "VALUES (%s, %s, %s, %s)",
+            (h, code, level, parent),
+        )
+
+    items: dict[str, UUID] = {}
+    for suffix, leaf_code in [("A1", prd1), ("A2", prd1), ("A3", prd2)]:
+        item_id = uuid4()
+        ext = f"BENCH-{tag}-{suffix}"
+        conn.execute(
+            "INSERT INTO items (item_id, name, item_type, uom, status, external_id) "
+            "VALUES (%s, %s, 'finished_good', 'EA', 'active', %s)",
+            (item_id, f"{ext} item", ext),
+        )
+        conn.execute(
+            "INSERT INTO item_hierarchy (item_id, hierarchy_id, leaf_code) "
+            "VALUES (%s, %s, %s)",
+            (item_id, h, leaf_code),
+        )
+        items[suffix] = item_id
+        for back in SEEDED_DAYS:
+            day = FIXED_TODAY - timedelta(days=back)
+            _insert_demand(
+                conn, item_id, ext, day,
+                AMPLITUDES[suffix] * WEEK_PATTERN[day.weekday()],
+            )
+    return fam, items
+
+
+def _insert_demand(conn, item_id: UUID, item_code: str, day: date, qty) -> None:
+    conn.execute(
+        """
+        INSERT INTO demand_history (
+            item_id, item_code, stream, booked_date,
+            ordered_quantity, value_ext, counts_for_asp,
+            fulfillment, order_number
+        ) VALUES (%s, %s, 'regular', %s, %s, 0, FALSE, 'standard', 'BENCH')
+        """,
+        (item_id, item_code, day, qty),
+    )
+
+
+def _run(conn, engine=None):
+    from ootils_core.pyramide.hierarchy.bench import run_reconciliation_bench
+
+    return run_reconciliation_bench(
+        conn,
+        domain="product",
+        recon_level="product",
+        lookback_days=LOOKBACK_DAYS,
+        horizon=HORIZON,
+        holdout_days=HOLDOUT_DAYS,
+        methods=("middleout",),
+        forecast_engine=engine,
+        today=FIXED_TODAY,
+    )
+
+
+class _RecordingEngine(PyramideForecastEngine):
+    """REAL engine + a record of every training history it was given.
+
+    Instrumentation, not a mock: forecasts are computed by the production
+    engine — the recording only makes the train split observable, which is
+    what the anti-leak test asserts on.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.histories: list[tuple[Decimal, ...]] = []
+
+    def forecast(self, **kwargs):
+        self.histories.append(tuple(kwargs["history"]))
+        return super().forecast(**kwargs)
+
+
+class TestReconciliationBench:
+    def test_middleout_scores_finitely_at_three_levels(self, conn):
+        from ootils_core.pyramide.hierarchy.bench import (
+            LEVEL_LEAF,
+            LEVEL_ROOT,
+            METHOD_BASE,
+        )
+
+        fam, items = _seed_block(conn, "bench-h-3lvl", "B1")
+        report = _run(conn)
+
+        assert report.domain == "product"
+        assert report.cutoff == CUTOFF
+        assert report.warnings == ()
+
+        by_cell = {(r.level, r.method): r for r in report.rows}
+        # middleout + the implicit 'base' comparator, each at 3 levels
+        assert set(by_cell) == {
+            (level, method)
+            for level in (LEVEL_LEAF, "product", LEVEL_ROOT)
+            for method in ("middleout", METHOD_BASE)
+        }
+        for level, n_series in [(LEVEL_LEAF, 3), ("product", 2), (LEVEL_ROOT, 1)]:
+            row = by_cell[(level, "middleout")]
+            assert row.block == fam
+            assert row.n_series == n_series
+            assert row.n_obs == n_series * HORIZON
+            # FINITE metrics: holdout has booked demand (wape/bias defined)
+            # and the weekly train pattern is non-constant (mase defined).
+            assert row.wape is not None and row.wape >= 0, level
+            assert row.mase is not None and row.mase >= 0, level
+            assert row.bias is not None, level
+
+    def test_two_calls_same_report_and_verdict(self, conn):
+        fam, _ = _seed_block(conn, "bench-h-det", "B2")
+        first = _run(conn)
+        second = _run(conn)
+        # frozen dataclasses of Decimals: byte-identical report
+        assert first == second
+        verdict = first.verdicts()
+        assert verdict == second.verdicts()
+        assert verdict[fam] is not None  # rankable, never arbitrary
+
+    def test_holdout_insert_changes_metrics_not_forecasts(self, conn):
+        """The anti-leak test: a demand line inserted INSIDE the holdout
+        window (on the cutoff day itself — boundary belongs to EVAL, train
+        is strictly before) must leave every training history — hence
+        every forecast — unchanged, while the actuals-side metrics move."""
+        fam, items = _seed_block(conn, "bench-h-leak", "B3")
+
+        engine_before = _RecordingEngine()
+        before = _run(conn, engine_before)
+
+        # Big spike on the FIRST holdout day for leaf A1.
+        _insert_demand(conn, items["A1"], "BENCH-B3-A1", CUTOFF, 500)
+
+        engine_after = _RecordingEngine()
+        after = _run(conn, engine_after)
+
+        # 1. TRAIN saw nothing: the real engine received byte-identical
+        #    histories, so (deterministic engine, seed 0) forecasts are
+        #    byte-identical too.
+        assert engine_before.histories == engine_after.histories
+        assert engine_before.histories  # the bench did call the engine
+
+        # 2. EVAL saw the spike: leaf-level metrics moved.
+        def leaf_row(report, method):
+            return next(
+                r for r in report.rows
+                if r.level == "leaf" and r.method == method
+            )
+
+        for method in ("middleout", "base"):
+            b, a = leaf_row(before, method), leaf_row(after, method)
+            assert b.wape != a.wape, method   # actuals changed under fixed forecasts
+            assert b.bias != a.bias, method
+            assert b.n_obs == a.n_obs, method  # same dense eval window

--- a/tests/test_pyramide_bench_report.py
+++ b/tests/test_pyramide_bench_report.py
@@ -1,0 +1,265 @@
+"""
+Pure unit tests of the reconciliation-bench report layer
+(``pyramide/hierarchy/bench.py``) — no database.
+
+Covers: BenchRow scoring via the accuracy module (hand-calculated golden,
+two methods, expected verdict), deterministic report ordering, None-safe
+verdicts (undefined WAPE never wins; all-None block -> None verdict),
+tie-breaking, and the strategy gate ('two_stage' raises
+NotImplementedError BEFORE any DB access — provable with db=None).
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from ootils_core.pyramide.hierarchy.bench import (
+    LEVEL_LEAF,
+    LEVEL_ROOT,
+    METHOD_BASE,
+    BenchRow,
+    build_bench_report,
+    compute_bench_row,
+    run_reconciliation_bench,
+)
+
+CUTOFF = date(2026, 6, 1)
+
+
+def _report(rows, **overrides):
+    kwargs = dict(
+        domain="test-domain",
+        cutoff=CUTOFF,
+        horizon=2,
+        holdout_days=2,
+        lookback_days=30,
+        warnings=(),
+    )
+    kwargs.update(overrides)
+    return build_bench_report(rows, **kwargs)
+
+
+def _row(
+    block="B1",
+    level=LEVEL_LEAF,
+    method="middleout",
+    wape="0.4",
+    mase=None,
+    bias="0",
+    n_series=2,
+    n_obs=4,
+):
+    return BenchRow(
+        block=block,
+        level=level,
+        method=method,
+        wape=None if wape is None else Decimal(wape),
+        mase=None if mase is None else Decimal(mase),
+        bias=None if bias is None else Decimal(bias),
+        n_series=n_series,
+        n_obs=n_obs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Golden: hand-calculated scoring of two methods, expected verdict
+# ---------------------------------------------------------------------------
+
+
+def test_golden_two_methods_leaf_scoring_and_verdict():
+    # Two leaves, horizon 2. Actuals: L1 = [10, 0], L2 = [0, 10].
+    actuals = [
+        (Decimal(10), Decimal(0)),
+        (Decimal(0), Decimal(10)),
+    ]
+    # Insamples: L1 constant (MASE denominator 0 -> None, excluded),
+    # L2 empty (too short -> None, excluded) => row MASE is None.
+    insamples = [(Decimal(10), Decimal(10), Decimal(10)), ()]
+
+    # middleout: L1 = [8, 2], L2 = [2, 8].
+    #   pooled |e| = 2+2+2+2 = 8 ; sum|a| = 20     -> WAPE = 0.4
+    #   bias = ((8-10)+(2-0)+(2-0)+(8-10)) / 4     -> 0
+    mo = compute_bench_row(
+        block="B1", level=LEVEL_LEAF, method="middleout",
+        actual_curves=actuals,
+        forecast_curves=[
+            (Decimal(8), Decimal(2)),
+            (Decimal(2), Decimal(8)),
+        ],
+        insamples=insamples,
+    )
+    assert mo.wape == Decimal("0.4")
+    assert mo.bias == Decimal("0")
+    assert mo.mase is None  # None-safe per-series exclusion
+    assert (mo.n_series, mo.n_obs) == (2, 4)
+
+    # base (uniform): both leaves [5, 5].
+    #   pooled |e| = 5+5+5+5 = 20 ; sum|a| = 20    -> WAPE = 1.0
+    base = compute_bench_row(
+        block="B1", level=LEVEL_LEAF, method=METHOD_BASE,
+        actual_curves=actuals,
+        forecast_curves=[
+            (Decimal(5), Decimal(5)),
+            (Decimal(5), Decimal(5)),
+        ],
+        insamples=insamples,
+    )
+    assert base.wape == Decimal("1")
+    assert base.bias == Decimal("0")
+
+    report = _report([base, mo])
+    assert report.verdicts() == {"B1": "middleout"}
+
+
+def test_golden_mase_averages_defined_series_only():
+    # L1: insample [0, 10, 0] -> naive MAE = (10+10)/2 = 10;
+    #     |e| = |10-8| + |0-2| = 4 over 2 obs -> MASE = 2/10 = 0.2
+    # L2: constant insample -> None (excluded from the mean).
+    row = compute_bench_row(
+        block="B1", level=LEVEL_LEAF, method="middleout",
+        actual_curves=[
+            (Decimal(10), Decimal(0)),
+            (Decimal(0), Decimal(10)),
+        ],
+        forecast_curves=[
+            (Decimal(8), Decimal(2)),
+            (Decimal(2), Decimal(8)),
+        ],
+        insamples=[
+            (Decimal(0), Decimal(10), Decimal(0)),
+            (Decimal(5), Decimal(5), Decimal(5)),
+        ],
+    )
+    assert row.mase == Decimal("0.2")
+
+
+def test_compute_bench_row_validates_alignment():
+    with pytest.raises(ValueError):
+        compute_bench_row(
+            block="B1", level=LEVEL_LEAF, method="m",
+            actual_curves=[], forecast_curves=[], insamples=[],
+        )
+    with pytest.raises(ValueError):
+        compute_bench_row(
+            block="B1", level=LEVEL_LEAF, method="m",
+            actual_curves=[(Decimal(1),)],
+            forecast_curves=[(Decimal(1),), (Decimal(2),)],
+            insamples=[()],
+        )
+    with pytest.raises(ValueError):
+        compute_bench_row(
+            block="B1", level=LEVEL_LEAF, method="m",
+            actual_curves=[(Decimal(1), Decimal(2))],
+            forecast_curves=[(Decimal(1),)],  # per-series length mismatch
+            insamples=[()],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Report construction: deterministic ordering, to_rows
+# ---------------------------------------------------------------------------
+
+
+def test_rows_sorted_block_then_level_rank_then_method():
+    shuffled = [
+        _row(block="B2", level=LEVEL_LEAF, method="middleout"),
+        _row(block="B1", level=LEVEL_LEAF, method="middleout"),
+        _row(block="B1", level=LEVEL_ROOT, method="middleout"),
+        _row(block="B1", level="family", method="middleout"),
+        _row(block="B1", level=LEVEL_LEAF, method=METHOD_BASE, wape="1.0"),
+    ]
+    report = _report(shuffled)
+    key = [(r.block, r.level, r.method) for r in report.rows]
+    assert key == [
+        ("B1", LEVEL_ROOT, "middleout"),   # root first
+        ("B1", "family", "middleout"),     # intermediate (recon) level
+        ("B1", LEVEL_LEAF, METHOD_BASE),   # leaves last, methods sorted
+        ("B1", LEVEL_LEAF, "middleout"),
+        ("B2", LEVEL_LEAF, "middleout"),
+    ]
+    # Same inputs in any order -> byte-identical report (determinism).
+    assert _report(list(reversed(shuffled))) == report
+
+
+def test_to_rows_mirrors_sorted_rows():
+    report = _report([_row(method="middleout"), _row(method=METHOD_BASE, wape="1.0")])
+    assert report.to_rows() == [
+        ("B1", LEVEL_LEAF, METHOD_BASE, Decimal("1.0"), None, Decimal("0"), 2, 4),
+        ("B1", LEVEL_LEAF, "middleout", Decimal("0.4"), None, Decimal("0"), 2, 4),
+    ]
+
+
+def test_report_is_frozen():
+    report = _report([_row()])
+    with pytest.raises(AttributeError):
+        report.horizon = 99  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Verdicts: None-safety, ties, non-leaf rows ignored
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_excludes_none_wape():
+    report = _report([
+        _row(method="middleout", wape=None),       # undefined -> never wins
+        _row(method=METHOD_BASE, wape="1.5"),
+    ])
+    assert report.verdicts() == {"B1": METHOD_BASE}
+
+
+def test_verdict_none_when_no_leaf_wape_defined():
+    report = _report([
+        _row(method="middleout", wape=None),
+        _row(method=METHOD_BASE, wape=None),
+        _row(block="B2", method="middleout", wape="0.3"),
+    ])
+    assert report.verdicts() == {"B1": None, "B2": "middleout"}
+
+
+def test_verdict_ignores_non_leaf_levels():
+    report = _report([
+        _row(level=LEVEL_ROOT, method="middleout", wape="0.01"),
+        _row(level="family", method="middleout", wape="0.02"),
+        _row(level=LEVEL_LEAF, method="middleout", wape=None),
+    ])
+    # Excellent root WAPE cannot crown a method: only leaves decide.
+    assert report.verdicts() == {"B1": None}
+
+
+def test_verdict_tie_breaks_on_method_name():
+    report = _report([
+        _row(method="zeta", wape="0.4"),
+        _row(method="alpha", wape="0.4"),
+    ])
+    assert report.verdicts() == {"B1": "alpha"}
+
+
+# ---------------------------------------------------------------------------
+# Strategy / parameter gate — validated BEFORE any DB access (db=None)
+# ---------------------------------------------------------------------------
+
+
+def test_two_stage_raises_not_implemented_without_db():
+    with pytest.raises(NotImplementedError, match="two_stage.*geo hierarchy"):
+        run_reconciliation_bench(None, domain="d", strategy="two_stage")
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"strategy": "nonsense"},
+        {"horizon": 0},
+        {"holdout_days": 0},
+        {"lookback_days": 0},
+        {"methods": ()},
+        {"methods": ("middleout", "definitely-not-a-method")},
+        # 'base' is the implicit comparator, not a requestable method.
+        {"methods": (METHOD_BASE,)},
+    ],
+)
+def test_invalid_params_raise_before_db_access(kwargs):
+    with pytest.raises(ValueError):
+        run_reconciliation_bench(None, domain="d", **kwargs)


### PR DESCRIPTION
## Pyramide V1 — axe A, PR4 : le harnais de bench (spec §8 — trancher sur chiffres)

Dernière PR de l'axe A. Généralise le POC `forecast_reconcile_poc.py` (pointeur de promotion posé) en module produit : **quelle méthode de réconciliation gagne, par bloc, mesuré**.

- **Anti-fuite mécanique** : cutoff explicite (jamais `CURRENT_DATE`), train strictement avant, parts calculées sur le train seul. Le test le prouve physiquement : un spike inséré **au jour exact du cutoff** change les métriques mais aucun forecast (moteur instrumenté, historiques train byte-identiques avant/après).
- **Scoring 100 % via `accuracy.py`** (zéro formule dupliquée) : WAPE/MASE/biais aux 3 niveaux (feuilles, niveau de réconciliation, racine), comparateur `base` toujours inclus.
- **Verdict par bloc** dérivé des chiffres (min WAPE feuilles, None-safe), `BenchReport` frozen déterministe.
- `strategy='two_stage'` → `NotImplementedError` propre **avant tout accès DB** — la comparaison croisé-vs-2-étapes s'activera à l'arrivée de la jambe géo (zones climatiques à définir).
- CLI read-only durci post-revue (le `SET default_transaction_read_only` était décoratif sans COMMIT — psycopg3) + garde `horizon ≤ holdout_days` (zéros fantômes).

**Usage pilote** : `python scripts/bench_reconciliation.py --dsn <pilote> --domain product --holdout-days 84 --methods middleout,mintrace_wls_shrink` → le tableau et les verdicts par `Gen_Fam` pour trancher la question §8.

18 goldens purs + 3 intégration · 1878 unitaires ✅ · ruff ✅.

Clôt l'axe A de la spec (PR1 #361, PR2 #362, PR3 #363, PR4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
