### PR TITLE
feat(pyramide): axe D PR-D2 — intervalles conformal persistés + backtest délégué (fin du dénominateur piégé)

### DIFF
--- a/src/ootils_core/pyramide/engines.py
+++ b/src/ootils_core/pyramide/engines.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import date
-from decimal import Decimal
+from decimal import ROUND_CEILING, Decimal, InvalidOperation
 from typing import Any, Mapping, Sequence
 
 from ootils_core.forecasting import ForecastMethod, ForecastingEngine, ForecastingError
 
+from .accuracy import AccuracyReport, conformal_intervals, evaluate_rolling_origin
 from .models import (
     METHOD_AUTO_SELECT,
     METHOD_ENSEMBLE_STAT,
@@ -41,6 +42,16 @@ class ForecastComputation:
     value_method: str
     engine_backend: str
     warnings: tuple[str, ...] = ()
+    # Rapport de backtest rolling-origin du modèle qui a PRODUIT `values`
+    # (accuracy.evaluate_rolling_origin) : la matière première des bornes
+    # conformal persistées par le runner. None = pas de backtest
+    # déterministe disponible pour ces valeurs — mélange ENSEMBLE_STAT
+    # (les résidus d'un candidat ne décrivent pas le blend), backend
+    # externe servi directement (backtester statsforecast/LGBM à chaque
+    # run est hors périmètre V1), ou historique trop court pour une seule
+    # origine. L'appelant ne doit JAMAIS inventer d'intervalles quand ce
+    # champ est None (colonnes NULL + provenance).
+    accuracy_report: AccuracyReport | None = None
 
 
 @dataclass(frozen=True)
@@ -84,7 +95,16 @@ class PyramideForecastEngine:
         # backends externes partagent la même valeur.
         params.setdefault("season_length", _default_season_length(granularity))
         if method in BASE_METHODS:
-            return self._classical(history, periods, method, params)
+            computed = self._classical(history, periods, method, params)
+            # Rapport d'accuracy du modèle demandé, attaché ICI (et pas dans
+            # _classical) pour ne pas re-backtester à chaque recomputation
+            # interne d'AUTO_SELECT / ENSEMBLE_STAT.
+            report = self._backtest_report(
+                history,
+                _Candidate(method=method, params=params, label=self._label(method, params)),
+                horizon=periods,
+            )
+            return replace(computed, accuracy_report=report)
         if method == METHOD_AUTO_SELECT:
             return self._auto_select(history, periods, params)
         if method == METHOD_ENSEMBLE_STAT:
@@ -156,15 +176,25 @@ class PyramideForecastEngine:
         params: Mapping[str, Any],
     ) -> ForecastComputation:
         candidates = self._candidate_specs(history, params)
-        scored = []
+        # Le rapport complet est conservé par candidat : celui du gagnant
+        # devient l'accuracy_report du résultat (résidus par horizon →
+        # bornes conformal côté runner), sans re-backtester.
+        scored: list[tuple[float, _Candidate, AccuracyReport]] = []
         for candidate in candidates:
-            score = self._backtest_score(history, candidate, horizon=periods)
-            if score is not None:
-                scored.append((score, candidate))
+            report = self._backtest_report(history, candidate, horizon=periods)
+            # report None (le candidat ne peut tourner sur aucune origine)
+            # ou WAPE None (demande totale nulle sur les fenêtres évaluées :
+            # métrique indéfinie, cf. accuracy.wape) = candidat non
+            # scorable, exclu du tri — même sémantique que l'ancien
+            # candidat sans score.
+            if report is not None and report.wape is not None:
+                scored.append((float(report.wape), candidate, report))
 
+        best_report: AccuracyReport | None = None
         if scored:
             scored.sort(key=lambda item: (item[0], item[1].label))
             best = scored[0][1]
+            best_report = scored[0][2]
         elif candidates:
             best = candidates[0]
         else:
@@ -178,6 +208,7 @@ class PyramideForecastEngine:
             value_method=best.method,
             engine_backend="internal:auto_select",
             warnings=(warning, *computed.warnings),
+            accuracy_report=best_report,
         )
 
     def _ensemble_stat(
@@ -194,7 +225,8 @@ class PyramideForecastEngine:
             except PyramideEngineError:
                 continue
             score = self._backtest_score(history, candidate, horizon=periods)
-            # score is None = pas de backtest possible → poids neutre 1.0.
+            # score is None = pas de backtest possible (ou WAPE indéfini sur
+            # demande nulle) → poids neutre 1.0.
             # Un score PARFAIT de 0.0 est falsy mais doit recevoir le poids
             # plafond (1/0.0001), pas le poids neutre : ne pas utiliser `or`.
             weight = 1.0 if score is None else 1.0 / max(score, 0.0001)
@@ -214,6 +246,11 @@ class PyramideForecastEngine:
             for step in range(periods)
         )
         model_names = ",".join(candidate.label for _, _, candidate in forecasts)
