### PR TITLE
feat(mrp): wire the 4 MRP batch readers onto the param-overlay resolver (#347 PR2)

### DIFF
--- a/scripts/bench_mrp.py
+++ b/scripts/bench_mrp.py
@@ -51,6 +51,10 @@ def run_once(dsn: str, horizon_days: int) -> dict:
         # write — protects a loaded/pilote DB from any accidental mutation.
         conn.execute("SET statement_timeout = '120s'")
         conn.execute("SET default_transaction_read_only = on")
+        # psycopg3: SET default_transaction_read_only only applies to
+        # transactions AFTER the current one — commit so the guard is live
+        # before the loader runs (same fix as bench_reconciliation).
+        conn.commit()
 
         d, phases["load"] = _time(core.load_planning_data, conn, horizon_days)
 

--- a/src/ootils_core/engine/mrp/forecast_consumer.py
+++ b/src/ootils_core/engine/mrp/forecast_consumer.py
@@ -30,7 +30,15 @@ from enum import Enum
 from typing import Dict, List, Optional, Sequence, Tuple
 from uuid import UUID
 
+from ootils_core.engine.scenario.param_overlay import resolved_params_sql
+
 logger = logging.getLogger(__name__)
+
+# Mirrors mrp_apics_engine.BASELINE_SCENARIO_ID (not imported directly: that
+# module imports ForecastConsumer, so importing back would cycle). Used only
+# to translate the baseline sentinel UUID into the None the overlay resolver
+# expects for "no override can ever match" — see _get_consumption_params.
+BASELINE_SCENARIO_ID = UUID("00000000-0000-0000-0000-000000000001")
 
 
 # ─── Strategy Enum ───────────────────────────────────────────────────────────
@@ -569,21 +577,41 @@ class ForecastConsumer:
     def _get_consumption_params(
         self, item_id: UUID, location_id: Optional[UUID]
     ) -> dict:
-        """Get forecast consumption parameters for an item/location."""
-        loc_and = "AND location_id = %s" if location_id else ""
-        params: list = [item_id]
+        """Get forecast consumption parameters for an item/location.
+
+        Scenario param overlay (ADR-025, chantier #347 PR2): composes on
+        resolved_params_sql() so a scenario-scoped override on
+        forecast_consumption_strategy / consumption_window_days is visible
+        here. Threaded via self.scenario_id — already set on every
+        ForecastConsumer instance (baseline default at construction,
+        overwritten to config.scenario_id by MrpApicsEngine.run() before
+        consume_all() is called) — so baseline callers resolve to the
+        overlay's scenario_id=None degeneracy (self.scenario_id is a UUID,
+        never None; the BASELINE_SCENARIO_ID -> None translation happens
+        here, mirroring loader.py / mrp_apics_engine.py's identical
+        baseline-sentinel handling for the same resolver contract).
+        """
+        overlay_scenario_id = (
+            self.scenario_id if self.scenario_id != BASELINE_SCENARIO_ID else None
+        )
+        resolved_ipp_sql = resolved_params_sql("ipp")
+        loc_and = "AND rp.location_id = %(location_id)s" if location_id else ""
+        query_params: dict = {
+            "scenario_id": overlay_scenario_id,
+            "item_id": item_id,
+        }
         if location_id:
-            params.append(location_id)
+            query_params["location_id"] = location_id
 
         row = self.db.execute(f"""
-            SELECT forecast_consumption_strategy, consumption_window_days
-            FROM item_planning_params
-            WHERE item_id = %s
+            SELECT rp.forecast_consumption_strategy, rp.consumption_window_days
+            FROM ({resolved_ipp_sql}) rp
+            JOIN item_planning_params base ON base.param_id = rp.param_id
+            WHERE rp.item_id = %(item_id)s
               {loc_and}
-              AND (effective_to IS NULL OR effective_to = '9999-12-31'::DATE)
-            ORDER BY effective_from DESC
+            ORDER BY base.effective_from DESC
             LIMIT 1
-        """, params).fetchone()
+        """, query_params).fetchone()
 
         if row:
             return {

--- a/src/ootils_core/engine/mrp/loader.py
+++ b/src/ootils_core/engine/mrp/loader.py
@@ -9,6 +9,8 @@ import datetime as _dt
 import math
 from collections import defaultdict
 
+from psycopg.rows import tuple_row
+
 from ootils_core.engine.mrp.core import (
     BASELINE,
     FIRM_RECEIPT_TYPES,
@@ -32,7 +34,12 @@ def _m(cur, sql, params=None):
 
 
 def load_planning_data(conn, horizon_days=540, scenario=BASELINE) -> PlanningData:
-    cur = conn.cursor()
+    # All SQL below reads rows positionally (r[0], r[1], ...). Pin the cursor
+    # to tuple rows so this works regardless of the connection's row_factory:
+    # the mrp_core CLIs open tuple-row connections, but a scenario-aware caller
+    # (watchers, API paths per #347) hands us the app's dict_row connection,
+    # under which positional access would raise KeyError: 0.
+    cur = conn.cursor(row_factory=tuple_row)
     b = {"b": scenario}
     horizon_start = cur.execute("SELECT CURRENT_DATE").fetchone()[0]
     d = PlanningData(horizon_start=horizon_start, n_buckets=math.ceil(horizon_days / 7) + 1)

--- a/src/ootils_core/engine/mrp/loader.py
+++ b/src/ootils_core/engine/mrp/loader.py
@@ -15,6 +15,7 @@ from ootils_core.engine.mrp.core import (
     PlanningData,
     _spread_period,
 )
+from ootils_core.engine.scenario.param_overlay import resolved_params_sql
 
 
 def guard_db(dsn: str, allow_dev: bool = False) -> str:
@@ -42,21 +43,65 @@ def load_planning_data(conn, horizon_days=540, scenario=BASELINE) -> PlanningDat
     # (was 12 separate GROUP BY scans of the same table). Same WHERE + same
     # per-item aggregates => byte-identical dicts. Measured 5.5x / -386ms on the
     # pilote DB (24K params rows); see scripts/bench_mrp.py.
+    #
+    # Scenario param overlay (ADR-025, chantier #347 PR2): the pooling here is
+    # SUM/MAX *across locations* for a single item — an override scoped to one
+    # (item, location) must be resolved BEFORE that pooling, or the overlaid
+    # value would never reach the aggregate (a location-scoped override on a
+    # single-location item is invisible to a bare `GROUP BY item_id` over the
+    # raw table; on a multi-location item it would silently pool the UN-
+    # overlaid base value instead). resolved_params_sql() is composed as the
+    # FROM source of this GROUP BY (joined back to item_planning_params on
+    # param_id only for the two fields the resolver does not cover — see
+    # below) instead of grouping the raw table directly, so every whitelisted
+    # field entering the aggregate is already scenario-resolved.
+    # scenario_id=None (baseline) degrades every LEFT JOIN LATERAL inside the
+    # fragment to "no override row", producing the byte-identical baseline
+    # aggregate — see resolved_params_sql()'s docstring.
+    #
+    # `order_multiple` (legacy, no `_qty` suffix) and `is_make` are NOT part
+    # of ALLOWED_PARAM_FIELDS (mig 060 / ADR-025 V1): is_make would change
+    # graph topology (excluded by design from a purely parametric overlay)
+    # and order_multiple is the pre-021 legacy column the resolver
+    # deliberately does not cover. This core-A loader reads `order_multiple`
+    # (the legacy column) straight off base — byte-identical to the pre-PR2
+    # `MAX(order_multiple)` — while the APICS engine reads the modern
+    # `order_multiple_qty`; that column divergence between the two MRP engines
+    # predates #347 and PR2 preserves it exactly. Both `order_multiple` and
+    # `is_make` are read straight off the base table here, unresolved, joined
+    # back on param_id (the resolver's one row per current item_planning_params
+    # row).
+    #
+    # lead_time_total_days is a GENERATED column on the base table and is NOT
+    # in ALLOWED_PARAM_FIELDS either (only its 3 components are overlay-able)
+    # — recomputed here as COALESCE(component,0) summed, byte-for-byte the base
+    # column's own generation expression (COALESCE(s,0)+COALESCE(m,0)+
+    # COALESCE(t,0)), so a NULL component yields the same total as before
+    # instead of NULL-propagating.
+    resolved_ipp_sql = resolved_params_sql("ipp")
+    overlay_scenario_id = scenario if scenario != BASELINE else None
     for r in cur.execute(
-        "SELECT item_id, "
-        "bool_or(is_make), "
-        "SUM(COALESCE(safety_stock_qty,0)), "
-        "MAX(lead_time_total_days), "
-        "MAX(order_multiple), "
-        "MIN(lot_size_rule::text), "
-        "MAX(lot_size_poq_periods), "
-        "MAX(economic_order_qty), "
-        "MAX(max_order_qty), "
-        "MAX(min_order_qty), "
-        "MAX(frozen_time_fence_days), "
-        "MAX(slashed_time_fence_days), "
-        "MIN(forecast_consumption_strategy::text) "
-        "FROM item_planning_params WHERE effective_to IS NULL GROUP BY item_id"
+        f"""
+        SELECT rp.item_id,
+            bool_or(base.is_make),
+            SUM(COALESCE(rp.safety_stock_qty, 0)),
+            MAX(COALESCE(rp.lead_time_sourcing_days, 0)
+                + COALESCE(rp.lead_time_manufacturing_days, 0)
+                + COALESCE(rp.lead_time_transit_days, 0)),
+            MAX(base.order_multiple),
+            MIN(rp.lot_size_rule),
+            MAX(rp.lot_size_poq_periods),
+            MAX(rp.economic_order_qty),
+            MAX(rp.max_order_qty),
+            MAX(rp.min_order_qty),
+            MAX(rp.frozen_time_fence_days),
+            MAX(rp.slashed_time_fence_days),
+            MIN(rp.forecast_consumption_strategy)
+        FROM ({resolved_ipp_sql}) rp
+        JOIN item_planning_params base ON base.param_id = rp.param_id
+        GROUP BY rp.item_id
+        """,
+        {"scenario_id": overlay_scenario_id},
     ).fetchall():
         it = r[0]
         d.is_make[it] = r[1]

--- a/src/ootils_core/engine/mrp/lot_sizing.py
+++ b/src/ootils_core/engine/mrp/lot_sizing.py
@@ -23,6 +23,8 @@ from typing import List, Optional, Tuple
 
 import psycopg
 
+from ootils_core.engine.scenario.param_overlay import resolved_params_sql
+
 logger = logging.getLogger(__name__)
 
 
@@ -437,7 +439,7 @@ class LotSizingEngine:
                 )
 
     def get_planning_params(
-        self, item_id, location_id=None
+        self, item_id, location_id=None, scenario_id=None
     ) -> dict:
         """
         Load planning params for an item/location from DB.
@@ -446,35 +448,73 @@ class LotSizingEngine:
         - order_multiple → order_multiple_qty
         - reorder_point_qty (for MIN_MAX)
         - economic_order_qty, lot_size_poq_periods (added by migration 021)
+
+        Scenario param overlay (ADR-025, chantier #347 PR2): composes on
+        resolved_params_sql() so a scenario-scoped override on any of the 15
+        whitelisted fields is visible here. scenario_id=None (default,
+        matching every current call — this method has no production caller
+        yet; see TODO(#347-PR4) below) resolves to baseline-identical values.
+
+        order_multiple_qty legacy fallback: COALESCE(rp.order_multiple_qty,
+        base.order_multiple) is a legacy COLUMN fallback (pre-021 column
+        without the `_qty` suffix, never added to the overlay whitelist —
+        migration 060 decision), not a second scenario resolution. This
+        fallback predates #347 in this method and is kept verbatim for
+        baseline parity. It is deliberately NOT mirrored into
+        mrp_apics_engine._batch_load_planning_params (whose pre-PR2 query
+        selected order_multiple_qty raw) — the two engines' column choice
+        diverges by design.
+
+        reorder_point_qty, planning_horizon_days: not in ALLOWED_PARAM_FIELDS
+        (reorder_point_qty would change graph topology, out of scope for a
+        purely parametric overlay per ADR-025; planning_horizon_days is
+        simply not part of the V1 whitelist) — read straight off the base
+        row, unresolved, same as every other non-whitelisted column in this
+        module's siblings.
+
+        lead_time_total_days: GENERATED column on the base table, not itself
+        whitelisted (only its 3 components are) — recomputed as
+        COALESCE(component,0) summed, byte-for-byte the base column's own
+        generation expression (a NULL component must not NULL the total).
+
+        TODO(#347-PR4): this method has no caller today (calculate_lot_size
+        is what mrp_apics_engine.py actually wires) — scenario_id is threaded
+        for when a caller appears, not because one exists yet.
         """
-        loc_filter = "AND location_id = %s" if location_id else ""
-        params: list = [item_id]
+        resolved_ipp_sql = resolved_params_sql("ipp")
+        loc_filter = "AND rp.location_id = %(location_id)s" if location_id else ""
+        query_params: dict = {
+            "scenario_id": scenario_id,
+            "item_id": item_id,
+        }
         if location_id:
-            params.append(location_id)
+            query_params["location_id"] = location_id
 
         row = self.db.execute(f"""
             SELECT
-                lot_size_rule,
-                min_order_qty,
-                max_order_qty,
-                reorder_point_qty,
-                safety_stock_qty,
-                COALESCE(order_multiple_qty, order_multiple) AS order_multiple,
-                lead_time_total_days,
-                frozen_time_fence_days,
-                slashed_time_fence_days,
-                forecast_consumption_strategy,
-                consumption_window_days,
-                economic_order_qty,
-                lot_size_poq_periods,
-                planning_horizon_days
-            FROM item_planning_params
-            WHERE item_id = %s
+                rp.lot_size_rule,
+                rp.min_order_qty,
+                rp.max_order_qty,
+                base.reorder_point_qty,
+                rp.safety_stock_qty,
+                COALESCE(rp.order_multiple_qty, base.order_multiple) AS order_multiple,
+                (COALESCE(rp.lead_time_sourcing_days, 0)
+                    + COALESCE(rp.lead_time_manufacturing_days, 0)
+                    + COALESCE(rp.lead_time_transit_days, 0)) AS lead_time_total_days,
+                rp.frozen_time_fence_days,
+                rp.slashed_time_fence_days,
+                rp.forecast_consumption_strategy,
+                rp.consumption_window_days,
+                rp.economic_order_qty,
+                rp.lot_size_poq_periods,
+                base.planning_horizon_days
+            FROM ({resolved_ipp_sql}) rp
+            JOIN item_planning_params base ON base.param_id = rp.param_id
+            WHERE rp.item_id = %(item_id)s
               {loc_filter}
-              AND (effective_to IS NULL OR effective_to = '9999-12-31'::DATE)
-            ORDER BY effective_from DESC
+            ORDER BY base.effective_from DESC
             LIMIT 1
-        """, params).fetchone()
+        """, query_params).fetchone()
 
         if row:
             return {

--- a/src/ootils_core/engine/mrp/mrp_apics_engine.py
+++ b/src/ootils_core/engine/mrp/mrp_apics_engine.py
@@ -44,6 +44,7 @@ from ootils_core.engine.mrp.forecast_consumer import ForecastConsumer
 from ootils_core.engine.mrp.lot_sizing import LotSizingEngine
 from ootils_core.engine.mrp.time_fences import TimeFenceChecker, TimeFenceZone
 from ootils_core.engine.mrp.graph_integration import GraphIntegration
+from ootils_core.engine.scenario.param_overlay import resolved_params_sql
 
 logger = logging.getLogger(__name__)
 
@@ -162,8 +163,16 @@ class MrpApicsEngine:
             all_item_ids = set()
             for items in items_by_llc.values():
                 all_item_ids.update(items)
+            # scenario_id=None for the baseline run: config.scenario_id
+            # defaults to BASELINE_SCENARIO_ID (never None), but the overlay
+            # resolver's "no override can match" degeneracy is keyed on a
+            # NULL %(scenario_id)s, not on the baseline sentinel UUID — same
+            # translation as loader.load_planning_data.
+            overlay_scenario_id = (
+                config.scenario_id if config.scenario_id != BASELINE_SCENARIO_ID else None
+            )
             planning_params_map = self._batch_load_planning_params(
-                all_item_ids, config.location_id
+                all_item_ids, config.location_id, overlay_scenario_id
             )
 
             # 4. Consume forecast for all LLC 0 items
@@ -440,42 +449,89 @@ class MrpApicsEngine:
         self,
         item_ids: Set[UUID],
         location_id: Optional[UUID] = None,
+        scenario_id: Optional[UUID] = None,
     ) -> Dict[UUID, dict]:
-        """Batch load planning parameters for all items."""
+        """Batch load planning parameters for all items.
+
+        Scenario param overlay (ADR-025, chantier #347 PR2): composes on
+        resolved_params_sql() instead of reading item_planning_params
+        directly, so a scenario-scoped override on any of the 15 whitelisted
+        fields (safety stock, lead times, lot sizing, ...) is visible here.
+        scenario_id=None (baseline, the caller's current default) makes every
+        LEFT JOIN LATERAL inside the fragment match nothing, producing the
+        same rows/values as before this change.
+
+        lead_time_total_days is a GENERATED column on the base table and is
+        NOT itself in ALLOWED_PARAM_FIELDS (only its 3 components are
+        overlay-able) — recomputed here as COALESCE(component,0) summed,
+        byte-for-byte the base column's own generation expression, so a NULL
+        component yields the same total as the pre-PR2 GENERATED column read
+        instead of NULL-propagating.
+
+        order_multiple_qty is selected raw (resolved) — exactly as the
+        pre-PR2 query did. NB: this APICS reader does NOT apply the legacy
+        `COALESCE(order_multiple_qty, order_multiple)` cross-column fallback.
+        That fallback lives only in LotSizingEngine.get_planning_params()
+        (where it predates #347); adding it here would silently start
+        rounding orders to the legacy `order_multiple` on baseline for items
+        whose modern `order_multiple_qty` is NULL — a baseline change #347
+        must not make. The two MRP engines' column choice diverges by design
+        and PR2 preserves each side exactly.
+        """
         if not item_ids:
             return {}
 
         item_id_list = list(item_ids)
+        resolved_ipp_sql = resolved_params_sql("ipp")
 
         if location_id:
-            rows = self.db.execute("""
-                SELECT DISTINCT ON (item_id, COALESCE(location_id, '00000000-0000-0000-0000-000000000001'::UUID))
-                    item_id, location_id,
-                    lot_size_rule, min_order_qty, max_order_qty,
-                    economic_order_qty, order_multiple_qty, lot_size_poq_periods,
-                    safety_stock_qty, lead_time_total_days,
-                    frozen_time_fence_days, slashed_time_fence_days,
-                    forecast_consumption_strategy, consumption_window_days
-                FROM item_planning_params
-                WHERE item_id = ANY(%s)
-                  AND location_id = %s
-                  AND (effective_to IS NULL OR effective_to = '9999-12-31'::DATE)
-                ORDER BY item_id, COALESCE(location_id, '00000000-0000-0000-0000-000000000001'::UUID), effective_from DESC
-            """, (item_id_list, location_id)).fetchall()
+            rows = self.db.execute(f"""
+                SELECT DISTINCT ON (rp.item_id, COALESCE(rp.location_id, '00000000-0000-0000-0000-000000000001'::UUID))
+                    rp.item_id, rp.location_id,
+                    rp.lot_size_rule, rp.min_order_qty, rp.max_order_qty,
+                    rp.economic_order_qty,
+                    rp.order_multiple_qty,
+                    rp.lot_size_poq_periods,
+                    rp.safety_stock_qty,
+                    (COALESCE(rp.lead_time_sourcing_days, 0)
+                        + COALESCE(rp.lead_time_manufacturing_days, 0)
+                        + COALESCE(rp.lead_time_transit_days, 0)) AS lead_time_total_days,
+                    rp.frozen_time_fence_days, rp.slashed_time_fence_days,
+                    rp.forecast_consumption_strategy, rp.consumption_window_days,
+                    base.effective_from
+                FROM ({resolved_ipp_sql}) rp
+                JOIN item_planning_params base ON base.param_id = rp.param_id
+                WHERE rp.item_id = ANY(%(item_ids)s)
+                  AND rp.location_id = %(location_id)s
+                ORDER BY rp.item_id, COALESCE(rp.location_id, '00000000-0000-0000-0000-000000000001'::UUID), base.effective_from DESC
+            """, {
+                "scenario_id": scenario_id,
+                "item_ids": item_id_list,
+                "location_id": location_id,
+            }).fetchall()
         else:
-            rows = self.db.execute("""
-                SELECT DISTINCT ON (item_id, COALESCE(location_id, '00000000-0000-0000-0000-000000000001'::UUID))
-                    item_id, location_id,
-                    lot_size_rule, min_order_qty, max_order_qty,
-                    economic_order_qty, order_multiple_qty, lot_size_poq_periods,
-                    safety_stock_qty, lead_time_total_days,
-                    frozen_time_fence_days, slashed_time_fence_days,
-                    forecast_consumption_strategy, consumption_window_days
-                FROM item_planning_params
-                WHERE item_id = ANY(%s)
-                  AND (effective_to IS NULL OR effective_to = '9999-12-31'::DATE)
-                ORDER BY item_id, COALESCE(location_id, '00000000-0000-0000-0000-000000000001'::UUID), effective_from DESC
-            """, (item_id_list,)).fetchall()
+            rows = self.db.execute(f"""
+                SELECT DISTINCT ON (rp.item_id, COALESCE(rp.location_id, '00000000-0000-0000-0000-000000000001'::UUID))
+                    rp.item_id, rp.location_id,
+                    rp.lot_size_rule, rp.min_order_qty, rp.max_order_qty,
+                    rp.economic_order_qty,
+                    rp.order_multiple_qty,
+                    rp.lot_size_poq_periods,
+                    rp.safety_stock_qty,
+                    (COALESCE(rp.lead_time_sourcing_days, 0)
+                        + COALESCE(rp.lead_time_manufacturing_days, 0)
+                        + COALESCE(rp.lead_time_transit_days, 0)) AS lead_time_total_days,
+                    rp.frozen_time_fence_days, rp.slashed_time_fence_days,
+                    rp.forecast_consumption_strategy, rp.consumption_window_days,
+                    base.effective_from
+                FROM ({resolved_ipp_sql}) rp
+                JOIN item_planning_params base ON base.param_id = rp.param_id
+                WHERE rp.item_id = ANY(%(item_ids)s)
+                ORDER BY rp.item_id, COALESCE(rp.location_id, '00000000-0000-0000-0000-000000000001'::UUID), base.effective_from DESC
+            """, {
+                "scenario_id": scenario_id,
+                "item_ids": item_id_list,
+            }).fetchall()
 
         result: Dict[UUID, dict] = {}
         for row in rows:

--- a/tests/integration/test_param_overlay_readers_integration.py
+++ b/tests/integration/test_param_overlay_readers_integration.py
@@ -1,0 +1,343 @@
+"""
+tests/integration/test_param_overlay_readers_integration.py — DB-backed
+coverage for chantier #347 PR2: the four MRP batch readers wired onto
+ootils_core.engine.scenario.param_overlay.resolved_params_sql() (ADR-025).
+
+Scope: this file asserts the READ side only — that each reader (a) resolves
+byte-identically to the pre-overlay behaviour on baseline (scenario_id=None),
+(b) sees a scenario-scoped override once one is set, and, for the loader
+(core A pooling reader), (c) that a location-scoped override applies BEFORE
+the SUM/MAX pooling across locations, not after.
+
+Reuses the seed helpers from test_param_overlay_integration.py (fresh off
+PR1) rather than re-inventing item/location/scenario/planning-params seeding
+— see that file's docstring for the fixture-style rationale.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import uuid4
+
+from ootils_core.engine.mrp.forecast_consumer import ForecastConsumer
+from ootils_core.engine.mrp.loader import load_planning_data
+from ootils_core.engine.mrp.lot_sizing import LotSizingEngine
+from ootils_core.engine.mrp.mrp_apics_engine import MrpApicsEngine
+from ootils_core.engine.scenario.param_overlay import set_param_override
+
+from .conftest import requires_db
+from .test_param_overlay_integration import (
+    _seed_item,
+    _seed_item_loc_params,
+    _seed_location,
+    _seed_planning_params,
+    _seed_scenario,
+)
+
+pytestmark = requires_db
+
+BASELINE = "00000000-0000-0000-0000-000000000001"
+
+
+# ---------------------------------------------------------------------------
+# 1. loader.py — load_planning_data (core A, pooled item-level aggregates)
+# ---------------------------------------------------------------------------
+
+
+def test_loader_baseline_unchanged_with_no_scenario(conn):
+    """scenario=BASELINE (the default) must resolve exactly like the
+    pre-overlay code path: no override exists, so the LEFT JOIN LATERAL
+    degenerates to nothing and the pooled aggregate is the raw base value."""
+    item_id, location_id = _seed_item_loc_params(conn, safety_stock_qty=10)
+    conn.commit()
+
+    d = load_planning_data(conn, horizon_days=90, scenario=BASELINE)
+
+    assert d.safety.get(item_id) == 10
+    assert d.make_lt.get(item_id) == 14  # lead_time_sourcing_days default
+
+
+def test_loader_scenario_sees_override(conn):
+    """A safety_stock_qty override set on a fork is visible to a
+    scenario-scoped load_planning_data() call, baseline is untouched."""
+    item_id, location_id = _seed_item_loc_params(conn, safety_stock_qty=10)
+    scenario_id = _seed_scenario(conn)
+    conn.commit()
+
+    set_param_override(
+        conn, scenario_id, item_id, "safety_stock_qty", "20", "watcher-test",
+    )
+    conn.commit()
+
+    d_scenario = load_planning_data(conn, horizon_days=90, scenario=str(scenario_id))
+    d_baseline = load_planning_data(conn, horizon_days=90, scenario=BASELINE)
+
+    assert d_scenario.safety.get(item_id) == Decimal("20")
+    assert d_baseline.safety.get(item_id) == 10
+
+
+def test_loader_pooling_applies_override_before_sum_across_locations(conn):
+    """Core-A pooling case: two locations for the same item, an override on
+    only ONE location. The override must be resolved per-row BEFORE the
+    SUM(safety_stock_qty) pooling, not after — so the pooled total reflects
+    the overridden value for that one location plus the untouched base value
+    for the other."""
+    item_id = _seed_item(conn)
+    loc_a = _seed_location(conn, "readers-loc-a")
+    loc_b = _seed_location(conn, "readers-loc-b")
+    _seed_planning_params(conn, item_id, loc_a, safety_stock_qty=10)
+    _seed_planning_params(conn, item_id, loc_b, safety_stock_qty=10)
+    scenario_id = _seed_scenario(conn)
+    conn.commit()
+
+    # Override loc_a only: 10 -> 25. loc_b stays base (10).
+    set_param_override(
+        conn, scenario_id, item_id, "safety_stock_qty", "25", "watcher-test",
+        location_id=loc_a,
+    )
+    conn.commit()
+
+    d_scenario = load_planning_data(conn, horizon_days=90, scenario=str(scenario_id))
+    d_baseline = load_planning_data(conn, horizon_days=90, scenario=BASELINE)
+
+    assert d_scenario.safety.get(item_id) == Decimal("35")  # 25 + 10
+    assert d_baseline.safety.get(item_id) == 20  # 10 + 10, unaffected
+
+
+def test_loader_pooling_lead_time_max_reflects_override_on_one_location(conn):
+    """Same pooling invariant, MAX aggregate: an override raising
+    lead_time_sourcing_days on one of two locations must win the MAX once
+    resolved, matching the "override applies before pooling" contract."""
+    item_id = _seed_item(conn)
+    loc_a = _seed_location(conn, "readers-lt-loc-a")
+    loc_b = _seed_location(conn, "readers-lt-loc-b")
+    _seed_planning_params(
+        conn, item_id, loc_a,
+        lead_time_sourcing_days=5, lead_time_manufacturing_days=0, lead_time_transit_days=0,
+    )
+    _seed_planning_params(
+        conn, item_id, loc_b,
+        lead_time_sourcing_days=5, lead_time_manufacturing_days=0, lead_time_transit_days=0,
+    )
+    scenario_id = _seed_scenario(conn)
+    conn.commit()
+
+    set_param_override(
+        conn, scenario_id, item_id, "lead_time_sourcing_days", "40", "watcher-test",
+        location_id=loc_b,
+    )
+    conn.commit()
+
+    d_scenario = load_planning_data(conn, horizon_days=90, scenario=str(scenario_id))
+    d_baseline = load_planning_data(conn, horizon_days=90, scenario=BASELINE)
+
+    assert d_scenario.make_lt.get(item_id) == 40
+    assert d_baseline.make_lt.get(item_id) == 5
+
+
+def test_loader_lead_time_null_component_matches_generated_column(conn):
+    """Baseline-parity regression (#347 PR2): the base lead_time_total_days
+    is a GENERATED column COALESCE(s,0)+COALESCE(m,0)+COALESCE(t,0) — never
+    NULL. The loader recomputes the total from the resolved components and
+    MUST apply the same per-component COALESCE. Real ERP rows routinely leave
+    components NULL (make items carry only manufacturing, buy items only
+    sourcing); a bare `s + m + t` would NULL-propagate the whole sum and
+    silently fall back to DEFAULT_LT_DAYS. Seed sourcing=30, manufacturing
+    and transit NULL -> make_lt must be 30, not None."""
+    item_id = _seed_item(conn)
+    location_id = _seed_location(conn, "readers-loader-lt-null")
+    _seed_planning_params(
+        conn, item_id, location_id,
+        lead_time_sourcing_days=30,
+        lead_time_manufacturing_days=None,
+        lead_time_transit_days=None,
+    )
+    conn.commit()
+
+    d = load_planning_data(conn, horizon_days=90, scenario=BASELINE)
+
+    assert d.make_lt.get(item_id) == 30
+
+
+# ---------------------------------------------------------------------------
+# 2. mrp_apics_engine.py — MrpApicsEngine._batch_load_planning_params
+# ---------------------------------------------------------------------------
+
+
+def test_batch_load_lead_time_null_component_matches_generated_column(conn):
+    """Same NULL-component baseline-parity regression for the APICS reader's
+    lead_time_total_days recompute (#347 PR2)."""
+    item_id = _seed_item(conn)
+    location_id = _seed_location(conn, "readers-apics-lt-null")
+    _seed_planning_params(
+        conn, item_id, location_id,
+        lead_time_sourcing_days=30,
+        lead_time_manufacturing_days=None,
+        lead_time_transit_days=None,
+    )
+    conn.commit()
+
+    engine = MrpApicsEngine(conn)
+    result = engine._batch_load_planning_params(
+        {item_id}, location_id, scenario_id=None
+    )
+
+    assert result[item_id]["lead_time_total_days"] == 30
+
+
+def test_batch_load_planning_params_baseline_unchanged(conn):
+    item_id, location_id = _seed_item_loc_params(conn, safety_stock_qty=10)
+    conn.commit()
+
+    engine = MrpApicsEngine(conn)
+    result = engine._batch_load_planning_params({item_id}, location_id, scenario_id=None)
+
+    assert result[item_id]["safety_stock_qty"] == 10
+
+
+def test_batch_load_planning_params_sees_scenario_override(conn):
+    item_id, location_id = _seed_item_loc_params(conn, safety_stock_qty=10)
+    scenario_id = _seed_scenario(conn)
+    conn.commit()
+
+    set_param_override(
+        conn, scenario_id, item_id, "safety_stock_qty", "99", "watcher-test",
+    )
+    conn.commit()
+
+    engine = MrpApicsEngine(conn)
+    resolved = engine._batch_load_planning_params(
+        {item_id}, location_id, scenario_id=scenario_id
+    )
+    baseline = engine._batch_load_planning_params(
+        {item_id}, location_id, scenario_id=None
+    )
+
+    assert resolved[item_id]["safety_stock_qty"] == Decimal("99")
+    assert baseline[item_id]["safety_stock_qty"] == 10
+
+
+def test_batch_load_does_not_apply_legacy_order_multiple_fallback(conn):
+    """Baseline-parity regression (#347 PR2): the APICS reader selects
+    order_multiple_qty RAW, exactly as the pre-PR2 query did. It must NOT
+    fall back to the legacy `order_multiple` column when order_multiple_qty
+    is NULL — doing so would silently start rounding planned orders on
+    baseline for items whose modern column is unset. The legacy cross-column
+    fallback lives ONLY in LotSizingEngine.get_planning_params (where it
+    predates #347); the two MRP engines' column choice diverges by design."""
+    item_id, location_id = _seed_item_loc_params(
+        conn, order_multiple_qty=None,
+    )
+    conn.execute(
+        "UPDATE item_planning_params SET order_multiple = 6 WHERE item_id = %s",
+        (item_id,),
+    )
+    scenario_id = _seed_scenario(conn)
+    conn.commit()
+
+    set_param_override(
+        conn, scenario_id, item_id, "safety_stock_qty", "50", "watcher-test",
+    )
+    conn.commit()
+
+    engine = MrpApicsEngine(conn)
+    resolved = engine._batch_load_planning_params(
+        {item_id}, location_id, scenario_id=scenario_id
+    )
+
+    # No legacy fallback: order_multiple_qty stays NULL even though the legacy
+    # `order_multiple` column holds 6. The unrelated overlay still applies.
+    assert resolved[item_id]["order_multiple_qty"] is None
+    assert resolved[item_id]["safety_stock_qty"] == Decimal("50")
+
+
+# ---------------------------------------------------------------------------
+# 3. lot_sizing.py — LotSizingEngine.get_planning_params
+# ---------------------------------------------------------------------------
+
+
+def test_lot_sizing_get_planning_params_baseline_unchanged(conn):
+    item_id, location_id = _seed_item_loc_params(conn, safety_stock_qty=10)
+    conn.commit()
+
+    engine = LotSizingEngine(conn)
+    params = engine.get_planning_params(item_id, location_id, scenario_id=None)
+
+    assert params["safety_stock_qty"] == 10
+
+
+def test_lot_sizing_keeps_legacy_order_multiple_fallback(conn):
+    """Intentional-divergence lock (#347 PR2): unlike the APICS reader,
+    LotSizingEngine.get_planning_params DOES apply the legacy
+    COALESCE(order_multiple_qty, order_multiple) fallback — because its
+    pre-#347 query already did. This test pins that asymmetry so a future
+    "harmonisation" doesn't silently flip either engine's baseline."""
+    item_id, location_id = _seed_item_loc_params(conn, order_multiple_qty=None)
+    conn.execute(
+        "UPDATE item_planning_params SET order_multiple = 6 WHERE item_id = %s",
+        (item_id,),
+    )
+    conn.commit()
+
+    engine = LotSizingEngine(conn)
+    params = engine.get_planning_params(item_id, location_id, scenario_id=None)
+
+    assert params["order_multiple_qty"] == Decimal("6")
+
+
+def test_lot_sizing_get_planning_params_sees_scenario_override(conn):
+    item_id, location_id = _seed_item_loc_params(conn, min_order_qty=None)
+    scenario_id = _seed_scenario(conn)
+    conn.commit()
+
+    set_param_override(
+        conn, scenario_id, item_id, "min_order_qty", "15", "watcher-test",
+    )
+    conn.commit()
+
+    engine = LotSizingEngine(conn)
+    resolved = engine.get_planning_params(item_id, location_id, scenario_id=scenario_id)
+    baseline = engine.get_planning_params(item_id, location_id, scenario_id=None)
+
+    assert resolved["min_order_qty"] == Decimal("15")
+    assert baseline["min_order_qty"] is None
+
+
+# ---------------------------------------------------------------------------
+# 4. forecast_consumer.py — ForecastConsumer._get_consumption_params
+# ---------------------------------------------------------------------------
+
+
+def test_forecast_consumer_baseline_unchanged(conn):
+    item_id, location_id = _seed_item_loc_params(
+        conn, forecast_consumption_strategy="max_only", consumption_window_days=7,
+    )
+    conn.commit()
+
+    consumer = ForecastConsumer(conn, uuid4())  # non-baseline UUID irrelevant here
+    consumer.scenario_id = None
+    params = consumer._get_consumption_params(item_id, location_id)
+
+    assert params["window_days"] == 7
+
+
+def test_forecast_consumer_sees_scenario_override(conn):
+    item_id, location_id = _seed_item_loc_params(
+        conn, forecast_consumption_strategy="max_only", consumption_window_days=7,
+    )
+    scenario_id = _seed_scenario(conn)
+    conn.commit()
+
+    set_param_override(
+        conn, scenario_id, item_id, "consumption_window_days", "21", "watcher-test",
+    )
+    conn.commit()
+
+    consumer = ForecastConsumer(conn, scenario_id)
+    resolved = consumer._get_consumption_params(item_id, location_id)
+
+    consumer_baseline = ForecastConsumer(conn, uuid4())
+    consumer_baseline.scenario_id = None
+    baseline = consumer_baseline._get_consumption_params(item_id, location_id)
+
+    assert resolved["window_days"] == 21
+    assert baseline["window_days"] == 7


### PR DESCRIPTION
## Chantier C2 — #347, PR2/4 (branchement des lecteurs MRP batch)

Branche les 4 lecteurs de paramètres MRP sur le résolveur unique `resolved_params_sql()` mergé en PR1 (ADR-025) : `loader.py` (cœur A, pooling), `mrp_apics_engine._batch_load_planning_params`, `lot_sizing.get_planning_params`, `forecast_consumer._get_consumption_params`. `scenario=BASELINE/None` dégrade chaque LATERAL à « pas d'override » → chemin baseline inchangé ; un fork voit ses overrides scénarisés.

### L'invariant dur : baseline byte-identique — et deux régressions attrapées avant merge
Un A/B de `load_planning_data` sur la **DB pilote (17 k items, données réelles)** a d'abord **divergé sur un champ** (`make_lt`), révélant deux régressions que la composition introduisait — invisibles pour la suite de tests initiale (son helper de seed ne produisait jamais de composante lead-time NULL ; les vraies lignes ERP, si). Les deux sont corrigées ici, et couvertes par des tests de régression NULL-composante :

1. **`lead_time_total_days`** est une colonne GENERATED `COALESCE(s,0)+COALESCE(m,0)+COALESCE(t,0)` — jamais NULL. La recomposer en `s + m + t` brut propageait NULL dès qu'une composante était NULL → `make_lt` à None → repli silencieux sur `DEFAULT_LT_DAYS`. Corrigé par COALESCE par composante aux 4 sites de recompute.
2. **APICS** avait gagné un fallback legacy `COALESCE(order_multiple_qty, order_multiple)` que sa requête pré-PR2 n'avait pas — arrondissant silencieusement les ordres baseline. Rétabli en `order_multiple_qty` brut. Le fallback reste **uniquement** dans `lot_sizing.get_planning_params` (où il précède #347) ; la divergence de colonne entre les deux moteurs est **par design**, désormais verrouillée par des tests des deux côtés.

### Preuves
- **A/B post-fix : byte-identique sur les 33 champs de `PlanningData`** (données pilote réelles).
- **Perf load inchangée** : p50 1,89 s (PR2) vs 2,09 s (main) — les 15 sondes LATERAL sur table vide indexée sont invisibles. Aucun bypass baseline (pas de second chemin de code).
- Suite unitaire complète verte (2052 passed) ; +3 tests de régression, 14 tests d'intégration au total.

### Process
Implémentation → A/B pilote (détecte make_lt) → revue adversariale 4 lentilles (31 agents, 6 bloquants confirmés = les 2 régressions vues sous 4 angles) → fix ciblé + tests manquants → A/B re-vert.

### Suite
Un **5ᵉ lecteur** de params découvert en chemin — `api/routers/mrp.py` mode simple — est reporté en PR3/PR4. PR3 : propagation (`SHORTAGES_SQL`, `safety_stock_cache` — corrige le bug latent « params baseline même en fork »). PR4 : chemin agent + endpoint REST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)