### PR TITLE
feat(bench): grain day/week/month + --today — WAPE headline au grain mensuel

### DIFF
--- a/scripts/bench_reconciliation.py
+++ b/scripts/bench_reconciliation.py
@@ -3,10 +3,13 @@ bench_reconciliation.py — reconciliation bench CLI (Pyramide axis A, design §
 
 Thin CLI over ``ootils_core.pyramide.hierarchy.bench.run_reconciliation_bench``:
 for each summing block of the domain's default hierarchy, replays a forecast
-as of ``cutoff = today - holdout_days`` (train strictly before the cutoff,
-never CURRENT_DATE-bounded — the anti-leak split lives in the module) and
-scores every requested reconciliation method plus the uniform 'base'
-comparator against the demand that actually booked in the holdout window.
+as of ``cutoff = bucket_start(today) - holdout buckets`` (train strictly
+before the cutoff, never CURRENT_DATE-bounded — the anti-leak split lives in
+the module) and scores every requested reconciliation method plus the uniform
+'base' comparator against the demand that actually booked in the holdout
+window. ``--grain`` picks the evaluation bucket (day / ISO week / calendar
+month — window flags then count buckets, eval buckets always complete);
+``--today`` fixes the as-of date for deterministic replays.
 
 **Read-only**: the bench only SELECTs (windowed demand_history reads +
 hierarchy registry); reconciliation and scoring are in-memory Python. Like
@@ -28,11 +31,15 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from datetime import date
 
 import psycopg
 from psycopg.rows import dict_row
 
 from ootils_core.pyramide.hierarchy.bench import (
+    GRAIN_DAY,
+    GRAIN_MONTH,
+    GRAIN_WEEK,
     BenchReport,
     run_reconciliation_bench,
 )
@@ -46,10 +53,13 @@ def _fmt(value, width: int = 9, digits: int = 4) -> str:
 
 
 def print_report(report: BenchReport) -> None:
+    unit = report.grain  # horizon/holdout/lookback count grain buckets
     print(
         f"=== Reconciliation bench -- domain={report.domain} "
-        f"cutoff={report.cutoff.isoformat()} horizon={report.horizon}d "
-        f"holdout={report.holdout_days}d lookback={report.lookback_days}d ===\n"
+        f"grain={report.grain} cutoff={report.cutoff.isoformat()} "
+        f"horizon={report.horizon}{unit[0]} "
+        f"holdout={report.holdout_days}{unit[0]} "
+        f"lookback={report.lookback_days}{unit[0]} ===\n"
     )
     if not report.rows:
         print("(no rows -- every block was skipped, see warnings)")
@@ -92,9 +102,23 @@ def main(argv=None) -> int:
                    help="level defining the blocks (default: hierarchy root)")
     p.add_argument("--recon-level", default=None,
                    help="reconciliation level (default: the block level)")
-    p.add_argument("--lookback-days", type=int, default=365)
-    p.add_argument("--horizon", type=int, default=28)
-    p.add_argument("--holdout-days", type=int, default=28)
+    p.add_argument("--grain", default=GRAIN_DAY,
+                   choices=[GRAIN_DAY, GRAIN_WEEK, GRAIN_MONTH],
+                   help="evaluation bucket (default: day). horizon / "
+                        "holdout-days / lookback-days count BUCKETS of "
+                        "this grain; eval buckets are always complete "
+                        "(today snaps to its bucket start: ISO Monday / "
+                        "1st of month — the partial bucket is excluded)")
+    p.add_argument("--today", type=date.fromisoformat, default=None,
+                   help="ISO date the bench runs 'as of' (default: wall "
+                        "clock) — for deterministic replays")
+    p.add_argument("--lookback-days", type=int, default=365,
+                   help="training window, in grain buckets (default 365)")
+    p.add_argument("--horizon", type=int, default=28,
+                   help="forecast/eval length, in grain buckets (default 28)")
+    p.add_argument("--holdout-days", type=int, default=28,
+                   help="held-out span before today's bucket, in grain "
+                        "buckets (default 28)")
     p.add_argument("--methods", default="middleout",
                    help="comma-separated reconciliation methods "
                         "('base' is always benched implicitly)")