+        # accuracy_report reste None : les résidus de backtest d'UN candidat
+        # ne décrivent pas le mélange pondéré, et backtester le blend
+        # lui-même (poids recalculés à chaque origine) est hors périmètre
+        # V1 — bornes NULL + provenance côté runner, jamais des bornes
+        # empruntées à un autre modèle.
         return ForecastComputation(
             values=values,
             selected_model=METHOD_ENSEMBLE_STAT,
@@ -236,11 +273,10 @@ class PyramideForecastEngine:
             if params.get("strict_backend"):
                 raise PyramideEngineError(f"{requested_method} failed: {exc}") from exc
             fallback = self._auto_select(history, periods, params)
-            return ForecastComputation(
-                values=fallback.values,
-                selected_model=fallback.selected_model,
-                value_method=fallback.value_method,
-                engine_backend=fallback.engine_backend,
+            # Les valeurs servies SONT celles d'AUTO_SELECT : son rapport de
+            # backtest reste honnête pour elles et voyage avec.
+            return replace(
+                fallback,
                 warnings=(f"{requested_method} unavailable; fell back to AUTO_SELECT: {exc}", *fallback.warnings),
             )
 
@@ -423,46 +459,91 @@ class PyramideForecastEngine:
             )
         return candidates
 
-    def _backtest_score(self, history: Sequence[Decimal], candidate: _Candidate, horizon: int = 1) -> float | None:
-        """Rolling-origin backtest sur des COURBES : à chaque origine, le
-        candidat prévoit jusqu'à `horizon` pas comparés aux réels suivants —
-        l'erreur porte sur les h pas, pas sur une valeur unique (un modèle plat
-        contribue la même valeur à chaque pas, un saisonnier sa courbe)."""
+    def _backtest_report(
+        self, history: Sequence[Decimal], candidate: _Candidate, horizon: int = 1
+    ) -> AccuracyReport | None:
+        """Backtest rolling-origin multi-horizon d'UN candidat, DÉLÉGUÉ à
+        accuracy.evaluate_rolling_origin (PR-D2) — le rapport complet
+        (WAPE/MASE/sMAPE/biais + résidus par horizon) est la matière
+        première des bornes conformal et du scalaire de tri.
+
+        Sémantique conservée de l'ancienne boucle locale :
+        - fenêtre d'évaluation = queue des 52 dernières origines,
+        - courbes multi-pas (fenêtres partielles en fin de série incluses,
+          même convention qu'evaluate_rolling_origin),
+        - candidat SEASONAL scoré uniquement sur les origines où il tourne
+          vraiment (>= 2 cycles complets d'entraînement) : sinon le score
+          mesurerait le fallback plat, pas le modèle saisonnier,
+        - forecast clampé à 0 comme les valeurs servies (_classical /
+          runner) : le backtest mesure ce qui serait réellement livré.
+
+        Origine de départ : les modèles internes sont monotones en longueur
+        d'entraînement (MA(window) exige window points, EXP/CROSTON >= 1,
+        SEASONAL géré ci-dessus), donc on avance l'origine jusqu'à la
+        première où le candidat tourne au lieu d'ignorer silencieusement
+        des origines au milieu de l'évaluation.
+
+        MASE : m=1 uniformément (naive lag-1) pour que le MASE du rapport
+        reste comparable ENTRE candidats d'un même AUTO_SELECT ; le tri
+        lui-même se fait sur le WAPE (cf. _backtest_score).
+
+        None = candidat non scorable : série trop courte (< 3 points),
+        aucune origine exploitable, ou échec du modèle en cours
+        d'évaluation (non-monotonie inattendue, tracée en debug).
+        """
         if len(history) < 3:
             return None
 
         horizon = max(1, horizon)
-        seasonal_min_train = 0
+        min_train = max(1, len(history) - 52)
         if candidate.method == ForecastMethod.SEASONAL:
-            # Ne scorer le candidat saisonnier que sur les origines où il
-            # tourne vraiment (>= 2 cycles complets) : sinon son score
-            # mesurerait le fallback plat, pas le modèle saisonnier.
-            seasonal_min_train = 2 * int(candidate.params.get("season_length", 0))
+            min_train = max(min_train, 2 * int(candidate.params.get("season_length", 0)))
 
-        errors = []
-        tail_start = max(1, len(history) - 52)
-        for index in range(tail_start, len(history)):
-            train = list(history[:index])
-            if not train or len(train) < seasonal_min_train:
-                continue
-            actual_window = list(history[index:index + horizon])
+        def forecast_fn(train: Sequence[Decimal], periods: int) -> Sequence[Decimal]:
+            series = self._forecasting_engine.forecast_series(
+                item_history=list(train),
+                method=candidate.method,
+                params=dict(candidate.params),
+                periods=periods,
+            )
+            return [max(value, Decimal("0")) for value in series]
+
+        while min_train < len(history):
             try:
-                series = self._forecasting_engine.forecast_series(
-                    item_history=train,
-                    method=candidate.method,
-                    params=dict(candidate.params),
-                    periods=len(actual_window),
-                )
+                forecast_fn(history[:min_train], 1)
+                break
             except (ForecastingError, ValueError):
-                continue
-            for actual, raw_forecast in zip(actual_window, series):
-                forecast = max(raw_forecast, Decimal("0"))
-                denom = max(abs(actual), Decimal("1"))
-                errors.append(float(abs(actual - forecast) / denom))
-
-        if not errors:
+                min_train += 1
+        if min_train >= len(history):
             return None
-        return sum(errors) / len(errors)
+
+        try:
+            return evaluate_rolling_origin(
+                series=list(history),
+                forecast_fn=forecast_fn,
+                horizon=horizon,
+                min_train=min_train,
+                step=1,
+                m=1,
+            )
+        except (ForecastingError, ValueError) as exc:
+            logger.debug("backtest impossible pour %s: %s", candidate.label, exc)
+            return None
+
+    def _backtest_score(self, history: Sequence[Decimal], candidate: _Candidate, horizon: int = 1) -> float | None:
+        """Scalaire de tri des candidats (AUTO_SELECT / ENSEMBLE_STAT) : le
+        WAPE du rapport rolling-origin délégué (_backtest_report).
+
+        CHANGEMENT ASSUMÉ (validé pilote) vs l'ancienne boucle locale : le
+        dénominateur piégé max(|actual|, 1) a disparu — sur des fenêtres à
+        demande totale nulle le WAPE est indéfini (None, cf. accuracy.wape)
+        et le candidat est « non scorable » : exclu du tri côté AUTO_SELECT,
+        poids neutre côté ENSEMBLE_STAT — même sémantique que l'ancien
+        candidat sans score."""
+        report = self._backtest_report(history, candidate, horizon=horizon)
+        if report is None or report.wape is None:
+            return None
+        return float(report.wape)
 
     @staticmethod
     def _zero_ratio(history: Sequence[Decimal]) -> float:
@@ -482,6 +563,126 @@ class PyramideForecastEngine:
         if method == ForecastMethod.SEASONAL:
             return f"SEASONAL(season_length={int(params.get('season_length', 0))})"
         return method
+
+
+# ─────────────────────────────────────────────────────────────
+# Bornes conformal persistables (migration 026) — PR-D2
+# ─────────────────────────────────────────────────────────────
+
+DEFAULT_CONFORMAL_ALPHA = Decimal("0.2")
+_ZERO = Decimal("0")
+_ONE = Decimal("1")
+
+
+def resolve_conformal_alpha(method_params: Mapping[str, Any]) -> Decimal:
+    """Taux de non-couverture alpha des intervalles conformal.
+
+    Défaut 0.2 (couverture nominale 80 %), paramétrable via
+    ``method_params["conformal_alpha"]``. Contrairement aux paramètres de
+    candidats (_candidate_specs, tolérants par design), un alpha illisible
+    ou hors (0, 1) est une erreur de CONFIGURATION des bornes publiées :
+    fail loudly (PyramideEngineError → 422 côté routeur), jamais un défaut
+    silencieux qui publierait des bornes à une couverture différente de
+    celle demandée."""
+    raw = method_params.get("conformal_alpha", DEFAULT_CONFORMAL_ALPHA)
+    try:
+        alpha = Decimal(str(raw))
+    except (InvalidOperation, ValueError, TypeError):
+        raise PyramideEngineError(
+            f"method_params.conformal_alpha must be a number in (0, 1) (got {raw!r})"
+        )
+    if not (_ZERO < alpha < _ONE):
+        raise PyramideEngineError(
+            f"method_params.conformal_alpha must be in (0, 1) (got {raw!r})"
+        )
+    return alpha
+
+
+def conformal_min_residuals(alpha: Decimal) -> int:
+    """Nombre minimal de résidus de calibration par horizon pour que la
+    garantie finite-sample du split conformal tienne : ceil(2/alpha) - 1
+    (cf. accuracy.conformal_intervals, « small-sample clamp »). En dessous,
+    accuracy.py clamperait aux statistiques d'ordre extrêmes (best-effort) ;
+    la couche persistance REFUSE ce mode dégradé — bornes NULL plutôt que
+    des bornes sans garantie (jamais de bornes inventées)."""
+    return int((Decimal(2) / alpha).to_integral_value(rounding=ROUND_CEILING)) - 1
+
+
+def conformal_bounds(
+    *,
+    report: AccuracyReport | None,
+    values: Sequence[Decimal],
+    method_params: Mapping[str, Any],
+    scale: Decimal = _ONE,
+) -> tuple[tuple[Decimal | None, ...], tuple[Decimal | None, ...], tuple[str, ...]]:
+    """Bornes conformal par bucket pour une courbe servie — la matière des
+    colonnes ``forecast_values.confidence_interval_lower/upper``.
+
+    ``report`` est le backtest rolling-origin du modèle qui a PRODUIT les
+    valeurs (ForecastComputation.accuracy_report). Pour chaque bucket i
+    (horizon h = i + 1) :
+
+        lower[i] = max(0, max(0, values[i]) + scale * lower_offset[h])
+        upper[i] = max(0, max(0, values[i]) + scale * upper_offset[h])
+
+    - Clamp à 0 de la borne inférieure (et supérieure, par cohérence) :
+      une demande négative n'existe pas — un offset très négatif sur un
+      point proche de zéro donne une borne 0, pas une borne absurde.
+    - Horizon sans assez de résidus (< conformal_min_residuals(alpha)) →
+      bornes None pour ce bucket + warning : la garantie finite-sample
+      n'existe plus en dessous du clamp small-sample d'accuracy.py.
+    - ``report`` absent (None) ou sans résidus → tout None + warning :
+      pas de backtest déterministe pour ces valeurs, on ne publie rien.
+    - ``scale`` : facteur appliqué aux offsets — 1 pour une série prévue
+      directement ; la part de désagrégation middle-out pour une FEUILLE
+      de bloc hiérarchique (feuille = part × nœud, donc l'erreur du nœud
+      se transporte multipliée par la part). Approximation V1 documentée :
+      l'erreur idiosyncratique de la feuille n'est pas observée au niveau
+      du nœud, la garantie de couverture est celle du nœud, pas de la
+      feuille.
+
+    Retour : (lowers, uppers, warnings), lowers/uppers alignés sur
+    ``values``. Lève PyramideEngineError si conformal_alpha est invalide.
+    """
+    alpha = resolve_conformal_alpha(method_params)
+    periods = len(values)
+    none_bounds: tuple[Decimal | None, ...] = (None,) * periods
+    if report is None or not report.per_horizon_residuals:
+        return none_bounds, none_bounds, (
+            "conformal intervals unavailable: no deterministic backtest "
+            "residuals for the served values (bounds NULL)",
+        )
+
+    n_min = conformal_min_residuals(alpha)
+    eligible = {
+        h: residuals
+        for h, residuals in report.per_horizon_residuals.items()
+        if len(residuals) >= n_min
+    }
+    lower_offsets, upper_offsets = conformal_intervals(eligible, alpha)
+
+    lowers: list[Decimal | None] = []
+    uppers: list[Decimal | None] = []
+    missing = 0
+    for index, value in enumerate(values):
+        h = index + 1
+        if h not in lower_offsets:
+            missing += 1
+            lowers.append(None)
+            uppers.append(None)
+            continue
+        point = max(value, _ZERO)
+        lowers.append(max(point + scale * lower_offsets[h], _ZERO))
+        uppers.append(max(point + scale * upper_offsets[h], _ZERO))
+
+    warnings: tuple[str, ...] = ()
+    if missing:
+        warnings = (
+            f"conformal intervals: {missing}/{periods} bucket(s) without "
+            f"enough backtest residuals (need >= {n_min} per horizon for "
+            f"alpha={alpha}); their bounds stay NULL",
+        )
+    return tuple(lowers), tuple(uppers), warnings
 
 
 def _as_int(value: Any) -> int | None:

--- a/src/ootils_core/pyramide/hierarchy/runner.py
+++ b/src/ootils_core/pyramide/hierarchy/runner.py
@@ -33,7 +33,7 @@ scenario-invariant by design (actuals do not fork).
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import date, timedelta
 from decimal import Decimal
 from types import MappingProxyType
@@ -42,7 +42,13 @@ from uuid import UUID
 
 import psycopg
 
-from ..engines import ForecastComputation, PyramideEngineError, PyramideForecastEngine
+from ..engines import (
+    ForecastComputation,
+    PyramideEngineError,
+    PyramideForecastEngine,
+    conformal_bounds,
+    resolve_conformal_alpha,
+)
 from ..models import METHOD_AUTO_SELECT, SUPPORTED_GRANULARITIES, SUPPORTED_METHODS
 from ..repository import (
     PyramidePersistedRun,
@@ -144,6 +150,12 @@ class HierarchicalRunner:
         self, db: psycopg.Connection, config: HierarchicalRunConfig
     ) -> HierarchicalRunResult:
         method = self._validate_config(config)
+        # Fail loudly BEFORE any forecast/persist work: an invalid
+        # conformal_alpha is a configuration error of the published bounds.
+        try:
+            resolve_conformal_alpha(config.method_params)
+        except PyramideEngineError as exc:
+            raise PyramideError(str(exc)) from exc
         block = self._load_block(db, config)
         recon_level = config.recon_level or block.block_level
         dates = bucket_dates(
@@ -210,10 +222,11 @@ class HierarchicalRunner:
             raise PyramideError(str(exc)) from exc
         warnings.extend(recon.warnings)
 
-        persisted = self._persist(
+        persisted, persist_warnings = self._persist(
             db, block, recon, recon_refs, base_computations,
             node_histories, config, method, dates,
         )
+        warnings.extend(persist_warnings)
         return HierarchicalRunResult(
             hierarchy_id=config.hierarchy_id,
             block_code=block.block_code,
@@ -290,12 +303,11 @@ class HierarchicalRunner:
         except PyramideEngineError as exc:
             raise PyramideError(str(exc)) from exc
         # Same clamp as the leaf runner: demand forecasts are >= 0.
-        return ForecastComputation(
+        # replace() keeps accuracy_report: the backtest residuals of the
+        # node's selected model feed the leaves' conformal bounds.
+        return replace(
+            computation,
             values=tuple(max(value, _ZERO) for value in computation.values),
-            selected_model=computation.selected_model,
-            value_method=computation.value_method,
-            engine_backend=computation.engine_backend,
-            warnings=computation.warnings,
         )
 
     def _build_mint_inputs(
@@ -389,14 +401,23 @@ class HierarchicalRunner:
         config: HierarchicalRunConfig,
         method: str,
         dates: Sequence[date],
-    ) -> list[HierarchicalPersistedSeries]:
+    ) -> tuple[list[HierarchicalPersistedSeries], list[str]]:
         parent_of: dict[str, str] = {}
         for i, ref in recon_refs:
             for j in block.rows[i]:
                 parent_of[block.leaves[j]] = ref.key
 
+        # Part de désagrégation par feuille (middle-out) : le facteur
+        # d'échelle des offsets conformal du nœud vers la feuille
+        # (feuille = part × nœud, donc résidu feuille implicite =
+        # part × résidu nœud). Vide sur le chemin MinT (pas de parts
+        # explicites) → bornes NULL pour les feuilles, documenté.
+        share_of = {ls.leaf: ls.share for ls in recon.shares}
+
         recon_backend = f"internal:reconciliation:{recon.recon_method}"
         persisted: list[HierarchicalPersistedSeries] = []
+        warnings: list[str] = []
+        leaves_without_bounds = 0
         for index, ref in enumerate(block.series):
             quantities = recon.values[index]
             if ref.kind == AGGREGATE:
@@ -412,6 +433,9 @@ class HierarchicalRunner:
                     engine_backend = recon_backend
                     value_method = method
                     history_count = 0
+                # Bornes NULL pour TOUS les agrégats : la réconciliation
+                # d'intervalles hiérarchiques (bornes cohérentes entre
+                # niveaux) est frontier — non-objectif V1 (spec §2.D).
                 record = persist_series_run(
                     db,
                     scenario_id=config.scenario_id,
@@ -444,6 +468,26 @@ class HierarchicalRunner:
                 value_method = (
                     computation.value_method if computation else method
                 )
+                # Bornes conformal de la FEUILLE : résidus de backtest du
+                # modèle du nœud de réconciliation, offsets transportés à
+                # l'échelle de la feuille par sa part de désagrégation
+                # (approximation V1 documentée dans conformal_bounds).
+                # Sans rapport de backtest (ex. base ENSEMBLE_STAT) ou sans
+                # part explicite (chemin MinT) → NULL + warning agrégé.
+                lowers: Sequence[Decimal | None] | None = None
+                uppers: Sequence[Decimal | None] | None = None
+                share = share_of.get(ref.key)
+                report = computation.accuracy_report if computation else None
+                if report is not None and share is not None:
+                    lowers, uppers, bound_warnings = conformal_bounds(
+                        report=report,
+                        values=quantities,
+                        method_params=config.method_params,
+                        scale=share,
+                    )
+                    warnings.extend(f"{ref.key}: {w}" for w in bound_warnings)
+                else:
+                    leaves_without_bounds += 1
                 record = persist_series_run(
                     db,
                     scenario_id=config.scenario_id,
@@ -463,9 +507,17 @@ class HierarchicalRunner:
                     value_method=value_method,
                     item_id=UUID(ref.key),
                     location_id=config.leaf_location_id,
+                    lowers=lowers,
+                    uppers=uppers,
                 )
             persisted.append(_persisted_series(ref, record))
-        return persisted
+        if leaves_without_bounds:
+            warnings.append(
+                f"conformal intervals: {leaves_without_bounds} leaf/leaves "
+                "persisted with NULL bounds (no base-model backtest report "
+                "or no explicit disaggregation share)"
+            )
+        return persisted, warnings
 
 
 def _series_key(ref: SeriesRef) -> str:

--- a/src/ootils_core/pyramide/models.py
+++ b/src/ootils_core/pyramide/models.py
@@ -69,6 +69,14 @@ class PyramideValue:
     forecast_date: date
     quantity: Decimal
     method: str
+    # Bornes conformal du bucket, persistées dans
+    # forecast_values.confidence_interval_lower/upper (migration 026).
+    # None = pas de calibration honnête disponible (pas de backtest
+    # déterministe pour les valeurs servies, ou trop peu de résidus pour
+    # la garantie finite-sample) → colonnes NULL, jamais des bornes
+    # inventées. Voir engines.conformal_bounds.
+    confidence_lower: Decimal | None = None
+    confidence_upper: Decimal | None = None
 
 
 @dataclass(frozen=True)

--- a/src/ootils_core/pyramide/repository.py
+++ b/src/ootils_core/pyramide/repository.py
@@ -393,13 +393,21 @@ def persist_run(db: psycopg.Connection, result: PyramideRunResult) -> PyramidePe
     )
 
     for value in result.values:
+        # confidence_interval_lower/upper (migration 026) : bornes conformal
+        # calibrées sur les résidus de backtest du modèle servi
+        # (engines.conformal_bounds). NULL quand aucune calibration honnête
+        # n'existe — la provenance vit dans result.warnings.
         db.execute(
             """
             INSERT INTO forecast_values (
-                value_id, forecast_id, forecast_date, quantity, method
-            ) VALUES (%s, %s, %s, %s, %s)
+                value_id, forecast_id, forecast_date, quantity, method,
+                confidence_interval_lower, confidence_interval_upper
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s)
             """,
-            (uuid4(), forecast_id, value.forecast_date, value.quantity, value.method),
+            (
+                uuid4(), forecast_id, value.forecast_date, value.quantity,
+                value.method, value.confidence_lower, value.confidence_upper,
+            ),
         )
 
     db.execute(
@@ -481,12 +489,21 @@ def persist_series_run(
     hierarchy_id: str | None = None,
     level: str | None = None,
     node_code: str | None = None,
+    lowers: Sequence[Decimal | None] | None = None,
+    uppers: Sequence[Decimal | None] | None = None,
 ) -> PyramidePersistedRun:
     """
     Persist ONE series of a hierarchical run (migration 053): either a
     LEAF (item_id + location_id) or an AGGREGATE (hierarchy_id + level +
     node_code) — never both (mirrors the DB CHECK, validated here first
     so the error is readable).
+
+    ``lowers`` / ``uppers`` are per-bucket conformal bounds
+    (confidence_interval_lower/upper, migration 026), aligned with
+    ``quantities``; omitted or None → NULL columns. NON-OBJECTIF V1 pour
+    les AGRÉGATS réconciliés : la réconciliation d'intervalles
+    hiérarchiques est frontier (spec Pyramide §2.D) — les appelants
+    laissent NULL pour les nœuds et ne remplissent que les feuilles.
 
     Writes forecasts + forecast_values + pyramide_runs for every series;
     pyramide_snapshots ONLY for leaves. Rationale: snapshots exist to
@@ -514,6 +531,14 @@ def persist_series_run(
         raise ValueError(
             f"{len(bucket_dates)} bucket dates but {len(quantities)} quantities"
         )
+    if lowers is not None and len(lowers) != len(quantities):
+        raise ValueError(
+            f"{len(lowers)} lower bounds but {len(quantities)} quantities"
+        )
+    if uppers is not None and len(uppers) != len(quantities):
+        raise ValueError(
+            f"{len(uppers)} upper bounds but {len(quantities)} quantities"
+        )
 
     run_id = uuid4()
     forecast_id = uuid4()
@@ -530,15 +555,20 @@ def persist_series_run(
         ),
     )
     total_quantity = Decimal("0")
-    for bucket_date, quantity in zip(bucket_dates, quantities):
+    for index, (bucket_date, quantity) in enumerate(zip(bucket_dates, quantities)):
         total_quantity += quantity
         db.execute(
             """
             INSERT INTO forecast_values (
-                value_id, forecast_id, forecast_date, quantity, method
-            ) VALUES (%s, %s, %s, %s, %s)
+                value_id, forecast_id, forecast_date, quantity, method,
+                confidence_interval_lower, confidence_interval_upper
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s)
             """,
-            (uuid4(), forecast_id, bucket_date, quantity, value_method),
+            (
+                uuid4(), forecast_id, bucket_date, quantity, value_method,
+                lowers[index] if lowers is not None else None,
+                uppers[index] if uppers is not None else None,
+            ),
         )
     db.execute(
         """

--- a/src/ootils_core/pyramide/runner.py
+++ b/src/ootils_core/pyramide/runner.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 from math import ceil
 from typing import Sequence
 
-from .engines import PyramideEngineError, PyramideForecastEngine
+from .engines import PyramideEngineError, PyramideForecastEngine, conformal_bounds
 from .models import (
     SUPPORTED_GRANULARITIES,
     SUPPORTED_METHODS,
@@ -79,6 +79,15 @@ class PyramideRunner:
                 horizon_start=config.horizon_start,
                 random_seed=config.random_seed,
             )
+            # Bornes conformal par bucket, dérivées des résidus du backtest
+            # du modèle qui a PRODUIT les valeurs (accuracy_report). Pas de
+            # rapport / trop peu de résidus → bornes None + provenance dans
+            # les warnings (jamais des bornes inventées).
+            lowers, uppers, conformal_warnings = conformal_bounds(
+                report=forecast.accuracy_report,
+                values=forecast.values[: len(bucket_dates)],
+                method_params=config.method_params,
+            )
         except PyramideEngineError as exc:
             raise PyramideError(str(exc)) from exc
 
@@ -88,6 +97,8 @@ class PyramideRunner:
                 forecast_date=bucket_date,
                 quantity=max(forecast.values[index], Decimal("0")),
                 method=forecast.value_method,
+                confidence_lower=lowers[index],
+                confidence_upper=uppers[index],
             )
             for index, bucket_date in enumerate(bucket_dates)
         )
@@ -97,7 +108,7 @@ class PyramideRunner:
             source_history_count=len(normalized_history),
             selected_model=forecast.selected_model,
             engine_backend=forecast.engine_backend,
-            warnings=forecast.warnings,
+            warnings=(*forecast.warnings, *conformal_warnings),
         )
 
     @staticmethod

--- a/tests/integration/test_forecast_conformal_integration.py
+++ b/tests/integration/test_forecast_conformal_integration.py
@@ -1,0 +1,442 @@
+"""
+Integration tests for Pyramide axis D — PR-D2 (persisted conformal
+intervals) against a real PostgreSQL database (no mocks).
+
+Covered:
+  - a leaf Pyramide run on a synthetic seed with KNOWN deterministic
+    "noise" persists non-NULL confidence_interval_lower/upper for every
+    bucket (migration 026 columns finally alive), with
+    lower >= 0 and lower <= point <= upper;
+  - empirical coverage of the persisted bounds on the seed's holdout
+    window is plausible for the nominal 1 - alpha = 0.8;
+  - a short series (not enough backtest residuals for the finite-sample
+    guarantee) persists NULL bounds and says so in the run provenance
+    (result.warnings) — never invented bounds;
+  - a HIERARCHICAL run persists non-NULL bounds for the LEAVES (node
+    backtest residuals transported by the disaggregation share) and NULL
+    bounds for every AGGREGATE (interval reconciliation is frontier —
+    documented V1 non-objective, spec §2.D);
+  - GET /v1/demand/forecast/{forecast_id} exposes the persisted bounds
+    without any contract change (fields were already Optional).
+
+Conventions (mirrors test_pyramide_hierarchy_integration.py):
+module-scoped migrated_db, autocommit _db_conn for seeding/teardown,
+every test creates its OWN items / locations / demand facts (fresh
+external ids) and cleans up in a finally block; the hierarchical test
+uses the rollback-scoped ``conn`` fixture instead (mirrors
+test_pyramide_reconcile_integration.py — the registry seed is heavier,
+rollback keeps it self-cleaning). Anti-flake rule for the demand-history
+reader (booked_date < server CURRENT_DATE): all seeded rows are at
+TODAY - 2 or earlier.
+"""
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+BASELINE_SCENARIO_ID = UUID("00000000-0000-0000-0000-000000000001")
+TODAY = date.today()
+
+# Deterministic "noise" around a base level of 100: amplitude ±9, zero
+# randomness (ADR-003 discipline applies to the test fixture too). The
+# pattern period (8) is coprime enough with the MA window (4) that the
+# rolling backtest observes the full residual spread.
+NOISE_PATTERN = (-8, 5, -3, 9, -6, 2, -7, 8)
+BASE_LEVEL = 100
+HOLDOUT = 14
+
+
+# ---------------------------------------------------------------------------
+# Helpers — DB access, seeding, teardown
+# ---------------------------------------------------------------------------
+
+
+def _db_conn(dsn):
+    import psycopg
+    from psycopg.rows import dict_row
+    return psycopg.connect(dsn, row_factory=dict_row, autocommit=True)
+
+
+def _create_item(conn, ext_id: str) -> UUID:
+    item_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO items (item_id, name, item_type, uom, status, external_id)
+        VALUES (%s, %s, 'finished_good', 'EA', 'active', %s)
+        """,
+        (item_id, f"{ext_id} conformal test item", ext_id),
+    )
+    return item_id
+
+
+def _create_location(conn, ext_id: str) -> UUID:
+    loc_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO locations (location_id, name, location_type, country, external_id)
+        VALUES (%s, %s, 'dc', 'US', %s)
+        """,
+        (loc_id, f"{ext_id} conformal test DC", ext_id),
+    )
+    return loc_id
+
+
+def _seed_demand(conn, item_id: UUID, item_code: str, warehouse_id: str,
+                 booked_date: date, qty) -> None:
+    """One booking fact routed to the leaf reader: stream='regular',
+    fulfillment standard, warehouse_id = the location's external_id (the
+    read-time mapping of migration 047)."""
+    conn.execute(
+        """
+        INSERT INTO demand_history (
+            item_id, item_code, stream, booked_date, ordered_quantity,
+            value_ext, counts_for_asp, org_id, fulfillment, order_number,
+            warehouse_id
+        ) VALUES (%s, %s, 'regular', %s, %s, 0, FALSE, 'PPS', 'standard',
+                  'TEST-CONF', %s)
+        """,
+        (item_id, item_code, booked_date, qty, warehouse_id),
+    )
+
+
+def _seed_noisy_series(conn, item_id: UUID, item_code: str, warehouse_id: str,
+                       days: int) -> list[Decimal]:
+    """``days`` consecutive daily facts ending at TODAY - 2, quantity =
+    BASE_LEVEL + NOISE_PATTERN cycling. Returns the quantities in
+    date-ascending order (the exact series the reader must reproduce)."""
+    quantities: list[Decimal] = []
+    start = TODAY - timedelta(days=2 + days - 1)
+    for i in range(days):
+        qty = Decimal(BASE_LEVEL + NOISE_PATTERN[i % len(NOISE_PATTERN)])
+        _seed_demand(conn, item_id, item_code, warehouse_id,
+                     start + timedelta(days=i), qty)
+        quantities.append(qty)
+    return quantities
+
+
+def _cleanup(conn, item_id: UUID, location_id: UUID) -> None:
+    """FK order: pyramide bookkeeping first, then forecast tables (values
+    cascade from forecasts), then facts, then master data."""
+    conn.execute(
+        """
+        DELETE FROM pyramide_snapshots WHERE forecast_id IN (
+            SELECT forecast_id FROM forecasts WHERE item_id = %s
+        )
+        """,
+        (item_id,),
+    )
+    conn.execute(
+        """
+        DELETE FROM pyramide_runs WHERE forecast_id IN (
+            SELECT forecast_id FROM forecasts WHERE item_id = %s
+        )
+        """,
+        (item_id,),
+    )
+    conn.execute("DELETE FROM forecasts WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM demand_history WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM items WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM locations WHERE location_id = %s", (location_id,))
+
+
+def _run_and_persist(conn, item_id: UUID, location_id: UUID,
+                     history: list[Decimal], horizon_days: int,
+                     method_params: dict | None = None):
+    """Run the leaf runner on an in-memory series and persist the result.
+    Returns (result, persisted)."""
+    from ootils_core.pyramide import PyramideRunConfig, PyramideRunner
+    from ootils_core.pyramide.repository import persist_run
+
+    config = PyramideRunConfig(
+        item_id=item_id,
+        location_id=location_id,
+        scenario_id=BASELINE_SCENARIO_ID,
+        horizon_start=TODAY + timedelta(days=2),
+        horizon_days=horizon_days,
+        granularity="daily",
+        method="MA",
+        method_params={"window": 4, **(method_params or {})},
+    )
+    result = PyramideRunner().run(config, history)
+    persisted = persist_run(conn, result)
+    return result, persisted
+
+
+def _fetch_bounds(conn, forecast_id: UUID):
+    return conn.execute(
+        """
+        SELECT forecast_date, quantity,
+               confidence_interval_lower AS lower,
+               confidence_interval_upper AS upper
+        FROM forecast_values
+        WHERE forecast_id = %s
+        ORDER BY forecast_date ASC
+        """,
+        (forecast_id,),
+    ).fetchall()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_leaf_run_persists_conformal_bounds_with_plausible_coverage(migrated_db):
+    """End-to-end on a synthetic seed with known deterministic noise:
+    demand_history -> shared reader -> PyramideRunner (train split) ->
+    persist_run -> forecast_values columns. The last HOLDOUT days of the
+    seed are NOT given to the runner and serve as the coverage holdout."""
+    from ootils_core.pyramide.repository import get_historical_demand
+
+    with _db_conn(migrated_db) as conn:
+        code = f"CONF-{uuid4().hex[:8].upper()}"
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            seeded = _seed_noisy_series(conn, item_id, code, f"DC-{code}", days=124)
+
+            history = get_historical_demand(
+                conn, item_id, location_id, lookback_days=200,
+                scenario_id=BASELINE_SCENARIO_ID,
+            )
+            assert history == seeded  # the reader reproduces the seed
+
+            train, holdout = history[:-HOLDOUT], history[-HOLDOUT:]
+            result, persisted = _run_and_persist(
+                conn, item_id, location_id, train, horizon_days=HOLDOUT,
+            )
+            # Long series: no conformal degradation expected.
+            assert not [w for w in result.warnings if "conformal" in w]
+
+            rows = _fetch_bounds(conn, persisted.forecast_id)
+            assert len(rows) == HOLDOUT
+            covered = 0
+            for row, actual in zip(rows, holdout):
+                lower = row["lower"]
+                upper = row["upper"]
+                point = Decimal(str(row["quantity"]))
+                # Columns finally alive (APS review finding): non-NULL.
+                assert lower is not None and upper is not None
+                lower = Decimal(str(lower))
+                upper = Decimal(str(upper))
+                assert lower >= Decimal("0")
+                assert lower <= point <= upper
+                if lower <= actual <= upper:
+                    covered += 1
+
+            # Nominal coverage is 1 - alpha = 0.8; the seed's noise is
+            # exchangeable-by-construction so the empirical coverage on
+            # the holdout must be plausible (anti-flake band, not an
+            # exact-quantile assertion).
+            coverage = covered / HOLDOUT
+            assert coverage >= 0.6, f"implausible coverage {coverage}"
+        finally:
+            _cleanup(conn, item_id, location_id)
+
+
+def test_short_series_persists_null_bounds_with_provenance(migrated_db):
+    """Not enough residuals for the finite-sample guarantee (default
+    alpha 0.2 needs 9 per horizon): the run must persist NULL bounds and
+    say so in its provenance — never invented bounds."""
+    with _db_conn(migrated_db) as conn:
+        code = f"CONF-{uuid4().hex[:8].upper()}"
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            seeded = _seed_noisy_series(conn, item_id, code, f"DC-{code}", days=5)
+            result, persisted = _run_and_persist(
+                conn, item_id, location_id, seeded, horizon_days=3,
+            )
+
+            assert any(
+                "conformal" in w and "NULL" in w for w in result.warnings
+            ), result.warnings
+
+            rows = _fetch_bounds(conn, persisted.forecast_id)
+            assert len(rows) == 3
+            for row in rows:
+                assert row["lower"] is None
+                assert row["upper"] is None
+        finally:
+            _cleanup(conn, item_id, location_id)
+
+
+def test_hierarchical_run_bounds_leaves_filled_aggregates_null(conn):
+    """Hierarchical middle-out run on a seeded 1-family / 3-leaf block with
+    a weekly seasonal pattern PLUS a deterministic 5-periodic perturbation
+    (coprime with the 7-day season, so the SEASONAL base model backtests
+    with non-zero residuals): every LEAF bucket gets non-NULL bounds
+    (node residual offsets scaled by the leaf's disaggregation share)
+    while every AGGREGATE keeps NULL bounds (interval reconciliation is
+    frontier — V1 non-objective)."""
+    from ootils_core.pyramide.hierarchy import (
+        HierarchicalRunConfig,
+        HierarchicalRunner,
+    )
+
+    h = "d2-h-conformal"
+    fam, prd1, prd2 = f"FAM-{h}", f"PRD-{h}1", f"PRD-{h}2"
+    conn.execute(
+        """
+        INSERT INTO hierarchy (hierarchy_id, domain, scope, levels, is_default)
+        VALUES (%s, 'product', 'local', %s, FALSE)
+        """,
+        (h, ["family", "product"]),
+    )
+    for code, level, parent in [
+        (fam, "family", None),
+        (prd1, "product", fam),
+        (prd2, "product", fam),
+    ]:
+        conn.execute(
+            "INSERT INTO hierarchy_node (hierarchy_id, code, level, parent_code) "
+            "VALUES (%s, %s, %s, %s)",
+            (h, code, level, parent),
+        )
+
+    # 56 consecutive days (8 full weeks) per leaf: amplitude x weekly
+    # pattern + 5-periodic perturbation. Both cycles are deterministic
+    # (ADR-003 discipline applies to fixtures); minimum quantity stays
+    # strictly positive (4*1 - 2 = 2).
+    week_pattern = (2, 1, 1, 1, 3, 4, 2)
+    perturbation = (-2, 1, 0, 2, -1)  # period 5, coprime with 7
+    amplitudes = {"A1": 10, "A2": 6, "A3": 4}
+    items: dict[str, UUID] = {}
+    for suffix, leaf_code in [("A1", prd1), ("A2", prd1), ("A3", prd2)]:
+        item_id = uuid4()
+        ext = f"D2-{h}-{suffix}"
+        conn.execute(
+            "INSERT INTO items (item_id, name, item_type, uom, status, external_id) "
+            "VALUES (%s, %s, 'finished_good', 'EA', 'active', %s)",
+            (item_id, f"{ext} item", ext),
+        )
+        conn.execute(
+            "INSERT INTO item_hierarchy (item_id, hierarchy_id, leaf_code) "
+            "VALUES (%s, %s, %s)",
+            (item_id, h, leaf_code),
+        )
+        items[suffix] = item_id
+        for i, back in enumerate(range(4, 60)):
+            day = TODAY - timedelta(days=back)
+            qty = (
+                amplitudes[suffix] * week_pattern[day.weekday()]
+                + perturbation[i % len(perturbation)]
+            )
+            conn.execute(
+                """
+                INSERT INTO demand_history (
+                    item_id, item_code, stream, booked_date,
+                    ordered_quantity, value_ext, counts_for_asp,
+                    fulfillment, order_number
+                ) VALUES (%s, %s, 'regular', %s, %s, 0, FALSE, 'standard', 'D2')
+                """,
+                (item_id, ext, day, qty),
+            )
+    loc_id = uuid4()
+    conn.execute(
+        "INSERT INTO locations (location_id, name, location_type, country, external_id) "
+        "VALUES (%s, %s, 'dc', 'US', %s)",
+        (loc_id, f"D2-{h} DC", f"D2-{h}-DC"),
+    )
+
+    result = HierarchicalRunner().run(
+        conn,
+        HierarchicalRunConfig(
+            hierarchy_id=h,
+            block_code=fam,
+            leaf_location_id=loc_id,
+            scenario_id=BASELINE_SCENARIO_ID,
+            horizon_start=TODAY + timedelta(days=2),
+            horizon_days=14,
+            granularity="daily",
+            method="SEASONAL",
+            method_params={"season_length": 7},
+            lookback_days=90,
+        ),
+    )
+
+    # 8 seasonal cycles -> 29+ backtest residuals per horizon at the node,
+    # well above the alpha=0.2 requirement (9): no degradation warning.
+    assert not [w for w in result.warnings if "conformal" in w], result.warnings
+
+    leaf_keys = {str(i) for i in items.values()}
+    any_strict = False
+    for series in result.persisted:
+        rows = _fetch_bounds(conn, series.forecast_id)
+        assert len(rows) == 14
+        if series.key in leaf_keys:
+            assert series.kind == "leaf"
+            for row in rows:
+                assert row["lower"] is not None and row["upper"] is not None
+                lower = Decimal(str(row["lower"]))
+                upper = Decimal(str(row["upper"]))
+                point = Decimal(str(row["quantity"]))
+                assert lower >= Decimal("0")
+                assert lower <= point <= upper
+                if lower < upper:
+                    any_strict = True
+        else:
+            # Aggregates: bounds stay NULL in V1 (interval reconciliation
+            # across levels is a documented non-objective).
+            assert series.kind == "aggregate"
+            for row in rows:
+                assert row["lower"] is None and row["upper"] is None
+    # The 5-periodic perturbation guarantees non-zero residuals: the
+    # intervals cannot all collapse onto the point forecast.
+    assert any_strict
+
+
+def test_get_forecast_endpoint_exposes_persisted_bounds(migrated_db):
+    """GET /v1/demand/forecast/{forecast_id} already declared the interval
+    fields (Optional, previously always null): with the columns now
+    populated the endpoint must return them without contract change."""
+    os.environ["OOTILS_API_TOKEN"] = "integration-test-token"
+
+    from fastapi.testclient import TestClient
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+    auth = {"Authorization": "Bearer integration-test-token"}
+
+    with _db_conn(migrated_db) as conn:
+        code = f"CONF-{uuid4().hex[:8].upper()}"
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            seeded = _seed_noisy_series(conn, item_id, code, f"DC-{code}", days=60)
+            _, persisted = _run_and_persist(
+                conn, item_id, location_id, seeded, horizon_days=5,
+            )
+
+            with TestClient(app) as client:
+                response = client.get(
+                    f"/v1/demand/forecast/{persisted.forecast_id}", headers=auth
+                )
+            assert response.status_code == 200
+            payload = response.json()
+            assert len(payload["values"]) == 5
+            for value in payload["values"]:
+                lower = value["confidence_interval_lower"]
+                upper = value["confidence_interval_upper"]
+                assert lower is not None and upper is not None
+                assert Decimal("0") <= Decimal(lower)
+                assert Decimal(lower) <= Decimal(value["quantity"]) <= Decimal(upper)
+        finally:
+            app.dependency_overrides.clear()
+            _cleanup(conn, item_id, location_id)

