### PR TITLE
chore(types): type psycopg connections as dict_row — 556 mypy errors cleared (mypy campaign phase 1)

### DIFF
--- a/src/ootils_core/api/dependencies.py
+++ b/src/ootils_core/api/dependencies.py
@@ -11,10 +11,10 @@ import logging
 from typing import Generator
 from uuid import UUID
 
-import psycopg
 from fastapi import Header, HTTPException, Query, status
 
 from ootils_core.db.connection import OotilsDB
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ def _get_ootils_db() -> OotilsDB:
     return _db
 
 
-def get_db() -> Generator[psycopg.Connection, None, None]:
+def get_db() -> Generator[DictRowConnection, None, None]:
     """
     FastAPI dependency: yield a psycopg3 Connection with dict_row.
     Commits on success, rolls back on any exception.

--- a/src/ootils_core/api/routers/bom.py
+++ b/src/ootils_core/api/routers/bom.py
@@ -14,12 +14,12 @@ from datetime import date
 from typing import Optional
 from uuid import UUID, uuid4
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID, get_db
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -100,7 +100,7 @@ class ExplodeResponse(BaseModel):
 # Helpers
 # ─────────────────────────────────────────────────────────────
 
-def _resolve_item_id(db: psycopg.Connection, external_id: str) -> UUID | None:
+def _resolve_item_id(db: DictRowConnection, external_id: str) -> UUID | None:
     """Resolve external_id → item_id. Returns None if not found."""
     row = db.execute(
         "SELECT item_id FROM items WHERE external_id = %s AND status != 'obsolete'",
@@ -109,7 +109,7 @@ def _resolve_item_id(db: psycopg.Connection, external_id: str) -> UUID | None:
     return row["item_id"] if row else None
 
 
-def _get_active_bom(db: psycopg.Connection, parent_item_id: UUID) -> dict | None:
+def _get_active_bom(db: DictRowConnection, parent_item_id: UUID) -> dict | None:
     """Return the active bom_header for a given parent_item_id."""
     row = db.execute(
         """
@@ -124,7 +124,7 @@ def _get_active_bom(db: psycopg.Connection, parent_item_id: UUID) -> dict | None
     return dict(row) if row else None
 
 