@@ -131,6 +155,8 @@ def main(argv=None) -> int:
             holdout_days=args.holdout_days,
             methods=methods,
             block_codes=blocks,
+            grain=args.grain,
+            today=args.today,
         )
 
     print_report(report)

--- a/src/ootils_core/pyramide/hierarchy/bench.py
+++ b/src/ootils_core/pyramide/hierarchy/bench.py
@@ -8,14 +8,34 @@ reconciliation method against the demand that actually booked afterwards.
 
 Temporal split — EXPLICIT, never CURRENT_DATE
 ---------------------------------------------
-``cutoff = today - holdout_days``. TRAIN is ``demand_history`` STRICTLY
-before the cutoff (bounded by ``lookback_days``); EVAL is
-``[cutoff, cutoff + horizon)``. The SQL here composes the shared
+``cutoff = bucket_start(today) - holdout buckets``. TRAIN is
+``demand_history`` STRICTLY before the cutoff (bounded by ``lookback``
+buckets); EVAL is ``[cutoff, cutoff + horizon buckets)``. The SQL here
+composes the shared
 ``_DEMAND_HISTORY_STREAM_PREDICATES`` of ``pyramide/repository.py`` (the
 pure business rules: stream='regular', inter-entity excluded, booked_date
 present) with an explicit parameterized window — reusing the runtime
 readers' CURRENT_DATE-bounded predicates would leak holdout days into
 training, which is exactly the bug this split exists to prevent.
+
+Grain — the bucket the bench scores in
+--------------------------------------
+``grain`` picks the evaluation bucket: ``'day'`` (default, the historical
+behaviour, windows in days), ``'week'`` (ISO weeks, Monday start) or
+``'month'`` (calendar months). With a non-day grain, ``horizon`` /
+``holdout_days`` / ``lookback_days`` are interpreted IN BUCKETS of that
+grain. Only ONE daily SQL read happens per split regardless of grain —
+bucketing is a pure in-memory aggregation (bucket key = the bucket's
+start date), and the base forecasts run at the grain's granularity so
+the engine's default season length matches (day→7, week→52, month→12 —
+an annual season is 12 monthly buckets, not 7 daily ones).
+
+Calendar alignment — evaluation buckets are COMPLETE, always: ``today``
+is snapped to the START of its bucket (month → 1st of the month, week →
+ISO Monday), which EXCLUDES the partial bucket containing ``today``.
+Example: data up to 26 May, ``grain='month'``, ``holdout_days=1``,
+``horizon=1`` → today snaps to 1 May (May is partial, excluded), cutoff
+= 1 April, and the last (only) evaluated month is April — complete.
 
 What is compared
 ----------------
@@ -78,6 +98,9 @@ from .summing import AGGREGATE, LEAF, SummingBlock, load_summing_blocks
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "GRAIN_DAY",
+    "GRAIN_MONTH",
+    "GRAIN_WEEK",
     "LEVEL_LEAF",
     "LEVEL_ROOT",
     "METHOD_BASE",