--- a/tests/test_pyramide_conformal.py
+++ b/tests/test_pyramide_conformal.py
@@ -1,0 +1,317 @@
+"""
+Pyramide axis D — PR-D2 unit tests (pure, no DB): the engine backtest is
+DELEGATED to accuracy.evaluate_rolling_origin, and the runner derives
+persistable conformal bounds from the selected model's backtest residuals.
+
+Covered:
+  - _backtest_score is the WAPE of the delegated rolling-origin report
+    (hand-computed golden), replacing the old max(|actual|, 1) trap;
+  - zero-demand evaluation windows -> WAPE None -> candidate "non
+    scorable" (excluded from AUTO_SELECT ranking, no invented score);
+  - the perfect candidate still wins AUTO_SELECT (behavioral contract,
+    complements tests/test_pyramide_runner.py);
+  - PyramideRunner attaches conformal bounds per bucket: point + offset,
+    lower clamped at 0, honest NULL (+ warning) when there is no
+    deterministic backtest or too few residuals for the finite-sample
+    guarantee;
+  - alpha is configurable via method_params.conformal_alpha and fails
+    loudly when invalid;
+  - conformal_bounds scale= transports node offsets to a hierarchy leaf
+    (share x offset), the documented V1 approximation.
+"""
+from datetime import date
+from decimal import Decimal
+from uuid import UUID
+
+import pytest
+
+from ootils_core.forecasting import ForecastMethod
+from ootils_core.pyramide import PyramideError, PyramideRunConfig, PyramideRunner
+from ootils_core.pyramide.accuracy import AccuracyReport
+from ootils_core.pyramide.engines import (
+    PyramideEngineError,
+    PyramideForecastEngine,
+    _Candidate,
+    conformal_bounds,
+    conformal_min_residuals,
+    resolve_conformal_alpha,
+)
+
+
+ITEM_ID = UUID("10000000-0000-0000-0000-000000000001")
+LOCATION_ID = UUID("20000000-0000-0000-0000-000000000001")
+SCENARIO_ID = UUID("00000000-0000-0000-0000-000000000001")
+
+
+def _config(**overrides) -> PyramideRunConfig:
+    values = {
+        "item_id": ITEM_ID,
+        "location_id": LOCATION_ID,
+        "scenario_id": SCENARIO_ID,
+        "horizon_start": date(2026, 7, 1),
+        "horizon_days": 3,
+        "granularity": "daily",
+        "method": "MA",
+        "method_params": {"window": 2},
+    }
+    values.update(overrides)
+    return PyramideRunConfig(**values)
+
+
+def _candidate(method: str, params: dict, label: str) -> _Candidate:
+    return _Candidate(method=method, params=params, label=label)
+
+
+# ---------------------------------------------------------------------------
+# Delegated backtest — golden WAPE, None semantics
+# ---------------------------------------------------------------------------
+
+
+def test_backtest_score_is_wape_of_delegated_report():
+    """Hand-computed golden. history=[10,10,10,10,20], MA(window=2):
+    origins 2..4 (MA needs 2 points), horizon 1 ->
+      o=2: f=10 a=10 e=0 ; o=3: f=10 a=10 e=0 ; o=4: f=10 a=20 e=10
+    WAPE = (0+0+10) / (10+10+20) = 0.25.
+    The OLD local loop would have scored mean(|e|/max(|a|,1)) = 1/6 —
+    the score scale changed by design (CHANGEMENT ASSUMÉ, validated)."""
+    engine = PyramideForecastEngine()
+    candidate = _candidate(ForecastMethod.MA, {"window": 2}, "MA(window=2)")
+    history = [Decimal(v) for v in (10, 10, 10, 10, 20)]
+
+    score = engine._backtest_score(history, candidate, horizon=1)
+    report = engine._backtest_report(history, candidate, horizon=1)
+
+    assert score == 0.25
+    assert report is not None
+    assert report.wape == Decimal("0.25")
+    assert report.n_cutoffs == 3
+    # Residuals are actual - forecast, in cutoff order (conformal input).
+    assert report.per_horizon_residuals[1] == (
+        Decimal("0.0"), Decimal("0.0"), Decimal("10.0"),
+    )
+
+
+def test_backtest_score_none_on_zero_demand_windows():
+    """Every evaluated window has zero total demand -> WAPE is undefined
+    (accuracy.wape returns None) -> the candidate is 'non scorable' (None),
+    NOT scored against the old masked max(|actual|, 1) denominator."""
+    engine = PyramideForecastEngine()
+    candidate = _candidate(ForecastMethod.MA, {"window": 1}, "MA(window=1)")
+    history = [Decimal(v) for v in (5, 0, 0, 0)]
+
+    assert engine._backtest_score(history, candidate, horizon=1) is None
+
+
+def test_auto_select_on_zero_demand_windows_has_no_accuracy_report():
+    """When no candidate is scorable (all evaluated windows are zero
+    demand), AUTO_SELECT still serves values (first candidate fallback)
+    but attaches NO accuracy report — the caller must not invent bounds."""
+    engine = PyramideForecastEngine()
+    computation = engine.forecast(
+        history=[Decimal(v) for v in (5, 0, 0, 0)],
+        periods=2,
+        method="AUTO_SELECT",
+        method_params={},
+        model_strategy="stat",
+        granularity="daily",
+        horizon_start=date(2026, 7, 1),
+        random_seed=0,
+    )
+    assert computation.values  # still forecastable
+    assert computation.accuracy_report is None
+
+
+def test_auto_select_winner_report_travels_with_the_computation():
+    """The winner's FULL report (multi-horizon residuals) is attached to
+    the AUTO_SELECT result without re-backtesting — the raw material of
+    the conformal bounds."""
+    engine = PyramideForecastEngine()
+    history = [Decimal(8) if i % 2 == 0 else Decimal(12) for i in range(20)]
+    computation = engine.forecast(
+        history=history,
+        periods=3,
+        method="AUTO_SELECT",
+        method_params={},
+        model_strategy="stat",
+        granularity="daily",
+        horizon_start=date(2026, 7, 1),
+        random_seed=0,
+    )
+    report = computation.accuracy_report
+    assert isinstance(report, AccuracyReport)
+    assert report.wape is not None
+    # Multi-horizon: horizons 1..3 all evaluated (partial windows included).
+    assert set(report.per_horizon_residuals) == {1, 2, 3}
+
+
+def test_backtest_report_none_when_no_origin_can_run():
+    """A candidate that cannot run on any origin (window larger than the
+    whole history) is non-scorable, not an exception."""
+    engine = PyramideForecastEngine()
+    candidate = _candidate(ForecastMethod.MA, {"window": 99}, "MA(window=99)")
+    history = [Decimal(10), Decimal(11), Decimal(12)]
+
+    assert engine._backtest_report(history, candidate, horizon=1) is None
+    assert engine._backtest_score(history, candidate, horizon=1) is None
+
+
+# ---------------------------------------------------------------------------
+# Runner — persisted conformal bounds
+# ---------------------------------------------------------------------------
+
+
+def test_runner_attaches_conformal_bounds_around_the_point():
+    """Alternating 8/12 series, MA(window=2): the point forecast is 10 and
+    every backtest residual is exactly +/-2, so at alpha=0.2 the bounds are
+    the observed extremes [8, 12] at every horizon (order statistics ARE
+    observed residuals — explainability)."""
+    history = [Decimal(8) if i % 2 == 0 else Decimal(12) for i in range(40)]
+    result = PyramideRunner().run(_config(), history)
+
+    assert len(result.values) == 3
+    for value in result.values:
+        assert value.quantity == Decimal("10.0")
+        assert value.confidence_lower == Decimal("8.0")
+        assert value.confidence_upper == Decimal("12.0")
+        assert value.confidence_lower <= value.quantity <= value.confidence_upper
+    assert not [w for w in result.warnings if "conformal" in w]
+
+
+def test_runner_lower_bound_is_clamped_at_zero():
+    """Declining-to-zero series: the MA(2) point forecast ends at 0 while
+    the calibration residuals are strongly negative — without the clamp the
+    lower bound would be negative demand, which does not exist."""
+    history = [Decimal(v) for v in (50, 40, 30, 20, 10, 0, 0, 0, 0, 0, 0, 0)]
+    result = PyramideRunner().run(_config(horizon_days=1), history)
+
+    value = result.values[0]
+    assert value.quantity == Decimal("0")
+    assert value.confidence_lower == Decimal("0")
+    assert value.confidence_upper is not None
+    assert value.confidence_upper >= Decimal("0")
+
+
+def test_runner_short_series_yields_null_bounds_and_provenance():
+    """Too few backtest residuals for the finite-sample guarantee
+    (n < ceil(2/alpha) - 1 = 9 at alpha 0.2): bounds are None and the
+    provenance says so — never invented bounds."""
+    result = PyramideRunner().run(
+        _config(),
+        [Decimal("10"), Decimal("12"), Decimal("14"), Decimal("16")],
+    )
+
+    for value in result.values:
+        assert value.confidence_lower is None
+        assert value.confidence_upper is None
+    assert any("conformal" in w and "NULL" in w for w in result.warnings)
+
+
+def test_runner_alpha_is_configurable_via_method_params():
+    """alpha=0.5 needs only ceil(2/0.5)-1 = 3 residuals per horizon: the
+    same short series that yields NULL at the default alpha=0.2 gets bounds
+    at alpha=0.5 (wider miscoverage, smaller calibration requirement)."""
+    history = [Decimal(8) if i % 2 == 0 else Decimal(12) for i in range(6)]
+
+    default_run = PyramideRunner().run(_config(horizon_days=1), history)
+    assert default_run.values[0].confidence_lower is None
+
+    loose_run = PyramideRunner().run(
+        _config(horizon_days=1, method_params={"window": 2, "conformal_alpha": 0.5}),
+        history,
+    )
+    value = loose_run.values[0]
+    assert value.confidence_lower is not None
+    assert value.confidence_upper is not None
+    assert value.confidence_lower <= value.quantity <= value.confidence_upper
+
+
+@pytest.mark.parametrize("alpha", ["n/a", 0, 1, -0.1, 2, None])
+def test_runner_rejects_invalid_conformal_alpha(alpha):
+    """An unreadable or out-of-range alpha is a configuration error of the
+    PUBLISHED bounds: fail loudly (422 at the router), no silent default."""
+    with pytest.raises(PyramideError):
+        PyramideRunner().run(
+            _config(method_params={"window": 2, "conformal_alpha": alpha}),
+            [Decimal(8) if i % 2 == 0 else Decimal(12) for i in range(40)],
+        )
+
+
+def test_runner_ensemble_stat_has_null_bounds():
+    """ENSEMBLE_STAT serves a weighted blend: no single candidate's
+    residuals describe it, so accuracy_report is None and the bounds stay
+    NULL with explicit provenance (never bounds borrowed from another
+    model)."""
+    history = [Decimal(8) if i % 2 == 0 else Decimal(12) for i in range(20)]
+    result = PyramideRunner().run(
+        _config(method="ENSEMBLE_STAT", method_params={}),
+        history,
+    )
+
+    assert result.engine_backend == "internal:ensemble_stat"
+    for value in result.values:
+        assert value.confidence_lower is None
+        assert value.confidence_upper is None
+    assert any("conformal" in w for w in result.warnings)
+
+
+# ---------------------------------------------------------------------------
+# conformal_bounds helper — scale (hierarchy leaves) and alpha resolution
+# ---------------------------------------------------------------------------
+
+
+def _report_with_residuals(residuals: tuple[Decimal, ...]) -> AccuracyReport:
+    return AccuracyReport(
+        mase=None,
+        wape=Decimal("0.1"),
+        smape=Decimal("0.1"),
+        bias=Decimal("0"),
+        coverage=None,
+        per_horizon_residuals={1: residuals},
+        n_cutoffs=len(residuals),
+        n_observations=len(residuals),
+    )
+
+
+def test_conformal_bounds_scale_transports_offsets_to_leaf_share():
+    """Hierarchy leaf = share x node: the node's residual offsets are
+    scaled by the share. 10 residuals +/-4 at alpha 0.2 -> node offsets
+    [-4, +4]; at share 0.5 the leaf bounds are point -/+ 2."""
+    residuals = tuple(
+        Decimal(-4) if i % 2 == 0 else Decimal(4) for i in range(10)
+    )
+    report = _report_with_residuals(residuals)
+
+    node_lowers, node_uppers, _ = conformal_bounds(
+        report=report, values=[Decimal(100)], method_params={},
+    )
+    assert node_lowers == (Decimal(96),)
+    assert node_uppers == (Decimal(104),)
+
+    leaf_lowers, leaf_uppers, _ = conformal_bounds(
+        report=report, values=[Decimal(50)], method_params={},
+        scale=Decimal("0.5"),
+    )
+    assert leaf_lowers == (Decimal(48),)
+    assert leaf_uppers == (Decimal(52),)
+
+
+def test_conformal_bounds_without_report_is_all_null_with_provenance():
+    lowers, uppers, warnings = conformal_bounds(
+        report=None, values=[Decimal(1), Decimal(2)], method_params={},
+    )
+    assert lowers == (None, None)
+    assert uppers == (None, None)
+    assert warnings and "no deterministic backtest" in warnings[0]
+
+
+def test_conformal_min_residuals_matches_finite_sample_requirement():
+    assert conformal_min_residuals(Decimal("0.2")) == 9
+    assert conformal_min_residuals(Decimal("0.5")) == 3
+    assert conformal_min_residuals(Decimal("0.1")) == 19
+
+
+def test_resolve_conformal_alpha_default_and_override():
+    assert resolve_conformal_alpha({}) == Decimal("0.2")
+    assert resolve_conformal_alpha({"conformal_alpha": "0.1"}) == Decimal("0.1")
+    with pytest.raises(PyramideEngineError):
+        resolve_conformal_alpha({"conformal_alpha": "not-a-number"})


