### PR TITLE
feat(pyramide): axe D PR-D3 — métriques de backtest persistées par horizon (migration 055)

### DIFF
--- a/src/ootils_core/api/routers/pyramide.py
+++ b/src/ootils_core/api/routers/pyramide.py
@@ -16,6 +16,7 @@ from ootils_core.pyramide import PyramideError, PyramideRunConfig, PyramideRunne
 from ootils_core.pyramide.repository import (
     PyramideAggregateCommitError,
     commit_run,
+    fetch_accuracy_metrics,
     fetch_run_summary,
     fetch_run_values,
     fetch_snapshot_values,
@@ -56,6 +57,22 @@ class PyramideRunRequest(BaseModel):
         return f"method must be one of: {sorted(SUPPORTED_METHODS)}"
 
 
+class PyramideAccuracyMetricOut(BaseModel):
+    # horizon None = all-horizons aggregate row; h >= 1 = per-horizon
+    # row (only bias + counts are derivable from the persisted backtest
+    # residuals — the other metrics need the actuals and stay None).
+    # A None metric = "not computable on this data" (None-honest
+    # contract of pyramide/accuracy.py), never a masked 0.
+    horizon: int | None = None
+    mase: Decimal | None = None
+    wape: Decimal | None = None
+    smape: Decimal | None = None
+    bias: Decimal | None = None
+    coverage: Decimal | None = None
+    n_cutoffs: int
+    n_observations: int
+
+
 class PyramideRunOut(BaseModel):
     # Leaf runs carry (item_id, location_id); aggregate runs (migration
     # 053) carry (hierarchy_id, level, node_code) — the unused side is
@@ -88,6 +105,12 @@ class PyramideRunOut(BaseModel):
     deterministic_artifact: str
     created_at: datetime
     committed_at: datetime | None = None
+    # Backtest accuracy metrics (migration 055) — populated by
+    # GET /runs/{run_id} only (backward-compatible optional field):
+    # aggregate row first, then per-horizon rows. None on the other
+    # endpoints (not fetched); [] = run persisted without a backtest
+    # report (e.g. ENSEMBLE_STAT blend, external backend).
+    accuracy_metrics: list[PyramideAccuracyMetricOut] | None = None
 
 
 class PyramideValueOut(BaseModel):
@@ -235,7 +258,12 @@ def get_pyramide_run(
     summary = fetch_run_summary(db, run_id)
     if summary is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Pyramide run '{run_id}' not found")
-    return _run_out(summary)
+    out = _run_out(summary)
+    out.accuracy_metrics = [
+        _accuracy_metric_out(metric)
+        for metric in fetch_accuracy_metrics(db, run_id)
+    ]
+    return out
 
 
 @router.get(
@@ -374,6 +402,19 @@ def _run_out(summary) -> PyramideRunOut:
         deterministic_artifact=summary.deterministic_artifact,
         created_at=summary.created_at,
         committed_at=summary.committed_at,
+    )
+
+
+def _accuracy_metric_out(metric) -> PyramideAccuracyMetricOut:
+    return PyramideAccuracyMetricOut(
+        horizon=metric.horizon,
+        mase=metric.mase,
+        wape=metric.wape,
+        smape=metric.smape,
+        bias=metric.bias,
+        coverage=metric.coverage,
+        n_cutoffs=metric.n_cutoffs,
+        n_observations=metric.n_observations,
     )
 
 

--- a/src/ootils_core/db/migrations/055_pyramide_accuracy_metrics.sql
+++ b/src/ootils_core/db/migrations/055_pyramide_accuracy_metrics.sql
@@ -1,0 +1,92 @@
+-- ============================================================
+-- Migration 055 — Pyramide backtest accuracy metrics (axis D, PR-D3)
+-- ============================================================
+-- Persists the rolling-origin backtest report (pyramide/accuracy.py,
+-- AccuracyReport) of the model that PRODUCED a run's values, so agents
+-- and planners can rank forecasts without re-running the backtest.
+--
+-- Row semantics — LIGNES-PAR-HORIZON (pilot arbitration):
+--   * horizon IS NULL  -> the all-horizons AGGREGATE row (pooled
+--     mase/wape/smape/bias/coverage of the report);
+--   * horizon = h >= 1 -> the per-horizon row. The report only carries
+--     RESIDUALS per horizon (actual - forecast), not the actuals — so
+--     only the residual-derivable metrics are populated per horizon
+--     (bias = -mean(residuals_h), counts). mase/wape/smape/coverage
+--     need the per-horizon actuals and therefore stay NULL on horizon
+--     rows: we persist what the report really contains, nothing more.
+--
+-- NULL semantics (None-honest contract of accuracy.py): a NULL metric
+-- means "not computable on this data" (e.g. WAPE with zero total
+-- demand, MASE with constant history, coverage without evaluated
+-- intervals) — NEVER a masked 0. Consumers must treat NULL as "not
+-- comparable".
+--
+-- UNIQUE NULLS NOT DISTINCT: plain UNIQUE treats NULLs as distinct in
+-- Postgres, so two aggregate rows (horizon NULL) for the same run would
+-- both be accepted. NULLS NOT DISTINCT (PG15+; the project runs PG16)
+-- makes (run_id, NULL) collide — exactly one aggregate row per run.
+--
+-- Write path: repository.persist_accuracy_metrics does DELETE + INSERT
+-- per run_id (full-set replace), so re-persisting a run is idempotent.
+-- A run without a backtest report writes NO row (absence = no honest
+-- backtest existed, e.g. ENSEMBLE_STAT blend or external backend).
+--
+-- Idempotence: IF NOT EXISTS everywhere (repo migration policy).
+-- No JSONB. Typed columns only.
+-- ============================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS pyramide_accuracy_metrics (
+    metric_id       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id          UUID NOT NULL REFERENCES pyramide_runs(run_id) ON DELETE CASCADE,
+    -- NULL = all-horizons aggregate row; h >= 1 = per-horizon row.
+    horizon         INT NULL CHECK (horizon IS NULL OR horizon >= 1),
+    mase            NUMERIC NULL,
+    wape            NUMERIC NULL,
+    smape           NUMERIC NULL,
+    bias            NUMERIC NULL,
+    coverage        NUMERIC NULL,
+    n_cutoffs       INT NOT NULL CHECK (n_cutoffs >= 0),
+    n_observations  INT NOT NULL CHECK (n_observations >= 0),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- NULLS NOT DISTINCT: dedupe the aggregate (horizon NULL) row too.
+    CONSTRAINT pyramide_accuracy_metrics_run_horizon_uniq
+        UNIQUE NULLS NOT DISTINCT (run_id, horizon)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pyramide_accuracy_metrics_run
+    ON pyramide_accuracy_metrics (run_id);
+
+COMMENT ON TABLE pyramide_accuracy_metrics IS
+    'Rolling-origin backtest metrics of the model that produced a Pyramide '
+    'run (accuracy.AccuracyReport). One aggregate row (horizon NULL) + one '
+    'row per horizon step. NULL metric = not computable on this data '
+    '(None-honest contract) — never a masked 0. Runs without a backtest '
+    'report have no rows.';
+COMMENT ON COLUMN pyramide_accuracy_metrics.horizon IS
+    'NULL = all-horizons aggregate; h >= 1 = metrics of forecast step h.';
+COMMENT ON COLUMN pyramide_accuracy_metrics.mase IS
+    'Mean Absolute Scaled Error (per-cutoff naive scaling). NULL when no '
+    'cutoff had a usable denominator, or on per-horizon rows (needs the '
+    'per-horizon actuals, which the report does not carry).';
+COMMENT ON COLUMN pyramide_accuracy_metrics.wape IS
+    'sum|a-f| / sum|a| pooled over evaluated pairs. NULL when total actual '
+    'demand is zero, or on per-horizon rows (needs the actuals).';
+COMMENT ON COLUMN pyramide_accuracy_metrics.smape IS
+    'Symmetric MAPE ratio in [0,2]. NULL on per-horizon rows (needs the '
+    'actuals).';
+COMMENT ON COLUMN pyramide_accuracy_metrics.bias IS
+    'Mean signed error forecast - actual; POSITIVE = over-forecast (the '
+    'stock-critical direction). On per-horizon rows: -mean(residuals_h), '
+    'since report residuals are actual - forecast.';
+COMMENT ON COLUMN pyramide_accuracy_metrics.coverage IS
+    'Share of actuals inside prediction intervals. NULL for rolling-origin '
+    'point-forecast backtests (no intervals were evaluated).';
+COMMENT ON COLUMN pyramide_accuracy_metrics.n_cutoffs IS
+    'Aggregate row: number of forecast origins evaluated. Per-horizon row: '
+    'number of cutoffs that reached this horizon (= residual count).';
+COMMENT ON COLUMN pyramide_accuracy_metrics.n_observations IS
+    'Number of (actual, forecast) pairs behind the row''s metrics.';
+
+COMMIT;

--- a/src/ootils_core/pyramide/hierarchy/runner.py
+++ b/src/ootils_core/pyramide/hierarchy/runner.py
@@ -436,6 +436,10 @@ class HierarchicalRunner:
                 # Bornes NULL pour TOUS les agrégats : la réconciliation
                 # d'intervalles hiérarchiques (bornes cohérentes entre
                 # niveaux) est frontier — non-objectif V1 (spec §2.D).
+                # Métriques de backtest (migration 055) : uniquement pour
+                # les nœuds du niveau de réconciliation, qui possèdent
+                # leur propre computation (les niveaux S-sommés n'ont pas
+                # été backtestés → zéro ligne, documenté).
                 record = persist_series_run(
                     db,
                     scenario_id=config.scenario_id,
@@ -456,6 +460,9 @@ class HierarchicalRunner:
                     hierarchy_id=config.hierarchy_id,
                     level=ref.level,
                     node_code=ref.key,
+                    accuracy_report=(
+                        computation.accuracy_report if computation else None
+                    ),
                 )
             else:
                 recon_node = parent_of.get(ref.key)
@@ -509,6 +516,20 @@ class HierarchicalRunner:
                     location_id=config.leaf_location_id,
                     lowers=lowers,
                     uppers=uppers,
+                    # Métriques de backtest de la FEUILLE (migration 055) :
+                    # mêmes provenance et garde-fou que les bornes — le
+                    # rapport du modèle du nœud de réconciliation, avec le
+                    # biais transporté par la part de désagrégation (les
+                    # métriques scale-free passent inchangées, approximation
+                    # V1 middle-out documentée dans accuracy_metric_rows).
+                    # Sans rapport ou sans part explicite (MinT) → None,
+                    # zéro ligne.
+                    accuracy_report=(
+                        report if (report is not None and share is not None) else None
+                    ),
+                    accuracy_bias_scale=(
+                        share if share is not None else Decimal("1")
+                    ),
                 )
             persisted.append(_persisted_series(ref, record))
         if leaves_without_bounds:

--- a/src/ootils_core/pyramide/models.py
+++ b/src/ootils_core/pyramide/models.py
@@ -9,6 +9,8 @@ from uuid import UUID
 
 from ootils_core.forecasting import ForecastMethod
 
+from .accuracy import AccuracyReport
+
 METHOD_AUTO_SELECT = "AUTO_SELECT"
 METHOD_ENSEMBLE_STAT = "ENSEMBLE_STAT"
 METHOD_STAT_AUTOETS = "STAT_AUTOETS"
@@ -88,6 +90,13 @@ class PyramideRunResult:
     engine_backend: str
     generated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     warnings: tuple[str, ...] = ()
+    # Rapport de backtest rolling-origin du modèle qui a PRODUIT les
+    # valeurs (ForecastComputation.accuracy_report, remonté par le
+    # runner). Persisté dans pyramide_accuracy_metrics (migration 055)
+    # par persist_run. None = pas de backtest déterministe disponible
+    # (ENSEMBLE_STAT, backend externe, historique trop court) → AUCUNE
+    # ligne de métriques, jamais des métriques inventées.
+    accuracy_report: AccuracyReport | None = None
 
     @property
     def total_quantity(self) -> Decimal:

--- a/src/ootils_core/pyramide/repository.py
+++ b/src/ootils_core/pyramide/repository.py
@@ -12,6 +12,7 @@ import psycopg
 
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID
 
+from .accuracy import AccuracyReport
 from .models import PyramideRunResult
 
 logger = logging.getLogger(__name__)
@@ -103,6 +104,31 @@ class PyramideSnapshotSummary:
 class PyramideCommitResult:
     summary: PyramideRunSummary
     demand_node_count: int
+
+
+@dataclass(frozen=True)
+class PyramideAccuracyMetric:
+    """One row of pyramide_accuracy_metrics (migration 055).
+
+    ``horizon is None`` = the all-horizons aggregate row; ``horizon >= 1``
+    = the per-horizon row. A ``None`` metric means "not computable on this
+    data" (None-honest contract of accuracy.py) — per-horizon rows only
+    carry the residual-derivable metrics (bias + counts): mase / wape /
+    smape / coverage need the per-horizon actuals, which the report does
+    not contain, so they stay None there.
+    """
+
+    metric_id: UUID
+    run_id: UUID
+    horizon: int | None
+    mase: Decimal | None
+    wape: Decimal | None
+    smape: Decimal | None
+    bias: Decimal | None
+    coverage: Decimal | None
+    n_cutoffs: int
+    n_observations: int
+    created_at: datetime
 
 
 def resolve_item_uuid(db: psycopg.Connection, external_id: str) -> UUID | None:
@@ -378,6 +404,149 @@ def get_historical_demand_totals_by_items(
     return {str(row["item_id"]): Decimal(str(row["total_qty"])) for row in rows}
 
 
+_ONE = Decimal("1")
+
+
+def accuracy_metric_rows(
+    report: AccuracyReport,
+    bias_scale: Decimal = _ONE,
+) -> list[tuple[int | None, Decimal | None, Decimal | None, Decimal | None, Decimal | None, Decimal | None, int, int]]:
+    """
+    Pure mapping AccuracyReport -> pyramide_accuracy_metrics rows
+    (migration 055). Returns tuples
+    ``(horizon, mase, wape, smape, bias, coverage, n_cutoffs, n_observations)``:
+
+    - one AGGREGATE row (horizon None) with the report's pooled metrics,
+      as-is (None stays None — the None-honest contract of accuracy.py);
+    - one row PER HORIZON with only the residual-derivable metrics:
+      ``bias_h = -mean(residuals_h)`` (report residuals are
+      ``actual - forecast`` while the bias contract is
+      ``forecast - actual``, positive = over-forecast — hence the sign
+      flip), and ``n_cutoffs = n_observations = len(residuals_h)`` (one
+      residual per cutoff that reached horizon h). mase/wape/smape/
+      coverage need the per-horizon actuals, which the report does not
+      carry: they stay None. Nothing is invented.
+
+    ``bias_scale`` is the middle-out transport factor for LEAF runs of a
+    hierarchical block (leaf = share x node): the scale-free metrics
+    (mase/wape/smape/coverage) are invariant under proportional
+    disaggregation and pass through unchanged, while bias — the only
+    scale-DEPENDENT metric persisted — is multiplied by the share,
+    exactly like the conformal offsets in ``engines.conformal_bounds``
+    (same documented V1 approximation). Default 1 = the report describes
+    the run's own series.
+    """
+    rows: list[tuple[int | None, Decimal | None, Decimal | None, Decimal | None, Decimal | None, Decimal | None, int, int]] = [
+        (
+            None,
+            report.mase,
+            report.wape,
+            report.smape,
+            report.bias * bias_scale,
+            report.coverage,
+            report.n_cutoffs,
+            report.n_observations,
+        )
+    ]
+    for horizon, residuals in sorted(report.per_horizon_residuals.items()):
+        if not residuals:
+            continue
+        mean_residual = sum(residuals, Decimal(0)) / Decimal(len(residuals))
+        rows.append(
+            (
+                horizon,
+                None,  # mase: needs per-horizon actuals — not in the report
+                None,  # wape: idem
+                None,  # smape: idem
+                -mean_residual * bias_scale,
+                None,  # coverage: no intervals evaluated per horizon
+                len(residuals),
+                len(residuals),
+            )
+        )
+    return rows
+
+
+def persist_accuracy_metrics(
+    db: psycopg.Connection,
+    run_id: UUID,
+    report: AccuracyReport,
+    bias_scale: Decimal = _ONE,
+) -> int:
+    """
+    Persist a run's backtest report into pyramide_accuracy_metrics
+    (migration 055): the aggregate row + one row per horizon (see
+    ``accuracy_metric_rows`` for the exact mapping and the ``bias_scale``
+    transport semantics).
+
+    Idempotence: DELETE + INSERT of the run's full row set. The report is
+    an atomic artifact of ONE backtest — replacing the whole set keeps
+    the (run_id, horizon) UNIQUE NULLS NOT DISTINCT invariant trivially
+    and never leaves a stale mix of two backtests (an upsert would, if a
+    re-run produced fewer horizons). Returns the number of rows written.
+    """
+    db.execute(
+        "DELETE FROM pyramide_accuracy_metrics WHERE run_id = %s",
+        (run_id,),
+    )
+    rows = accuracy_metric_rows(report, bias_scale=bias_scale)
+    for horizon, mase, wape, smape, bias_value, coverage, n_cutoffs, n_observations in rows:
+        db.execute(
+            """
+            INSERT INTO pyramide_accuracy_metrics (
+                run_id, horizon, mase, wape, smape, bias, coverage,
+                n_cutoffs, n_observations
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                run_id, horizon, mase, wape, smape, bias_value, coverage,
+                n_cutoffs, n_observations,
+            ),
+        )
+    return len(rows)
+
+
+def fetch_accuracy_metrics(
+    db: psycopg.Connection, run_id: UUID
+) -> list[PyramideAccuracyMetric]:
+    """
+    Backtest metrics of a run, aggregate row FIRST (horizon NULL), then
+    per-horizon rows in ascending horizon order. Empty list = the run
+    was persisted without a backtest report (documented absence, e.g.
+    ENSEMBLE_STAT blend or external backend) — never invented rows.
+    """
+    rows = db.execute(
+        """
+        SELECT metric_id, run_id, horizon, mase, wape, smape, bias,
+               coverage, n_cutoffs, n_observations, created_at
+        FROM pyramide_accuracy_metrics
+        WHERE run_id = %s
+        ORDER BY horizon ASC NULLS FIRST
+        """,
+        (run_id,),
+    ).fetchall()
+    return [
+        PyramideAccuracyMetric(
+            metric_id=row["metric_id"],
+            run_id=row["run_id"],
+            horizon=row["horizon"],
+            mase=_optional_decimal(row["mase"]),
+            wape=_optional_decimal(row["wape"]),
+            smape=_optional_decimal(row["smape"]),
+            bias=_optional_decimal(row["bias"]),
+            coverage=_optional_decimal(row["coverage"]),
+            n_cutoffs=row["n_cutoffs"],
+            n_observations=row["n_observations"],
+            created_at=row["created_at"],
+        )
+        for row in rows
+    ]
+
+
+def _optional_decimal(value) -> Decimal | None:
+    return None if value is None else Decimal(str(value))
+
+
 def persist_run(db: psycopg.Connection, result: PyramideRunResult) -> PyramidePersistedRun:
     run_id = uuid4()
     snapshot_id = uuid4()
@@ -474,6 +643,11 @@ def persist_run(db: psycopg.Connection, result: PyramideRunResult) -> PyramidePe
             result.total_quantity,
         ),
     )
+    # Métriques de backtest (migration 055) : uniquement quand un rapport
+    # honnête existe — run sans rapport (ENSEMBLE_STAT, backend externe,
+    # historique trop court) = zéro ligne, documenté.
+    if result.accuracy_report is not None:
+        persist_accuracy_metrics(db, run_id, result.accuracy_report)
     return PyramidePersistedRun(run_id=run_id, snapshot_id=snapshot_id, forecast_id=forecast_id)
 
 
@@ -502,12 +676,23 @@ def persist_series_run(
     node_code: str | None = None,
     lowers: Sequence[Decimal | None] | None = None,
     uppers: Sequence[Decimal | None] | None = None,
+    accuracy_report: AccuracyReport | None = None,
+    accuracy_bias_scale: Decimal = _ONE,
 ) -> PyramidePersistedRun:
     """
     Persist ONE series of a hierarchical run (migration 053): either a
     LEAF (item_id + location_id) or an AGGREGATE (hierarchy_id + level +
     node_code) — never both (mirrors the DB CHECK, validated here first
     so the error is readable).
+
+    ``accuracy_report`` is the rolling-origin backtest report of the
+    model that produced this series' values; when non-None it is
+    persisted into pyramide_accuracy_metrics (migration 055). None →
+    zero metric rows (documented absence, never invented metrics).
+    ``accuracy_bias_scale`` transports the scale-dependent bias for a
+    LEAF whose values are share x reconciliation-node curve — same V1
+    middle-out approximation as the conformal bounds (see
+    ``accuracy_metric_rows``).
 
     ``lowers`` / ``uppers`` are per-bucket conformal bounds
     (confidence_interval_lower/upper, migration 026), aligned with
@@ -619,6 +804,10 @@ def persist_series_run(
                 scenario_id, horizon_start, horizon_end, granularity, method,
                 len(quantities), total_quantity,
             ),
+        )
+    if accuracy_report is not None:
+        persist_accuracy_metrics(
+            db, run_id, accuracy_report, bias_scale=accuracy_bias_scale
         )
     return PyramidePersistedRun(
         run_id=run_id, snapshot_id=snapshot_id, forecast_id=forecast_id

--- a/src/ootils_core/pyramide/runner.py
+++ b/src/ootils_core/pyramide/runner.py
@@ -109,6 +109,9 @@ class PyramideRunner:
             selected_model=forecast.selected_model,
             engine_backend=forecast.engine_backend,
             warnings=(*forecast.warnings, *conformal_warnings),
+            # Remonté tel quel pour la persistance des métriques de
+            # backtest (pyramide_accuracy_metrics, migration 055).
+            accuracy_report=forecast.accuracy_report,
         )
 
     @staticmethod

--- a/tests/integration/test_pyramide_accuracy_metrics_integration.py
+++ b/tests/integration/test_pyramide_accuracy_metrics_integration.py
@@ -1,0 +1,394 @@
+"""
+Integration tests for Pyramide axis D — PR-D3 (persisted backtest
+accuracy metrics, migration 055) against a real PostgreSQL database
+(no mocks).
+
+Covered:
+  - a leaf Pyramide run on a synthetic deterministic seed persists ONE
+    aggregate row (horizon NULL, the report's pooled metrics) + one row
+    PER HORIZON (bias + counts only — the other metrics need the
+    actuals the report does not carry, so they stay NULL, None-honest);
+  - re-persisting the SAME run_id replaces the row set (DELETE +
+    INSERT, documented in persist_accuracy_metrics) instead of
+    violating the UNIQUE NULLS NOT DISTINCT (run_id, horizon)
+    constraint;
+  - a hierarchical run persists metrics for every LEAF run (node-model
+    report transported like the conformal bounds) and for the
+    reconciliation-level aggregate node; S-summed non-backtested levels
+    get none;
+  - a run WITHOUT a backtest report (ENSEMBLE_STAT blend) persists
+    ZERO metric rows — documented absence, never invented metrics;
+  - GET /v1/forecast/runs/{run_id} exposes the rows in the optional
+    accuracy_metrics field (aggregate first), backward-compatible.
+
+Conventions mirror test_forecast_conformal_integration.py:
+module-scoped migrated_db, autocommit _db_conn + finally-cleanup for
+leaf tests, rollback-scoped ``conn`` fixture for the heavier
+hierarchical seed. Anti-flake rule: all seeded demand facts are at
+TODAY - 2 or earlier (booked_date < server CURRENT_DATE).
+"""
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+BASELINE_SCENARIO_ID = UUID("00000000-0000-0000-0000-000000000001")
+TODAY = date.today()
+
+# Deterministic "noise" (ADR-003 discipline applies to fixtures too).
+NOISE_PATTERN = (-8, 5, -3, 9, -6, 2, -7, 8)
+BASE_LEVEL = 100
+
+
+def _db_conn(dsn):
+    import psycopg
+    from psycopg.rows import dict_row
+    return psycopg.connect(dsn, row_factory=dict_row, autocommit=True)
+
+
+def _create_item(conn, ext_id: str) -> UUID:
+    item_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO items (item_id, name, item_type, uom, status, external_id)
+        VALUES (%s, %s, 'finished_good', 'EA', 'active', %s)
+        """,
+        (item_id, f"{ext_id} accuracy test item", ext_id),
+    )
+    return item_id
+
+
+def _create_location(conn, ext_id: str) -> UUID:
+    loc_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO locations (location_id, name, location_type, country, external_id)
+        VALUES (%s, %s, 'dc', 'US', %s)
+        """,
+        (loc_id, f"{ext_id} accuracy test DC", ext_id),
+    )
+    return loc_id
+
+
+def _synthetic_series(days: int) -> list[Decimal]:
+    return [
+        Decimal(BASE_LEVEL + NOISE_PATTERN[i % len(NOISE_PATTERN)])
+        for i in range(days)
+    ]
+
+
+def _cleanup(conn, item_id: UUID, location_id: UUID) -> None:
+    """FK order: pyramide bookkeeping first (accuracy metrics cascade
+    from pyramide_runs), then forecast tables, then master data."""
+    conn.execute(
+        """
+        DELETE FROM pyramide_snapshots WHERE forecast_id IN (
+            SELECT forecast_id FROM forecasts WHERE item_id = %s
+        )
+        """,
+        (item_id,),
+    )
+    conn.execute(
+        """
+        DELETE FROM pyramide_runs WHERE forecast_id IN (
+            SELECT forecast_id FROM forecasts WHERE item_id = %s
+        )
+        """,
+        (item_id,),
+    )
+    conn.execute("DELETE FROM forecasts WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM items WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM locations WHERE location_id = %s", (location_id,))
+
+
+def _run_and_persist(conn, item_id: UUID, location_id: UUID,
+                     history: list[Decimal], horizon_days: int,
+                     method: str = "MA"):
+    from ootils_core.pyramide import PyramideRunConfig, PyramideRunner
+    from ootils_core.pyramide.repository import persist_run
+
+    config = PyramideRunConfig(
+        item_id=item_id,
+        location_id=location_id,
+        scenario_id=BASELINE_SCENARIO_ID,
+        horizon_start=TODAY + timedelta(days=2),
+        horizon_days=horizon_days,
+        granularity="daily",
+        method=method,
+        method_params={"window": 4} if method == "MA" else {},
+    )
+    result = PyramideRunner().run(config, history)
+    persisted = persist_run(conn, result)
+    return result, persisted
+
+
+def test_leaf_run_round_trips_aggregate_and_per_horizon_rows(migrated_db):
+    """Mono-series run -> one aggregate row (report metrics verbatim) +
+    one row per horizon (bias + counts only), read back in order
+    (aggregate first) by fetch_accuracy_metrics."""
+    from ootils_core.pyramide.repository import fetch_accuracy_metrics
+
+    with _db_conn(migrated_db) as conn:
+        code = f"ACC-{uuid4().hex[:8].upper()}"
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            history = _synthetic_series(60)
+            horizon = 7
+            result, persisted = _run_and_persist(
+                conn, item_id, location_id, history, horizon_days=horizon,
+            )
+            report = result.accuracy_report
+            assert report is not None  # MA on a long series backtests
+
+            metrics = fetch_accuracy_metrics(conn, persisted.run_id)
+            # Aggregate row first, then horizons 1..7 ascending.
+            assert [m.horizon for m in metrics] == [None] + list(range(1, horizon + 1))
+
+            aggregate = metrics[0]
+            assert aggregate.mase == report.mase
+            assert aggregate.wape == report.wape
+            assert aggregate.smape == report.smape
+            assert aggregate.bias == report.bias
+            assert aggregate.coverage is None  # point-forecast backtest
+            assert aggregate.n_cutoffs == report.n_cutoffs
+            assert aggregate.n_observations == report.n_observations
+
+            for row in metrics[1:]:
+                residuals = report.per_horizon_residuals[row.horizon]
+                expected_bias = -sum(residuals, Decimal(0)) / Decimal(len(residuals))
+                assert row.bias == expected_bias  # sign contract: f - a
+                # Residual-only rows: the actuals-dependent metrics are
+                # NULL — persisted honesty, never invented values.
+                assert row.mase is None and row.wape is None
+                assert row.smape is None and row.coverage is None
+                assert row.n_cutoffs == row.n_observations == len(residuals)
+        finally:
+            _cleanup(conn, item_id, location_id)
+
+
+def test_re_persisting_same_run_replaces_rows_unique_respected(migrated_db):
+    """persist_accuracy_metrics is DELETE + INSERT per run_id: calling it
+    again for the same run must not violate the UNIQUE NULLS NOT
+    DISTINCT (run_id, horizon) constraint (which also dedupes the
+    horizon-NULL aggregate row) and must leave exactly one row set."""
+    from ootils_core.pyramide.repository import (
+        fetch_accuracy_metrics,
+        persist_accuracy_metrics,
+    )
+
+    with _db_conn(migrated_db) as conn:
+        code = f"ACC-{uuid4().hex[:8].upper()}"
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            result, persisted = _run_and_persist(
+                conn, item_id, location_id, _synthetic_series(60), horizon_days=5,
+            )
+            first = fetch_accuracy_metrics(conn, persisted.run_id)
+            assert len(first) == 6  # aggregate + 5 horizons
+
+            written = persist_accuracy_metrics(
+                conn, persisted.run_id, result.accuracy_report
+            )
+            assert written == 6
+            second = fetch_accuracy_metrics(conn, persisted.run_id)
+            assert len(second) == 6
+            assert [m.horizon for m in second] == [m.horizon for m in first]
+            assert [m.bias for m in second] == [m.bias for m in first]
+        finally:
+            _cleanup(conn, item_id, location_id)
+
+
+def test_run_without_backtest_report_persists_zero_rows(migrated_db):
+    """ENSEMBLE_STAT blends candidates: no single candidate's residuals
+    describe the blend, so accuracy_report is None (engines contract)
+    and the run must persist ZERO metric rows — absence is the honest
+    provenance, never metrics borrowed from another model."""
+    from ootils_core.pyramide.repository import fetch_accuracy_metrics
+
+    with _db_conn(migrated_db) as conn:
+        code = f"ACC-{uuid4().hex[:8].upper()}"
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            result, persisted = _run_and_persist(
+                conn, item_id, location_id, _synthetic_series(60),
+                horizon_days=5, method="ENSEMBLE_STAT",
+            )
+            assert result.accuracy_report is None
+            assert fetch_accuracy_metrics(conn, persisted.run_id) == []
+        finally:
+            _cleanup(conn, item_id, location_id)
+
+
+def test_hierarchical_run_persists_metrics_per_leaf_run(conn):
+    """Hierarchical middle-out run (same seed shape as the conformal
+    integration test): every LEAF run gets metric rows — the recon
+    node's backtest report transported by the disaggregation share
+    (scale-free metrics unchanged, bias scaled), same provenance as its
+    conformal bounds. The reconciliation-level aggregate carries its own
+    (unscaled) report."""
+    from ootils_core.pyramide.hierarchy import (
+        HierarchicalRunConfig,
+        HierarchicalRunner,
+    )
+    from ootils_core.pyramide.repository import fetch_accuracy_metrics
+
+    h = "d3-h-accuracy"
+    fam, prd1, prd2 = f"FAM-{h}", f"PRD-{h}1", f"PRD-{h}2"
+    conn.execute(
+        """
+        INSERT INTO hierarchy (hierarchy_id, domain, scope, levels, is_default)
+        VALUES (%s, 'product', 'local', %s, FALSE)
+        """,
+        (h, ["family", "product"]),
+    )
+    for code, level, parent in [
+        (fam, "family", None),
+        (prd1, "product", fam),
+        (prd2, "product", fam),
+    ]:
+        conn.execute(
+            "INSERT INTO hierarchy_node (hierarchy_id, code, level, parent_code) "
+            "VALUES (%s, %s, %s, %s)",
+            (h, code, level, parent),
+        )
+
+    week_pattern = (2, 1, 1, 1, 3, 4, 2)
+    perturbation = (-2, 1, 0, 2, -1)  # period 5, coprime with 7
+    amplitudes = {"A1": 10, "A2": 6, "A3": 4}
+    items: dict[str, UUID] = {}
+    for suffix, leaf_code in [("A1", prd1), ("A2", prd1), ("A3", prd2)]:
+        item_id = uuid4()
+        ext = f"D3-{h}-{suffix}"
+        conn.execute(
+            "INSERT INTO items (item_id, name, item_type, uom, status, external_id) "
+            "VALUES (%s, %s, 'finished_good', 'EA', 'active', %s)",
+            (item_id, f"{ext} item", ext),
+        )
+        conn.execute(
+            "INSERT INTO item_hierarchy (item_id, hierarchy_id, leaf_code) "
+            "VALUES (%s, %s, %s)",
+            (item_id, h, leaf_code),
+        )
+        items[suffix] = item_id
+        for i, back in enumerate(range(4, 60)):
+            day = TODAY - timedelta(days=back)
+            qty = (
+                amplitudes[suffix] * week_pattern[day.weekday()]
+                + perturbation[i % len(perturbation)]
+            )
+            conn.execute(
+                """
+                INSERT INTO demand_history (
+                    item_id, item_code, stream, booked_date,
+                    ordered_quantity, value_ext, counts_for_asp,
+                    fulfillment, order_number
+                ) VALUES (%s, %s, 'regular', %s, %s, 0, FALSE, 'standard', 'D3')
+                """,
+                (item_id, ext, day, qty),
+            )
+    loc_id = uuid4()
+    conn.execute(
+        "INSERT INTO locations (location_id, name, location_type, country, external_id) "
+        "VALUES (%s, %s, 'dc', 'US', %s)",
+        (loc_id, f"D3-{h} DC", f"D3-{h}-DC"),
+    )
+
+    result = HierarchicalRunner().run(
+        conn,
+        HierarchicalRunConfig(
+            hierarchy_id=h,
+            block_code=fam,
+            leaf_location_id=loc_id,
+            scenario_id=BASELINE_SCENARIO_ID,
+            horizon_start=TODAY + timedelta(days=2),
+            horizon_days=14,
+            granularity="daily",
+            method="SEASONAL",
+            method_params={"season_length": 7},
+            lookback_days=90,
+        ),
+    )
+
+    leaf_keys = {str(i) for i in items.values()}
+    leaf_rows_seen = 0
+    aggregate_with_metrics = 0
+    for series in result.persisted:
+        metrics = fetch_accuracy_metrics(conn, series.run_id)
+        if series.key in leaf_keys:
+            assert series.kind == "leaf"
+            # Every leaf run carries metric rows: aggregate first, then
+            # per-horizon rows with bias + counts only.
+            assert metrics, f"leaf {series.key} has no accuracy metrics"
+            assert metrics[0].horizon is None
+            assert all(m.horizon >= 1 for m in metrics[1:])
+            assert all(
+                m.mase is None and m.wape is None and m.smape is None
+                for m in metrics[1:]
+            )
+            leaf_rows_seen += 1
+        elif metrics:
+            # Only backtested aggregates (the reconciliation level) own
+            # a report; S-summed levels persist nothing.
+            assert metrics[0].horizon is None
+            aggregate_with_metrics += 1
+    assert leaf_rows_seen == 3
+    assert aggregate_with_metrics >= 1
+
+
+def test_get_run_endpoint_exposes_accuracy_metrics(migrated_db):
+    """GET /v1/forecast/runs/{run_id}: the optional accuracy_metrics
+    field carries the persisted rows (aggregate first) — additive,
+    backward-compatible contract change."""
+    os.environ["OOTILS_API_TOKEN"] = "integration-test-token"
+
+    from fastapi.testclient import TestClient
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+    auth = {"Authorization": "Bearer integration-test-token"}
+
+    with _db_conn(migrated_db) as conn:
+        code = f"ACC-{uuid4().hex[:8].upper()}"
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            _, persisted = _run_and_persist(
+                conn, item_id, location_id, _synthetic_series(60), horizon_days=4,
+            )
+            with TestClient(app) as client:
+                response = client.get(
+                    f"/v1/forecast/runs/{persisted.run_id}", headers=auth
+                )
+            assert response.status_code == 200
+            payload = response.json()
+            metrics = payload["accuracy_metrics"]
+            assert [m["horizon"] for m in metrics] == [None, 1, 2, 3, 4]
+            aggregate = metrics[0]
+            assert aggregate["wape"] is not None
+            assert aggregate["coverage"] is None
+            assert aggregate["n_cutoffs"] >= 1
+            for row in metrics[1:]:
+                assert row["bias"] is not None
+                assert row["mase"] is None
+        finally:
+            app.dependency_overrides.clear()
+            _cleanup(conn, item_id, location_id)

--- a/tests/test_pyramide_accuracy_metrics.py
+++ b/tests/test_pyramide_accuracy_metrics.py
@@ -1,0 +1,81 @@
+"""
+Unit tests for the PURE mapping AccuracyReport -> pyramide_accuracy_metrics
+rows (repository.accuracy_metric_rows, PR-D3). No DB: the round-trip and
+the UNIQUE / re-persist semantics live in
+tests/integration/test_pyramide_accuracy_metrics_integration.py.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+from ootils_core.pyramide.accuracy import AccuracyReport
+from ootils_core.pyramide.repository import accuracy_metric_rows
+
+D = Decimal
+
+
+def _report(**overrides) -> AccuracyReport:
+    base = dict(
+        mase=D("0.8"),
+        wape=D("0.15"),
+        smape=D("0.2"),
+        bias=D("-2.5"),
+        coverage=None,
+        per_horizon_residuals={
+            1: (D("1"), D("3"), D("2")),
+            2: (D("-4"), D("2")),
+        },
+        n_cutoffs=3,
+        n_observations=5,
+    )
+    base.update(overrides)
+    return AccuracyReport(**base)
+
+
+def test_aggregate_row_first_carries_report_metrics_verbatim():
+    rows = accuracy_metric_rows(_report())
+    horizon, mase, wape, smape, bias, coverage, n_cutoffs, n_obs = rows[0]
+    assert horizon is None
+    assert (mase, wape, smape, bias) == (D("0.8"), D("0.15"), D("0.2"), D("-2.5"))
+    assert coverage is None  # rolling-origin: no intervals evaluated
+    assert (n_cutoffs, n_obs) == (3, 5)
+
+
+def test_per_horizon_rows_bias_sign_flip_and_counts():
+    # Residuals are actual - forecast; bias contract is forecast - actual
+    # (positive = over-forecast) -> bias_h = -mean(residuals_h).
+    rows = accuracy_metric_rows(_report())
+    assert [row[0] for row in rows] == [None, 1, 2]
+
+    h1 = rows[1]
+    assert h1[4] == -(D("1") + D("3") + D("2")) / D("3")  # -mean = -2
+    assert (h1[6], h1[7]) == (3, 3)  # one residual per cutoff reaching h
+
+    h2 = rows[2]
+    assert h2[4] == -(D("-4") + D("2")) / D("2")  # -mean = 1
+    assert (h2[6], h2[7]) == (2, 2)
+
+    # Metrics needing the per-horizon actuals stay None — the report only
+    # carries residuals; nothing is invented.
+    for row in rows[1:]:
+        assert row[1] is None and row[2] is None and row[3] is None  # mase/wape/smape
+        assert row[5] is None  # coverage
+
+
+def test_none_metrics_pass_through_none_honest():
+    rows = accuracy_metric_rows(_report(mase=None, wape=None))
+    assert rows[0][1] is None and rows[0][2] is None
+
+
+def test_bias_scale_transports_only_scale_dependent_metrics():
+    # Middle-out leaf transport: leaf = share x node -> bias scales by the
+    # share; mase/wape/smape are scale-free and pass through unchanged.
+    rows = accuracy_metric_rows(_report(), bias_scale=D("0.25"))
+    assert rows[0][4] == D("-2.5") * D("0.25")
+    assert (rows[0][1], rows[0][2], rows[0][3]) == (D("0.8"), D("0.15"), D("0.2"))
+    assert rows[1][4] == D("-2") * D("0.25")
+
+
+def test_empty_residuals_yield_aggregate_row_only():
+    rows = accuracy_metric_rows(_report(per_horizon_residuals={}))
+    assert len(rows) == 1 and rows[0][0] is None


### PR DESCRIPTION
## Pyramide V1 — axe D, PR-D3 : les métriques de backtest deviennent un actif requêtable

Chaque run Pyramide persiste désormais son bulletin de notes (migration 055, **lignes-par-horizon** — arbitrage pilote) :

- **Agrégat** : MASE/WAPE/sMAPE/biais/coverage du rapport, verbatim
- **Par horizon** : uniquement ce que les résidus permettent de dériver honnêtement (biais avec flip de signe documenté, comptes) — le reste **NULL avec COMMENT** (« rien d'inventé » vérifié ligne à ligne par le reviewer contre le contrat d'`accuracy.py`)
- `UNIQUE NULLS NOT DISTINCT` (le piège PostgreSQL des UNIQUE avec NULL), DELETE+INSERT au re-run (pas d'horizons orphelins), FK CASCADE raisonnée vs ADR-011
- Runs hiérarchiques : feuilles = rapport du nœud transporté par la part (provenance « empruntée » documentée à 3 niveaux — même approximation V1 que le conformal de la PR-D2)
- `GET /v1/forecast/runs/{run_id}` expose `accuracy_metrics` (champ optionnel, rétro-compatible)

C'est la matière première de la PR-D4 (score de confiance = f(accuracy récente, profondeur, fraîcheur)) et du routage tête/traîne piloté par les données (spec §5).

5 tests purs + 5 intégration · 1884 unitaires ✅ · ruff ✅ · revue adversariale : zéro défaut bloquant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