@@ -93,6 +116,18 @@ __all__ = [
 _ZERO = Decimal("0")
 
 METHOD_BASE = "base"
+
+GRAIN_DAY = "day"
+GRAIN_WEEK = "week"
+GRAIN_MONTH = "month"
+# Bench grain -> forecast-engine granularity. The engine derives its
+# default season_length from the granularity (daily→7, weekly→52,
+# monthly→12) — single source of seasonal truth, nothing duplicated here.
+_ENGINE_GRANULARITY = {
+    GRAIN_DAY: "daily",
+    GRAIN_WEEK: "weekly",
+    GRAIN_MONTH: "monthly",
+}
 
 LEVEL_LEAF = "leaf"
 LEVEL_ROOT = "root"
@@ -139,6 +174,8 @@ class BenchReport:
     lookback_days: int
     rows: tuple[BenchRow, ...]
     warnings: tuple[str, ...] = ()
+    # Evaluation bucket; horizon/holdout_days/lookback_days count THESE.
+    grain: str = GRAIN_DAY
 
     def verdicts(self) -> dict[str, str | None]:
         """Per block: the method with the minimal leaf-level WAPE.
@@ -187,6 +224,7 @@ def build_bench_report(
     holdout_days: int,
     lookback_days: int,
     warnings: Sequence[str] = (),
+    grain: str = GRAIN_DAY,
 ) -> BenchReport:
     """Assemble a report with deterministic row order.
 
@@ -207,6 +245,7 @@ def build_bench_report(
         lookback_days=lookback_days,
         rows=ordered,
         warnings=tuple(warnings),
+        grain=grain,
     )
 
 
@@ -286,15 +325,26 @@ def run_reconciliation_bench(
     block_codes: Sequence[str] | None = None,
     forecast_engine: PyramideForecastEngine | None = None,
     today: date | None = None,
+    grain: str = GRAIN_DAY,
 ) -> BenchReport:
     """Run the reconciliation bench on the domain's default hierarchy.
 
     For every block (optionally restricted to ``block_codes``): train
-    strictly before ``cutoff = today - holdout_days`` (lookback-bounded),
-    forecast+reconcile over ``horizon`` days from the cutoff with each
-    requested method, score against the booked actuals of
-    ``[cutoff, cutoff + horizon)`` — plus the ``'base'`` comparator (see
-    module docstring for its naive-uniform leaf floor).
+    strictly before the cutoff (lookback-bounded), forecast+reconcile
+    over ``horizon`` buckets from the cutoff with each requested method,
+    score against the booked actuals of ``[cutoff, cutoff + horizon)`` —
+    plus the ``'base'`` comparator (see module docstring for its
+    naive-uniform leaf floor).
+
+    ``grain`` (``'day'`` | ``'week'`` | ``'month'``) is the evaluation
+    bucket; ``horizon`` / ``holdout_days`` / ``lookback_days`` count
+    BUCKETS of that grain (``'day'``, the default, is the historical
+    day-windowed behaviour, unchanged). Evaluation buckets are always
+    COMPLETE: ``today`` snaps to the start of its bucket (month → the
+    1st, week → ISO Monday), excluding the partial bucket in progress,
+    and ``cutoff = bucket_start(today) - holdout_days buckets``. E.g.
+    data up to 26 May at ``grain='month'``: today snaps to 1 May, so
+    with ``holdout_days=1`` the last complete evaluated month is April.
 
     ``today`` exists for deterministic replays (defaults to the wall
     clock — a bench is an operator tool, not a core calculation).
@@ -307,8 +357,8 @@ def run_reconciliation_bench(
     Raises:
         NotImplementedError: ``strategy='two_stage'`` (gated on the geo
             hierarchy leg — validated before any DB access).
-        ValueError: unknown strategy/method, non-positive windows, or
-            ``block_codes`` naming blocks the hierarchy does not have.
+        ValueError: unknown strategy/method/grain, non-positive windows,
+            or ``block_codes`` naming blocks the hierarchy does not have.
     """
     _validate_bench_params(
         strategy=strategy,
@@ -316,9 +366,10 @@ def run_reconciliation_bench(
         holdout_days=holdout_days,
         lookback_days=lookback_days,
         methods=methods,
+        grain=grain,
     )
     engine = forecast_engine or PyramideForecastEngine()
-    cutoff = (today or date.today()) - timedelta(days=holdout_days)
+    cutoff = _bench_cutoff(today or date.today(), grain, holdout_days)
 
     blocks = load_summing_blocks(db, domain=domain, block_level=block_level)
     if block_codes is not None:
@@ -348,6 +399,7 @@ def run_reconciliation_bench(
             horizon=horizon,
             lookback_days=lookback_days,
             methods=tuple(methods),
+            grain=grain,
         )
         rows.extend(block_rows)
         warnings.extend(block_warnings)
@@ -360,6 +412,7 @@ def run_reconciliation_bench(
         holdout_days=holdout_days,
         lookback_days=lookback_days,
         warnings=warnings,
+        grain=grain,
     )
 
 
@@ -370,8 +423,14 @@ def _validate_bench_params(
     holdout_days: int,
     lookback_days: int,
     methods: Sequence[str],
+    grain: str = GRAIN_DAY,
 ) -> None:
     """Parameter gate — runs BEFORE any DB access (testable without one)."""
+    if grain not in _ENGINE_GRANULARITY:
+        raise ValueError(
+            f"unknown grain '{grain}' "
+            f"(supported: {sorted(_ENGINE_GRANULARITY)})"
+        )
     if strategy == STRATEGY_TWO_STAGE:
         raise NotImplementedError("two_stage: gated on the geo hierarchy")
     if strategy != STRATEGY_EXACT:
@@ -415,9 +474,16 @@ def _bench_block(
     horizon: int,
     lookback_days: int,
     methods: tuple[str, ...],
+    grain: str = GRAIN_DAY,
 ) -> tuple[list[BenchRow], list[str]]:
-    """Score one block: train before cutoff, evaluate on the holdout."""
+    """Score one block: train before cutoff, evaluate on the holdout.
+
+    ``cutoff`` is a bucket start (snapped by the caller); windows count
+    ``grain`` buckets. History is read DAILY (one query per split, grain
+    or not) then bucketed in memory — see ``_bucket_daily``.
+    """
     warnings: list[str] = []
+    granularity = _ENGINE_GRANULARITY[grain]
     recon_refs = [
         (i, ref)
         for i, ref in enumerate(block.series)
@@ -429,20 +495,29 @@ def _bench_block(
             f"'{recon_level}' — skipped"
         ]
 
-    train = _load_daily_by_item(
-        db,
-        block.leaves,
-        start=cutoff - timedelta(days=lookback_days),
-        stop=cutoff,
+    train = _bucket_daily(
+        _load_daily_by_item(
+            db,
+            block.leaves,
+            start=_shift_buckets(cutoff, -lookback_days, grain),
+            stop=cutoff,
+        ),
+        grain,
     )
-    holdout = _load_daily_by_item(
-        db, block.leaves, start=cutoff, stop=cutoff + timedelta(days=horizon)
+    holdout = _bucket_daily(
+        _load_daily_by_item(
+            db,
+            block.leaves,
+            start=cutoff,
+            stop=_shift_buckets(cutoff, horizon, grain),
+        ),
+        grain,
     )
     leaf_totals = {
         key: sum(by_date.values(), _ZERO) for key, by_date in train.items()
     }
     leaf_actuals = [
-        _dense_curve(holdout.get(leaf, {}), cutoff, horizon)
+        _dense_curve(holdout.get(leaf, {}), cutoff, horizon, grain)
         for leaf in block.leaves
     ]
     leaf_insamples = [
@@ -474,20 +549,23 @@ def _bench_block(
         node_insample[ref.key] = series
         try:
             base_curves[ref.key] = _clamped_forecast(
-                engine, series, horizon, cutoff
+                engine, series, horizon, cutoff, granularity
             )
         except PyramideEngineError as exc:
             warnings.append(
                 f"block '{block.block_code}': base forecast failed for node "
                 f"'{ref.key}': {exc} — forecasting zero for its subtree"
             )
-            node_insample[ref.key] = [_ZERO]
+            # Keep the REAL insample (set above): the node HAS history, only
+            # its forecast failed — wiping it would corrupt MASE scaling and
+            # the MinT inputs for this node (review PR grain).
             base_curves[ref.key] = zero_curve
 
     mint_inputs: MintInputs | None = None
     if RECON_MINT_SHRINK in methods:
         mint_inputs, mint_warnings = _bench_mint_inputs(
-            block, base_curves, train, node_insample, engine, cutoff, horizon
+            block, base_curves, train, node_insample, engine, cutoff,
+            horizon, granularity,
         )
         warnings.extend(
             f"block '{block.block_code}': {w}" for w in mint_warnings
@@ -600,6 +678,7 @@ def _bench_mint_inputs(
     engine: PyramideForecastEngine,
     cutoff: date,
     horizon: int,
+    granularity: str = "daily",
 ) -> tuple[MintInputs | None, list[str]]:
     """In-memory MinT inputs from the TRAIN split (no extra DB reads).
 
@@ -641,7 +720,9 @@ def _bench_mint_inputs(
             curve: Sequence[Decimal] = base_curves[ref.key]
         else:
             try:
-                curve = _clamped_forecast(engine, series, horizon, cutoff)
+                curve = _clamped_forecast(
+                    engine, series, horizon, cutoff, granularity
+                )
             except PyramideEngineError as exc:
                 return None, [
                     f"{RECON_MINT_SHRINK} skipped: base forecast failed "
@@ -711,8 +792,57 @@ def _load_daily_by_item(
     return out
 
 
+def _bucket_start(day: date, grain: str) -> date:
+    """Start of the ``grain`` bucket containing ``day`` (day: identity;
+    week: ISO Monday; month: the 1st)."""
+    if grain == GRAIN_DAY:
+        return day
+    if grain == GRAIN_WEEK:
+        return day - timedelta(days=day.weekday())
+    if grain == GRAIN_MONTH:
+        return day.replace(day=1)
+    raise ValueError(f"unknown grain '{grain}'")
+
+
+def _shift_buckets(bucket: date, n: int, grain: str) -> date:
+    """``bucket`` (a bucket start) shifted by ``n`` buckets (n may be < 0)."""
+    if grain == GRAIN_DAY:
+        return bucket + timedelta(days=n)
+    if grain == GRAIN_WEEK:
+        return bucket + timedelta(weeks=n)
+    if grain == GRAIN_MONTH:
+        months = bucket.year * 12 + (bucket.month - 1) + n
+        return date(months // 12, months % 12 + 1, 1)
+    raise ValueError(f"unknown grain '{grain}'")
+
+
+def _bench_cutoff(today: date, grain: str, holdout: int) -> date:
+    """Snap ``today`` to its bucket start (the partial in-progress bucket
+    is thereby EXCLUDED from evaluation) and back off ``holdout`` buckets.
+    Pure — golden-testable without a database."""
+    return _shift_buckets(_bucket_start(today, grain), -holdout, grain)
+
+
+def _bucket_daily(
+    daily: dict[str, dict[date, Decimal]], grain: str
+) -> dict[str, dict[date, Decimal]]:
+    """Aggregate per-item DAILY sums into per-item GRAIN-bucket sums
+    (bucket key = the bucket's start date). Pure in-memory fold over the
+    single daily read — no second SQL query, whatever the grain.
+    ``'day'`` is the identity: byte-identical to the historical path."""
+    if grain == GRAIN_DAY:
+        return daily
+    out: dict[str, dict[date, Decimal]] = {}
+    for item, by_date in daily.items():
+        buckets = out.setdefault(item, {})
+        for day, qty in by_date.items():
+            key = _bucket_start(day, grain)
+            buckets[key] = buckets.get(key, _ZERO) + qty
+    return out
+
+
 def _sparse_series(by_date: Mapping[date, Decimal]) -> list[Decimal]:
-    """Sparse daily series, date ASC — the engines' history contract."""
+    """Sparse per-bucket series, date ASC — the engines' history contract."""
     return [by_date[d] for d in sorted(by_date)]
 
 
@@ -728,13 +858,18 @@ def _sparse_sum(
 
 
 def _dense_curve(
-    by_date: Mapping[date, Decimal], start: date, horizon: int
+    by_date: Mapping[date, Decimal],
+    start: date,
+    horizon: int,
+    grain: str = GRAIN_DAY,
 ) -> tuple[Decimal, ...]:
-    """DENSE daily actuals over the eval window: a day without booking IS
-    zero demand (unlike the sparse training contract — the forecast made
-    a claim for every day of the horizon, so every day is scored)."""
+    """DENSE actuals over the eval window, one value PER BUCKET: a bucket
+    without booking IS zero demand (unlike the sparse training contract —
+    the forecast made a claim for every bucket of the horizon, so every
+    bucket is scored). ``start`` and the mapping keys are bucket starts."""
     return tuple(
-        by_date.get(start + timedelta(days=t), _ZERO) for t in range(horizon)
+        by_date.get(_shift_buckets(start, t, grain), _ZERO)
+        for t in range(horizon)
     )
 
 
@@ -751,15 +886,20 @@ def _clamped_forecast(
     history: Sequence[Decimal],
     horizon: int,
     cutoff: date,
+    granularity: str = "daily",
 ) -> tuple[Decimal, ...]:
-    """Base forecast on the TRAIN slice, clamped at 0 (same as runners)."""
+    """Base forecast on the TRAIN slice, clamped at 0 (same as runners).
+
+    ``granularity`` is the engine granularity of the bench grain: the
+    engine derives its default season_length from it (daily→7, weekly→52,
+    monthly→12) — an annual season lands on 12 monthly buckets."""
     computation = engine.forecast(
         history=list(history),
         periods=horizon,
         method=METHOD_AUTO_SELECT,
         method_params={},
         model_strategy="stat",
-        granularity="daily",
+        granularity=granularity,
         horizon_start=cutoff,
         random_seed=0,
     )

--- a/tests/integration/test_reconciliation_bench_integration.py
+++ b/tests/integration/test_reconciliation_bench_integration.py
@@ -8,6 +8,9 @@ Covered:
     test_pyramide_reconcile_integration.py, but with a history long enough
     to carve out a holdout window) and produces FINITE wape/mase/bias for
     'middleout' at all three levels (leaf, recon level, block root);
+  - grain='week' on the same seed: cutoff snaps to an ISO Monday, the 4
+    holdout weeks are complete (n_obs = n_series x 4), wape/bias finite
+    (mase None: the weekly sums of the seed are constant);
   - determinism: two identical calls (fixed ``today``) return equal
     BenchReports and the same non-None verdict;
   - anti-leak: a demand line inserted INSIDE the holdout window (on the
@@ -234,7 +237,63 @@ class TestReconciliationBench:
             "forecasting zero for its subtree" in w for w in report.warnings
         ), report.warnings
 
+    def test_grain_week_scores_four_complete_weeks(self, conn):
+        """grain='week' on the SAME seed: FIXED_TODAY (2026-03-02) is a
+        Monday, so it snaps to itself and cutoff = today - 4 weeks — the
+        very same date as the daily CUTOFF. The 28 seeded holdout days
+        are exactly 4 COMPLETE ISO weeks; the 84 train days are 12
+        Monday-aligned weekly buckets, each summing the weekly pattern
+        (amplitude x 14 — constant). Metrics must be finite where the
+        accuracy contract defines them: wape/bias always (non-zero
+        weekly actuals), mase None (weekly aggregation flattens the
+        intra-week signal into a CONSTANT insample -> excluded, per the
+        accuracy contract — not a bug, the contract working)."""
+        from ootils_core.pyramide.hierarchy.bench import (
+            GRAIN_WEEK,
+            LEVEL_LEAF,
+            LEVEL_ROOT,
+            METHOD_BASE,
+            run_reconciliation_bench,
+        )
+
+        fam, _ = _seed_block(conn, "bench-h-week", "B5")
+        weeks = 4
+        report = run_reconciliation_bench(
+            conn,
+            domain="product",
+            recon_level="product",
+            lookback_days=17,       # 17 WEEKS — covers the 12 seeded ones
+            horizon=weeks,          # 4 WEEKLY buckets
+            holdout_days=weeks,
+            methods=("middleout",),
+            today=FIXED_TODAY,
+            grain=GRAIN_WEEK,
+        )
+
+        assert report.grain == GRAIN_WEEK
+        assert report.cutoff == CUTOFF          # Monday-aligned snap
+        assert report.cutoff.weekday() == 0     # ISO week start
+
+        by_cell = {(r.level, r.method): r for r in report.rows}
+        assert set(by_cell) == {
+            (level, method)
+            for level in (LEVEL_LEAF, "product", LEVEL_ROOT)
+            for method in ("middleout", METHOD_BASE)
+        }
+        for level, n_series in [(LEVEL_LEAF, 3), ("product", 2), (LEVEL_ROOT, 1)]:
+            row = by_cell[(level, "middleout")]
+            assert row.block == fam
+            assert row.n_series == n_series
+            # 4 complete weekly buckets per series — nothing partial.
+            assert row.n_obs == n_series * weeks
+            assert row.wape is not None and row.wape >= 0, level
+            assert row.bias is not None, level
+            assert row.mase is None, level  # constant weekly insample
+        assert report.verdicts()[fam] is not None
+
     def test_two_calls_same_report_and_verdict(self, conn):
+        """Determinism: two identical calls (fixed ``today``) return equal
+        BenchReports and the same non-None verdict."""
         fam, _ = _seed_block(conn, "bench-h-det", "B2")
         first = _run(conn)
         second = _run(conn)

--- a/tests/test_pyramide_bench_report.py
+++ b/tests/test_pyramide_bench_report.py
@@ -5,21 +5,31 @@ Pure unit tests of the reconciliation-bench report layer
 Covers: BenchRow scoring via the accuracy module (hand-calculated golden,
 two methods, expected verdict), deterministic report ordering, None-safe
 verdicts (undefined WAPE never wins; all-None block -> None verdict),
-tie-breaking, and the strategy gate ('two_stage' raises
-NotImplementedError BEFORE any DB access — provable with db=None).
+tie-breaking, the strategy gate ('two_stage' raises
+NotImplementedError BEFORE any DB access — provable with db=None), and
+the grain layer (golden bucketing of a known daily series, today-snapping
+to complete buckets, unknown grain -> ValueError, day == historical
+behaviour).
 """
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal
 
 import pytest
 
 from ootils_core.pyramide.hierarchy.bench import (
+    GRAIN_DAY,
+    GRAIN_MONTH,
+    GRAIN_WEEK,
     LEVEL_LEAF,
     LEVEL_ROOT,
     METHOD_BASE,
     BenchRow,
+    _bench_cutoff,
+    _bucket_daily,
+    _dense_curve,
+    _shift_buckets,
     build_bench_report,
     compute_bench_row,
     run_reconciliation_bench,
@@ -258,8 +268,97 @@ def test_two_stage_raises_not_implemented_without_db():
         {"methods": ("middleout", "definitely-not-a-method")},
         # 'base' is the implicit comparator, not a requestable method.
         {"methods": (METHOD_BASE,)},
+        # unknown grain — rejected before any DB access.
+        {"grain": "quarter"},
+        {"grain": "daily"},  # engine vocabulary, not a bench grain
     ],
 )
 def test_invalid_params_raise_before_db_access(kwargs):
     with pytest.raises(ValueError):
         run_reconciliation_bench(None, domain="d", **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Grain: bucketing goldens, today-snapping, day == historical behaviour
+# ---------------------------------------------------------------------------
+
+# 2026 calendar facts used below: 2026-01-26, 2026-02-09, 2026-03-02 and
+# 2026-05-25 are Mondays; 2026-05-26 is a Tuesday.
+_DAILY = {
+    "A": {
+        date(2026, 1, 30): Decimal(3),   # Fri, week of Mon 2026-01-26
+        date(2026, 1, 31): Decimal(4),   # Sat, same week
+        date(2026, 2, 1): Decimal(5),    # Sun, SAME week — but February
+        date(2026, 2, 14): Decimal(2),   # Sat, week of Mon 2026-02-09
+        date(2026, 3, 2): Decimal(7),    # Mon, its own week start
+    }
+}
+
+
+def test_golden_monthly_bucketing_hand_calculated():
+    assert _bucket_daily(_DAILY, GRAIN_MONTH) == {
+        "A": {
+            date(2026, 1, 1): Decimal(7),   # 3 + 4
+            date(2026, 2, 1): Decimal(7),   # 5 + 2
+            date(2026, 3, 1): Decimal(7),
+        }
+    }
+
+
+def test_golden_weekly_bucketing_iso_monday_keys():
+    # Feb 1 (Sunday) belongs to the week STARTING Mon Jan 26 — the ISO
+    # week wins over the month boundary at grain='week'.
+    assert _bucket_daily(_DAILY, GRAIN_WEEK) == {
+        "A": {
+            date(2026, 1, 26): Decimal(12),  # 3 + 4 + 5
+            date(2026, 2, 9): Decimal(2),
+            date(2026, 3, 2): Decimal(7),
+        }
+    }
+
+
+def test_today_snapping_month_mid_month_excludes_partial_month():
+    # Data up to 26 May: May is partial -> excluded. holdout=1 -> the
+    # last complete evaluated month is April (docstring example).
+    assert _bench_cutoff(date(2026, 5, 26), GRAIN_MONTH, 1) == date(2026, 4, 1)
+    assert _bench_cutoff(date(2026, 5, 26), GRAIN_MONTH, 2) == date(2026, 3, 1)
+    # Year boundary in month arithmetic.
+    assert _bench_cutoff(date(2026, 1, 15), GRAIN_MONTH, 12) == date(2025, 1, 1)
+    assert _shift_buckets(date(2026, 1, 1), -1, GRAIN_MONTH) == date(2025, 12, 1)
+    assert _shift_buckets(date(2025, 12, 1), 1, GRAIN_MONTH) == date(2026, 1, 1)
+
+
+def test_today_snapping_week_mid_week_excludes_partial_week():
+    # Tue 2026-05-26 snaps to Mon 2026-05-25 (partial week excluded).
+    assert _bench_cutoff(date(2026, 5, 26), GRAIN_WEEK, 4) == date(2026, 4, 27)
+    # A Monday is already a bucket start — snapping is a no-op.
+    assert _bench_cutoff(date(2026, 5, 25), GRAIN_WEEK, 4) == date(2026, 4, 27)
+
+
+def test_dense_curve_fills_empty_buckets_with_zero():
+    monthly = {date(2026, 4, 1): Decimal(7)}
+    assert _dense_curve(monthly, date(2026, 2, 1), 3, GRAIN_MONTH) == (
+        Decimal(0), Decimal(0), Decimal(7),
+    )
+
+
+def test_grain_day_is_the_historical_behaviour():
+    # Bucketing is the identity (the very same object — zero rewrite).
+    assert _bucket_daily(_DAILY, GRAIN_DAY) is _DAILY
+    # cutoff = today - holdout days, exactly the historical formula.
+    today = date(2026, 5, 26)
+    assert _bench_cutoff(today, GRAIN_DAY, 28) == today - timedelta(days=28)
+    # Bucket stepping is day stepping.
+    assert _shift_buckets(today, -3, GRAIN_DAY) == today - timedelta(days=3)
+    # Dense eval curve: default grain == explicit day == daily stepping.
+    by_date = {today: Decimal(1), today + timedelta(days=2): Decimal(5)}
+    expected = (Decimal(1), Decimal(0), Decimal(5))
+    assert _dense_curve(by_date, today, 3) == expected
+    assert _dense_curve(by_date, today, 3, GRAIN_DAY) == expected
+    # Reports built without a grain carry the day default.
+    assert _report([_row()]).grain == GRAIN_DAY
+
+
+def test_report_carries_grain():
+    report = _report([_row()], grain=GRAIN_MONTH)
+    assert report.grain == GRAIN_MONTH


### PR DESCRIPTION
## Bench : grain day/week/month + `--today` — le chiffre headline au grain mensuel

Le bench ne parlait que le jour (saison hebdo, `season_length` 7) — or la saisonnalité métier du pilote est **annuelle**. Ce PR ajoute le grain, générique :

- **`grain='day'` bit-identique à l'existant** (bucketing identité, testé)
- **week/month** : paramètres en *buckets*, **alignement calendaire strict** — `today` snappé au début de bucket, bucket partiel courant exclu, fenêtres d'éval toujours complètes (« data au 26 mai → dernier mois complet = avril »). Arithmétique de mois pure, bords d'année golden-testés
- Une seule requête SQL (bucketing en mémoire), anti-fuite intact, `season_length` par grain via le défaut moteur existant (7/52/12)
- CLI : `--grain`, `--today` (le contournement scratchpad disparaît)

**Post-revue (verdict KO réparé)** : le test de déterminisme dont le `def` avait été écrasé par une fusion accidentelle est restauré en méthode propre (5 tests d'intégration) ; sur échec moteur d'un nœud, l'insample réel n'est plus écrasé par zéro (MASE/MinT préservés).

9 goldens calendaires main-calculés + 1 intégration week · 1998 unitaires ✅ · ruff ✅.

**Usage cible (run headline pilote)** : `--grain month --today 2026-05-26 --lookback-days 36 --holdout-days 3 --horizon 3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
