### PR TITLE
ci: make the mypy job blocking (src/ootils_core is clean)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,12 @@ jobs:
         run: ruff check src/
 
   typecheck:
-    name: mypy (non-blocking)
+    name: mypy
     runs-on: ubuntu-latest
-    # Reports type issues without blocking merges. The codebase has untyped
-    # boundaries (psycopg row dicts, dynamic SQL helpers); strict mode is a
-    # future goal. See [tool.mypy] in pyproject.toml.
-    continue-on-error: true
+    # Blocking: src/ootils_core type-checks clean under [tool.mypy] (see
+    # pyproject.toml). The permissive-but-green baseline was reached by the
+    # mypy campaign (PRs #378/#379); this gate keeps it from regressing.
+    # Strict mode remains a future, rule-at-a-time goal.
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Ligne d'arrivée de la campagne mypy

La campagne ([#378](https://github.com/ngoineau/ootils-core/pull/378) typage dict_row, [#379](https://github.com/ngoineau/ootils-core/pull/379) sweep du résidu) a amené `python -m mypy src/ootils_core` de **770 erreurs à 0**. Cette PR retire `continue-on-error` du job mypy et le renomme (plus « non-blocking »), pour que **toute régression de type bloque désormais les merges**.

- Décision de gouvernance validée par le pilote.
- Le mode strict reste un objectif futur, une règle à la fois (cf. `[tool.mypy]`).
- Cette PR ne touche que `.github/workflows/ci.yml` ; le job mypy sur cette PR tourne maintenant en bloquant et doit passer (main est à 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)