### PR DESCRIPTION
## Pyramide V1 — axe D, PR-D2 : le conformal devient réel, le backtest devient honnête

Deux dettes historiques soldées :

1. **Délégation du backtest** : AUTO_SELECT/ENSEMBLE scorent désormais via `accuracy.evaluate_rolling_origin`. Le dénominateur piégé `max(|actual|,1)` disparaît — demande nulle → `None` = candidat non scorable (jamais un score menteur). Le rapport complet (résidus par horizon) voyage avec le gagnant (`ForecastComputation.accuracy_report`), zéro re-backtest.
2. **`confidence_interval_lower/upper` enfin alimentées** (migration 026 — vides depuis leur création, constat revue APS) : split-conformal, α = 0.2 paramétrable (fail-loudly hors (0,1)), bornes clampées à 0, **NULL honnête + provenance** quand la garantie finite-sample n'existe pas. Hiérarchique : feuilles = offsets du nœud × part de désagrégation (approximation V1 documentée), agrégats = NULL (réconciliation d'intervalles = frontier de la spec).

**Réserves de revue (toutes non-bloquantes, zéro correctif requis)** — le reviewer a reproduit la validation indépendamment (1879 tests, merge-tree 0 conflit) :
- Premier passage réel des 4 tests d'intégration = cette CI (couverture ≥ 0.6 pour nominal 0.8 = bande anti-flake)
- `lower ≤ point ≤ upper` n'est **pas** un invariant universel du conformal (modèle biaisé → offsets de même signe) — noté dans le commit pour les futurs mainteneurs
- Les poids d'ENSEMBLE changent d'échelle (WAPE vs ancienne moyenne masquée) — comparaisons bit-à-bit avec d'anciens runs invalides, comportement validé par les tests existants

20 tests purs + 4 intégration · 1879 unitaires ✅ · ruff ✅.

Prochaines briques de l'axe D : D3 (persistance des métriques par horizon) puis D4 (fraîcheur `ingested_at` + score de confiance déterministe, ADR-023).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
