### PR TITLE
fix(api): stop leaking exception text via HTTPException detail= (closes #352)

### DIFF
--- a/src/ootils_core/api/routers/dq.py
+++ b/src/ootils_core/api/routers/dq.py
@@ -103,8 +103,8 @@ def run_dq_batch(
         logger.exception("DQ run failed for batch %s: %s", batch_id, exc)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"DQ run failed: {exc}",
-        )
+            detail="DQ run failed.",
+        ) from exc
 
     return DQRunResponse(
         batch_id=result.batch_id,
@@ -359,8 +359,8 @@ def run_agent_batch(
         logger.exception("DQ Agent run failed for batch %s: %s", batch_id, exc)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"DQ Agent run failed: {exc}",
-        )
+            detail="DQ Agent run failed.",
+        ) from exc
 
     return AgentRunResponse(
         run_id=result.run_id,

--- a/src/ootils_core/api/routers/events.py
+++ b/src/ootils_core/api/routers/events.py
@@ -246,11 +246,14 @@ def create_event(
             # The 503 tells the caller to retry; on retry, the event
             # is idempotent because event_id is unique + the engine's
             # F-014 seq-guard skips already-applied writes.
+            # Generic detail — the full exception (possibly raw psycopg text)
+            # is in the logger.error above, never echoed to the client
+            # (CLAUDE.md generic-handler doctrine). event_id is a safe path UUID.
             raise HTTPException(
                 status_code=503,
                 detail=(
-                    f"propagation engine error: {type(exc).__name__}: {exc}. "
-                    "Event {event_id} recorded; retry safe."
+                    f"Propagation engine error. Event {event_id} recorded; "
+                    "retry safe."
                 ),
             ) from exc
 

--- a/src/ootils_core/api/routers/pyramide.py
+++ b/src/ootils_core/api/routers/pyramide.py
@@ -247,6 +247,10 @@ def create_pyramide_run(
     try:
         result = PyramideRunner().run(config, history)
     except PyramideError as exc:
+        # Typed domain-exception carve-out (cf. CLAUDE.md): hand-authored
+        # message from config validation (horizon_days, granularity, method)
+        # or a wrapped forecasting-engine error — both DB-free, no SQL/DSN
+        # can reach this string.
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
 
     # Freshness gate (ADR-023) — measured at ITEM level: the ingest

--- a/src/ootils_core/api/routers/scenarios.py
+++ b/src/ootils_core/api/routers/scenarios.py
@@ -478,9 +478,10 @@ def create_sandbox_scenario(
     except RuntimeError as exc:
         raise _engine_unavailable_response(exc) from exc
     except Exception as exc:  # noqa: BLE001
+        logger.exception("sandbox.fork_scenario_failed name=%s", body.name)
         raise HTTPException(
             status_code=500,
-            detail=f"engine ForkScenario failed: {exc}",
+            detail="engine ForkScenario failed.",
         ) from exc
 
     logger.info(

--- a/src/ootils_core/api/routers/simulate.py
+++ b/src/ootils_core/api/routers/simulate.py
@@ -112,8 +112,8 @@ def create_simulation(
         logger.exception("simulate.create_scenario_failed name=%s", body.scenario_name)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to create scenario: {exc}",
-        )
+            detail="Failed to create scenario.",
+        ) from exc
 
     # Apply overrides
     applied = 0

--- a/src/ootils_core/atp/api.py
+++ b/src/ootils_core/atp/api.py
@@ -178,8 +178,8 @@ async def check_atp_availability(
         logger.exception("ATP calculation failed: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"ATP calculation failed: {str(e)}",
-        )
+            detail="ATP calculation failed.",
+        ) from e
     
     # Build response
     buckets_detail = [_convert_bucket_to_detail(b) for b in result.buckets]

--- a/src/ootils_core/atp/routers.py
+++ b/src/ootils_core/atp/routers.py
@@ -166,8 +166,8 @@ async def check_atp(
         logger.exception("ATP calculation failed: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"ATP calculation failed: {str(e)}",
-        )
+            detail="ATP calculation failed.",
+        ) from e
 
     # Import here to avoid circular dependency
     from ootils_core.atp.api import _convert_bucket_to_detail, _extract_shortage_details
@@ -257,8 +257,8 @@ async def check_ctp(
         logger.exception("CTP check failed: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"CTP check failed: {str(e)}",
-        )
+            detail="CTP check failed.",
+        ) from e
     
     # Build response
     from ootils_core.atp.api import _convert_bucket_to_detail
@@ -360,8 +360,8 @@ async def simulate_ctp(
         logger.exception("CTP simulation failed: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"CTP simulation failed: {str(e)}",
-        )
+            detail="CTP simulation failed.",
+        ) from e
     
     # Find first feasible date
     first_feasible = None

--- a/src/ootils_core/crp/routers.py
+++ b/src/ootils_core/crp/routers.py
@@ -163,8 +163,8 @@ async def calculate_crp(
         logger.exception("CRP calculation failed: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"CRP calculation failed: {str(e)}",
-        )
+            detail="CRP calculation failed.",
+        ) from e
     
     # Convert load profiles to output format
     load_profiles_out: Dict[str, LoadProfileOut] = {}
@@ -259,8 +259,8 @@ async def get_load_profile(
         logger.exception("Failed to get load profile: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to get load profile: {str(e)}",
-        )
+            detail="Failed to get load profile.",
+        ) from e
     
     if profile is None:
         raise HTTPException(
@@ -348,8 +348,8 @@ async def get_overloads(
         logger.exception("Failed to get overloads: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to get overloads: {str(e)}",
-        )
+            detail="Failed to get overloads.",
+        ) from e
     
     # Calculate horizon dates (approximate based on current calculation)
     horizon_start = date.today()
@@ -464,8 +464,8 @@ async def suggest_resolutions(
         logger.exception("Failed to suggest resolutions: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to suggest resolutions: {str(e)}",
-        )
+            detail="Failed to suggest resolutions.",
+        ) from e
     
     horizon_start = date.today()
     horizon_end = horizon_start + timedelta(days=body.horizon_days)

--- a/src/ootils_core/mps/api.py
+++ b/src/ootils_core/mps/api.py
@@ -328,16 +328,20 @@ async def aggregate_demand(
             clear_existing=body.clear_existing,
         )
     except ValueError as e:
+        # Safe: AggregateDemandEngine.aggregate() raises ValueError only from
+        # its own parameter validation (time_grain/forecast_weight/
+        # orders_weight/horizon), before any DB access — psycopg errors are
+        # never ValueError, so no SQL/DSN text can reach this branch.
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=str(e),
-        )
+            detail=f"Invalid aggregation parameters: {e}",
+        ) from e
     except Exception as e:
         logger.exception("mps.aggregate_demand failed: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Aggregation failed: {str(e)}",
-        )
+            detail="Aggregation failed.",
+        ) from e
 
     # 3. Fetch MPS node summaries for response
     mps_summaries = engine.get_mps_nodes_summary(

--- a/tests/test_exception_detail_leak.py
+++ b/tests/test_exception_detail_leak.py
@@ -1,0 +1,259 @@
+"""
+test_exception_detail_leak.py — regression tests for #352.
+
+Asserts the generic-exception carve-out doctrine (CLAUDE.md): broad
+``except Exception`` handlers in routers must NOT echo ``str(e)`` /
+``f"...{exc}..."`` back to the client, because psycopg raises expose raw
+SQL text, table/column/constraint names and sometimes the DSN. The operator
+keeps the full detail via ``logger.exception`` (unchanged); the client only
+gets a stable, generic message.
+
+Each test forces the underlying engine/manager call to raise an exception
+whose message SIMULATES a leaked psycopg error (SQL text + a fake DSN), then
+asserts the HTTP response body contains neither that text nor 'psycopg' /
+'postgresql://'.
+
+No DB is used — ``get_db`` is overridden with a mock, and the exception is
+injected via ``unittest.mock.patch`` on the call the router awaits/invokes.
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("OOTILS_API_TOKEN", "test-token")
+
+from ootils_core.api.app import create_app
+from ootils_core.api.dependencies import get_db
+
+
+AUTH = {"Authorization": "Bearer test-token"}
+
+# A message shaped like a real psycopg / SQL error — if this text (or the
+# generic 'psycopg' / 'postgresql://' markers) ever leaks into a response
+# body, the test fails.
+_FAKE_DB_LEAK = (
+    'relation "nodes" does not exist\n'
+    "LINE 1: SELECT * FROM nodes WHERE id = %s\n"
+    "connection to server at postgresql://ootils:s3cr3t@10.0.0.5:5432/ootils_prod failed: "
+    "psycopg.errors.UndefinedTable"
+)
+
+
+def _make_db_mock() -> MagicMock:
+    conn = MagicMock(name="psycopg_conn")
+    conn.execute.return_value = MagicMock()
+    return conn
+
+
+def _make_client(db_mock: MagicMock) -> TestClient:
+    app = create_app()
+
+    def override_db():
+        yield db_mock
+
+    app.dependency_overrides[get_db] = override_db
+    return TestClient(app)
+
+
+def _assert_no_leak(resp) -> None:
+    body_text = resp.text
+    assert "nodes" not in body_text or "does not exist" not in body_text, (
+        f"raw SQL error text leaked into response: {body_text!r}"
+    )
+    assert _FAKE_DB_LEAK not in body_text
+    assert "psycopg" not in body_text.lower()
+    assert "postgresql://" not in body_text
+    assert "s3cr3t" not in body_text
+
+
+# ─────────────────────────────────────────────────────────────
+# POST /v1/atp/check
+# ─────────────────────────────────────────────────────────────
+
+def test_atp_check_failure_does_not_leak_db_error():
+    db = _make_db_mock()
+    item_uuid = uuid4()
+    location_uuid = uuid4()
+
+    payload = {
+        "item_id": "ITEM-1",
+        "location_id": "LOC-1",
+        "quantity": "10",
+        "requested_date": "2026-08-01",
+        "horizon_days": 30,
+    }
+
+    with patch(
+        "ootils_core.atp.routers._resolve_item_uuid", return_value=item_uuid
+    ), patch(
+        "ootils_core.atp.routers._resolve_location_uuid", return_value=location_uuid
+    ), patch(
+        "ootils_core.atp.routers.ATPEngine.calculate",
+        side_effect=Exception(_FAKE_DB_LEAK),
+    ):
+        client = _make_client(db)
+        resp = client.post("/v1/atp/check", json=payload, headers=AUTH)
+
+    assert resp.status_code == 500, resp.text
+    _assert_no_leak(resp)
+    assert resp.json()["detail"] == "ATP calculation failed."
+
+
+# ─────────────────────────────────────────────────────────────
+# POST /v1/simulate
+# ─────────────────────────────────────────────────────────────
+
+def test_create_simulation_failure_does_not_leak_db_error():
+    db = _make_db_mock()
+
+    payload = {"scenario_name": "what-if-leak-test"}
+
+    with patch(
+        "ootils_core.api.routers.simulate.ScenarioManager.create_scenario",
+        side_effect=Exception(_FAKE_DB_LEAK),
+    ):
+        client = _make_client(db)
+        resp = client.post("/v1/simulate", json=payload, headers=AUTH)
+
+    assert resp.status_code == 500, resp.text
+    _assert_no_leak(resp)
+    assert resp.json()["detail"] == "Failed to create scenario."
+
+
+# ─────────────────────────────────────────────────────────────
+# POST /v1/dq/run/{batch_id}
+# ─────────────────────────────────────────────────────────────
+
+def test_run_dq_batch_failure_does_not_leak_db_error():
+    db = _make_db_mock()
+    batch_id = uuid4()
+
+    cur = MagicMock()
+    cur.fetchone.return_value = {"batch_id": batch_id}
+    db.execute.return_value = cur
+
+    with patch(
+        "ootils_core.api.routers.dq.run_dq",
+        side_effect=Exception(_FAKE_DB_LEAK),
+    ):
+        client = _make_client(db)
+        resp = client.post(f"/v1/dq/run/{batch_id}", headers=AUTH)
+
+    assert resp.status_code == 500, resp.text
+    _assert_no_leak(resp)
+    assert resp.json()["detail"] == "DQ run failed."
+
+
+# ─────────────────────────────────────────────────────────────
+# POST /v1/dq/agent/run/{batch_id}
+# ─────────────────────────────────────────────────────────────
+
+def test_run_agent_batch_failure_does_not_leak_db_error():
+    db = _make_db_mock()
+    batch_id = uuid4()
+
+    cur = MagicMock()
+    cur.fetchone.return_value = {"batch_id": batch_id}
+    db.execute.return_value = cur
+
+    with patch(
+        "ootils_core.engine.dq.agent.run_dq_agent",
+        side_effect=Exception(_FAKE_DB_LEAK),
+    ):
+        client = _make_client(db)
+        resp = client.post(f"/v1/dq/agent/run/{batch_id}", headers=AUTH)
+
+    assert resp.status_code == 500, resp.text
+    _assert_no_leak(resp)
+    assert resp.json()["detail"] == "DQ Agent run failed."
+
+
+# ─────────────────────────────────────────────────────────────
+# POST /v1/crp/calculate
+# ─────────────────────────────────────────────────────────────
+
+def test_crp_calculate_failure_does_not_leak_db_error():
+    db = _make_db_mock()
+
+    payload = {"horizon_days": 90}
+
+    with patch(
+        "ootils_core.crp.routers.CRPEngine.calculate",
+        side_effect=Exception(_FAKE_DB_LEAK),
+    ):
+        client = _make_client(db)
+        resp = client.post("/v1/crp/calculate", json=payload, headers=AUTH)
+
+    assert resp.status_code == 500, resp.text
+    _assert_no_leak(resp)
+    assert resp.json()["detail"] == "CRP calculation failed."
+
+
+# ─────────────────────────────────────────────────────────────
+# Structural guard — the whole doctrine, enforced source-wide
+# ─────────────────────────────────────────────────────────────
+
+import ast  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+import ootils_core  # noqa: E402
+
+_BROAD_EXC_NAMES = {"Exception", "BaseException"}
+
+
+def _handler_is_broad(handler: ast.ExceptHandler) -> bool:
+    """A bare ``except:`` or one catching Exception / BaseException. Narrow
+    named excepts (ValueError, ParamOverlayError, PyramideError, ...) — the
+    documented domain carve-outs — are NOT broad and are never flagged."""
+    t = handler.type
+    if t is None:
+        return True
+    candidates = t.elts if isinstance(t, ast.Tuple) else [t]
+    return any(isinstance(n, ast.Name) and n.id in _BROAD_EXC_NAMES for n in candidates)
+
+
+def _references(node: ast.AST, varname: str) -> bool:
+    return any(isinstance(sub, ast.Name) and sub.id == varname for sub in ast.walk(node))
+
+
+def _detail_echoes(call: ast.Call, varname: str) -> bool:
+    """True if a call has a ``detail=`` kwarg whose value references varname
+    (covers ``str(e)``, ``f"...{e}..."``, ``f"...{str(e)}..."``, bare ``e``)."""
+    return any(kw.arg == "detail" and _references(kw.value, varname) for kw in call.keywords)
+
+
+def _find_broad_except_detail_echoes() -> list[str]:
+    src_root = Path(ootils_core.__file__).resolve().parent
+    violations: list[str] = []
+    for py in src_root.rglob("*.py"):
+        tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
+        for handler in ast.walk(tree):
+            if not isinstance(handler, ast.ExceptHandler) or not _handler_is_broad(handler):
+                continue
+            var = handler.name
+            if var is None:  # bare ``except:`` with no ``as x`` — cannot echo a var
+                continue
+            for node in ast.walk(handler):
+                if isinstance(node, ast.Call) and _detail_echoes(node, var):
+                    violations.append(f"{py.relative_to(src_root.parent)}:{node.lineno}")
+    return violations
+
+
+def test_no_broad_except_echoes_exception_in_http_detail():
+    """Structural regression guard for #352 (like the ADR-021 consistency
+    guard): a broad ``except Exception as e`` must NEVER put the exception into
+    an HTTPException ``detail=`` (``str(e)`` / ``f"...{e}..."``) — psycopg raises
+    expose raw SQL, schema names and sometimes the DSN. To satisfy this, either
+    narrow the except to a named domain exception with a hand-authored safe
+    message (the documented carve-out), or return a generic ``detail`` and keep
+    ``logger.exception``. Narrow named excepts are not flagged."""
+    leaky = _find_broad_except_detail_echoes()
+    assert leaky == [], (
+        "broad-except handlers echo the caught exception into an HTTPException "
+        "detail= (psycopg leak risk — CLAUDE.md generic-handler doctrine): "
+        + ", ".join(leaky)
+    )


### PR DESCRIPTION
## #352 — fuite d'erreurs psycopg via `detail=str(e)`

Des handlers `except Exception as e` larges dans les routers renvoyaient `str(e)`/`f"...{exc}..."` au client. Les erreurs psycopg exposent le SQL brut, les noms de tables/colonnes/contraintes et parfois le DSN — précisément ce que le handler générique d'`api/app.py` masque volontairement. Chaque site **logue déjà** l'exception complète → le fix est un message client générique, l'opérateur garde le détail dans les logs.

### 14 sites génériqués (plus large que la liste initiale de #352 — grep de tout l'arbre)
`atp/routers.py` ×3, `atp/api.py`, `api/routers/{simulate,dq×2,scenarios,events}.py`, `crp/routers.py` ×4, `mps/api.py`. **`events.py` a été raté par les deux greps manuels** (sa f-string est multi-ligne) et attrapé uniquement par la **garde AST** (qui a aussi révélé un bug latent : `{event_id}` dans une string non-f, corrigé).

### Carve-outs vérifiés, laissés intacts
Exceptions de domaine nommées à messages hand-authored (UUID/enum only), ou `except ValueError` de parsing d'input qui ne peut structurellement pas attraper un `psycopg.Error` : `staging.py`, `pyramide.py` (PyramideError — engines/forecasting sans DB ; PyramideAggregateCommitError), `param_overrides.py`, `mps/api.py` (parses date/UUID). Le site `PyramideError` a reçu le commentaire carve-out qui lui manquait.

### Garde anti-régression
`tests/test_exception_detail_leak.py` : 5 tests TestClient forcent une erreur psycopg-shaped et vérifient que la réponse **ne fuit ni le SQL ni `psycopg`/`postgresql://`/le secret DSN** ; **plus une garde structurelle AST** qui échoue si N'IMPORTE quel `except Exception` large renvoie son exception dans un `detail=` (un grep orienté-ligne ne voit pas les f-strings multi-lignes ; l'AST oui).

**mypy 0/163 (bloquant), ruff clean, suite unitaire 2099 passed.**

Closes #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)