-def _get_bom_lines(db: psycopg.Connection, bom_id: UUID) -> list[dict]:
+def _get_bom_lines(db: DictRowConnection, bom_id: UUID) -> list[dict]:
     """Return all active bom_lines for a given bom_id, with external_id for each component."""
     rows = db.execute(
         """
@@ -141,7 +141,7 @@ def _get_bom_lines(db: psycopg.Connection, bom_id: UUID) -> list[dict]:
 
 
 def _get_on_hand_qty(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     item_id: UUID,
     location_id: UUID | None,
 ) -> float:
@@ -176,7 +176,7 @@ def _get_on_hand_qty(
 
 
 def _detect_cycle(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     parent_item_id: UUID,
     new_component_ids: list[UUID],
 ) -> bool:
@@ -230,7 +230,7 @@ def _detect_cycle(
     return False
 
 
-def _recalculate_llc(db: psycopg.Connection, affected_item_ids: list[UUID]) -> int:
+def _recalculate_llc(db: DictRowConnection, affected_item_ids: list[UUID]) -> int:
     """
     Recalculate Low-Level Code (LLC) for all components in the BOM graph.
     LLC = deepest level at which an item appears across all BOMs.
@@ -319,7 +319,7 @@ def _recalculate_llc(db: psycopg.Connection, affected_item_ids: list[UUID]) -> i
 @router.post("/ingest/bom", response_model=IngestBOMResponse, summary="Import BOM", description="Import a complete Bill of Materials for an item. Automatically computes Low-Level Codes (LLC).")
 def ingest_bom(
     body: IngestBOMRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> IngestBOMResponse:
     """Import a complete BOM for a parent item. Upsert with cycle detection."""
@@ -456,7 +456,7 @@ def ingest_bom(
 @router.get("/bom/{parent_external_id}", response_model=BOMResponse, summary="Get BOM", description="Return the active BOM for an item with its components and LLC.")
 def get_bom(
     parent_external_id: str,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> BOMResponse:
     """Return the active BOM for a given item."""
@@ -502,7 +502,7 @@ def get_bom(
 @router.post("/bom/explode", response_model=ExplodeResponse, summary="MRP explosion", description="Compute gross and net component requirements for a given quantity (multi-level explosion, netting against available stock).")
 def explode_bom(
     body: ExplodeRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> ExplodeResponse:
     """

--- a/src/ootils_core/api/routers/calc.py
+++ b/src/ootils_core/api/routers/calc.py
@@ -8,12 +8,12 @@ from uuid import UUID, uuid4
 from datetime import datetime, timezone
 from typing import Optional
 
-import psycopg
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1/calc", tags=["calc"])
@@ -35,7 +35,7 @@ class CalcRunResponse(BaseModel):
 @router.post("/run", response_model=CalcRunResponse)
 def trigger_calc_run(
     body: CalcRunRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
     scenario_id: UUID = Depends(resolve_scenario_id),
 ) -> CalcRunResponse:

--- a/src/ootils_core/api/routers/calendars.py
+++ b/src/ootils_core/api/routers/calendars.py
@@ -13,12 +13,12 @@ from datetime import date, timedelta
 from typing import Optional
 from uuid import UUID
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, field_validator
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ router = APIRouter(tags=["calendars"])
 # Helpers
 # ─────────────────────────────────────────────────────────────
 
-def _resolve_location(db: psycopg.Connection, external_id: str) -> Optional[UUID]:
+def _resolve_location(db: DictRowConnection, external_id: str) -> Optional[UUID]:
     """Return location_id for external_id, or None if not found."""
     row = db.execute(
         "SELECT location_id FROM locations WHERE external_id = %s",
@@ -120,7 +120,7 @@ class WorkingDaysResponse(BaseModel):
 @router.post("/v1/ingest/calendars", response_model=IngestCalendarsResponse, summary="Import calendar", description="Import non-working days for a location. Upsert per (location × date). Missing entry = working day by default.")
 def ingest_calendars(
     body: IngestCalendarsRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> IngestCalendarsResponse:
     """
@@ -223,7 +223,7 @@ def get_calendars(
     from_date: Optional[date] = Query(default=None),
     to_date: Optional[date] = Query(default=None),
     working_only: bool = Query(default=False),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> GetCalendarsResponse:
     """
@@ -291,7 +291,7 @@ def get_calendars(
 @router.post("/v1/calendars/working-days", response_model=WorkingDaysResponse, summary="Compute working days", description="Return the date resulting from adding N working days to a start date, respecting the location calendar.")
 def compute_working_days(
     body: WorkingDaysRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> WorkingDaysResponse:
     """

--- a/src/ootils_core/api/routers/demo.py
+++ b/src/ootils_core/api/routers/demo.py
@@ -7,12 +7,12 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db
+from ootils_core.db.types import DictRowConnection
 from ootils_core.demo.phase1 import run_phase1_demo_from_env
 
 logger = logging.getLogger(__name__)
@@ -86,7 +86,7 @@ def run_phase1_demo_endpoint(token: str = Depends(require_auth)) -> dict:
 )
 def list_phase1_demo_runs(
     limit: int = Query(default=5, ge=1, le=50),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> DemoRunListResponse:
     rows = db.execute(

--- a/src/ootils_core/api/routers/dq.py
+++ b/src/ootils_core/api/routers/dq.py
@@ -14,12 +14,12 @@ import logging
 from typing import Any, Optional
 from uuid import UUID
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.dq.engine import run_dq
 
 logger = logging.getLogger(__name__)
@@ -83,7 +83,7 @@ class DQIssuesResponse(BaseModel):
 )
 def run_dq_batch(
     batch_id: UUID,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> DQRunResponse:
     # Verify batch exists
@@ -134,7 +134,7 @@ def list_issues(
     entity_type: Optional[str] = Query(default=None, description="Filter by entity_type (e.g. purchase_orders)"),
     limit: int = Query(default=200, ge=1, le=1000, description="Max results"),
     offset: int = Query(default=0, ge=0, description="Pagination offset"),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> DQIssuesResponse:
     conditions: list[str] = ["i.resolved = FALSE"]
@@ -207,7 +207,7 @@ def list_issues(
 )
 def get_batch_dq(
     batch_id: UUID,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> DQBatchResponse:
     batch = db.execute(
@@ -332,7 +332,7 @@ class AgentRunsResponse(BaseModel):
 )
 def run_agent_batch(
     batch_id: UUID,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> AgentRunResponse:
     # Verify batch exists
@@ -376,7 +376,7 @@ def run_agent_batch(
 )
 def get_agent_report(
     batch_id: UUID,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> AgentReportResponse:
     batch = db.execute(
@@ -478,7 +478,7 @@ def get_agent_report(
 def list_agent_runs(
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> AgentRunsResponse:
     total = db.execute(

--- a/src/ootils_core/api/routers/events.py
+++ b/src/ootils_core/api/routers/events.py
@@ -10,12 +10,12 @@ from decimal import Decimal
 from typing import List, Optional
 from uuid import UUID
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1/events", tags=["events"])
@@ -161,7 +161,7 @@ class EventListResponse(BaseModel):
 @router.post("", response_model=EventResponse, status_code=status.HTTP_202_ACCEPTED)
 def create_event(
     body: EventRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
     scenario_id: UUID = Depends(resolve_scenario_id),
 ) -> EventResponse:
@@ -264,7 +264,7 @@ def create_event(
 
 @router.get("", response_model=EventListResponse)
 def list_events(
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
     limit: int = Query(default=50, ge=1, le=500, description="Max events to return"),
     offset: int = Query(default=0, ge=0, description="Pagination offset"),

--- a/src/ootils_core/api/routers/explain.py
+++ b/src/ootils_core/api/routers/explain.py
@@ -12,12 +12,12 @@ import logging
 from typing import Optional
 from uuid import UUID
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.kernel.explanation.builder import ExplanationBuilder
 from ootils_core.engine.kernel.graph.store import GraphStore
 
@@ -45,7 +45,7 @@ class ExplainResponse(BaseModel):
 @router.get("", response_model=ExplainResponse)
 def get_explanation(
     node_id: str = Query(..., description="Target node UUID to explain"),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
     scenario_id: UUID = Depends(resolve_scenario_id),
 ) -> ExplainResponse:

--- a/src/ootils_core/api/routers/forecasting.py
+++ b/src/ootils_core/api/routers/forecasting.py
@@ -22,12 +22,12 @@ from decimal import Decimal
 from typing import List, Optional
 from uuid import UUID, uuid4
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID, get_db
+from ootils_core.db.types import DictRowConnection
 from ootils_core.forecasting.algorithms import ForecastingError
 from ootils_core.forecasting.engine import ForecastingEngine
 from ootils_core.pyramide.confidence import DEFAULT_SLA_DAYS, compute_confidence
@@ -191,7 +191,7 @@ class ForecastAdjustResponse(BaseModel):
 # Helpers
 # ─────────────────────────────────────────────────────────────
 
-def _resolve_item_uuid(db: psycopg.Connection, external_id: str) -> UUID | None:
+def _resolve_item_uuid(db: DictRowConnection, external_id: str) -> UUID | None:
     """Resolve item external_id → item_id UUID."""
     row = db.execute(
         "SELECT item_id FROM items WHERE external_id = %s AND status != 'obsolete'",
@@ -200,7 +200,7 @@ def _resolve_item_uuid(db: psycopg.Connection, external_id: str) -> UUID | None:
     return row["item_id"] if row else None
 
 
-def _resolve_location_uuid(db: psycopg.Connection, external_id: str) -> UUID | None:
+def _resolve_location_uuid(db: DictRowConnection, external_id: str) -> UUID | None:
     """Resolve location external_id → location_id UUID."""
     row = db.execute(
         "SELECT location_id FROM locations WHERE external_id = %s",
@@ -209,7 +209,7 @@ def _resolve_location_uuid(db: psycopg.Connection, external_id: str) -> UUID | N
     return row["location_id"] if row else None
 
 
-def _resolve_scenario_uuid(db: psycopg.Connection, scenario_id_str: str | None) -> UUID:
+def _resolve_scenario_uuid(db: DictRowConnection, scenario_id_str: str | None) -> UUID:
     """Resolve scenario_id string → UUID, defaulting to baseline."""
     if scenario_id_str is None or scenario_id_str.lower() == "baseline":
         return BASELINE_SCENARIO_ID
@@ -223,7 +223,7 @@ def _resolve_scenario_uuid(db: psycopg.Connection, scenario_id_str: str | None) 
 
 
 def _get_historical_demand(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     item_id: UUID,
     location_id: UUID,
     periods: int = 90,
@@ -251,7 +251,7 @@ def _get_historical_demand(
     )
 
 
-def _soft_delete_forecast(db: psycopg.Connection, forecast_id: UUID) -> None:
+def _soft_delete_forecast(db: DictRowConnection, forecast_id: UUID) -> None:
     """
     Soft delete a forecast by deactivating its values.
     The forecast header remains for audit purposes.
@@ -294,7 +294,7 @@ def _soft_delete_forecast(db: psycopg.Connection, forecast_id: UUID) -> None:
 )
 def generate_forecast(
     body: ForecastGenerateRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> ForecastOut:
     """
@@ -513,7 +513,7 @@ def generate_forecast(
 )
 def get_forecast(
     forecast_id: UUID,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> ForecastOut:
     """
@@ -662,7 +662,7 @@ def list_forecasts(
     granularity: Optional[str] = Query(default=None, pattern="^(daily|weekly|monthly)$"),
     method: Optional[str] = Query(default=None, pattern="^(MA|EXP_SMOOTHING|CROSTON|SEASONAL)$"),
     limit: int = Query(default=50, ge=1, le=500),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> ForecastListResponse:
     """
@@ -796,7 +796,7 @@ def list_forecasts(
 def adjust_forecast(
     forecast_id: UUID,
     body: ForecastAdjustRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> ForecastAdjustResponse:
     """
@@ -908,7 +908,7 @@ def adjust_forecast(
 )
 def delete_forecast(
     forecast_id: UUID,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> dict:
     """

--- a/src/ootils_core/api/routers/ghosts.py
+++ b/src/ootils_core/api/routers/ghosts.py
@@ -14,12 +14,12 @@ from datetime import date
 from typing import Any, Optional
 from uuid import UUID, uuid4
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field, field_validator
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID, get_db
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.ghost.ghost_engine import run_ghost
 
 logger = logging.getLogger(__name__)
@@ -155,7 +155,7 @@ def _validate_membership(ghost_type: str, members: list[GhostMemberInput]) -> li
 )
 def ingest_ghost(
     body: IngestGhostRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> dict[str, Any]:
     """
@@ -321,7 +321,7 @@ def list_ghosts(
     ghost_type: Optional[str] = None,
     scenario_id: Optional[UUID] = None,
     ghost_status: Optional[str] = None,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> dict[str, Any]:
     """Return all ghosts filtered by optional ghost_type, scenario_id, status."""
@@ -391,7 +391,7 @@ def list_ghosts(
 )
 def get_ghost(
     ghost_id: UUID,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> dict[str, Any]:
     """Return a single ghost with its members and graph node."""
@@ -480,7 +480,7 @@ def get_ghost(
 def run_ghost_endpoint(
     ghost_id: UUID,
     body: GhostRunRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> dict[str, Any]:
     """

--- a/src/ootils_core/api/routers/graph.py
+++ b/src/ootils_core/api/routers/graph.py
@@ -9,12 +9,12 @@ from decimal import Decimal
 from typing import Optional
 from uuid import UUID
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.kernel.graph.store import GraphStore
 
 logger = logging.getLogger(__name__)
@@ -59,7 +59,7 @@ def get_graph(
     depth: int = Query(default=2, ge=1, le=5, description="Graph traversal depth"),
     from_date: Optional[date] = Query(default=None, alias="from"),
     to_date: Optional[date] = Query(default=None, alias="to"),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
     scenario_id: UUID = Depends(resolve_scenario_id),
 ) -> GraphResponse:
@@ -209,7 +209,7 @@ def list_nodes(
     node_type: Optional[str] = Query(default=None),
     scenario_id: Optional[UUID] = Query(default=None),
     limit: int = Query(default=100, ge=1, le=500),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> NodeListResponse:
     """List nodes with optional filters — used for UI dropdowns (e.g. Simulate page)."""

--- a/src/ootils_core/api/routers/ingest.py
+++ b/src/ootils_core/api/routers/ingest.py
@@ -26,13 +26,13 @@ from datetime import date
 from typing import Any, Optional
 from uuid import UUID, uuid4
 
-import psycopg
 from psycopg import sql
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, Field, field_validator
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID, get_db
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.dq.engine import run_dq
 
 logger = logging.getLogger(__name__)
@@ -114,7 +114,7 @@ def _request_hash(body: BaseModel) -> str:
 
 
 def _load_idempotent_response(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     entity_type: str,
     request: Request,
     response: Response,
@@ -160,7 +160,7 @@ def _load_idempotent_response(
 
 
 def _create_ingest_batch(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     entity_type: str,
     rows_data: list[Any],
     source_system: str = "ingest_api",
@@ -221,7 +221,7 @@ def _create_ingest_batch(
 
 
 def _finalize_ingest_batch(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     batch_id: UUID,
     response_payload: IngestResponse,
 ) -> None:
@@ -238,7 +238,7 @@ def _finalize_ingest_batch(
     )
 
 
-def _trigger_dq(db: psycopg.Connection, batch_id: UUID) -> str:
+def _trigger_dq(db: DictRowConnection, batch_id: UUID) -> str:
     """Run DQ pipeline on a batch. Returns dq_status string, never raises."""
     try:
         with db.transaction():
@@ -250,7 +250,7 @@ def _trigger_dq(db: psycopg.Connection, batch_id: UUID) -> str:
 
 
 def _ensure_projection_series(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     item_id: UUID,
     location_id: UUID,
     scenario_id: UUID,
@@ -329,7 +329,7 @@ def _ensure_projection_series(
 
 
 def _wire_node_to_pi(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     node_id: UUID,
     node_type: str,
     item_id: UUID,
@@ -391,7 +391,7 @@ def _wire_node_to_pi(
     return 1
 
 
-def _emit_ingestion_event(db: psycopg.Connection, scenario_id: UUID, node_id: UUID) -> None:
+def _emit_ingestion_event(db: DictRowConnection, scenario_id: UUID, node_id: UUID) -> None:
     """Create an unprocessed ingestion_complete event to trigger recalculation."""
     from datetime import datetime, timezone
     db.execute(
@@ -411,7 +411,7 @@ _ALLOWED_COLUMNS = {
 
 
 def _batch_existing(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     table: str,
     id_col: str,
     pk_col: str,
@@ -470,7 +470,7 @@ def ingest_items(
     body: IngestItemsRequest,
     request: Request,
     response: Response,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> IngestResponse:
     """Upsert items by external_id. All-or-nothing: any validation error → HTTP 422."""
@@ -578,7 +578,7 @@ def ingest_locations(
     body: IngestLocationsRequest,
     request: Request,
     response: Response,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> IngestResponse:
     """Upsert locations by external_id. All-or-nothing: any validation error → HTTP 422."""
@@ -702,7 +702,7 @@ def ingest_suppliers(
     body: IngestSuppliersRequest,
     request: Request,
     response: Response,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> IngestResponse:
     """Upsert suppliers by external_id. All-or-nothing: any validation error → HTTP 422."""
@@ -802,7 +802,7 @@ def ingest_supplier_items(
     body: IngestSupplierItemsRequest,
     request: Request,
     response: Response,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> IngestResponse:
     """Upsert supplier_items by (supplier_id, item_id). All-or-nothing: any error → HTTP 422."""
@@ -941,7 +941,7 @@ def ingest_on_hand(
     body: IngestOnHandRequest,
     request: Request,
     response: Response,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> IngestResponse:
     """Upsert OnHandSupply nodes in the baseline scenario. All-or-nothing: any error → HTTP 422."""
@@ -1105,7 +1105,7 @@ def ingest_purchase_orders(
     body: IngestPurchaseOrdersRequest,
     request: Request,
     response: Response,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> IngestResponse:
     """Upsert PurchaseOrderSupply nodes, tracked via external_references. All-or-nothing: any error → HTTP 422."""
@@ -1266,7 +1266,7 @@ def ingest_forecast_demand(
     body: IngestForecastRequest,
     request: Request,
     response: Response,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> IngestResponse:
     """Upsert ForecastDemand nodes. Keyed by (item, location, bucket_date, time_grain, scenario).
@@ -1453,7 +1453,7 @@ def ingest_resources(
     body: IngestResourcesRequest,
     request: Request,
     response: Response,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> IngestResponse:
     """Upsert resources by external_id. Also maintains a Resource node in the graph."""
@@ -1623,7 +1623,7 @@ def ingest_work_orders(
     body: IngestWorkOrdersRequest,
     request: Request,
     response: Response,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> IngestResponse:
     """Upsert WorkOrderSupply nodes, tracked via external_references. All-or-nothing: any error → HTTP 422."""
@@ -1777,7 +1777,7 @@ def ingest_customer_orders(
     body: IngestCustomerOrdersRequest,
     request: Request,
     response: Response,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> IngestResponse:
     """Upsert CustomerOrderDemand nodes, tracked via external_references. All-or-nothing: any error → HTTP 422."""
@@ -1935,7 +1935,7 @@ def ingest_transfers(
     body: IngestTransfersRequest,
     request: Request,
     response: Response,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> IngestResponse:
     """Upsert TransferSupply nodes, tracked via external_references. All-or-nothing: any error → HTTP 422."""
@@ -2160,7 +2160,7 @@ class IngestPlanningParamsRequest(BaseModel):
 
 
 def _planning_params_active_row(
-    db: psycopg.Connection, item_id: UUID, location_id: UUID
+    db: DictRowConnection, item_id: UUID, location_id: UUID
 ) -> Optional[dict]:
     """Return the currently active (effective_to IS NULL) row, or None."""
     row = db.execute(
@@ -2255,7 +2255,7 @@ def ingest_planning_params(
     body: IngestPlanningParamsRequest,
     request: Request,
     response: Response,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> IngestResponse:
     """SCD2-transparent upsert of item_planning_params (ADR-014 D3)."""
@@ -2518,7 +2518,7 @@ def ingest_routings(
     body: IngestRoutingsRequest,
     request: Request,
     response: Response,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> IngestResponse:
     """Full-reload routings + operations per (item, sequence). ADR-014 D2 unit checks at ingest."""

--- a/src/ootils_core/api/routers/issues.py
+++ b/src/ootils_core/api/routers/issues.py
@@ -9,12 +9,12 @@ from decimal import Decimal
 from typing import Optional
 from uuid import UUID
 
-import psycopg
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.kernel.shortage.detector import ShortageDetector
 
 logger = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ def get_issues(
     location_id: Optional[str] = Query(default=None, description="Filter by location ID"),
     limit: int = Query(default=200, ge=1, le=1000, description="Max results to return (1–1000)"),
     offset: int = Query(default=0, ge=0, description="Result offset for pagination"),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
     scenario_id: UUID = Depends(resolve_scenario_id),
 ) -> IssuesResponse:

--- a/src/ootils_core/api/routers/mrp.py
+++ b/src/ootils_core/api/routers/mrp.py
@@ -16,12 +16,12 @@ from decimal import Decimal
 from typing import List, Optional
 from uuid import UUID, uuid4
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID, get_db
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.scenario.param_overlay import resolved_field_lateral_sql
 
 logger = logging.getLogger(__name__)
@@ -94,7 +94,7 @@ class MrpRunResponseApics(BaseModel):
 # Helpers — Simple MRP
 # ─────────────────────────────────────────────────────────────
 
-def _resolve_item_uuid(db: psycopg.Connection, external_id: str) -> UUID | None:
+def _resolve_item_uuid(db: DictRowConnection, external_id: str) -> UUID | None:
     """Resolve item external_id → item_id UUID."""
     row = db.execute(
         "SELECT item_id FROM items WHERE external_id = %s AND status != 'obsolete'",
@@ -103,7 +103,7 @@ def _resolve_item_uuid(db: psycopg.Connection, external_id: str) -> UUID | None:
     return row["item_id"] if row else None
 
 
-def _resolve_location_uuid(db: psycopg.Connection, external_id: str) -> UUID | None:
+def _resolve_location_uuid(db: DictRowConnection, external_id: str) -> UUID | None:
     """Resolve location external_id → location_id UUID."""
     row = db.execute(
         "SELECT location_id FROM locations WHERE external_id = %s",
@@ -112,7 +112,7 @@ def _resolve_location_uuid(db: psycopg.Connection, external_id: str) -> UUID | N
     return row["location_id"] if row else None
 
 
-def _resolve_scenario_uuid(db: psycopg.Connection, scenario_id_str: str | None) -> UUID:
+def _resolve_scenario_uuid(db: DictRowConnection, scenario_id_str: str | None) -> UUID:
     """Resolve scenario_id string → UUID, defaulting to baseline."""
     if scenario_id_str is None or scenario_id_str.lower() == "baseline":
         return BASELINE_SCENARIO_ID
@@ -126,7 +126,7 @@ def _resolve_scenario_uuid(db: psycopg.Connection, scenario_id_str: str | None) 
 
 
 def _get_planning_params(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     item_id: UUID,
     location_id: UUID,
     scenario_id: UUID,
@@ -189,7 +189,7 @@ def _get_planning_params(
 
 
 def _get_pi_nodes_in_horizon(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     item_id: UUID,
     location_id: UUID,
     scenario_id: UUID,
@@ -237,7 +237,7 @@ def _apply_lot_sizing(raw_qty: Decimal, min_order_qty: Decimal | None) -> tuple[
 
 
 def _clear_existing_planned_supply(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     item_id: UUID,
     location_id: UUID,
     scenario_id: UUID,
@@ -293,7 +293,7 @@ def _clear_existing_planned_supply(
 )
 def run_mrp(
     body: MrpRunRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> MrpRunResponse | MrpRunResponseApics:
     """
@@ -316,7 +316,7 @@ def run_mrp(
 
 def _run_simple_mrp(
     body: MrpRunRequest,
-    db: psycopg.Connection,
+    db: DictRowConnection,
     scenario_uuid: UUID,
 ) -> MrpRunResponse:
     """Execute simple single-level MRP (legacy behavior)."""
@@ -474,7 +474,7 @@ def _run_simple_mrp(
 
 def _run_apics_mrp(
     body: MrpRunRequest,
-    db: psycopg.Connection,
+    db: DictRowConnection,
     scenario_uuid: UUID,
 ) -> MrpRunResponseApics:
     """Execute full APICS multi-level MRP."""

--- a/src/ootils_core/api/routers/planning_params.py
+++ b/src/ootils_core/api/routers/planning_params.py
@@ -8,12 +8,12 @@ from typing import Optional
 from uuid import UUID
 from decimal import Decimal
 
-import psycopg
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1/items", tags=["planning-params"])
@@ -39,7 +39,7 @@ class PlanningParamsResponse(BaseModel):
 def get_planning_params(
     item_id: Optional[str] = Query(default=None, description="Filter by item UUID"),
     location_id: Optional[str] = Query(default=None, description="Filter by location UUID"),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> PlanningParamsResponse:
     """Return the latest active planning parameters per (item, location)."""

--- a/src/ootils_core/api/routers/projection.py
+++ b/src/ootils_core/api/routers/projection.py
@@ -12,12 +12,12 @@ from decimal import Decimal
 from typing import Optional
 from uuid import UUID
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.kernel.graph.store import GraphStore
 
 logger = logging.getLogger(__name__)
@@ -149,7 +149,7 @@ def _aggregate_buckets(buckets: list[ProjectionBucket], grain: str) -> list[Proj
 
 
 def _fetch_supply_demand_details(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     node_ids: list[UUID],
     scenario_id: UUID,
 ) -> tuple[dict[UUID, list[SupplyDetail]], dict[UUID, list[DemandDetail]]]:
@@ -225,7 +225,7 @@ def get_projection(
     item_id: str = Query(..., description="Item identifier (UUID or external_id)"),
     location_id: str = Query(..., description="Location identifier (UUID or external_id)"),
     grain: Optional[str] = Query(default=None, description="day / week / month — aggregates daily buckets"),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
     scenario_id: UUID = Depends(resolve_scenario_id),
 ) -> ProjectionResponse:
@@ -345,7 +345,7 @@ def get_projection(
 
 @router.get("/portfolio", response_model=PortfolioResponse)
 def get_portfolio(
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
     scenario_id: UUID = Depends(resolve_scenario_id),
 ) -> PortfolioResponse:
@@ -403,7 +403,7 @@ def get_portfolio(
 def get_pegging(
     node_id: str,
     depth: int = Query(default=3, ge=1, le=5, description="Max traversal depth"),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
     scenario_id: UUID = Depends(resolve_scenario_id),
 ) -> PeggingResponse:

--- a/src/ootils_core/api/routers/pyramide.py
+++ b/src/ootils_core/api/routers/pyramide.py
@@ -6,12 +6,12 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db
+from ootils_core.db.types import DictRowConnection
 from ootils_core.pyramide import PyramideError, PyramideRunConfig, PyramideRunner, SUPPORTED_METHODS
 from ootils_core.pyramide.confidence import DEFAULT_SLA_DAYS
 from ootils_core.pyramide.repository import (
@@ -187,7 +187,7 @@ class PyramideSnapshotDiffOut(BaseModel):
 )
 def create_pyramide_run(
     body: PyramideRunRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> PyramideRunOut:
     body.method = body.method.upper()
@@ -297,7 +297,7 @@ def create_pyramide_run(
 )
 def get_pyramide_run(
     run_id: UUID,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> PyramideRunOut:
     summary = fetch_run_summary(db, run_id)
@@ -318,7 +318,7 @@ def get_pyramide_run(
 )
 def get_pyramide_run_result(
     run_id: UUID,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> PyramideRunResultOut:
     summary = fetch_run_summary(db, run_id)
@@ -338,7 +338,7 @@ def get_pyramide_run_result(
 )
 def commit_pyramide_run(
     run_id: UUID,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> PyramideCommitOut:
     try:
@@ -364,7 +364,7 @@ def commit_pyramide_run(
 )
 def list_pyramide_snapshots(
     limit: int = Query(default=100, ge=1, le=500),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> PyramideSnapshotListOut:
     snapshots = list_snapshots(db, limit=limit)
@@ -382,7 +382,7 @@ def list_pyramide_snapshots(
 def diff_pyramide_snapshots(
     snapshot_id: UUID,
     compare_to: UUID = Query(...),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> PyramideSnapshotDiffOut:
     base_values = fetch_snapshot_values(db, snapshot_id)

--- a/src/ootils_core/api/routers/rccp.py
+++ b/src/ootils_core/api/routers/rccp.py
@@ -34,12 +34,12 @@ from datetime import date, timedelta
 from typing import Optional
 from uuid import UUID
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1/rccp", tags=["rccp"])
@@ -131,7 +131,7 @@ def _generate_buckets(from_date: date, to_date: date, grain: str) -> list[tuple[
 
 
 def _count_working_days(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     location_id: Optional[str],
     start: date,
     end: date,
@@ -185,7 +185,7 @@ def get_rccp(
     to_date: date = Query(default=None, description="Fin de l'horizon (YYYY-MM-DD). Défaut : from_date + 84 jours."),
     grain: str = Query(default="week", description="Granularité : day | week | month."),
     scenario_id: UUID = Depends(resolve_scenario_id),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> RCCPResponse:
     """RCCP endpoint — charge vs capacité par bucket."""

--- a/src/ootils_core/api/routers/recommendations.py
+++ b/src/ootils_core/api/routers/recommendations.py
@@ -25,12 +25,12 @@ from decimal import Decimal
 from typing import Any, List, Literal, Optional
 from uuid import UUID, uuid4
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.recommendation.state_machine import (
     ALLOWED_TRANSITIONS,
     HumanGateError,
@@ -170,7 +170,7 @@ def _to_out(row: dict) -> RecommendationOut:
 
 @router.get("", response_model=RecommendationsListResponse)
 def list_recommendations(
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
     scenario_id: UUID = Depends(resolve_scenario_id),
     status_filter: Optional[str] = Query(default=None, alias="status"),
@@ -231,7 +231,7 @@ def list_recommendations(
 @router.get("/{recommendation_id}", response_model=RecommendationDetailOut)
 def get_recommendation(
     recommendation_id: UUID,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> RecommendationDetailOut:
     """Recommendation detail: evidence trail (explainability) + full transition history."""
@@ -277,7 +277,7 @@ def get_recommendation(
 def transition_recommendation(
     recommendation_id: UUID,
     body: TransitionRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> TransitionResponse:
     """Apply a governed state-machine transition to one recommendation."""

--- a/src/ootils_core/api/routers/scenarios.py
+++ b/src/ootils_core/api/routers/scenarios.py
@@ -32,13 +32,13 @@ import logging
 from typing import Literal, Optional
 from uuid import UUID
 
-import psycopg
 from psycopg import sql
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db, BASELINE_SCENARIO_ID
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.recommendation.state_machine import (
     HumanGateError,
     enforce_human_gate,
@@ -69,7 +69,7 @@ class ScenariosListResponse(BaseModel):
 
 @router.get("", response_model=ScenariosListResponse)
 def list_scenarios(
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
     status_filter: Optional[str] = Query(default=None, alias="status"),
     limit: int = Query(default=50, ge=1, le=200),
@@ -114,7 +114,7 @@ def list_scenarios(
 @router.get("/{scenario_id}", response_model=ScenarioOut)
 def get_scenario(
     scenario_id: UUID,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> ScenarioOut:
     row = db.execute("SELECT * FROM scenarios WHERE scenario_id = %s", (scenario_id,)).fetchone()
@@ -134,7 +134,7 @@ def get_scenario(
 @router.delete("/{scenario_id}", status_code=204)
 def delete_scenario(
     scenario_id: UUID,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> None:
     if scenario_id == BASELINE_SCENARIO_ID:
@@ -221,7 +221,7 @@ class PromoteResponse(BaseModel):
     event_id: UUID
 
 
-def _load_scenario_or_404(scenario_id: UUID, db: psycopg.Connection) -> dict:
+def _load_scenario_or_404(scenario_id: UUID, db: DictRowConnection) -> dict:
     row = db.execute(
         "SELECT * FROM scenarios WHERE scenario_id = %s", (scenario_id,)
     ).fetchone()
@@ -233,7 +233,7 @@ def _load_scenario_or_404(scenario_id: UUID, db: psycopg.Connection) -> dict:
 @router.get("/{scenario_id}/diff", response_model=ScenarioDiffResponse)
 def diff_scenario(
     scenario_id: UUID,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
     baseline_id: UUID = Query(default=BASELINE_SCENARIO_ID),
 ) -> ScenarioDiffResponse:
@@ -292,7 +292,7 @@ def diff_scenario(
 def promote_scenario(
     scenario_id: UUID,
     body: PromoteRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> PromoteResponse:
     """Promote a scenario's overrides onto the baseline (L3+ decision).

--- a/src/ootils_core/api/routers/simulate.py
+++ b/src/ootils_core/api/routers/simulate.py
@@ -7,12 +7,12 @@ import logging
 from typing import Literal, Optional
 from uuid import UUID
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, field_validator
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID, get_db
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.scenario.manager import ScenarioManager, _ALLOWED_FIELDS
 
 logger = logging.getLogger(__name__)
@@ -81,7 +81,7 @@ class SimulateResponse(BaseModel):
 @router.post("", response_model=SimulateResponse, status_code=status.HTTP_201_CREATED)
 def create_simulation(
     body: SimulateRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> SimulateResponse:
     """Create a new scenario with overrides and compute the delta vs base.

--- a/src/ootils_core/api/routers/staging.py
+++ b/src/ootils_core/api/routers/staging.py
@@ -32,7 +32,6 @@ import logging
 from typing import Annotated, Optional
 from uuid import UUID
 
-import psycopg
 from fastapi import (
     APIRouter,
     Depends,
@@ -47,6 +46,7 @@ from pydantic import BaseModel, Field
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db
+from ootils_core.db.types import DictRowConnection
 from ootils_core.staging.approve import ApprovalError, approve_batch
 from ootils_core.staging.diff import DiffError, compute_diff
 from ootils_core.staging.loader import LoaderError, load_to_staging
@@ -95,7 +95,7 @@ def upload_file(
     format_hint: Annotated[Optional[str], Form(description="tsv/csv/xlsx/json — skip auto-detect")] = None,
     sheet_name: Annotated[Optional[str], Form(description="XLSX sheet override")] = None,
     delimiter: Annotated[Optional[str], Form(description="CSV delimiter override")] = None,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
 ) -> dict:
     """Upload a file into the staging zone (ADR-013 step 1 of the lifecycle)."""
 
@@ -220,7 +220,7 @@ def _extract_submitter() -> str | None:
 )
 def get_batch_diff(
     batch_id: UUID,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
 ) -> dict:
     """Preview the impact of approving this batch (ADR-013 D4).
 
@@ -300,7 +300,7 @@ class ApproveRequest(BaseModel):
 def approve(
     batch_id: UUID,
     body: ApproveRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
 ) -> dict:
     """Apply the validated batch to canonical tables (ADR-013 D3+D4).
 
@@ -377,7 +377,7 @@ class RejectRequest(BaseModel):
 def reject(
     batch_id: UUID,
     body: RejectRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
 ) -> dict:
     """Close out a batch as rejected without writing to canonical."""
     try:

--- a/src/ootils_core/atp/api.py
+++ b/src/ootils_core/atp/api.py
@@ -12,7 +12,6 @@ from decimal import Decimal
 from typing import List, Optional
 from uuid import UUID
 
-import psycopg
 from fastapi import Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
@@ -20,6 +19,7 @@ from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
 from ootils_core.atp.engine import ATPEngine
 from ootils_core.atp.models import ATPBucket, ATPResult
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +72,7 @@ class ATPBucketDetail(BaseModel):
 # Helpers
 # ─────────────────────────────────────────────────────────────
 
-def _resolve_item_uuid(db: psycopg.Connection, external_id: str) -> Optional[UUID]:
+def _resolve_item_uuid(db: DictRowConnection, external_id: str) -> Optional[UUID]:
     """Resolve item external_id → item_id UUID."""
     # Try as UUID first
     try:
@@ -88,7 +88,7 @@ def _resolve_item_uuid(db: psycopg.Connection, external_id: str) -> Optional[UUI
     return row["item_id"] if row else None
 
 
-def _resolve_location_uuid(db: psycopg.Connection, external_id: str) -> Optional[UUID]:
+def _resolve_location_uuid(db: DictRowConnection, external_id: str) -> Optional[UUID]:
     """Resolve location external_id → location_id UUID."""
     # Try as UUID first
     try:
@@ -138,7 +138,7 @@ def _extract_shortage_details(result: ATPResult) -> List[ShortageDetail]:
 async def check_atp_availability(
     body: ATPCheckRequest,
     scenario_id: UUID = Depends(resolve_scenario_id),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> ATPCheckResponse:
     """

--- a/src/ootils_core/atp/ctp.py
+++ b/src/ootils_core/atp/ctp.py
@@ -15,11 +15,10 @@ from decimal import Decimal
 from typing import List, Optional, Tuple, Dict, Any
 from uuid import UUID
 
-import psycopg
-
 from ootils_core.atp.engine import ATPEngine
 from ootils_core.atp.models import ATPResult, ATPConfig
 from ootils_core.constants import BASELINE_SCENARIO_ID
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +105,7 @@ class CTPEngine:
     4. Returns combined result with capacity feasibility
     """
     
-    def __init__(self, db_conn: Optional[psycopg.Connection] = None, config: Optional[ATPConfig] = None):
+    def __init__(self, db_conn: Optional[DictRowConnection] = None, config: Optional[ATPConfig] = None):
         """
         Initialize the CTP engine.
         
@@ -119,12 +118,12 @@ class CTPEngine:
         self._atp_engine = ATPEngine(db_conn=db_conn, config=config)
     
     @property
-    def connection(self) -> Optional[psycopg.Connection]:
+    def connection(self) -> Optional[DictRowConnection]:
         """Get the database connection."""
         return self._conn
     
     @connection.setter
-    def connection(self, conn: psycopg.Connection):
+    def connection(self, conn: DictRowConnection):
         """Set the database connection."""
         self._conn = conn
         self._atp_engine.connection = conn

--- a/src/ootils_core/atp/engine.py
+++ b/src/ootils_core/atp/engine.py
@@ -20,8 +20,6 @@ from decimal import Decimal
 from typing import List, Optional, Tuple, Dict, Any
 from uuid import UUID
 
-import psycopg
-
 from ootils_core.atp.models import (
     ATPResult,
     ATPBucket,
@@ -30,6 +28,7 @@ from ootils_core.atp.models import (
     ATPConfig,
 )
 from ootils_core.constants import BASELINE_SCENARIO_ID
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +59,7 @@ class ATPEngine:
     Performance: <100ms for 1 year horizon with daily buckets
     """
     
-    def __init__(self, db_conn: Optional[psycopg.Connection] = None, config: Optional[ATPConfig] = None):
+    def __init__(self, db_conn: Optional[DictRowConnection] = None, config: Optional[ATPConfig] = None):
         """
         Initialize the ATP engine.
         
@@ -72,12 +71,12 @@ class ATPEngine:
         self._config = config or ATPConfig()
     
     @property
-    def connection(self) -> Optional[psycopg.Connection]:
+    def connection(self) -> Optional[DictRowConnection]:
         """Get the database connection."""
         return self._conn
     
     @connection.setter
-    def connection(self, conn: psycopg.Connection):
+    def connection(self, conn: DictRowConnection):
         """Set the database connection."""
         self._conn = conn
     

--- a/src/ootils_core/atp/routers.py
+++ b/src/ootils_core/atp/routers.py
@@ -14,7 +14,6 @@ from decimal import Decimal
 from typing import List, Optional
 from uuid import UUID
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
@@ -29,6 +28,7 @@ from ootils_core.atp.api import (
 )
 from ootils_core.atp.ctp import CTPEngine
 from ootils_core.atp.engine import ATPEngine
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +114,7 @@ class CTPSimulateResponse(BaseModel):
 async def check_atp(
     body: ATPCheckRequest,
     scenario_id: UUID = Depends(resolve_scenario_id),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> ATPCheckResponse:
     """
@@ -204,7 +204,7 @@ async def check_atp(
 async def check_ctp(
     body: CTPCheckRequest,
     scenario_id: UUID = Depends(resolve_scenario_id),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> CTPCheckResponse:
     """
@@ -308,7 +308,7 @@ async def check_ctp(
 async def simulate_ctp(
     body: CTPSimulateRequest,
     scenario_id: UUID = Depends(resolve_scenario_id),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> CTPSimulateResponse:
     """

--- a/src/ootils_core/crp/engine.py
+++ b/src/ootils_core/crp/engine.py
@@ -25,9 +25,8 @@ from decimal import Decimal
 from typing import Dict, List, Optional, Tuple, Any
 from uuid import UUID
 
-import psycopg
-
 from ootils_core.crp.models import WorkCenter, Routing, Operation
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -298,7 +297,7 @@ class CRPEngine:
     Performance: <500ms for 1000+ planned orders
     """
     
-    def __init__(self, db_conn: Optional[psycopg.Connection] = None):
+    def __init__(self, db_conn: Optional[DictRowConnection] = None):
         """
         Initialize the CRP engine.
         
@@ -308,12 +307,12 @@ class CRPEngine:
         self._conn = db_conn
     
     @property
-    def connection(self) -> Optional[psycopg.Connection]:
+    def connection(self) -> Optional[DictRowConnection]:
         """Get the database connection."""
         return self._conn
     
     @connection.setter
-    def connection(self, conn: psycopg.Connection):
+    def connection(self, conn: DictRowConnection):
         """Set the database connection."""
         self._conn = conn
     

--- a/src/ootils_core/crp/routers.py
+++ b/src/ootils_core/crp/routers.py
@@ -13,13 +13,13 @@ from datetime import date, timedelta
 from typing import List, Optional, Dict, Any
 from uuid import UUID
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, Query, status, Path
 from pydantic import BaseModel, Field
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db
 from ootils_core.crp.engine import CRPEngine
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +106,7 @@ class CRPOverloadsResponse(BaseModel):
 )
 async def calculate_crp(
     body: CRPCalculateRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> CRPCalculateResponse:
     """
@@ -231,7 +231,7 @@ async def calculate_crp(
 async def get_load_profile(
     work_center_id: UUID = Path(..., description="Work center UUID"),
     horizon_days: int = Query(default=90, ge=1, le=365, description="Planning horizon in days"),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> LoadProfileOut:
     """
@@ -306,7 +306,7 @@ async def get_load_profile(
 async def get_overloads(
     horizon_days: int = Query(default=90, ge=1, le=365, description="Planning horizon in days"),
     work_center_ids: Optional[str] = Query(None, description="Comma-separated list of work center IDs to filter"),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> CRPOverloadsResponse:
     """
@@ -424,7 +424,7 @@ class CRPSuggestResolutionsResponse(BaseModel):
 )
 async def suggest_resolutions(
     body: CRPSuggestResolutionsRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> CRPSuggestResolutionsResponse:
     """

--- a/src/ootils_core/db/connection.py
+++ b/src/ootils_core/db/connection.py
@@ -26,6 +26,8 @@ from typing import Generator
 import psycopg
 from psycopg.rows import dict_row
 
+from ootils_core.db.types import DictRowConnection
+
 logger = logging.getLogger(__name__)
 
 # Migrations are applied in filename order.
@@ -113,7 +115,7 @@ class OotilsDB:
             pool.close()
 
     @contextmanager
-    def conn(self) -> Generator[psycopg.Connection, None, None]:
+    def conn(self) -> Generator[DictRowConnection, None, None]:
         """
         Yield a configured psycopg3 Connection with dict_row factory.
         Commits on success, rolls back on exception, always closes.

--- a/src/ootils_core/db/types.py
+++ b/src/ootils_core/db/types.py
@@ -1,0 +1,17 @@
+"""
+types.py — shared type aliases for psycopg connections.
+
+Every runtime connection in this codebase is configured with
+``row_factory=dict_row`` (see connection.py). Plain ``psycopg.Connection``
+annotations tell mypy nothing about the row factory, so it falls back to
+assuming tuple rows and rejects ``row["col"]`` access across ~275 call
+sites. ``DictRowConnection`` documents the runtime reality in the type
+system so mypy can check dict-style row access correctly.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+
+DictRowConnection = psycopg.Connection[dict[str, Any]]

--- a/src/ootils_core/engine/dq/agent/agent.py
+++ b/src/ootils_core/engine/dq/agent/agent.py
@@ -18,12 +18,11 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
-import psycopg
-
 from .stat_rules import AgentIssue, run_stat_rules
 from .temporal_rules import run_temporal_rules
 from .impact_scorer import score_issues
 from .llm_reporter import generate_llm_report, LLMReport
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +42,7 @@ class AgentResult:
 
 
 def _load_existing_issues(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     batch_id: UUID,
 ) -> list[AgentIssue]:
     """Load L1+L2 issues already in data_quality_issues for this batch."""
@@ -75,7 +74,7 @@ def _load_existing_issues(
     return issues
 
 
-def _get_entity_type(db: psycopg.Connection, batch_id: UUID) -> str:
+def _get_entity_type(db: DictRowConnection, batch_id: UUID) -> str:
     row = db.execute(
         "SELECT entity_type, total_rows FROM ingest_batches WHERE batch_id = %s",
         (batch_id,),
@@ -84,7 +83,7 @@ def _get_entity_type(db: psycopg.Connection, batch_id: UUID) -> str:
 
 
 def _persist_agent_run(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     run_id: UUID,
     batch_id: UUID,
     status: str,
@@ -122,7 +121,7 @@ def _persist_agent_run(
 
 
 def _persist_new_issues(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     batch_id: UUID,
     run_id: UUID,
     issues: list[AgentIssue],
@@ -158,7 +157,7 @@ def _persist_new_issues(
 
 
 def _enrich_existing_issues(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     run_id: UUID,
     issues: list[AgentIssue],
 ) -> None:
@@ -184,7 +183,7 @@ def _enrich_existing_issues(
 
 
 def run_dq_agent(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     batch_id: UUID,
 ) -> AgentResult:
     """

--- a/src/ootils_core/engine/dq/agent/impact_scorer.py
+++ b/src/ootils_core/engine/dq/agent/impact_scorer.py
@@ -15,9 +15,8 @@ import math
 from dataclasses import dataclass
 from uuid import UUID
 
-import psycopg
-
 from .stat_rules import AgentIssue
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +37,7 @@ class IssueImpact:
 
 
 def _get_item_ids_for_issue(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     batch_id: UUID,
     row_id: UUID | None,
 ) -> list[str]:
@@ -82,7 +81,7 @@ def _get_item_ids_for_issue(
 
 
 def _get_active_shortages_for_items(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     item_external_ids: list[str],
 ) -> tuple[int, list[str]]:
     """
@@ -110,7 +109,7 @@ def _get_active_shortages_for_items(
 
 
 def _get_finished_goods_via_bom(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     item_external_ids: list[str],
 ) -> list[str]:
     """
@@ -165,7 +164,7 @@ def _get_finished_goods_via_bom(
 
 
 def score_issues(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     batch_id: UUID,
     issues: list[AgentIssue],
 ) -> list[AgentIssue]:

--- a/src/ootils_core/engine/dq/agent/stat_rules.py
+++ b/src/ootils_core/engine/dq/agent/stat_rules.py
@@ -16,7 +16,7 @@ import statistics
 from dataclasses import dataclass, field
 from uuid import UUID, uuid4
 
-import psycopg
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ class AgentIssue:
 
 
 def _load_history(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     entity_type: str,
     current_batch_id: UUID,
     window: int = HISTORY_WINDOW,
@@ -85,7 +85,7 @@ def _load_history(
 
 
 def _load_current_rows(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     batch_id: UUID,
 ) -> list[tuple[UUID, int, dict]]:
     """Load (row_id, row_number, content) for all rows in the current batch."""
@@ -110,7 +110,7 @@ def _load_current_rows(
     return result
 
 
-def _get_entity_type(db: psycopg.Connection, batch_id: UUID) -> str:
+def _get_entity_type(db: DictRowConnection, batch_id: UUID) -> str:
     row = db.execute(
         "SELECT entity_type FROM ingest_batches WHERE batch_id = %s",
         (batch_id,),
@@ -333,7 +333,7 @@ def _check_price_outlier(
 # ──────────────────────────────────────────────────────────────
 
 def _check_safety_stock_zero(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     batch_id: UUID,
     current_rows: list[tuple[UUID, int, dict]],
 ) -> list[AgentIssue]:
@@ -440,7 +440,7 @@ def _check_negative_onhand(
 # ──────────────────────────────────────────────────────────────
 
 def run_stat_rules(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     batch_id: UUID,
 ) -> list[AgentIssue]:
     """Run all stat rules for a batch. Returns list of AgentIssue."""

--- a/src/ootils_core/engine/dq/agent/temporal_rules.py
+++ b/src/ootils_core/engine/dq/agent/temporal_rules.py
@@ -14,14 +14,13 @@ import logging
 from datetime import date, datetime
 from uuid import UUID, uuid4
 
-import psycopg
-
 from .stat_rules import AgentIssue, SEVERITY_WARNING, SEVERITY_ERROR
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
 
-def _load_batch_rows(db: psycopg.Connection, batch_id: UUID) -> list[dict]:
+def _load_batch_rows(db: DictRowConnection, batch_id: UUID) -> list[dict]:
     """Load all row contents for a batch."""
     rows = db.execute(
         "SELECT raw_content FROM ingest_rows WHERE batch_id = %s ORDER BY row_number",
@@ -39,7 +38,7 @@ def _load_batch_rows(db: psycopg.Connection, batch_id: UUID) -> list[dict]:
 
 
 def _get_previous_batch_id(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     entity_type: str,
     current_batch_id: UUID,
 ) -> UUID | None:
@@ -59,7 +58,7 @@ def _get_previous_batch_id(
     return UUID(str(row["batch_id"])) if row else None
 
 
-def _get_entity_type(db: psycopg.Connection, batch_id: UUID) -> str:
+def _get_entity_type(db: DictRowConnection, batch_id: UUID) -> str:
     row = db.execute(
         "SELECT entity_type FROM ingest_batches WHERE batch_id = %s",
         (batch_id,),
@@ -77,7 +76,7 @@ def _row_fingerprint(content: dict) -> frozenset:
 # ──────────────────────────────────────────────────────────────
 
 def _check_duplicate_batch(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     batch_id: UUID,
     entity_type: str,
 ) -> list[AgentIssue]:
@@ -178,7 +177,7 @@ def _check_po_date_past(
 # ──────────────────────────────────────────────────────────────
 
 def _check_forecast_horizon_short(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     batch_id: UUID,
     current_rows: list[tuple[UUID, int, dict]],
     entity_type: str,
@@ -254,7 +253,7 @@ def _check_forecast_horizon_short(
 # ──────────────────────────────────────────────────────────────
 
 def _check_mass_change(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     batch_id: UUID,
     entity_type: str,
 ) -> list[AgentIssue]:
@@ -318,7 +317,7 @@ def _check_mass_change(
 # ──────────────────────────────────────────────────────────────
 
 def run_temporal_rules(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     batch_id: UUID,
 ) -> list[AgentIssue]:
     """Run all temporal rules for a batch. Returns list of AgentIssue."""

--- a/src/ootils_core/engine/dq/engine.py
+++ b/src/ootils_core/engine/dq/engine.py
@@ -2,7 +2,7 @@
 DQ Engine — Data Quality pipeline, L1 (structural) + L2 (referential).
 
 Interface:
-    run_dq(db: psycopg.Connection, batch_id: UUID) -> DQResult
+    run_dq(db: DictRowConnection, batch_id: UUID) -> DQResult
 
 L1 rules — structural checks on raw_content (JSON):
     - L1_MISSING_FIELD : mandatory field absent or None
@@ -28,7 +28,7 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID, uuid4
 
-import psycopg
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -307,7 +307,7 @@ _BATCH_CHUNK_SIZE = 10_000  # safe below PostgreSQL's ANY() array limit (~32 767
 
 
 def _chunked_resolve(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     table: str,
     external_ids: list[str],
 ) -> set[str]:
@@ -330,23 +330,23 @@ def _chunked_resolve(
     return found
 
 
-def _batch_resolve_items(db: psycopg.Connection, external_ids: list[str]) -> set[str]:
+def _batch_resolve_items(db: DictRowConnection, external_ids: list[str]) -> set[str]:
     """Return set of external_ids that exist in items table."""
     return _chunked_resolve(db, "items", external_ids)
 
 
-def _batch_resolve_locations(db: psycopg.Connection, external_ids: list[str]) -> set[str]:
+def _batch_resolve_locations(db: DictRowConnection, external_ids: list[str]) -> set[str]:
     return _chunked_resolve(db, "locations", external_ids)
 
 
-def _batch_resolve_suppliers(db: psycopg.Connection, external_ids: list[str]) -> set[str]:
+def _batch_resolve_suppliers(db: DictRowConnection, external_ids: list[str]) -> set[str]:
     return _chunked_resolve(db, "suppliers", external_ids)
 
 
 def _check_l2(
     rows_data: list[tuple[UUID, int, dict[str, Any]]],
     entity_type: str,
-    db: psycopg.Connection,
+    db: DictRowConnection,
 ) -> list[DQIssue]:
     """
     Batch L2 checks for all rows of a given entity_type.
@@ -441,7 +441,7 @@ def _check_l2(
 # Persist issues + update row/batch statuses
 # ──────────────────────────────────────────────────────────────
 
-def _persist_issues(db: psycopg.Connection, batch_id: UUID, issues: list[DQIssue]) -> None:
+def _persist_issues(db: DictRowConnection, batch_id: UUID, issues: list[DQIssue]) -> None:
     if not issues:
         return
     with db.cursor() as cur:
@@ -469,7 +469,7 @@ def _persist_issues(db: psycopg.Connection, batch_id: UUID, issues: list[DQIssue
 
 
 def _update_row_statuses(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     row_issues: dict[UUID, list[DQIssue]],
     all_row_ids: list[UUID],
     max_level_reached: dict[UUID, int],
@@ -500,7 +500,7 @@ def _update_row_statuses(
 
 
 def _update_batch_status(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     batch_id: UUID,
     all_issues: list[DQIssue],
     total_rows: int,
@@ -531,7 +531,7 @@ def _update_batch_status(
 # Main entry point
 # ──────────────────────────────────────────────────────────────
 
-def run_dq(db: psycopg.Connection, batch_id: UUID) -> DQResult:
+def run_dq(db: DictRowConnection, batch_id: UUID) -> DQResult:
     """
     Execute L1 + L2 DQ checks for all rows in a batch.
 

--- a/src/ootils_core/engine/dq/l4_rules.py
+++ b/src/ootils_core/engine/dq/l4_rules.py
@@ -26,8 +26,7 @@ from collections import Counter
 from collections.abc import Callable
 from uuid import UUID
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.dq.engine import DQIssue
 
 
@@ -65,7 +64,7 @@ def _issue(
 def _l4_duplicate_external_id(
     rows: list[tuple[UUID, int, dict]],
     batch_id: UUID,  # noqa: ARG001 (signature uniform across rules)
-    db: psycopg.Connection,  # noqa: ARG001
+    db: DictRowConnection,  # noqa: ARG001
     *,
     field: str = "external_id",
 ) -> list[DQIssue]:
@@ -106,7 +105,7 @@ def _l4_duplicate_external_id(
 def _l4_inter_batch_collision(
     rows: list[tuple[UUID, int, dict]],
     batch_id: UUID,
-    db: psycopg.Connection,
+    db: DictRowConnection,
     *,
     field: str = "external_id",
 ) -> list[DQIssue]:
@@ -164,7 +163,7 @@ def _l4_inter_batch_collision(
 def _l4_supplier_inactive(
     rows: list[tuple[UUID, int, dict]],
     batch_id: UUID,  # noqa: ARG001
-    db: psycopg.Connection,
+    db: DictRowConnection,
 ) -> list[DQIssue]:
     """A supplier_items row references a supplier whose status is not
     'active' (i.e. inactive or blocked). Approving would create a link
@@ -213,7 +212,7 @@ def _l4_supplier_inactive(
 def _l4_orphan_item_no_planning(
     rows: list[tuple[UUID, int, dict]],
     batch_id: UUID,  # noqa: ARG001
-    db: psycopg.Connection,
+    db: DictRowConnection,
 ) -> list[DQIssue]:
     """An item in this batch has zero item_planning_params rows in the DB.
 
@@ -267,7 +266,7 @@ def _l4_orphan_item_no_planning(
 # ---------------------------------------------------------------------------
 
 
-L4RuleFn = Callable[[list[tuple[UUID, int, dict]], UUID, psycopg.Connection], list[DQIssue]]
+L4RuleFn = Callable[[list[tuple[UUID, int, dict]], UUID, DictRowConnection], list[DQIssue]]
 
 
 # Rules that apply to every entity_type carrying an external_id
@@ -295,7 +294,7 @@ def check_l4(
     rows: list[tuple[UUID, int, dict]],
     entity_type: str,
     batch_id: UUID,
-    db: psycopg.Connection,
+    db: DictRowConnection,
 ) -> list[DQIssue]:
     """Run all L4 rules for `entity_type` over the given rows.
 

--- a/src/ootils_core/engine/ghost/capacity_aggregate.py
+++ b/src/ootils_core/engine/ghost/capacity_aggregate.py
@@ -12,11 +12,11 @@ from __future__ import annotations
 from datetime import date, timedelta
 from typing import Any
 
-import psycopg
+from ootils_core.db.types import DictRowConnection
 
 
 def run_capacity_aggregate(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     ghost_id: str,
     scenario_id: str,
     from_date: date,
@@ -113,7 +113,7 @@ def run_capacity_aggregate(
     }
 
 
-def _get_resource_capacity(db: psycopg.Connection, resource_id: str) -> float:
+def _get_resource_capacity(db: DictRowConnection, resource_id: str) -> float:
     """Return capacity_per_day for a resource."""
     row = db.execute(
         "SELECT capacity_per_day FROM resources WHERE resource_id = %s",
@@ -123,7 +123,7 @@ def _get_resource_capacity(db: psycopg.Connection, resource_id: str) -> float:
 
 
 def _get_supply_load(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     item_id: str,
     scenario_id: str,
     ref_date: date,

--- a/src/ootils_core/engine/ghost/ghost_engine.py
+++ b/src/ootils_core/engine/ghost/ghost_engine.py
@@ -9,14 +9,13 @@ from __future__ import annotations
 from datetime import date
 from typing import Any
 
-import psycopg
-
 from .phase_transition import run_phase_transition
 from .capacity_aggregate import run_capacity_aggregate
+from ootils_core.db.types import DictRowConnection
 
 
 def run_ghost(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     ghost_id: str,
     scenario_id: str,
     from_date: date,

--- a/src/ootils_core/engine/ghost/phase_transition.py
+++ b/src/ootils_core/engine/ghost/phase_transition.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from datetime import date, timedelta
 from typing import Any
 
-import psycopg
+from ootils_core.db.types import DictRowConnection
 
 
 # ---------------------------------------------------------------------------
@@ -76,7 +76,7 @@ INCONSISTENCY_THRESHOLD = 0.10  # 10% deviation triggers alert
 
 
 def run_phase_transition(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     ghost_id: str,
     scenario_id: str,
     from_date: date,
@@ -196,7 +196,7 @@ def run_phase_transition(
 
 
 def _get_projected_inventory(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     item_id: str,
     scenario_id: str,
     ref_date: date,

--- a/src/ootils_core/engine/kernel/allocation/engine.py
+++ b/src/ootils_core/engine/kernel/allocation/engine.py
@@ -25,8 +25,7 @@ from datetime import date as _date_type
 from decimal import Decimal
 from uuid import UUID
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.kernel._clock import Clock, SystemClock
 from ootils_core.engine.kernel._ids import deterministic_uuid
 
@@ -61,7 +60,7 @@ class AllocationEngine:
     def allocate(
         self,
         scenario_id: UUID,
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> AllocationResult:
         """
         Run a full allocation pass for *scenario_id*.
@@ -141,7 +140,7 @@ class AllocationEngine:
     def get_demand_nodes(
         self,
         scenario_id: UUID,
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> list[Node]:
         """
         Fetch all active demand nodes for *scenario_id* and sort them by:
@@ -191,7 +190,7 @@ class AllocationEngine:
         self,
         demand_node: Node,
         scenario_id: UUID,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         store: GraphStore,
     ) -> tuple[Decimal, int, int]:
         """

--- a/src/ootils_core/engine/kernel/graph/store.py
+++ b/src/ootils_core/engine/kernel/graph/store.py
@@ -12,8 +12,7 @@ from decimal import Decimal
 from typing import Optional
 from uuid import UUID
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.kernel._clock import Clock, SystemClock
 from ootils_core.engine.kernel._ids import deterministic_uuid
 from ootils_core.models import (
@@ -33,7 +32,7 @@ class GraphStore:
     The store does NOT manage transactions — callers own commit/rollback.
     """
 
-    def __init__(self, conn: psycopg.Connection, clock: Clock | None = None) -> None:
+    def __init__(self, conn: DictRowConnection, clock: Clock | None = None) -> None:
         self._conn = conn
         self._clock = clock or SystemClock()
 

--- a/src/ootils_core/engine/kernel/temporal/bridge.py
+++ b/src/ootils_core/engine/kernel/temporal/bridge.py
@@ -18,8 +18,7 @@ from datetime import date, timedelta
 from decimal import Decimal
 from uuid import UUID
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.kernel.graph.store import GraphStore
 from ootils_core.models import Node, NodeTypeTemporalPolicy
 
@@ -130,7 +129,7 @@ class TemporalBridge:
     def get_policy(
         self,
         node_type: str,
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> NodeTypeTemporalPolicy:
         """
         Load the NodeTypeTemporalPolicy for a node type from node_type_policies.
@@ -173,7 +172,7 @@ class TemporalBridge:
         self,
         series_id: UUID,
         target_grain: str,
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> list[AggregatedBucket]:
         """
         Aggregate the PI nodes in a projection series to a coarser grain.
@@ -256,7 +255,7 @@ class TemporalBridge:
         series_id: UUID,
         source_grain: str,
         target_grain: str,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         distribution: str = "FLAT",
     ) -> list[AggregatedBucket]:
         """
@@ -362,7 +361,7 @@ class TemporalBridge:
     def _load_series_nodes(
         self,
         series_id: UUID,
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> list[Node]:
         """Load all active PI nodes for a series, ordered by bucket_sequence."""
         store = GraphStore(db)

--- a/src/ootils_core/engine/kernel/temporal/zone_transition.py
+++ b/src/ootils_core/engine/kernel/temporal/zone_transition.py
@@ -19,8 +19,7 @@ from datetime import date, timedelta
 from decimal import Decimal
 from uuid import UUID
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.kernel._ids import deterministic_uuid
 from ootils_core.engine.kernel.graph.store import GraphStore
 from ootils_core.models import Node
@@ -93,7 +92,7 @@ class ZoneTransitionEngine:
         series_id: UUID,
         scenario_id: UUID,
         as_of_date: date,
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> dict[str, bool]:
         """
         Execute the applicable zone transition(s) for a series on as_of_date.
@@ -186,7 +185,7 @@ class ZoneTransitionEngine:
         series_id: UUID,
         scenario_id: UUID,
         as_of_date: date,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         store: GraphStore,
     ) -> bool:
         """
@@ -258,7 +257,7 @@ class ZoneTransitionEngine:
         series_id: UUID,
         scenario_id: UUID,
         as_of_date: date,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         store: GraphStore,
     ) -> bool:
         """
@@ -332,7 +331,7 @@ class ZoneTransitionEngine:
         source_node: Node,
         scenario_id: UUID,
         series_id: UUID,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         store: GraphStore,
     ) -> list[Node]:
         """
@@ -410,7 +409,7 @@ class ZoneTransitionEngine:
         source_node: Node,
         scenario_id: UUID,
         series_id: UUID,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         store: GraphStore,
     ) -> list[Node]:
         """
@@ -491,7 +490,7 @@ class ZoneTransitionEngine:
     def _is_transition_done(
         self,
         idempotency_key: str,
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> bool:
         """Return True if a completed transition run exists for this idempotency_key."""
         row = db.execute(
@@ -510,7 +509,7 @@ class ZoneTransitionEngine:
         job_type: str,
         transition_date: date,
         idempotency_key: str,
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> UUID:
         """
         Insert a zone_transition_runs record in 'running' status.
@@ -543,7 +542,7 @@ class ZoneTransitionEngine:
         run_id: UUID,
         series_total: int,
         series_done: int,
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> None:
         """Mark a zone_transition_runs record as completed."""
         db.execute(
@@ -561,7 +560,7 @@ class ZoneTransitionEngine:
     def _fail_transition_run(
         self,
         run_id: UUID,
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> None:
         """Mark a zone_transition_runs record as failed."""
         db.execute(
@@ -578,7 +577,7 @@ class ZoneTransitionEngine:
     # Advisory lock helpers
     # ------------------------------------------------------------------
 
-    def _try_acquire_lock(self, db: psycopg.Connection) -> bool:
+    def _try_acquire_lock(self, db: DictRowConnection) -> bool:
         """
         Try to acquire the zone_transition global advisory lock.
         Returns True if acquired, False if already held.
@@ -589,7 +588,7 @@ class ZoneTransitionEngine:
         ).fetchone()
         return bool(row["locked"]) if row else False
 
-    def _release_lock(self, db: psycopg.Connection) -> None:
+    def _release_lock(self, db: DictRowConnection) -> None:
         """Release the zone_transition global advisory lock."""
         db.execute(
             "SELECT pg_advisory_unlock(hashtext(%s))",
@@ -606,7 +605,7 @@ def _rewire_edges(
     source_node: "Node",
     new_nodes: list["Node"],
     scenario_id: UUID,
-    db: psycopg.Connection,
+    db: DictRowConnection,
     store: "GraphStore",
 ) -> None:
     """

--- a/src/ootils_core/engine/mrp/graph_integration.py
+++ b/src/ootils_core/engine/mrp/graph_integration.py
@@ -19,8 +19,7 @@ from decimal import Decimal
 from typing import Dict, List, Optional, Tuple
 from uuid import UUID, uuid4
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.mrp.gross_to_net import BucketRecord
 
 logger = logging.getLogger(__name__)
@@ -48,7 +47,7 @@ class GraphIntegration:
       picks up downstream effects.
     """
 
-    def __init__(self, db: psycopg.Connection, scenario_id: UUID):
+    def __init__(self, db: DictRowConnection, scenario_id: UUID):
         self.db = db
         self.scenario_id = scenario_id
 

--- a/src/ootils_core/engine/mrp/gross_to_net.py
+++ b/src/ootils_core/engine/mrp/gross_to_net.py
@@ -30,7 +30,7 @@ from decimal import Decimal
 from typing import Dict, List, Optional
 from uuid import UUID, uuid4
 
-import psycopg
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +109,7 @@ class GrossToNetCalculator:
         # Then apply lot-sizing and lead-time offset externally.
     """
 
-    def __init__(self, db: psycopg.Connection, scenario_id: UUID):
+    def __init__(self, db: DictRowConnection, scenario_id: UUID):
         self.db = db
         self.scenario_id = scenario_id
 

--- a/src/ootils_core/engine/mrp/lot_sizing.py
+++ b/src/ootils_core/engine/mrp/lot_sizing.py
@@ -21,8 +21,7 @@ from enum import Enum
 from decimal import Decimal
 from typing import List, Optional, Tuple
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.scenario.param_overlay import resolved_params_sql
 
 logger = logging.getLogger(__name__)
@@ -68,7 +67,7 @@ class LotSizingEngine:
     - (planned_order_qty, lot_size_rule_applied)
     """
 
-    def __init__(self, db: psycopg.Connection):
+    def __init__(self, db: DictRowConnection):
         self.db = db
 
     def calculate_lot_size(

--- a/src/ootils_core/engine/mrp/mrp_apics_engine.py
+++ b/src/ootils_core/engine/mrp/mrp_apics_engine.py
@@ -31,9 +31,9 @@ from decimal import Decimal
 from typing import Dict, List, Optional, Set
 from uuid import UUID, uuid4
 
-import psycopg
 import json
 
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.mrp.llc_calculator import LLCCalculator
 from ootils_core.engine.mrp.gross_to_net import (
     BucketRecord,
@@ -89,7 +89,7 @@ class MrpApicsEngine:
     offsetting by lead time, and exploding dependent demand to child items.
     """
 
-    def __init__(self, db: psycopg.Connection):
+    def __init__(self, db: DictRowConnection):
         self.db = db
         self.llc_calculator = LLCCalculator(db)
         self.gross_to_net = GrossToNetCalculator(db, BASELINE_SCENARIO_ID)

--- a/src/ootils_core/engine/orchestration/calc_run.py
+++ b/src/ootils_core/engine/orchestration/calc_run.py
@@ -13,8 +13,7 @@ from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID, uuid4
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.models import CalcRun, Scenario
 
 
@@ -29,7 +28,7 @@ class CalcRunManager:
         self,
         scenario_id: UUID,
         event_ids: list[UUID],
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> Optional[CalcRun]:
         """
         Try to acquire an advisory lock for this scenario and start a calc run.
@@ -109,7 +108,7 @@ class CalcRunManager:
         self,
         run: CalcRun,
         scenario: Scenario,
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> None:
         """
         Mark a calc run as completed or completed_stale.
@@ -165,7 +164,7 @@ class CalcRunManager:
         self,
         run: CalcRun,
         error: str,
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> None:
         """Mark a calc run as failed with an error message.
 
@@ -207,7 +206,7 @@ class CalcRunManager:
         except Exception:
             pass
 
-    def recover_pending_runs(self, db: psycopg.Connection) -> list[CalcRun]:
+    def recover_pending_runs(self, db: DictRowConnection) -> list[CalcRun]:
         """
         On startup: transition all 'running' runs to 'interrupted'.
         Return all replayable runs (pending + interrupted) so the engine can retry them.

--- a/src/ootils_core/engine/orchestration/propagator.py
+++ b/src/ootils_core/engine/orchestration/propagator.py
@@ -13,9 +13,8 @@ from decimal import Decimal
 from typing import Optional
 from uuid import UUID
 
-import psycopg
-
 from ootils_core.constants import BASELINE_SCENARIO_ID
+from ootils_core.db.types import DictRowConnection
 from ootils_core.models import CalcRun, Node, Scenario
 from ootils_core.engine.kernel.graph.store import GraphStore
 from ootils_core.engine.kernel.graph.traversal import GraphTraversal
@@ -66,7 +65,7 @@ class PropagationEngine:
         self,
         event_id: UUID,
         scenario_id: UUID,
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> Optional[CalcRun]:
         """
         Main entry point. Acquires advisory lock, expands dirty subgraph, propagates.
@@ -179,7 +178,7 @@ class PropagationEngine:
             self._calc_run_mgr.fail_calc_run(calc_run, str(exc), db)
             raise
 
-    def _finish_run(self, calc_run: CalcRun, scenario_id: UUID, db: psycopg.Connection) -> None:
+    def _finish_run(self, calc_run: CalcRun, scenario_id: UUID, db: DictRowConnection) -> None:
         """Load scenario and complete the calc run."""
         scenario_row = db.execute(
             "SELECT * FROM scenarios WHERE scenario_id = %s",
@@ -240,7 +239,7 @@ class PropagationEngine:
         self,
         calc_run: CalcRun,
         dirty_nodes: set[UUID],
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> None:
         """
         Topological sort over dirty nodes, then compute each one in order.
@@ -419,7 +418,7 @@ class PropagationEngine:
         node_id: UUID,
         scenario_id: UUID,
         calc_run_id: UUID,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         nodes_cache: Optional[dict[UUID, Optional[Node]]] = None,
         edges_by_target: Optional[dict[UUID, dict[str, list]]] = None,
         safety_stock_cache: Optional[dict[tuple[UUID, Optional[UUID]], Decimal]] = None,
@@ -675,7 +674,7 @@ class PropagationEngine:
         return changed
 
     def _get_safety_stock(
-        self, node: Node, scenario_id: UUID, db: psycopg.Connection
+        self, node: Node, scenario_id: UUID, db: DictRowConnection
     ) -> Optional[Decimal]:
         """Fetch safety_stock_qty from item_planning_params for this node's
         item/location, resolved for `scenario_id` (chantier #347 PR3,

--- a/src/ootils_core/engine/orchestration/propagator_rust.py
+++ b/src/ootils_core/engine/orchestration/propagator_rust.py
@@ -27,7 +27,6 @@ import os
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-import psycopg
 
 try:
     import ootils_kernel  # type: ignore[import-not-found]
@@ -37,6 +36,7 @@ except ImportError as _exc:  # pragma: no cover — guarded at construction
 else:
     _IMPORT_ERROR = None
 
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.orchestration.propagator import PropagationEngine
 from ootils_core.engine.orchestration.propagator_sql import (
     CLEAR_DIRTY_SQL,
@@ -85,7 +85,7 @@ class RustPropagationEngine(PropagationEngine):
         self,
         calc_run: "CalcRun",
         dirty_nodes: set[UUID],
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> None:
         """
         Hybrid dispatch:
@@ -108,7 +108,7 @@ class RustPropagationEngine(PropagationEngine):
         # Large subgraph — Rust beats SQL by 3-5× thanks to bulk COPY.
         self._propagate_via_rust(calc_run, db)
 
-    def _propagate_via_sql(self, calc_run: "CalcRun", db: psycopg.Connection) -> None:
+    def _propagate_via_sql(self, calc_run: "CalcRun", db: DictRowConnection) -> None:
         """SQL-engine fallback for small dirty sets. Same SQL strings."""
         params = {
             "scenario_id": calc_run.scenario_id,
@@ -120,7 +120,7 @@ class RustPropagationEngine(PropagationEngine):
             db.execute(SHORTAGES_SQL, params)
         db.execute(CLEAR_DIRTY_SQL, params)
 
-    def _propagate_via_rust(self, calc_run: "CalcRun", db: psycopg.Connection) -> None:
+    def _propagate_via_rust(self, calc_run: "CalcRun", db: DictRowConnection) -> None:
         """Delegate the heavy lifting to ootils_kernel."""
         # Commit dirty_nodes inserts so Rust (separate session) can see them.
         db.commit()

--- a/src/ootils_core/engine/orchestration/propagator_rust_svc.py
+++ b/src/ootils_core/engine/orchestration/propagator_rust_svc.py
@@ -27,8 +27,7 @@ import os
 from typing import TYPE_CHECKING, Optional
 from uuid import UUID
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.orchestration.propagator import PropagationEngine
 from ootils_core.engine_rust_service import EngineClient
 
@@ -76,7 +75,7 @@ class RustServicePropagationEngine(PropagationEngine):
         self,
         event_id: UUID,
         scenario_id: UUID,
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> Optional["CalcRun"]:
         """
         Override the full lifecycle (not just `_propagate`). The Rust
@@ -165,7 +164,7 @@ class RustServicePropagationEngine(PropagationEngine):
         self,
         calc_run: "CalcRun",
         scenario_id: UUID,
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> None:
         """Bare-minimum completion: mark calc_run complete, flag event
         as processed. Skips the shortage_detector.resolve_stale step

--- a/src/ootils_core/engine/orchestration/propagator_sql.py
+++ b/src/ootils_core/engine/orchestration/propagator_sql.py
@@ -30,8 +30,7 @@ import logging
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.orchestration.propagator import PropagationEngine
 from ootils_core.engine.scenario.param_overlay import resolved_field_lateral_sql
 
@@ -374,7 +373,7 @@ class SqlPropagationEngine(PropagationEngine):
         self,
         calc_run: "CalcRun",
         dirty_nodes: set[UUID],
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> None:
         if not dirty_nodes:
             return

--- a/src/ootils_core/engine/recommendation/state_machine.py
+++ b/src/ootils_core/engine/recommendation/state_machine.py
@@ -31,8 +31,9 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-import psycopg
 from psycopg.rows import dict_row
+
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +133,7 @@ class TransitionResult:
 
 
 def transition_one(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     recommendation_id: UUID,
     to_status: str,
     actor: str,
@@ -197,7 +198,7 @@ def transition_one(
 
 
 def transition_many(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     to_status: str,
     actor: str,
     *,

--- a/src/ootils_core/engine/scenario/manager.py
+++ b/src/ootils_core/engine/scenario/manager.py
@@ -19,6 +19,7 @@ from uuid import UUID, uuid4
 
 import psycopg
 
+from ootils_core.db.types import DictRowConnection
 from ootils_core.models import (
     Scenario,
     ScenarioDiff,
@@ -109,7 +110,7 @@ class ScenarioManager:
         self,
         name: str,
         parent_scenario_id: UUID,
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> Scenario:
         """
         Create a new (non-baseline) scenario branched from parent_scenario_id.
@@ -161,7 +162,7 @@ class ScenarioManager:
         self,
         source_scenario_id: UUID,
         target_scenario_id: UUID,
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> dict:
         """
         Copy projection_series from source to target scenario.
@@ -209,7 +210,7 @@ class ScenarioManager:
         self,
         source_scenario_id: UUID,
         target_scenario_id: UUID,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         series_mapping: dict | None = None,
     ) -> int:
         """
@@ -378,7 +379,7 @@ class ScenarioManager:
         field_name: str,
         new_value: str,
         applied_by: Optional[str],
-        db: psycopg.Connection,
+        db: DictRowConnection,
     ) -> ScenarioOverride:
         """
         Apply a field-level override to a node within a scenario.
@@ -549,7 +550,7 @@ class ScenarioManager:
         self,
         scenario_id: UUID,
         baseline_id: UUID,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         baseline_calc_run_id: Optional[UUID] = None,
         scenario_calc_run_id: Optional[UUID] = None,
     ) -> list[ScenarioDiff]:
@@ -648,7 +649,7 @@ class ScenarioManager:
         )
         return diffs
 
-    def _latest_calc_run(self, scenario_id: UUID, db: psycopg.Connection) -> UUID:
+    def _latest_calc_run(self, scenario_id: UUID, db: DictRowConnection) -> UUID:
         """Return the calc_run_id of the latest completed calc_run for a scenario."""
         row = db.execute(
             """
@@ -673,7 +674,7 @@ class ScenarioManager:
     def promote(
         self,
         scenario_id: UUID,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         promoted_by: Optional[str] = None,
     ) -> PromoteResult:
         """
@@ -927,7 +928,7 @@ def _validate_field_name(field_name: str) -> None:
         )
 
 
-def _fetch_nodes_as_dict(scenario_id: UUID, db: psycopg.Connection) -> list[dict]:
+def _fetch_nodes_as_dict(scenario_id: UUID, db: DictRowConnection) -> list[dict]:
     """Fetch all active nodes for a scenario as raw dicts."""
     return db.execute(
         "SELECT * FROM nodes WHERE scenario_id = %s AND active = TRUE",

--- a/src/ootils_core/engine/scenario/param_overlay.py
+++ b/src/ootils_core/engine/scenario/param_overlay.py
@@ -33,8 +33,9 @@ from decimal import Decimal, InvalidOperation
 from typing import NamedTuple, Optional
 from uuid import UUID, uuid4
 
-import psycopg
 from psycopg.errors import ForeignKeyViolation
+
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -356,7 +357,7 @@ def _validate_value(field_name: str, value: str) -> str:
         return normalized
 
 
-def _fetch_scenario(conn: psycopg.Connection, scenario_id: UUID) -> dict:
+def _fetch_scenario(conn: DictRowConnection, scenario_id: UUID) -> dict:
     """Return the scenario row or raise ParamOverlayError if it doesn't exist.
 
     Shared by set_param_override and clear_param_override so both ends of
@@ -618,7 +619,7 @@ def resolved_field_lateral_sql(field: str, base_alias: str, out_col: str) -> str
 
 
 def _assert_current_planning_params_row_exists(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     item_id: UUID,
     location_id: Optional[UUID],
 ) -> None:
@@ -681,7 +682,7 @@ def _assert_current_planning_params_row_exists(
 
 
 def set_param_override(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     scenario_id: UUID,
     item_id: UUID,
     field_name: str,
@@ -801,7 +802,7 @@ def set_param_override(
 
 
 def clear_param_override(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     scenario_id: UUID,
     item_id: UUID,
     field_name: str,
@@ -849,7 +850,7 @@ def clear_param_override(
     return deleted
 
 
-def list_param_overrides(conn: psycopg.Connection, scenario_id: UUID) -> list[dict]:
+def list_param_overrides(conn: DictRowConnection, scenario_id: UUID) -> list[dict]:
     """Return every planning-param override for a scenario, for audit display."""
     rows = conn.execute(
         """

--- a/src/ootils_core/mps/api.py
+++ b/src/ootils_core/mps/api.py
@@ -18,12 +18,12 @@ from decimal import Decimal
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-import psycopg
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, field_validator
 
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID, get_db
+from ootils_core.db.types import DictRowConnection
 from ootils_core.mps.engine import AggregateDemandEngine
 from ootils_core.mps.capacity_engine import CapacityCheckEngine
 
@@ -185,7 +185,7 @@ class CapacityCheckResponse(BaseModel):
 # Helpers
 # ─────────────────────────────────────────────────────────────
 
-def _resolve_item_uuid(db: psycopg.Connection, external_id: str) -> UUID | None:
+def _resolve_item_uuid(db: DictRowConnection, external_id: str) -> UUID | None:
     """Resolve item external_id → item_id UUID."""
     # Try UUID first
     try:
@@ -207,7 +207,7 @@ def _resolve_item_uuid(db: psycopg.Connection, external_id: str) -> UUID | None:
     return row["item_id"] if row else None
 
 
-def _resolve_location_uuid(db: psycopg.Connection, external_id: str) -> UUID | None:
+def _resolve_location_uuid(db: DictRowConnection, external_id: str) -> UUID | None:
     """Resolve location external_id → location_id UUID."""
     # Try UUID first
     try:
@@ -229,7 +229,7 @@ def _resolve_location_uuid(db: psycopg.Connection, external_id: str) -> UUID | N
     return row["location_id"] if row else None
 
 
-def _resolve_scenario_uuid(db: psycopg.Connection, scenario_id_str: str | None) -> UUID:
+def _resolve_scenario_uuid(db: DictRowConnection, scenario_id_str: str | None) -> UUID:
     """Resolve scenario_id string → UUID, defaulting to baseline."""
     if scenario_id_str is None or scenario_id_str.lower() == "baseline":
         return BASELINE_SCENARIO_ID
@@ -270,7 +270,7 @@ def _resolve_scenario_uuid(db: psycopg.Connection, scenario_id_str: str | None) 
 )
 async def aggregate_demand(
     body: AggregateDemandRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> AggregateDemandResponse:
     """
@@ -425,7 +425,7 @@ async def list_mps_nodes(
     date_to: Optional[date] = Query(default=None),
     status: Optional[str] = Query(default=None, pattern="^(DRAFT|REVIEWED|APPROVED|RELEASED)$"),
     limit: int = Query(default=100, ge=1, le=1000),
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> MPSNodeListResponse:
     """
@@ -532,7 +532,7 @@ async def list_mps_nodes(
 )
 async def get_mps_node(
     mps_id: UUID,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> MPSNodeDetailOut:
     """
@@ -624,7 +624,7 @@ async def get_mps_node(
 )
 async def capacity_check(
     body: CapacityCheckRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> CapacityCheckResponse:
     """
@@ -713,7 +713,7 @@ async def capacity_check(
 )
 async def suggest_adjustments(
     mps_id: UUID,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> List[AdjustmentSuggestionOut]:
     """
@@ -801,7 +801,7 @@ class ApproveMPSResponse(BaseModel):
 async def approve_mps_node(
     mps_id: UUID,
     body: ApproveMPSRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     token: str = Depends(require_auth),
 ) -> ApproveMPSResponse:
     """Approve an MPS node for MRP promotion."""
@@ -944,7 +944,7 @@ class PromoteToMRPResponse(BaseModel):
 async def promote_to_mrp(
     mps_id: UUID,
     body: PromoteToMRPRequest,
-    db: psycopg.Connection = Depends(get_db),
+    db: DictRowConnection = Depends(get_db),
     token: str = Depends(require_auth),
 ) -> PromoteToMRPResponse:
     """

--- a/src/ootils_core/mps/capacity_engine.py
+++ b/src/ootils_core/mps/capacity_engine.py
@@ -19,7 +19,7 @@ from decimal import Decimal
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-import psycopg
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +97,7 @@ class CapacityCheckEngine:
     
     def check_capacity(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         mps_node_ids: List[UUID],
         horizon_buffer_days: int = 7,
     ) -> CapacityCheckResult:
@@ -197,7 +197,7 @@ class CapacityCheckEngine:
     
     def _fetch_mps_nodes(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         mps_node_ids: List[UUID],
     ) -> List[Dict[str, Any]]:
         """Fetch les MPS nodes avec leurs détails."""
@@ -223,7 +223,7 @@ class CapacityCheckEngine:
     
     def _get_critical_resources(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         mps_nodes: List[Dict[str, Any]],
     ) -> List[Dict[str, Any]]:
         """
@@ -289,7 +289,7 @@ class CapacityCheckEngine:
     
     def _get_base_resource_load(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         resource_id: UUID,
         horizon_start: date,
         horizon_end: date,
@@ -328,7 +328,7 @@ class CapacityCheckEngine:
     
     def _calculate_added_load_from_mps(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         mps_nodes: List[Dict[str, Any]],
         resource_id: UUID,
     ) -> Dict[date, Decimal]:
@@ -367,7 +367,7 @@ class CapacityCheckEngine:
     
     def _get_resource_capacity(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         resource_id: UUID,
         location_id: Optional[UUID],
         horizon_start: date,
@@ -538,7 +538,7 @@ class CapacityCheckEngine:
     
     def _generate_adjustment_suggestions(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         violations: List[CapacityViolation],
         mps_nodes: List[Dict[str, Any]],
     ) -> List[AdjustmentSuggestion]:
@@ -619,7 +619,7 @@ class CapacityCheckEngine:
     
     def _find_next_available_slot(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         mps: Dict[str, Any],
         resource_id: UUID,
         search_from: date,

--- a/src/ootils_core/mps/engine.py
+++ b/src/ootils_core/mps/engine.py
@@ -14,8 +14,7 @@ from decimal import Decimal
 from typing import Any, Dict, List, Optional, Tuple
 from uuid import UUID, uuid4
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.mps.models import MPSStatus
 
 logger = logging.getLogger(__name__)
@@ -133,7 +132,7 @@ class AggregateDemandEngine:
     
     def aggregate(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         item_id: UUID,
         location_id: UUID,
         scenario_id: UUID,
@@ -252,7 +251,7 @@ class AggregateDemandEngine:
     
     def _clear_existing_mps_nodes(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         item_id: UUID,
         location_id: UUID,
         scenario_id: UUID,
@@ -344,7 +343,7 @@ class AggregateDemandEngine:
     
     def _fetch_forecast_demand(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         item_id: UUID,
         location_id: UUID,
         scenario_id: UUID,
@@ -391,7 +390,7 @@ class AggregateDemandEngine:
     
     def _fetch_sales_orders_demand(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         item_id: UUID,
         location_id: UUID,
         scenario_id: UUID,
@@ -489,7 +488,7 @@ class AggregateDemandEngine:
     
     def _upsert_mps_node(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         bucket: TimeBucketDemand,
         item_id: UUID,
         location_id: UUID,
@@ -574,7 +573,7 @@ class AggregateDemandEngine:
     
     def get_mps_nodes_summary(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         item_id: UUID,
         location_id: UUID,
         scenario_id: UUID,
@@ -637,7 +636,7 @@ class AggregateDemandEngine:
     
     def promote_to_mrp(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         mps_id: UUID,
         explode_components: bool = True,
         dry_run: bool = False,
@@ -789,7 +788,7 @@ class AggregateDemandEngine:
     
     def _trigger_mrp_explosion(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         planned_supply_id: UUID,
         item_id: UUID,
         location_id: UUID,

--- a/src/ootils_core/pyramide/hierarchy/bench.py
+++ b/src/ootils_core/pyramide/hierarchy/bench.py
@@ -77,8 +77,6 @@ from decimal import Decimal
 from typing import Mapping, Sequence
 from uuid import UUID
 
-import psycopg
-
 from ..accuracy import bias as accuracy_bias
 from ..accuracy import mase as accuracy_mase
 from ..accuracy import wape as accuracy_wape
@@ -94,6 +92,7 @@ from .reconcile import (
     reconcile,
 )
 from .summing import AGGREGATE, LEAF, SummingBlock, load_summing_blocks
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -312,7 +311,7 @@ def compute_bench_row(
 
 
 def run_reconciliation_bench(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     *,
     domain: str,
     block_level: str | None = None,
@@ -465,7 +464,7 @@ def _validate_bench_params(
 
 
 def _bench_block(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     block: SummingBlock,
     recon_level: str,
     engine: PyramideForecastEngine,
@@ -754,7 +753,7 @@ def _bench_mint_inputs(
 
 
 def _load_daily_by_item(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     leaves: Sequence[str],
     *,
     start: date,

--- a/src/ootils_core/pyramide/hierarchy/runner.py
+++ b/src/ootils_core/pyramide/hierarchy/runner.py
@@ -40,8 +40,6 @@ from types import MappingProxyType
 from typing import Any, Mapping, Sequence
 from uuid import UUID
 
-import psycopg
-
 from ..engines import (
     ForecastComputation,
     PyramideEngineError,
@@ -76,6 +74,7 @@ from .reconcile import (
     reconcile,
 )
 from .summing import AGGREGATE, SeriesRef, SummingBlock, load_summing_blocks
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -187,7 +186,7 @@ class HierarchicalRunner:
         self._engine = forecast_engine or PyramideForecastEngine()
 
     def run(
-        self, db: psycopg.Connection, config: HierarchicalRunConfig
+        self, db: DictRowConnection, config: HierarchicalRunConfig
     ) -> HierarchicalRunResult:
         method = self._validate_config(config)
         # Fail loudly BEFORE any forecast/persist work: an invalid
@@ -365,7 +364,7 @@ class HierarchicalRunner:
 
     @staticmethod
     def _load_block(
-        db: psycopg.Connection, config: HierarchicalRunConfig
+        db: DictRowConnection, config: HierarchicalRunConfig
     ) -> SummingBlock:
         blocks = load_summing_blocks(
             db,
@@ -411,7 +410,7 @@ class HierarchicalRunner:
 
     def _build_mint_inputs(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         block: SummingBlock,
         config: HierarchicalRunConfig,
         method: str,
@@ -491,7 +490,7 @@ class HierarchicalRunner:
 
     def _persist(
         self,
-        db: psycopg.Connection,
+        db: DictRowConnection,
         block: SummingBlock,
         recon: ReconciledBlock,
         recon_refs: Sequence[tuple[int, SeriesRef]],

--- a/src/ootils_core/pyramide/hierarchy/summing.py
+++ b/src/ootils_core/pyramide/hierarchy/summing.py
@@ -43,7 +43,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Iterable, Sequence
 
-import psycopg
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -307,7 +307,7 @@ def _build_block(
 # ---------------------------------------------------------------------------
 
 
-def resolve_default_hierarchy_id(db: psycopg.Connection, domain: str) -> str:
+def resolve_default_hierarchy_id(db: DictRowConnection, domain: str) -> str:
     """
     The is_default hierarchy of a domain (migration 047 registry).
     Fails loudly if the domain has zero or several defaults — the
@@ -334,7 +334,7 @@ def resolve_default_hierarchy_id(db: psycopg.Connection, domain: str) -> str:
 
 
 def load_summing_blocks(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     hierarchy_id: str | None = None,
     domain: str | None = None,
     block_level: str | None = None,

--- a/src/ootils_core/pyramide/repository.py
+++ b/src/ootils_core/pyramide/repository.py
@@ -8,10 +8,10 @@ from decimal import Decimal
 from typing import Sequence
 from uuid import UUID, uuid4
 
-import psycopg
 from psycopg.types.json import Jsonb
 
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID
+from ootils_core.db.types import DictRowConnection
 
 from .accuracy import AccuracyReport
 from .models import PyramideRunResult
@@ -161,7 +161,7 @@ class DemandFreshness:
 
 
 def get_demand_freshness(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     item_id: UUID | None = None,
     warehouse_id: str | None = None,
 ) -> DemandFreshness:
@@ -223,7 +223,7 @@ FRESHNESS_GATE_AGENT_NAME = "pyramide_freshness_gate"
 
 
 def record_stale_demand_finding(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     *,
     run_id: UUID,
     scenario_id: UUID,
@@ -315,7 +315,7 @@ def record_stale_demand_finding(
     return dq_finding_id
 
 
-def resolve_item_uuid(db: psycopg.Connection, external_id: str) -> UUID | None:
+def resolve_item_uuid(db: DictRowConnection, external_id: str) -> UUID | None:
     row = db.execute(
         "SELECT item_id FROM items WHERE external_id = %s AND status != 'obsolete'",
         (external_id,),
@@ -323,7 +323,7 @@ def resolve_item_uuid(db: psycopg.Connection, external_id: str) -> UUID | None:
     return row["item_id"] if row else None
 
 
-def resolve_location_uuid(db: psycopg.Connection, external_id: str) -> UUID | None:
+def resolve_location_uuid(db: DictRowConnection, external_id: str) -> UUID | None:
     row = db.execute(
         "SELECT location_id FROM locations WHERE external_id = %s",
         (external_id,),
@@ -367,7 +367,7 @@ _DEMAND_HISTORY_BUSINESS_PREDICATES = _DEMAND_HISTORY_STREAM_PREDICATES + """
 
 
 def get_historical_demand(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     item_id: UUID,
     location_id: UUID,
     lookback_days: int,
@@ -454,7 +454,7 @@ def get_historical_demand(
 
 
 def get_historical_demand_by_node(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     hierarchy_id: str,
     node_code: str,
     lookback_days: int,
@@ -528,7 +528,7 @@ def get_historical_demand_by_node(
 
 
 def get_historical_demand_by_item(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     item_id: UUID,
     lookback_days: int,
 ) -> list[Decimal]:
@@ -560,7 +560,7 @@ def get_historical_demand_by_item(
 
 
 def get_historical_demand_totals_by_items(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     item_ids: Sequence[UUID],
     lookback_days: int,
 ) -> dict[str, Decimal]:
@@ -652,7 +652,7 @@ def accuracy_metric_rows(
 
 
 def persist_accuracy_metrics(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     run_id: UUID,
     report: AccuracyReport,
     bias_scale: Decimal = _ONE,
@@ -691,7 +691,7 @@ def persist_accuracy_metrics(
 
 
 def fetch_accuracy_metrics(
-    db: psycopg.Connection, run_id: UUID
+    db: DictRowConnection, run_id: UUID
 ) -> list[PyramideAccuracyMetric]:
     """
     Backtest metrics of a run, aggregate row FIRST (horizon NULL), then
@@ -728,7 +728,7 @@ def fetch_accuracy_metrics(
 
 
 def fetch_latest_aggregate_wape(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     *,
     item_id: UUID,
     location_id: UUID,
@@ -770,7 +770,7 @@ def _optional_decimal(value) -> Decimal | None:
 
 
 def persist_run(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     result: PyramideRunResult,
     *,
     stale_demand: bool = False,
@@ -898,7 +898,7 @@ def persist_run(
 
 
 def persist_series_run(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     *,
     scenario_id: UUID,
     horizon_start: date,
@@ -1079,7 +1079,7 @@ def persist_series_run(
     )
 
 
-def fetch_run_summary(db: psycopg.Connection, run_id: UUID) -> PyramideRunSummary | None:
+def fetch_run_summary(db: DictRowConnection, run_id: UUID) -> PyramideRunSummary | None:
     # LEFT JOIN: aggregate runs (migration 053) have no snapshot — their
     # value_count/total come straight from the frozen forecast_values.
     row = db.execute(
@@ -1110,7 +1110,7 @@ def fetch_run_summary(db: psycopg.Connection, run_id: UUID) -> PyramideRunSummar
     return _summary_from_row(row) if row else None
 
 
-def fetch_run_values(db: psycopg.Connection, run_id: UUID) -> list[PyramideForecastValue] | None:
+def fetch_run_values(db: DictRowConnection, run_id: UUID) -> list[PyramideForecastValue] | None:
     run = db.execute(
         "SELECT forecast_id FROM pyramide_runs WHERE run_id = %s",
         (run_id,),
@@ -1138,7 +1138,7 @@ def fetch_run_values(db: psycopg.Connection, run_id: UUID) -> list[PyramideForec
     ]
 
 
-def commit_run(db: psycopg.Connection, run_id: UUID) -> PyramideCommitResult | None:
+def commit_run(db: DictRowConnection, run_id: UUID) -> PyramideCommitResult | None:
     """
     Materialize a LEAF run's frozen values as ForecastDemand graph nodes.
 
@@ -1178,7 +1178,7 @@ def commit_run(db: psycopg.Connection, run_id: UUID) -> PyramideCommitResult | N
 
 
 def list_snapshots(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     item_id: UUID | None = None,
     location_id: UUID | None = None,
     limit: int = 100,
@@ -1208,7 +1208,7 @@ def list_snapshots(
     return [_snapshot_from_row(row) for row in rows]
 
 
-def fetch_snapshot_values(db: psycopg.Connection, snapshot_id: UUID) -> list[PyramideForecastValue] | None:
+def fetch_snapshot_values(db: DictRowConnection, snapshot_id: UUID) -> list[PyramideForecastValue] | None:
     row = db.execute(
         "SELECT forecast_id FROM pyramide_snapshots WHERE snapshot_id = %s",
         (snapshot_id,),
@@ -1286,7 +1286,7 @@ def _snapshot_from_row(row) -> PyramideSnapshotSummary:
     )
 
 
-def _commit_snapshot_to_demand_nodes(db: psycopg.Connection, summary: PyramideRunSummary) -> int:
+def _commit_snapshot_to_demand_nodes(db: DictRowConnection, summary: PyramideRunSummary) -> int:
     """
     LEAF-ONLY materialization contract: only leaf (item, location) series
     ever become ForecastDemand nodes. Aggregate series live exclusively
@@ -1402,7 +1402,7 @@ def _commit_snapshot_to_demand_nodes(db: psycopg.Connection, summary: PyramideRu
 
 
 def _ensure_projection_series_window(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     item_id: UUID,
     location_id: UUID,
     scenario_id: UUID,
@@ -1495,7 +1495,7 @@ def _ensure_projection_series_window(
 
 
 def _wire_demand_node_to_pi(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     demand_node_id: UUID,
     item_id: UUID,
     location_id: UUID,
@@ -1544,7 +1544,7 @@ def _wire_demand_node_to_pi(
 
 
 def _emit_commit_event(
-    db: psycopg.Connection,
+    db: DictRowConnection,
     scenario_id: UUID,
     demand_node_id: UUID,
     quantity: Decimal,

--- a/src/ootils_core/seed/demand/customer_orders.py
+++ b/src/ootils_core/seed/demand/customer_orders.py
@@ -22,8 +22,7 @@ from datetime import date, timedelta
 from decimal import Decimal
 from uuid import UUID, uuid4
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.seed.config import Profile
 from ootils_core.seed.master.items import ItemSet
 from ootils_core.seed.master.locations import LocationSet
@@ -100,7 +99,7 @@ def generate_customer_orders(
     return nodes
 
 
-def insert_customer_orders(conn: psycopg.Connection, nodes: list[OrderNode]) -> int:
+def insert_customer_orders(conn: DictRowConnection, nodes: list[OrderNode]) -> int:
     if not nodes:
         return 0
     ids = [n.node_id for n in nodes]

--- a/src/ootils_core/seed/demand/forecasts.py
+++ b/src/ootils_core/seed/demand/forecasts.py
@@ -30,8 +30,7 @@ from datetime import date
 from decimal import Decimal
 from uuid import UUID, uuid4
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.seed.config import Profile
 from ootils_core.seed.master.items import ItemSet
 from ootils_core.seed.master.locations import LocationSet
@@ -134,7 +133,7 @@ def generate_forecasts(
     return nodes
 
 
-def insert_forecasts(conn: psycopg.Connection, nodes: list[ForecastNode]) -> int:
+def insert_forecasts(conn: DictRowConnection, nodes: list[ForecastNode]) -> int:
     """Bulk-insert forecasts as ForecastDemand nodes."""
     if not nodes:
         return 0

--- a/src/ootils_core/seed/demand/order_history.py
+++ b/src/ootils_core/seed/demand/order_history.py
@@ -26,8 +26,7 @@ from datetime import date, timedelta
 from decimal import Decimal
 from uuid import UUID, uuid4
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.seed.config import Profile
 from ootils_core.seed.master.items import ItemSet
 from ootils_core.seed.master.locations import LocationSet
@@ -145,7 +144,7 @@ def generate_order_history(
 
 
 def insert_order_history(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     nodes: list[HistoricOrderNode],
     batch_size: int = 50_000,
 ) -> int:

--- a/src/ootils_core/seed/master/boms.py
+++ b/src/ootils_core/seed/master/boms.py
@@ -27,8 +27,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from uuid import UUID, uuid4
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.seed.config import Profile
 from ootils_core.seed.master.items import ItemRecord, ItemSet
 
@@ -166,7 +165,7 @@ def generate_boms(profile: Profile, item_set: ItemSet) -> BomSet:
     return BomSet(headers=headers, lines=lines)
 
 
-def insert_boms(conn: psycopg.Connection, bom_set: BomSet) -> tuple[int, int]:
+def insert_boms(conn: DictRowConnection, bom_set: BomSet) -> tuple[int, int]:
     """Bulk-insert headers then lines via UNNEST. Returns (n_headers, n_lines)."""
     # Headers
     h_ids = [h.bom_id for h in bom_set.headers]

--- a/src/ootils_core/seed/master/items.py
+++ b/src/ootils_core/seed/master/items.py
@@ -27,8 +27,7 @@ import random
 from dataclasses import dataclass
 from uuid import UUID, uuid4
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.seed.config import Profile, UomMix
 
 
@@ -131,7 +130,7 @@ def generate_items(profile: Profile) -> ItemSet:
     return ItemSet(by_level=by_level)
 
 
-def insert_items(conn: psycopg.Connection, item_set: ItemSet) -> int:
+def insert_items(conn: DictRowConnection, item_set: ItemSet) -> int:
     """Bulk-insert all items via UNNEST. Returns rowcount."""
     ids = [it.item_id for it in item_set.all]
     names = [it.name for it in item_set.all]

--- a/src/ootils_core/seed/master/locations.py
+++ b/src/ootils_core/seed/master/locations.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from uuid import UUID, uuid4
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.seed.config import Profile
 
 
@@ -56,7 +55,7 @@ def generate_locations(profile: Profile) -> LocationSet:
     return LocationSet(records=records)
 
 
-def insert_locations(conn: psycopg.Connection, loc_set: LocationSet) -> int:
+def insert_locations(conn: DictRowConnection, loc_set: LocationSet) -> int:
     """Bulk-insert all locations via UNNEST. Returns rowcount."""
     ids = [r.location_id for r in loc_set.records]
     names = [r.name for r in loc_set.records]

--- a/src/ootils_core/seed/master/suppliers.py
+++ b/src/ootils_core/seed/master/suppliers.py
@@ -16,8 +16,7 @@ import random
 from dataclasses import dataclass
 from uuid import UUID, uuid4
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.seed.config import Profile
 
 
@@ -126,7 +125,7 @@ def generate_suppliers(profile: Profile) -> SupplierSet:
     return SupplierSet(records=records)
 
 
-def insert_suppliers(conn: psycopg.Connection, sup_set: SupplierSet) -> int:
+def insert_suppliers(conn: DictRowConnection, sup_set: SupplierSet) -> int:
     """Bulk-insert suppliers via UNNEST. Returns rowcount."""
     ids = [r.supplier_id for r in sup_set.records]
     ext_ids = [r.external_id for r in sup_set.records]

--- a/src/ootils_core/seed/network/planning_params.py
+++ b/src/ootils_core/seed/network/planning_params.py
@@ -34,8 +34,7 @@ from datetime import date
 from decimal import Decimal
 from uuid import UUID, uuid4
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.seed.config import Profile
 from ootils_core.seed.master.items import ItemRecord, ItemSet
 from ootils_core.seed.master.locations import LocationRecord, LocationSet
@@ -219,7 +218,7 @@ def generate_planning_params(
 
 
 def insert_planning_params(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     pp_set: PlanningParamSet,
 ) -> int:
     """Bulk-insert item_planning_params via UNNEST."""

--- a/src/ootils_core/seed/network/supplier_items.py
+++ b/src/ootils_core/seed/network/supplier_items.py
@@ -23,8 +23,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from uuid import UUID, uuid4
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.seed.config import Profile
 from ootils_core.seed.master.items import ItemRecord, ItemSet
 from ootils_core.seed.master.suppliers import SupplierRecord, SupplierSet
@@ -164,7 +163,7 @@ def generate_supplier_items(
 
 
 def insert_supplier_items(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     si_set: SupplierItemSet,
 ) -> int:
     """Bulk-insert supplier_items via UNNEST. Returns rowcount."""

--- a/src/ootils_core/seed/projection/calibration.py
+++ b/src/ootils_core/seed/projection/calibration.py
@@ -20,8 +20,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from uuid import UUID
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.kernel.graph.dirty import DirtyFlagManager
 from ootils_core.engine.orchestration.calc_run import CalcRunManager
 from ootils_core.engine.orchestration.propagator_sql import SqlPropagationEngine
@@ -46,7 +45,7 @@ class CalibrationResult:
     total_seconds: float
 
 
-def _measure_shortage_pct(conn: psycopg.Connection) -> tuple[int, int]:
+def _measure_shortage_pct(conn: DictRowConnection) -> tuple[int, int]:
     """Return (pi_with_shortage, pi_total) for the baseline scenario."""
     row = conn.execute(
         """
@@ -63,7 +62,7 @@ def _measure_shortage_pct(conn: psycopg.Connection) -> tuple[int, int]:
     return int(row["short_n"]), int(row["total_n"])
 
 
-def _mark_all_pi_dirty_and_start_run(conn: psycopg.Connection) -> tuple[UUID, set[UUID]]:
+def _mark_all_pi_dirty_and_start_run(conn: DictRowConnection) -> tuple[UUID, set[UUID]]:
     """Create a fresh calc_run, persist all active PIs as dirty under it."""
     # Complete any prior running calc_run on this scenario so the advisory
     # lock can be re-acquired.
@@ -96,7 +95,7 @@ def _mark_all_pi_dirty_and_start_run(conn: psycopg.Connection) -> tuple[UUID, se
     return calc_run.calc_run_id, pi_ids
 
 
-def _scale_on_hand(conn: psycopg.Connection, factor: float) -> int:
+def _scale_on_hand(conn: DictRowConnection, factor: float) -> int:
     """Multiply every OnHandSupply.quantity by `factor`. Returns rowcount."""
     cur = conn.execute(
         """
@@ -111,7 +110,7 @@ def _scale_on_hand(conn: psycopg.Connection, factor: float) -> int:
     return cur.rowcount or 0
 
 
-def _build_sql_engine(conn: psycopg.Connection) -> SqlPropagationEngine:
+def _build_sql_engine(conn: DictRowConnection) -> SqlPropagationEngine:
     from ootils_core.engine.kernel.graph.store import GraphStore
     from ootils_core.engine.kernel.graph.traversal import GraphTraversal
     from ootils_core.engine.kernel.calc.projection import ProjectionKernel
@@ -128,7 +127,7 @@ def _build_sql_engine(conn: psycopg.Connection) -> SqlPropagationEngine:
     )
 
 
-def _run_propagation(conn: psycopg.Connection) -> float:
+def _run_propagation(conn: DictRowConnection) -> float:
     """One full propagation pass on all dirty PIs. Returns wall_seconds."""
     from ootils_core.models import CalcRun
 
@@ -170,7 +169,7 @@ def _run_propagation(conn: psycopg.Connection) -> float:
 
 
 def _bootstrap_oh_from_demand(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     horizon_days: int,
     target_cover_days: int = 30,
 ) -> int:
@@ -255,7 +254,7 @@ def _next_oh_scale(pct: float, target_pct: float, tolerance: float) -> tuple[flo
 
 
 def calibrate(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     target_pct: float = 0.07,
     tolerance: float = 0.02,
     max_iterations: int = 10,

--- a/src/ootils_core/seed/projection/graph.py
+++ b/src/ootils_core/seed/projection/graph.py
@@ -34,8 +34,7 @@ from dataclasses import dataclass
 from datetime import date, timedelta
 from uuid import UUID, uuid4
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.seed.master.items import ItemSet
 from ootils_core.seed.master.locations import LocationSet
 from ootils_core.seed.transactional.nodes import BASELINE_SCENARIO_ID
@@ -67,7 +66,7 @@ class SeededGraph:
 
 
 def seed_projection_graph(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     item_set: ItemSet,
     loc_set: LocationSet,
     horizon_days: int = 90,

--- a/src/ootils_core/seed/transactional/nodes.py
+++ b/src/ootils_core/seed/transactional/nodes.py
@@ -20,8 +20,7 @@ from datetime import date, timedelta
 from decimal import Decimal
 from uuid import UUID, uuid4
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.seed.config import Profile
 from ootils_core.seed.master.items import ItemSet
 from ootils_core.seed.master.locations import LocationSet
@@ -260,7 +259,7 @@ def generate_transactional(
 
 
 def insert_transactional(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     tx_set: TransactionalSet,
 ) -> int:
     """Bulk-insert all four node types in ONE statement via UNNEST."""

--- a/src/ootils_core/staging/approve.py
+++ b/src/ootils_core/staging/approve.py
@@ -35,8 +35,7 @@ import logging
 from dataclasses import dataclass, field
 from uuid import UUID, uuid4
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.staging.diff import (
     DELETION_RATIO_THRESHOLD,
     DiffError,
@@ -122,7 +121,7 @@ _SPECS: dict[str, _ApprovalSpec] = {
 
 
 def approve_batch(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     batch_id: UUID,
     approved_by: str,
     notes: str | None = None,
@@ -308,7 +307,7 @@ def approve_batch(
 
 
 def _load_batch_records(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     batch_id: UUID,
     spec: _ApprovalSpec,
 ) -> dict[str, dict]:
@@ -338,7 +337,7 @@ def _load_batch_records(
 
 
 def _upsert_canonical_rows(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     spec: _ApprovalSpec,
     source_system: str,
     batch_records: dict[str, dict],
@@ -388,7 +387,7 @@ def _upsert_canonical_rows(
 
 
 def _all_soft_delete_targets(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     spec: _ApprovalSpec,
     source_system: str,
     batch_external_ids: set[str],
@@ -411,7 +410,7 @@ def _all_soft_delete_targets(
 
 
 def _soft_delete_missing(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     spec: _ApprovalSpec,
     source_system: str,
     soft_delete_ids: list[str],

--- a/src/ootils_core/staging/diff.py
+++ b/src/ootils_core/staging/diff.py
@@ -32,7 +32,7 @@ import logging
 from dataclasses import dataclass, field
 from uuid import UUID
 
-import psycopg
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -125,7 +125,7 @@ _SPECS: dict[str, _EntitySpec] = {
 # ---------------------------------------------------------------------------
 
 
-def compute_diff(conn: psycopg.Connection, batch_id: UUID) -> DiffResult:
+def compute_diff(conn: DictRowConnection, batch_id: UUID) -> DiffResult:
     """Compute insert/update/soft-delete impact of approving this batch.
 
     Raises:
@@ -183,7 +183,7 @@ def compute_diff(conn: psycopg.Connection, batch_id: UUID) -> DiffResult:
 
 
 def _load_batch_records(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     batch_id: UUID,
     spec: _EntitySpec,
 ) -> dict[str, dict]:
@@ -215,7 +215,7 @@ def _load_batch_records(
 
 
 def _load_canonical_records(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     source_system: str,
     spec: _EntitySpec,
 ) -> dict[str, dict]:

--- a/src/ootils_core/staging/loader.py
+++ b/src/ootils_core/staging/loader.py
@@ -30,8 +30,7 @@ import json
 from dataclasses import dataclass
 from uuid import UUID, uuid4
 
-import psycopg
-
+from ootils_core.db.types import DictRowConnection
 from ootils_core.staging.parser import ParseResult
 
 
@@ -59,7 +58,7 @@ class LoadResult:
 
 
 def load_to_staging(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     parse_result: ParseResult,
     entity_type: str,
     source_system: str,
@@ -162,7 +161,7 @@ def load_to_staging(
 
 
 def _bulk_insert_rows(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     batch_id: UUID,
     parse_result: ParseResult,
 ) -> int:

--- a/src/ootils_core/staging/reject.py
+++ b/src/ootils_core/staging/reject.py
@@ -23,7 +23,7 @@ import logging
 from dataclasses import dataclass
 from uuid import UUID, uuid4
 
-import psycopg
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ class RejectionResult:
 
 
 def reject_batch(
-    conn: psycopg.Connection,
+    conn: DictRowConnection,
     batch_id: UUID,
     rejected_by: str,
     reason: str,


### PR DESCRIPTION
## Campagne mypy — Phase 1/2

Le job CI `mypy (non-blocking)` était rouge sur **770 erreurs / 62 fichiers**. Analyse par catégorie : **556 (72 %) sont une seule cause bénigne** — le type de connexion psycopg non paramétré. Au runtime tout passe par `row_factory=dict_row`, mais ~275 signatures typaient `conn: psycopg.Connection` nu, donc mypy croyait les lignes SQL être des `tuple` et rejetait chaque `row["col"]` (`__getitem__ of "tuple" ... str` [call-overload]).

### Contenu
- **`db/types.py`** (nouveau) : `DictRowConnection = psycopg.Connection[dict[str, Any]]`.
- Appliqué à **77 fichiers** (302 occurrences), variantes `Optional` incluses ; `OotilsDB.conn()` et `get_db()` retournent/yield `DictRowConnection`. Imports `psycopg` orphelins nettoyés (ruff F401).
- **`engine/mrp/loader.py::load_planning_data` laissé volontairement non typé** : réellement polymorphe — les CLIs `mrp_core` (scripts/) passent une connexion tuple-row, l'app/watchers une dict_row (d'où le curseur `tuple_row` interne). Le typer aurait été un mensonge pour la moitié des appelants.

### Résultat
**mypy : 770 → 154 erreurs, `call-overload` 556 → 0** (l'effondrement a aussi nettoyé `attr-defined` 45→8 en cascade). **Zéro changement de comportement** (typage pur) : ruff vert, suite unitaire complète verte (2067 passed).

Le résidu (154 : `arg-type`, `index`, `union-attr`, `.fetchone()` indexés sans garde `None`, …) est la **Phase 2** — et il contient de vraies anomalies désormais visibles, pas seulement du bruit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)