### PR TITLE
chore(quality): psycopg.sql WHERE, drop ghosts N+1, docker mem limits (closes #185 #186 #188)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,15 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+    # shared_buffers=1GB above is a hard Postgres allocation at startup, plus
+    # work_mem/maintenance_work_mem headroom for concurrent queries — the
+    # memory limit must clear shared_buffers with margin or Postgres OOMs on
+    # boot. 2g matches the "2 cores / 5-6 GB RAM dev VM" target this tuning
+    # was benchmarked against (see comment above and docs/SCALABILITY.md).
+    deploy:
+      resources:
+        limits:
+          memory: 2g
 
   api:
     build:
@@ -53,6 +62,11 @@ services:
       postgres:
         condition: service_healthy
     command: uvicorn ootils_core.api.app:app --host 0.0.0.0 --port 8000
+    # Demo-scale FastAPI/uvicorn process (single worker, pool max 10 conns).
+    deploy:
+      resources:
+        limits:
+          memory: 512m
 
 volumes:
   postgres_data:

--- a/src/ootils_core/api/routers/ghosts.py
+++ b/src/ootils_core/api/routers/ghosts.py
@@ -15,6 +15,7 @@ from typing import Any, Optional
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from psycopg import sql
 from pydantic import BaseModel, Field, field_validator
 
 from ootils_core.api.auth import require_auth
@@ -324,59 +325,88 @@ def list_ghosts(
     db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> dict[str, Any]:
-    """Return all ghosts filtered by optional ghost_type, scenario_id, status."""
+    """Return all ghosts filtered by optional ghost_type, scenario_id, status.
+
+    Single LEFT JOIN against ghost_members (grouped in Python) instead of an
+    N+1 per-ghost query. Ghosts are grouped by insertion order into a dict
+    keyed by ghost_id, which — for CPython dicts — preserves first-seen
+    order, i.e. the ORDER BY created_at DESC ordering below (no itertools
+    .groupby, which would require contiguous rows per key).
+    """
     params: list[Any] = []
-    where_clauses: list[str] = []
+    conditions: list[sql.Composable] = []
 
     if ghost_type:
-        where_clauses.append("g.ghost_type = %s")
+        conditions.append(sql.SQL("g.ghost_type = %s"))
         params.append(ghost_type)
     if scenario_id:
-        where_clauses.append("g.scenario_id = %s")
+        conditions.append(sql.SQL("g.scenario_id = %s"))
         params.append(scenario_id)
     if ghost_status:
-        where_clauses.append("g.status = %s")
+        conditions.append(sql.SQL("g.status = %s"))
         params.append(ghost_status)
 
-    where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+    where_sql = (
+        sql.SQL("WHERE ") + sql.SQL(" AND ").join(conditions)
+        if conditions
+        else sql.SQL("")
+    )
 
-    ghost_rows = db.execute(
-        f"""
-        SELECT ghost_id, name, ghost_type, scenario_id, resource_id,
-               node_id, status, description, created_at, updated_at
+    query = sql.SQL(
+        """
+        SELECT g.ghost_id, g.name, g.ghost_type, g.scenario_id, g.resource_id,
+               g.node_id, g.status, g.description, g.created_at, g.updated_at,
+               gm.member_id AS member_id, gm.item_id AS member_item_id,
+               gm.role AS member_role,
+               gm.transition_start_date AS member_transition_start_date,
+               gm.transition_end_date AS member_transition_end_date,
+               gm.transition_curve AS member_transition_curve,
+               gm.weight_at_start AS member_weight_at_start,
+               gm.weight_at_end AS member_weight_at_end
         FROM ghost_nodes g
+        LEFT JOIN ghost_members gm ON gm.ghost_id = g.ghost_id
         {where_sql}
-        ORDER BY created_at DESC
-        """,
-        params,
-    ).fetchall()
+        ORDER BY g.created_at DESC
+        """
+    ).format(where_sql=where_sql)
 
-    results = []
-    for g in ghost_rows:
-        members = db.execute(
-            """
-            SELECT member_id, item_id, role,
-                   transition_start_date, transition_end_date,
-                   transition_curve, weight_at_start, weight_at_end
-            FROM ghost_members WHERE ghost_id = %s
-            """,
-            (g["ghost_id"],),
-        ).fetchall()
+    rows = db.execute(query, params or None).fetchall()
 
-        results.append({
-            "ghost_id": str(g["ghost_id"]),
-            "name": g["name"],
-            "ghost_type": g["ghost_type"],
-            "scenario_id": str(g["scenario_id"]) if g["scenario_id"] else None,
-            "resource_id": str(g["resource_id"]) if g["resource_id"] else None,
-            "node_id": str(g["node_id"]) if g["node_id"] else None,
-            "status": g["status"],
-            "description": g["description"],
-            "created_at": g["created_at"].isoformat() if g["created_at"] else None,
-            "updated_at": g["updated_at"].isoformat() if g["updated_at"] else None,
-            "members": [_serialize_member(m) for m in members],
-        })
+    ghosts_by_id: dict[Any, dict[str, Any]] = {}
+    for r in rows:
+        ghost_id = r["ghost_id"]
+        if ghost_id not in ghosts_by_id:
+            ghosts_by_id[ghost_id] = {
+                "ghost_id": str(r["ghost_id"]),
+                "name": r["name"],
+                "ghost_type": r["ghost_type"],
+                "scenario_id": str(r["scenario_id"]) if r["scenario_id"] else None,
+                "resource_id": str(r["resource_id"]) if r["resource_id"] else None,
+                "node_id": str(r["node_id"]) if r["node_id"] else None,
+                "status": r["status"],
+                "description": r["description"],
+                "created_at": r["created_at"].isoformat() if r["created_at"] else None,
+                "updated_at": r["updated_at"].isoformat() if r["updated_at"] else None,
+                "members": [],
+            }
 
+        if r["member_id"] is not None:
+            ghosts_by_id[ghost_id]["members"].append(
+                _serialize_member(
+                    {
+                        "member_id": r["member_id"],
+                        "item_id": r["member_item_id"],
+                        "role": r["member_role"],
+                        "transition_start_date": r["member_transition_start_date"],
+                        "transition_end_date": r["member_transition_end_date"],
+                        "transition_curve": r["member_transition_curve"],
+                        "weight_at_start": r["member_weight_at_start"],
+                        "weight_at_end": r["member_weight_at_end"],
+                    }
+                )
+            )
+
+    results = list(ghosts_by_id.values())
     return {"ghosts": results, "total": len(results)}
 
 

--- a/src/ootils_core/api/routers/planning_params.py
+++ b/src/ootils_core/api/routers/planning_params.py
@@ -9,6 +9,7 @@ from uuid import UUID
 from decimal import Decimal
 
 from fastapi import APIRouter, Depends, Query
+from psycopg import sql
 from pydantic import BaseModel
 
 from ootils_core.api.auth import require_auth
@@ -45,28 +46,32 @@ def get_planning_params(
     """Return the latest active planning parameters per (item, location)."""
     # Build query — get most recent params per (item_id, location_id)
     # Uses effective_to IS NULL to get active/current records (SCD2 pattern)
-    conditions = [
-        "(ipp.effective_to IS NULL OR ipp.effective_to = '9999-12-31'::DATE)"
+    conditions: list[sql.Composable] = [
+        sql.SQL("(ipp.effective_to IS NULL OR ipp.effective_to = '9999-12-31'::DATE)")
     ]
     params: list = []
 
     if item_id:
         try:
-            conditions.append("ipp.item_id = %s")
-            params.append(UUID(item_id))
+            parsed_item_id = UUID(item_id)
         except ValueError:
             pass
+        else:
+            conditions.append(sql.SQL("ipp.item_id = %s"))
+            params.append(parsed_item_id)
 
     if location_id:
         try:
-            conditions.append("ipp.location_id = %s")
-            params.append(UUID(location_id))
+            parsed_location_id = UUID(location_id)
         except ValueError:
             pass
+        else:
+            conditions.append(sql.SQL("ipp.location_id = %s"))
+            params.append(parsed_location_id)
 
-    where = " AND ".join(conditions)
-    rows = db.execute(
-        f"""
+    where = sql.SQL(" AND ").join(conditions)
+    query = sql.SQL(
+        """
         SELECT ipp.item_id,
                ipp.location_id,
                ipp.safety_stock_qty,
@@ -78,9 +83,9 @@ def get_planning_params(
         FROM item_planning_params ipp
         WHERE {where}
         ORDER BY ipp.item_id, ipp.location_id
-        """,
-        params or None,
-    ).fetchall()
+        """
+    ).format(where=where)
+    rows = db.execute(query, params or None).fetchall()
 
     result = [
         PlanningParamsOut(

--- a/tests/integration/test_router_ghosts_integration.py
+++ b/tests/integration/test_router_ghosts_integration.py
@@ -441,6 +441,170 @@ class TestListGhostsEndpoint:
                 conn.commit()
 
 
+class TestListGhostsJoinAndOrdering:
+    """Non-regression for #188 (N+1 -> single LEFT JOIN) and #185 (psycopg.sql
+    WHERE composition): a ghost with 2 members, a ghost with 0 members, and a
+    3rd ghost used only for the scenario_id/status filter assertions. Verifies
+    created_at DESC ordering, correct member grouping (including the
+    zero-member LEFT JOIN case), and that the composed WHERE still filters
+    correctly on ghost_type / scenario_id / status.
+    """
+
+    def test_list_ghosts_join_grouping_and_order(self, api_client, auth, seeded_db):
+        import time
+
+        import psycopg
+        from psycopg.rows import dict_row
+
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            pump_id, valve_id = _seed_item_uuids(conn)
+
+        suffix = uuid4().hex[:6]
+        name_first = f"g_join_a_{suffix}"       # created first -> should sort LAST
+        name_no_members = f"g_join_b_{suffix}"  # created second, 0 members
+        name_last = f"g_join_c_{suffix}"        # created last -> should sort FIRST
+
+        try:
+            r1 = api_client.post(
+                "/v1/ingest/ghosts",
+                json={
+                    "name": name_first,
+                    "ghost_type": "capacity_aggregate",
+                    "members": [
+                        {"item_id": pump_id, "role": "member"},
+                        {"item_id": valve_id, "role": "member"},
+                    ],
+                },
+                headers=auth,
+            )
+            assert r1.status_code == 201, r1.text
+            ghost_id_first = r1.json()["ghost_id"]
+
+            # created_at has TIMESTAMPTZ precision; force ordering apart.
+            time.sleep(1.1)
+
+            r2 = api_client.post(
+                "/v1/ingest/ghosts",
+                json={
+                    "name": name_no_members,
+                    "ghost_type": "capacity_aggregate",
+                },
+                headers=auth,
+            )
+            assert r2.status_code == 201, r2.text
+            ghost_id_no_members = r2.json()["ghost_id"]
+            assert r2.json()["member_count"] == 0
+
+            time.sleep(1.1)
+
+            r3 = api_client.post(
+                "/v1/ingest/ghosts",
+                json={
+                    "name": name_last,
+                    "ghost_type": "capacity_aggregate",
+                    "members": [{"item_id": pump_id, "role": "member"}],
+                },
+                headers=auth,
+            )
+            assert r3.status_code == 201, r3.text
+            ghost_id_last = r3.json()["ghost_id"]
+
+            resp = api_client.get(
+                "/v1/ghosts",
+                params={"ghost_type": "capacity_aggregate"},
+                headers=auth,
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+
+            ids_in_order = [g["ghost_id"] for g in body["ghosts"]]
+            our_ids_in_order = [
+                gid for gid in ids_in_order
+                if gid in (ghost_id_first, ghost_id_no_members, ghost_id_last)
+            ]
+            # created_at DESC -> most recently inserted ghost appears first.
+            assert our_ids_in_order == [ghost_id_last, ghost_id_no_members, ghost_id_first]
+
+            by_id = {g["ghost_id"]: g for g in body["ghosts"]}
+
+            g_no_members = by_id[ghost_id_no_members]
+            assert g_no_members["members"] == []
+
+            g_first = by_id[ghost_id_first]
+            assert len(g_first["members"]) == 2
+            assert {m["item_id"] for m in g_first["members"]} == {pump_id, valve_id}
+            for m in g_first["members"]:
+                assert m["role"] == "member"
+                assert m["member_id"] is not None
+
+            g_last = by_id[ghost_id_last]
+            assert len(g_last["members"]) == 1
+            assert g_last["members"][0]["item_id"] == pump_id
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                for n in (name_first, name_no_members, name_last):
+                    _cleanup_ghost(conn, n)
+                conn.commit()
+
+    def test_list_ghosts_filters_scenario_id_and_status(self, api_client, auth, seeded_db):
+        """WHERE composed via psycopg.sql still filters correctly on
+        scenario_id AND status combined (multi-condition AND join)."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+            pump_id, _ = _seed_item_uuids(conn)
+
+        scenario_id = "00000000-0000-0000-0000-000000000001"  # baseline, always present
+        name = f"g_filt_{uuid4().hex[:6]}"
+        try:
+            r_ins = api_client.post(
+                "/v1/ingest/ghosts",
+                json={
+                    "name": name,
+                    "ghost_type": "capacity_aggregate",
+                    "scenario_id": scenario_id,
+                    "status": "draft",
+                    "members": [{"item_id": pump_id, "role": "member"}],
+                },
+                headers=auth,
+            )
+            assert r_ins.status_code == 201, r_ins.text
+            ghost_id = r_ins.json()["ghost_id"]
+
+            # Matches all three conditions (ghost_type AND scenario_id AND status).
+            resp = api_client.get(
+                "/v1/ghosts",
+                params={
+                    "ghost_type": "capacity_aggregate",
+                    "scenario_id": scenario_id,
+                    "ghost_status": "draft",
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 200
+            ids = [g["ghost_id"] for g in resp.json()["ghosts"]]
+            assert ghost_id in ids
+
+            # Same filters but status='active' -> our draft ghost must NOT match.
+            resp_wrong_status = api_client.get(
+                "/v1/ghosts",
+                params={
+                    "ghost_type": "capacity_aggregate",
+                    "scenario_id": scenario_id,
+                    "ghost_status": "active",
+                },
+                headers=auth,
+            )
+            assert resp_wrong_status.status_code == 200
+            ids_wrong_status = [g["ghost_id"] for g in resp_wrong_status.json()["ghosts"]]
+            assert ghost_id not in ids_wrong_status
+        finally:
+            with psycopg.connect(seeded_db, row_factory=dict_row) as conn:
+                _cleanup_ghost(conn, name)
+                conn.commit()
+
+
 # ---------------------------------------------------------------------------
 # GET /v1/ghosts/{ghost_id} (detail)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Lot de dette qualité — 3 issues, comportement préservé

### #185 — WHERE en `psycopg.sql` (hygiène anti-injection)
`ghosts.py::list_ghosts` et `planning_params.py::get_planning_params` construisaient leur WHERE par `" AND ".join(...)` + f-string. Migré vers `psycopg.sql` composable (fragments `sql.SQL`, `sql.SQL(" AND ").join`, `.format()`), aligné sur `scenarios.py`. Les valeurs étaient déjà en `%s` (pas de faille active) — c'est de l'hygiène, injection-proof par construction. Bonus : corrigé un travers latent dans planning_params (la condition était `append`ée dans le `try/except` du parse UUID → désormais seulement après parse réussi).

### #188 — N+1 dans `list_ghosts` → un seul LEFT JOIN
Une requête `SELECT ... FROM ghost_members WHERE ghost_id=%s` **par ghost** → **une** requête `LEFT JOIN ghost_members`, regroupée en Python via un dict keyé par ghost_id (préserve `created_at DESC` par ordre d'insertion CPython ; pas de `groupby` qui exigerait des lignes contiguës). Ghost sans membre → `members: []`. `_serialize_member` inchangée.

### #186 — limites mémoire docker-compose
`api: 512m`, `postgres: 2g`. **Pas le `512m` suggéré pour postgres** : le compose fixe déjà `shared_buffers=1GB` → un cap 512m ferait OOM Postgres au boot ; 2g couvre `shared_buffers` + `work_mem` de pointe.

### Vérifs
`TestListGhostsJoinAndOrdering` (intégration) : 3 ghosts (2/0/1 membres) → ordre `created_at DESC`, `members: []` pour le ghost sans membre, contenu membre correct, filtre WHERE multi-AND composé. **mypy 0/163 (bloquant), ruff clean, suite unitaire 2099 passed, `docker compose config` valide.**

Closes #185, #186, #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)