### PR TITLE
feat(mrp): canonical receipt-vs-need comparison — reschedule signals + FPO loading (#346 PR-A)

### DIFF
--- a/scripts/mrp_core.py
+++ b/scripts/mrp_core.py
@@ -16,9 +16,12 @@ from ootils_core.engine.mrp.core import (
     _spread_period,
     apply_lot_rule,
     PlanningData,
+    ReceiptOrder,
+    RescheduleSignal,
     consume_demand,
     run_timephased,
     first_shortage,
+    reschedule_signals,
     excess_obsolete,
     peg_origins,
 )

--- a/src/ootils_core/db/migrations/061_reschedule_and_fpo.sql
+++ b/src/ootils_core/db/migrations/061_reschedule_and_fpo.sql
@@ -1,0 +1,160 @@
+-- ============================================================
+-- Migration 061 — Reschedule messages + Firm Planned Orders + dampening (#346)
+-- ============================================================
+-- Chantier #346 foundation. ADR-026 (à venir) : "Reschedule action
+-- messages, Firm Planned Orders (FPO) and message dampening".
+--
+-- Three coordinated schema additions, all baseline-safe and idempotent:
+--
+--   (a) nodes.is_firm — the Firm Planned Order flag. A PlannedSupply with
+--       is_firm=TRUE is EXCLUDED from the MRP full-regeneration purge
+--       (engine/mrp/graph_integration.py:cleanup_previous_run, run_id=None
+--       scope: "firmed orders must survive this purge", already
+--       anticipated in the code comments) and is treated as a CLOSED /
+--       committed receipt in netting (gross-to-net counts it as scheduled
+--       supply, not a re-plannable planned order). It stays RE-DATABLE by a
+--       reschedule message — that is precisely the APICS point of an FPO:
+--       the planner (or a governed agent reco) owns its date, MRP no longer
+--       regenerates it, but a RESCHEDULE_IN/OUT can still move it. Only a
+--       tiny minority of PlannedSupply rows are firmed, hence a PARTIAL
+--       index (WHERE is_firm) rather than a full index.
+--
+--   (b) recommendations — extend the governed action state machine
+--       (migration 039) with the reschedule/defer/cancel vocabulary and
+--       add the three typed columns that carry a reschedule message
+--       (target node + current date + proposed date). All three are NULL
+--       for the existing EXPEDITE/ORDER_* actions (which reference no
+--       specific supply node), populated for RESCHEDULE_*/DEFER/CANCEL.
+--
+--   (c) item_planning_params — dampening thresholds (anti message-storm):
+--       don't disturb the planner for a sub-threshold date/qty nudge.
+--
+-- Idempotence (repo migration policy: a re-run marked "already exists" is
+-- recorded as applied, so every statement must be safe to replay):
+--   * ADD COLUMN IF NOT EXISTS              — no-op on re-run.
+--   * CREATE INDEX IF NOT EXISTS            — no-op on re-run.
+--   * DROP CONSTRAINT IF EXISTS + ADD       — deterministic re-create (the
+--     only safe way to WIDEN a CHECK; PG has no ALTER CONSTRAINT for CHECK).
+-- No JSONB. Typed columns only.
+--
+-- SCD2 / GENERATED note: item_planning_params (migration 007) is a SCD2
+-- table (effective_from/to, a btree_gist EXCLUDE constraint on
+-- (item_id, location_id, daterange), and a GENERATED ALWAYS STORED column
+-- lead_time_total_days). ADD COLUMN ... DEFAULT is safe here: the new
+-- columns are not referenced by the generated expression nor by the
+-- exclusion constraint, so no version row is invalidated and no GiST
+-- recheck is triggered. The DEFAULT backfills every existing SCD2 version
+-- row (all historical + current) uniformly, which is the intended
+-- behaviour for a newly-introduced planning threshold.
+--
+-- Scenario overlay note (#347): reschedule_min_days /
+-- reschedule_qty_tolerance_pct are DELIBERATELY NOT added to the
+-- scenario_planning_overrides whitelist (migration 060). Forkability of
+-- the dampening thresholds is a deferred V2 refinement — what actually
+-- shifts need-dates inside a fork (lead times, safety stock) is ALREADY
+-- forkable through the overlay, which is the substance. These two knobs
+-- stay baseline-only for this V1.
+-- ============================================================
+
+BEGIN;
+
+-- ------------------------------------------------------------
+-- (a) Firm Planned Order flag on nodes
+-- ------------------------------------------------------------
+ALTER TABLE nodes ADD COLUMN IF NOT EXISTS is_firm BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN nodes.is_firm IS
+    'Firm Planned Order flag (#346). TRUE on a PlannedSupply node means: '
+    'excluded from the MRP full-regeneration purge (cleanup_previous_run) '
+    'and netted as a CLOSED/committed receipt, but still re-datable by a '
+    'RESCHEDULE_IN/OUT message. FALSE (default) = ordinary re-generatable '
+    'planned order. Only meaningful for node_type=PlannedSupply.';
+
+-- FPOs are a small minority of PlannedSupply rows → partial index, matching
+-- the scenario-scoped (scenario_id, item_id) lookup the netting/reschedule
+-- passes use to find firmed supply.
+CREATE INDEX IF NOT EXISTS idx_nodes_firm
+    ON nodes (scenario_id, item_id)
+    WHERE is_firm;
+
+-- ------------------------------------------------------------
+-- (b) Governed recommendation actions: reschedule/defer/cancel vocabulary
+-- ------------------------------------------------------------
+-- The action CHECK created in migration 039 is an inline single-column
+-- constraint (action TEXT NOT NULL CHECK (action IN (...))), so Postgres
+-- auto-named it 'recommendations_action_check' (<table>_<column>_check).
+-- Widen it: keep the three existing actions, add the #346 reschedule set.
+-- DEFER/CANCEL apply to an existing (planned or firm) supply node;
+-- RESCHEDULE_IN pulls a receipt earlier, RESCHEDULE_OUT pushes it later.
+-- Keep this list in sync with the VALID action vocabulary in the agent /
+-- recommendation code (scripts/agent_governance.py:decision_level and the
+-- recommendation writers).
+ALTER TABLE recommendations DROP CONSTRAINT IF EXISTS recommendations_action_check;
+ALTER TABLE recommendations ADD CONSTRAINT recommendations_action_check CHECK (
+    action IN (
+        'EXPEDITE', 'ORDER_RUSH', 'ORDER_NOW',
+        'DEFER', 'CANCEL', 'RESCHEDULE_IN', 'RESCHEDULE_OUT'
+    )
+);
+
+-- Reschedule-message payload: which supply node, its current date, the
+-- engine-proposed date. NULL for the existing order/expedite actions.
+--
+-- target_node_id FK policy: REFERENCES nodes(node_id) ON DELETE SET NULL,
+-- nullable.
+--   * A hard FK to nodes(node_id) is the house pattern (edges, events,
+--     explanations, shortages all declare one — migrations 002/004/005).
+--   * nodes are SOFT-deleted in normal operation (active=FALSE, never a
+--     hard DELETE — see graph_integration.py cleanup_previous_run), so the
+--     ON DELETE branch is a safety net, not a live path.
+--   * ON DELETE SET NULL (not the default RESTRICT, not CASCADE) is the
+--     right semantics for an audit message: if the target supply node is
+--     ever genuinely hard-deleted, the recommendation must SURVIVE as an
+--     audit record (its current_receipt_date / proposed_date / item_id
+--     still carry the message) with a dangling target nulled out — it must
+--     neither block the delete (RESTRICT) nor be destroyed (CASCADE).
+ALTER TABLE recommendations
+    ADD COLUMN IF NOT EXISTS target_node_id       UUID REFERENCES nodes(node_id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS current_receipt_date DATE,
+    ADD COLUMN IF NOT EXISTS proposed_date        DATE;
+
+COMMENT ON COLUMN recommendations.target_node_id IS
+    'PlannedSupply/FPO node this reschedule message targets (#346). NULL '
+    'for EXPEDITE/ORDER_* (no specific target node). ON DELETE SET NULL: '
+    'the reco survives as an audit record if the node is hard-deleted.';
+COMMENT ON COLUMN recommendations.current_receipt_date IS
+    'Current receipt date of the targeted order (#346). NULL for '
+    'EXPEDITE/ORDER_* actions.';
+COMMENT ON COLUMN recommendations.proposed_date IS
+    'Engine-proposed new receipt date for the targeted order (#346). NULL '
+    'for EXPEDITE/ORDER_* actions.';
+
+-- Reschedule messages are looked up by their target node (e.g. "is there a
+-- pending reschedule on this FPO?"); partial index keeps it lean.
+CREATE INDEX IF NOT EXISTS ix_reco_target_node
+    ON recommendations (target_node_id)
+    WHERE target_node_id IS NOT NULL;
+
+-- ------------------------------------------------------------
+-- (c) Dampening thresholds on item_planning_params (baseline-only, #346)
+-- ------------------------------------------------------------
+-- Below reschedule_min_days of date movement OR within
+-- reschedule_qty_tolerance_pct of quantity change, no message is emitted —
+-- the planner is not disturbed by nervous, sub-material nudges. Domain
+-- CHECKs match the >= 0 style of the other item_planning_params thresholds.
+ALTER TABLE item_planning_params
+    ADD COLUMN IF NOT EXISTS reschedule_min_days INTEGER NOT NULL DEFAULT 3
+        CHECK (reschedule_min_days >= 0),
+    ADD COLUMN IF NOT EXISTS reschedule_qty_tolerance_pct NUMERIC(6,2) NOT NULL DEFAULT 5.0
+        CHECK (reschedule_qty_tolerance_pct >= 0);
+
+COMMENT ON COLUMN item_planning_params.reschedule_min_days IS
+    'Dampening (#346): minimum receipt-date movement in days before a '
+    'reschedule message is emitted. Below this, no message. Baseline-only '
+    '(not in the #347 scenario overlay whitelist for V1).';
+COMMENT ON COLUMN item_planning_params.reschedule_qty_tolerance_pct IS
+    'Dampening (#346): quantity-change tolerance in percent before a '
+    'reschedule message is emitted. Within this band, no message. '
+    'Baseline-only (not in the #347 scenario overlay whitelist for V1).';
+
+COMMIT;

--- a/src/ootils_core/engine/mrp/core.py
+++ b/src/ootils_core/engine/mrp/core.py
@@ -16,6 +16,20 @@ SUPPLY_TYPES = ["OnHandSupply", "PurchaseOrderSupply", "TransferSupply"]
 FIRM_RECEIPT_TYPES = ["PurchaseOrderSupply", "WorkOrderSupply", "TransferSupply"]
 DEMAND_TYPES = ["CustomerOrderDemand", "ForecastDemand"]
 
+# Reschedule dampening defaults — mirror the item_planning_params column
+# DEFAULTs (migration 061): don't emit a message for a sub-material date/qty
+# nudge. Used when an item carries no explicit per-item threshold.
+DEFAULT_RESCHEDULE_MIN_DAYS = 3
+DEFAULT_RESCHEDULE_QTY_TOLERANCE_PCT = 5.0
+
+# Reschedule actions the core emits (#346 PR-A). DEFER is in the migration-061
+# CHECK vocabulary but is DELIBERATELY not produced here: it is reserved for
+# manual/agent use (a planner choosing to push an order without a computed
+# need-date). The deterministic core only emits the three data-driven actions.
+RESCHEDULE_IN = "RESCHEDULE_IN"
+RESCHEDULE_OUT = "RESCHEDULE_OUT"
+CANCEL = "CANCEL"
+
 
 def lot_size(qty, moq, mult):
     """MOQ floor + order-multiple rounding (final guard applied to every rule)."""
@@ -83,6 +97,50 @@ def apply_lot_rule(rule, shortfall, pa, ss, netreq, t, P, eoq, maxoq, moq, mult,
     return q
 
 
+@dataclass(frozen=True)
+class ReceiptOrder:
+    """A single closed/firm receipt with its identity preserved (#346).
+
+    Unlike PlanningData.sched_b (which pre-aggregates receipts into weekly
+    buckets and so LOSES the per-order identity), a ReceiptOrder keeps the
+    (node_id, receipt_date, qty) triple so the reschedule pass can propose a
+    new date for THIS specific order. is_firm distinguishes a firmed planned
+    order (FPO) from an ordinary closed receipt; node_type is retained for
+    downstream message attribution.
+    """
+
+    node_id: str
+    item_id: str
+    receipt_date: _dt.date
+    qty: float
+    is_firm: bool
+    node_type: str
+
+
+@dataclass(frozen=True)
+class RescheduleSignal:
+    """A dampened reschedule action message for one receipt (#346 PR-A).
+
+    action is one of RESCHEDULE_IN / RESCHEDULE_OUT / CANCEL. proposed_date is
+    None for CANCEL (no new date — the whole receipt is surplus). qty is the
+    receipt's own quantity; the message targets the receipt as a unit (V1 does
+    not split a receipt).
+
+    node_type / is_firm are carried through verbatim from the source
+    ReceiptOrder so PR-B (governed emission + decision_level) can attribute the
+    message to the right supply kind without re-fetching the node.
+    """
+
+    node_id: str
+    item_id: str
+    action: str
+    current_receipt_date: _dt.date
+    proposed_date: _dt.date | None
+    qty: float
+    node_type: str
+    is_firm: bool
+
+
 @dataclass
 class PlanningData:
     horizon_start: _dt.date
@@ -115,6 +173,13 @@ class PlanningData:
     co_b: dict = field(default_factory=dict)
     fc_b: dict = field(default_factory=dict)
     sched_b: dict = field(default_factory=dict)
+    # Per-item list of closed/firm receipts WITH identity (#346). Parallel to
+    # sched_b (the bucket aggregate kept for projection); reschedule uses this.
+    sched_orders: dict = field(default_factory=dict)
+    # Dampening thresholds (baseline-only, migration 061). Missing key => the
+    # module DEFAULT_* is used by reschedule_signals.
+    resched_min_days: dict = field(default_factory=dict)
+    resched_qty_tol_pct: dict = field(default_factory=dict)
     involved: set = field(default_factory=set)
     by_level: dict = field(default_factory=dict)
     max_llc: int = 0
@@ -253,6 +318,158 @@ def first_shortage(d: PlanningData, gross: dict) -> dict:
                              "deficit": ss - pa, "balance": pa}
                 break
     return out
+
+
+def _need_bucket_for_receipts(
+    orders: list[ReceiptOrder], on_hand: float, ss: float, g: dict, n_buckets: int
+) -> dict[str, int | None]:
+    """Derive a NEED BUCKET for each firm receipt of one item (#346, PURE).
+
+    Convention (single source of the need-date semantics): walk weekly buckets
+    forward on a running projected-on-hand balance. Start at on_hand. Each
+    bucket subtracts that bucket's consumed independent demand (g). Safety stock
+    is a floor: the balance must stay at or above ss, so a requirement appears as
+    soon as the balance (before applying receipts) would fall below ss.
+
+    Receipts are matched to requirements FIFO by their OWN date (earliest receipt
+    covers the earliest requirement). The need bucket of a receipt is the bucket
+    where the CENTRE OF GRAVITY of its own consumption sits — precisely the
+    bucket at which the cumulative quantity allocated to that receipt first
+    reaches 50% of the receipt quantity (its median / median-unit bucket). This
+    is deliberately NOT the first requirement the receipt marginally touches: a
+    receipt of 200 that covers 10 @wk1 + 190 @wk10 has its median unit consumed
+    at wk10, so its need bucket is wk10 — proposing to pull all 200 units to wk1
+    (56 days early for 190 of them) would be over-eager. The median rule dates
+    the order by where the bulk of it is actually pulled.
+
+    A receipt whose quantity is never pulled at all (all demand already covered
+    by on-hand + earlier receipts) has need bucket None => CANCEL candidate.
+
+    Returns {node_id: need_bucket or None}. Deterministic: receipts are sorted by
+    (receipt_date, node_id) so ties never depend on input ordering, and the 50%
+    crossing uses a fixed tolerance.
+    """
+    ordered = sorted(orders, key=lambda o: (o.receipt_date, o.node_id))
+    # Cumulative demand requirement (net of on-hand + safety) per bucket. balance
+    # walks down; each bucket's shortfall below ss is a requirement quantity that
+    # must be met at that bucket.
+    requirements: list[tuple[int, float]] = []
+    balance = on_hand
+    for t in range(n_buckets):
+        balance -= g.get(t, 0.0)
+        if balance < ss:
+            requirements.append((t, ss - balance))
+            balance = ss  # requirement is deemed met; keep walking for later ones
+    # FIFO allocation: consume requirement quantity with receipts in date order.
+    # For each receipt track its allocated-so-far running total; its need bucket
+    # is the requirement bucket at which that total first reaches half its qty.
+    need: dict[str, int | None] = {o.node_id: None for o in ordered}
+    ri = 0
+    remaining = requirements[ri][1] if requirements else 0.0
+    for o in ordered:
+        supply = o.qty
+        allocated = 0.0
+        half = o.qty / 2.0
+        while supply > 0 and ri < len(requirements):
+            req_bucket = requirements[ri][0]
+            take = min(supply, remaining)
+            if take > 0:
+                allocated += take
+                # Median-unit rule: the need bucket is where cumulative
+                # allocation first covers 50% of the receipt (centre of gravity).
+                if need[o.node_id] is None and allocated >= half - 1e-9:
+                    need[o.node_id] = req_bucket
+            supply -= take
+            remaining -= take
+            if remaining <= 1e-9:
+                ri += 1
+                remaining = requirements[ri][1] if ri < len(requirements) else 0.0
+    return need
+
+
+def reschedule_signals(d: PlanningData, gross: dict) -> list[RescheduleSignal]:
+    """Canonical receipt-vs-need comparison (#346 PR-A). PURE, DB-free.
+
+    For every item with firm receipts (d.sched_orders), derive each receipt's
+    NEED DATE from the time-phased projection (see _need_bucket_for_receipts),
+    compare it to the receipt's current date, and emit a DAMPENED action message:
+
+      RESCHEDULE_IN  — receipt arrives AFTER its need date (pull it earlier).
+      RESCHEDULE_OUT — receipt arrives BEFORE its need date (push it later to
+                       free stock/cash).
+      CANCEL         — receipt has no matching need on the horizon (surplus).
+
+    Dampening (mandatory, anti message-storm):
+      * a RESCHEDULE is emitted only if |proposed - current| >= reschedule_min_days.
+      * a CANCEL is emitted for any firm receipt that is ENTIRELY surplus
+        (need bucket None) — with a horizon-edge guard (see below). V1 does NOT
+        apply reschedule_qty_tolerance_pct to CANCEL: a receipt that reaches the
+        CANCEL branch is 100% surplus by construction, so a graded quantity
+        tolerance is meaningless without splitting the receipt. The threshold is
+        RESERVED for the V2 partial-split path (emit a CANCEL only for the
+        surplus fraction of a partially-needed receipt); it is intentionally a
+        no-op in V1. Not pretending a graded semantics that does not exist.
+
+    Horizon-edge CANCEL guard (anti false-positive): a receipt landing in the
+    LAST bucket of the loaded horizon is NEVER cancelled even when it has no
+    matching need. The demand that justifies it may simply sit just beyond the
+    loaded window (visibility, not surplus): cancelling on incomplete horizon
+    visibility is unsafe. One bucket (~1 week) of margin is the V1 threshold —
+    the minimum that removes the boundary artefact without masking a genuine
+    surplus that sits well inside the horizon.
+
+    THE CENTRAL INVARIANT: re-running on unchanged data emits ZERO signals — a
+    receipt already on (or within dampening of) its need date produces no message.
+    Stability is the goal.
+
+    Deterministic: items and, within an item, receipts are processed in a stable
+    sorted order; the returned list is sorted by (item_id, node_id).
+
+    DEFER is not emitted (reserved for manual/agent use — see module constants).
+    """
+    signals: list[RescheduleSignal] = []
+    # Receipts at or past this bucket are on the horizon edge: no CANCEL there
+    # (their justifying demand may fall just beyond the loaded window).
+    cancel_cutoff_bucket = d.n_buckets - 1
+    for item in sorted(d.sched_orders):
+        orders = d.sched_orders.get(item) or []
+        if not orders:
+            continue
+        on_hand = float(d.on_hand.get(item, 0) or 0)
+        ss = float(d.safety.get(item, 0) or 0)
+        g = gross.get(item) or {}
+        md = d.resched_min_days.get(item)
+        min_days = int(md) if md is not None else DEFAULT_RESCHEDULE_MIN_DAYS
+        need = _need_bucket_for_receipts(orders, on_hand, ss, g, d.n_buckets)
+        for o in sorted(orders, key=lambda x: (x.receipt_date, x.node_id)):
+            nb = need.get(o.node_id)
+            if nb is None:
+                # Entirely surplus (no need on the horizon) => CANCEL, UNLESS the
+                # receipt sits on the horizon edge, where its demand may be just
+                # out of the loaded window (guard against a phantom CANCEL).
+                if o.qty > 0 and d.bucket(o.receipt_date) < cancel_cutoff_bucket:
+                    signals.append(RescheduleSignal(
+                        node_id=o.node_id, item_id=item, action=CANCEL,
+                        current_receipt_date=o.receipt_date, proposed_date=None,
+                        qty=o.qty, node_type=o.node_type, is_firm=o.is_firm))
+                continue
+            # The projection resolves need at BUCKET granularity, so a receipt
+            # already sitting in its need bucket is on time by construction — no
+            # message, whatever its intra-bucket weekday. This is what makes the
+            # stability invariant hold (re-run on unchanged data => 0 signals).
+            if d.bucket(o.receipt_date) == nb:
+                continue
+            proposed = d.horizon_start + _dt.timedelta(weeks=nb)
+            delta_days = (proposed - o.receipt_date).days
+            if abs(delta_days) < min_days:
+                continue  # within dampening: no message (the stability path)
+            action = RESCHEDULE_IN if delta_days < 0 else RESCHEDULE_OUT
+            signals.append(RescheduleSignal(
+                node_id=o.node_id, item_id=item, action=action,
+                current_receipt_date=o.receipt_date, proposed_date=proposed,
+                qty=o.qty, node_type=o.node_type, is_firm=o.is_firm))
+    signals.sort(key=lambda s: (s.item_id, s.node_id))
+    return signals
 
 
 def excess_obsolete(d: PlanningData, gross: dict, months: float = 12.0) -> dict:

--- a/src/ootils_core/engine/mrp/loader.py
+++ b/src/ootils_core/engine/mrp/loader.py
@@ -15,6 +15,7 @@ from ootils_core.engine.mrp.core import (
     BASELINE,
     FIRM_RECEIPT_TYPES,
     PlanningData,
+    ReceiptOrder,
     _spread_period,
 )
 from ootils_core.engine.scenario.param_overlay import resolved_params_sql
@@ -124,6 +125,23 @@ def load_planning_data(conn, horizon_days=540, scenario=BASELINE) -> PlanningDat
         d.slushy_d[it] = r[11]
         d.strat[it] = r[12]
 
+    # Reschedule dampening thresholds (#346, migration 061). These two columns
+    # are DELIBERATELY baseline-only — not in the #347 overlay whitelist (mig 061
+    # header) — so they are read straight off item_planning_params, unresolved,
+    # with the same current-SCD2-row predicate the resolver uses. Pooled per item
+    # by MAX across locations (a single per-item threshold is the intent); a
+    # missing item just falls back to the module DEFAULT_* in reschedule_signals.
+    for r in cur.execute(
+        "SELECT item_id, MAX(reschedule_min_days), MAX(reschedule_qty_tolerance_pct) "
+        "FROM item_planning_params "
+        "WHERE effective_to IS NULL OR effective_to = '9999-12-31'::DATE "
+        "GROUP BY item_id"
+    ).fetchall():
+        if r[1] is not None:
+            d.resched_min_days[r[0]] = r[1]
+        if r[2] is not None:
+            d.resched_qty_tol_pct[r[0]] = r[2]
+
     # nodes: on-hand + firm receipts in ONE scenario-scoped scan (was 2), via
     # FILTER. MIN/SUM-over-empty => NULL, skipped, so dict keys match the old
     # per-type queries exactly. Scenario-scoped (scenario MRP reads its fork).
@@ -227,12 +245,52 @@ def load_planning_data(conn, horizon_days=540, scenario=BASELINE) -> PlanningDat
         for i, (tref, qty) in enumerate(rows):
             end = rows[i + 1][0] if i + 1 < len(rows) else tref + _dt.timedelta(days=default_span)
             _spread_period(qty, tref, end, horizon_start, horizon_end, d.n_buckets, d.fc_b[item])
+    # Firm receipts loaded from ONE scan, feeding two structures (#346):
+    #   * d.sched_b — the weekly-bucket AGGREGATE the projection/cascade consumes.
+    #     GOLDEN-MASTER: only the committed order types (PO/WO/Transfer) contribute
+    #     here, exactly as before — the sched_b aggregate is STRICTLY UNCHANGED.
+    #   * d.sched_orders — the re-datable receipts keeping per-order IDENTITY
+    #     (node_id/date/qty/is_firm/node_type) so reschedule_signals can re-date
+    #     THIS order.
+    #
+    # The two structures have DIFFERENT membership on purpose:
+    #   sched_orders = committed receipts (PO/WO/Transfer — always) PLUS every
+    #                  PlannedSupply that is FIRM (is_firm=TRUE). A firm
+    #                  PlannedSupply (an FPO, migration 061) is netted as a closed
+    #                  receipt yet stays re-datable — it is the headline case of
+    #                  #346, so it MUST enter sched_orders. A NON-firm PlannedSupply
+    #                  is regenerated from scratch on every run, so re-dating it is
+    #                  meaningless: it is deliberately excluded.
+    #   sched_b      = committed receipts ONLY (the WHERE below keeps PlannedSupply
+    #                  out of the bucket aggregate so projection/golden-master do
+    #                  not shift). is_firm on a ReceiptOrder is TRUE by nature for
+    #                  the committed types (an engaged order) and the column value
+    #                  for a PlannedSupply.
     d.sched_b = defaultdict(lambda: defaultdict(float))
-    for item, tref, qty in cur.execute(
-        "SELECT item_id, time_ref, quantity FROM nodes WHERE scenario_id=%(b)s AND active "
-        "AND node_type=ANY(%(t)s) AND time_ref IS NOT NULL AND quantity IS NOT NULL",
+    d.sched_orders = defaultdict(list)
+    for node_id, item, ntype, tref, qty, is_firm in cur.execute(
+        "SELECT node_id, item_id, node_type, time_ref, quantity, is_firm FROM nodes "
+        "WHERE scenario_id=%(b)s AND active "
+        "AND (node_type=ANY(%(t)s) OR (node_type='PlannedSupply' AND is_firm)) "
+        "AND time_ref IS NOT NULL AND quantity IS NOT NULL",
         {"b": scenario, "t": FIRM_RECEIPT_TYPES}).fetchall():
-        d.sched_b[item][d.bucket(tref)] += float(qty)
+        q = float(qty)
+        if ntype in FIRM_RECEIPT_TYPES:
+            # Committed order: contributes to the bucket aggregate (golden-master)
+            # and is firm by nature (an engaged receipt).
+            d.sched_b[item][d.bucket(tref)] += q
+            order_firm = True
+        else:
+            # Firm PlannedSupply (FPO): re-datable, but deliberately NOT added to
+            # the sched_b bucket aggregate — sched_b stays byte-identical to the
+            # pre-#346 golden master (committed types only). This math core is
+            # read-only; it surfaces the FPO for reschedule identity only. FPO
+            # netting as a closed receipt is the APICS engine's concern
+            # (graph_integration / gross_to_net), not this loader.
+            order_firm = bool(is_firm)
+        d.sched_orders[item].append(ReceiptOrder(
+            node_id=str(node_id), item_id=item, receipt_date=tref, qty=q,
+            is_firm=order_firm, node_type=ntype))
 
     involved: set = set()
     for m in (d.llc, d.is_make, d.on_hand, d.safety, d.co_b, d.fc_b, d.sched_b):

--- a/tests/test_mrp_shim_compat.py
+++ b/tests/test_mrp_shim_compat.py
@@ -24,7 +24,9 @@ from ootils_core.engine.mrp import core, loader  # noqa: E402
 CORE_SYMBOLS = [
     "BASELINE", "DEFAULT_LT_DAYS", "SUPPLY_TYPES", "FIRM_RECEIPT_TYPES", "DEMAND_TYPES",
     "lot_size", "cost_of", "_spread_period", "apply_lot_rule", "PlanningData",
-    "consume_demand", "run_timephased", "first_shortage", "excess_obsolete", "peg_origins",
+    "ReceiptOrder", "RescheduleSignal",
+    "consume_demand", "run_timephased", "first_shortage", "reschedule_signals",
+    "excess_obsolete", "peg_origins",
 ]
 LOADER_SYMBOLS = ["guard_db", "_m", "load_planning_data"]
 

--- a/tests/test_reschedule_signals.py
+++ b/tests/test_reschedule_signals.py
@@ -1,0 +1,397 @@
+"""
+Unit tests for the canonical receipt-vs-need reschedule comparison (#346 PR-A).
+
+reschedule_signals lives in the DB-free MRP math core (engine/mrp/core.py), so
+these run with no database — PlanningData is built in memory exactly like the
+core golden-master (test_mrp_core_golden.py).
+
+The most important test here is STABILITY: regenerating a plan on unchanged data
+must emit ZERO signals. A receipt already on its need date (or within dampening)
+produces no message. An MRP that spits reschedule messages on a stable plan is
+unusable.
+
+Need-date convention (mirrors the projection): the need date of a receipt is the
+START of the weekly bucket where the CENTRE OF GRAVITY of that receipt's own
+consumption sits — the bucket at which its cumulative allocated quantity first
+reaches 50% of the receipt qty (its median unit), NOT the first requirement it
+marginally touches (see core._need_bucket_for_receipts). Bucket t start =
+HS + t weeks.
+"""
+from __future__ import annotations
+
+import datetime as dt
+from collections import defaultdict
+
+from ootils_core.engine.mrp import core  # noqa: E402
+
+HS = dt.date(2026, 1, 5)  # fixed Monday horizon start (same as the golden-master)
+
+
+def _ro(node_id, item, date, qty, is_firm=False, node_type="PurchaseOrderSupply"):
+    return core.ReceiptOrder(
+        node_id=node_id, item_id=item, receipt_date=date, qty=qty,
+        is_firm=is_firm, node_type=node_type)
+
+
+def build_pd(**kw) -> core.PlanningData:
+    d = core.PlanningData(
+        horizon_start=kw.pop("horizon_start", HS),
+        n_buckets=kw.pop("n_buckets", 12))
+    for k, v in kw.items():
+        setattr(d, k, v)
+    involved = set()
+    for m in (d.llc, d.is_make, d.on_hand, d.safety, d.co_b, d.fc_b, d.sched_b):
+        involved.update(m.keys())
+    d.involved = involved
+    d.max_llc = max((d.llc.get(i, 0) for i in involved), default=0)
+    by_level: defaultdict[int, list] = defaultdict(list)
+    for i in involved:
+        by_level[d.llc.get(i, 0)].append(i)
+    d.by_level = by_level
+    return d
+
+
+def _bucket_date(t: int) -> dt.date:
+    return HS + dt.timedelta(weeks=t)
+
+
+# ───────────────────────── (a) stability — THE central invariant ─────────────
+
+def test_stability_unchanged_plan_emits_zero_signals():
+    """Demand 100 @wk2, one receipt of 100 arriving IN wk2. The receipt is on its
+    need bucket => not a single message. This is the whole point of #346:
+    regenerating a stable plan must be silent."""
+    d = build_pd(
+        on_hand={"X": 0},
+        sched_orders={"X": [_ro("po1", "X", _bucket_date(2), 100.0)]},
+    )
+    gross = {"X": {2: 100.0}}
+    assert core.reschedule_signals(d, gross) == []
+
+
+def test_stability_intra_bucket_weekday_still_silent():
+    """A receipt landing mid-need-bucket (Thursday, not the bucket-start Monday)
+    is still on time — need is resolved at bucket granularity, so no message."""
+    d = build_pd(
+        on_hand={"X": 0},
+        sched_orders={"X": [_ro("po1", "X", _bucket_date(2) + dt.timedelta(days=3), 100.0)]},
+    )
+    gross = {"X": {2: 100.0}}
+    assert core.reschedule_signals(d, gross) == []
+
+
+# ───────────────────────── (b) receipt too late → RESCHEDULE_IN ──────────────
+
+def test_receipt_too_late_emits_reschedule_in():
+    """Demand 100 @wk2 (need = wk2 start), receipt arrives wk6 — far too late.
+    Pull it in: RESCHEDULE_IN, proposed = wk2 start."""
+    receipt_date = _bucket_date(6)
+    d = build_pd(
+        on_hand={"X": 0},
+        sched_orders={"X": [_ro("po1", "X", receipt_date, 100.0)]},
+    )
+    gross = {"X": {2: 100.0}}
+    sigs = core.reschedule_signals(d, gross)
+    assert len(sigs) == 1
+    s = sigs[0]
+    assert s.action == core.RESCHEDULE_IN
+    assert s.node_id == "po1"
+    assert s.current_receipt_date == receipt_date
+    assert s.proposed_date == _bucket_date(2)
+    assert s.qty == 100.0
+
+
+# ───────────────────────── (c) receipt too early → RESCHEDULE_OUT ────────────
+
+def test_receipt_too_early_emits_reschedule_out():
+    """Demand 100 @wk6 (need = wk6 start), receipt arrives wk0 — far too early.
+    Push it out: RESCHEDULE_OUT, proposed = wk6 start."""
+    receipt_date = _bucket_date(0)
+    d = build_pd(
+        on_hand={"X": 0},
+        sched_orders={"X": [_ro("po1", "X", receipt_date, 100.0)]},
+    )
+    gross = {"X": {6: 100.0}}
+    sigs = core.reschedule_signals(d, gross)
+    assert len(sigs) == 1
+    s = sigs[0]
+    assert s.action == core.RESCHEDULE_OUT
+    assert s.current_receipt_date == receipt_date
+    assert s.proposed_date == _bucket_date(6)
+
+
+# ───────────────────────── (d) demand disappeared → CANCEL ───────────────────
+
+def test_no_matching_need_emits_cancel():
+    """A receipt of 100 with NO demand anywhere on the horizon is pure surplus:
+    CANCEL, proposed_date None."""
+    receipt_date = _bucket_date(2)
+    d = build_pd(
+        on_hand={"X": 0},
+        sched_orders={"X": [_ro("po1", "X", receipt_date, 100.0)]},
+    )
+    gross: dict = {}  # demand vanished
+    sigs = core.reschedule_signals(d, gross)
+    assert len(sigs) == 1
+    s = sigs[0]
+    assert s.action == core.CANCEL
+    assert s.proposed_date is None
+    assert s.current_receipt_date == receipt_date
+    assert s.qty == 100.0
+
+
+def test_receipt_covered_by_on_hand_is_cancel():
+    """On-hand already covers all demand — the incoming receipt has no need."""
+    d = build_pd(
+        on_hand={"X": 200},
+        sched_orders={"X": [_ro("po1", "X", _bucket_date(2), 100.0)]},
+    )
+    gross = {"X": {2: 100.0}}  # fully covered by on-hand 200
+    sigs = core.reschedule_signals(d, gross)
+    assert [s.action for s in sigs] == [core.CANCEL]
+
+
+# ───────────────────────── (e) date dampening ───────────────────────────────
+
+def test_date_delta_below_min_days_is_dampened():
+    """Receipt one bucket (7 days) off its need bucket, but reschedule_min_days is
+    30 → the 7-day nudge is below threshold: NO message (dampening)."""
+    d = build_pd(
+        on_hand={"X": 0},
+        sched_orders={"X": [_ro("po1", "X", _bucket_date(3), 100.0)]},
+        resched_min_days={"X": 30},  # very tolerant threshold
+    )
+    gross = {"X": {2: 100.0}}  # need = wk2, receipt wk3 → 7-day delta < 30
+    assert core.reschedule_signals(d, gross) == []
+
+
+def test_date_delta_at_min_days_boundary_emits():
+    """Threshold is inclusive: |delta| >= min_days emits. 7-day delta, min_days 7
+    → RESCHEDULE_IN fires."""
+    d = build_pd(
+        on_hand={"X": 0},
+        sched_orders={"X": [_ro("po1", "X", _bucket_date(3), 100.0)]},
+        resched_min_days={"X": 7},
+    )
+    gross = {"X": {2: 100.0}}
+    sigs = core.reschedule_signals(d, gross)
+    assert [s.action for s in sigs] == [core.RESCHEDULE_IN]
+
+
+# ───────────────────────── (f) qty tolerance is a V1 no-op for CANCEL ────────
+
+def test_qty_tolerance_does_not_suppress_cancel_in_v1():
+    """V1 semantics (Défaut 3 fix): reschedule_qty_tolerance_pct is NOT applied
+    to CANCEL. A receipt reaching the CANCEL branch is 100% surplus by
+    construction; a graded tolerance is meaningless without splitting the
+    receipt (reserved for V2). So even a 100% tolerance does NOT suppress the
+    CANCEL of a fully-surplus receipt sitting inside the horizon."""
+    d = build_pd(
+        on_hand={"X": 0},
+        sched_orders={"X": [_ro("po1", "X", _bucket_date(2), 100.0)]},
+        resched_qty_tol_pct={"X": 100.0},  # ignored in V1
+    )
+    assert [s.action for s in core.reschedule_signals(d, {})] == [core.CANCEL]
+
+
+def test_full_surplus_cancels():
+    """A 100%-surplus receipt well inside the horizon → CANCEL fires."""
+    d = build_pd(
+        on_hand={"X": 0},
+        sched_orders={"X": [_ro("po1", "X", _bucket_date(2), 100.0)]},
+    )
+    assert [s.action for s in core.reschedule_signals(d, {})] == [core.CANCEL]
+
+
+# ───────────────────────── determinism & multi-receipt ──────────────────────
+
+def test_multiple_receipts_fifo_need_allocation():
+    """Two receipts, demand pulls the earlier one to its need bucket and leaves
+    the later one surplus. FIFO by receipt date decides which is needed."""
+    d = build_pd(
+        on_hand={"X": 0},
+        sched_orders={"X": [
+            _ro("po_early", "X", _bucket_date(2), 100.0),
+            _ro("po_late", "X", _bucket_date(2), 100.0),
+        ]},
+    )
+    gross = {"X": {2: 100.0}}  # only 100 needed at wk2; one receipt is surplus
+    sigs = core.reschedule_signals(d, gross)
+    # The earlier receipt covers the need (on its bucket → silent); the later is
+    # surplus → CANCEL. Result sorted by (item, node_id).
+    assert len(sigs) == 1
+    assert sigs[0].action == core.CANCEL
+    assert sigs[0].node_id == "po_late"
+
+
+def test_deterministic_output_is_sorted():
+    """Signals come back sorted by (item_id, node_id) regardless of input order."""
+    d = build_pd(
+        on_hand={"A": 0, "B": 0},
+        sched_orders={
+            "B": [_ro("b_po", "B", _bucket_date(0), 50.0)],
+            "A": [_ro("a_po", "A", _bucket_date(0), 50.0)],
+        },
+    )
+    # Both receipts are pure surplus (no demand) → two CANCELs, A before B.
+    sigs = core.reschedule_signals(d, {})
+    assert [(s.item_id, s.node_id) for s in sigs] == [("A", "a_po"), ("B", "b_po")]
+
+
+def test_safety_stock_pulls_need_earlier():
+    """Safety stock is a floor: with ss=20, demand 100 @wk4 makes the balance
+    breach safety at wk4 (need = wk4). A receipt on wk4 is on time."""
+    d = build_pd(
+        on_hand={"X": 20},
+        safety={"X": 20},
+        sched_orders={"X": [_ro("po1", "X", _bucket_date(4), 100.0)]},
+    )
+    gross = {"X": {4: 100.0}}
+    assert core.reschedule_signals(d, gross) == []
+
+
+# ───────────────────────── (g) Défaut 2 — median / centre-of-gravity need ────
+
+def test_over_pull_median_no_reschedule_in_to_first_touch():
+    """A receipt of 200 covering 10 @wk1 + 190 @wk10. The OLD first-touch
+    convention set need=wk1 and proposed pulling all 200 to wk1 (56 days early
+    for 190 units — the over-pull bug). The MEDIAN convention (Défaut 2 fix)
+    sets need=wk10 (its median unit is consumed at wk10). A receipt at wk9 is
+    then only ~1 week early → at most a small 1-week nudge, NEVER a RESCHEDULE_IN
+    toward wk1."""
+    d = build_pd(
+        n_buckets=14,
+        on_hand={"X": 0},
+        sched_orders={"X": [_ro("po1", "X", _bucket_date(9), 200.0)]},
+    )
+    gross = {"X": {1: 10.0, 10: 190.0}}
+    sigs = core.reschedule_signals(d, gross)
+    # The over-pull is gone: no pull-IN toward the marginal first touch (wk1).
+    assert [s for s in sigs if s.action == core.RESCHEDULE_IN] == []
+    # The receipt sits 1 week early vs its centre of gravity (wk10) → a modest
+    # push-out to wk10, not a 56-day pull-in.
+    assert len(sigs) == 1
+    assert sigs[0].action == core.RESCHEDULE_OUT
+    assert sigs[0].proposed_date == _bucket_date(10)
+
+
+def test_median_receipt_on_gravity_center_is_silent():
+    """Same 10 @wk1 / 190 @wk10 split, receipt landing exactly on its median
+    bucket wk10 → on time, no message. Confirms the median convention makes the
+    stability invariant hold for a lumpy consumption profile."""
+    d = build_pd(
+        n_buckets=14,
+        on_hand={"X": 0},
+        sched_orders={"X": [_ro("po1", "X", _bucket_date(10), 200.0)]},
+    )
+    gross = {"X": {1: 10.0, 10: 190.0}}
+    assert core.reschedule_signals(d, gross) == []
+
+
+def test_median_need_bucket_is_gravity_center():
+    """Same 10 @wk1 / 190 @wk10 split, receipt far too late at wk13. The proposed
+    date must be the median bucket wk10 (centre of gravity), NOT the first-touch
+    wk1."""
+    d = build_pd(
+        n_buckets=16,
+        on_hand={"X": 0},
+        sched_orders={"X": [_ro("po1", "X", _bucket_date(13), 200.0)]},
+    )
+    gross = {"X": {1: 10.0, 10: 190.0}}
+    sigs = core.reschedule_signals(d, gross)
+    assert len(sigs) == 1
+    assert sigs[0].action == core.RESCHEDULE_IN
+    assert sigs[0].proposed_date == _bucket_date(10)
+
+
+# ───────────────────────── (h) Défaut 4 — horizon-edge CANCEL guard ──────────
+
+def test_no_cancel_on_horizon_edge_receipt():
+    """A fully-surplus receipt landing in the LAST bucket of the loaded horizon
+    must NOT be cancelled: the demand justifying it may sit just beyond the
+    window (visibility, not surplus)."""
+    d = build_pd(
+        n_buckets=12,
+        on_hand={"X": 0},
+        sched_orders={"X": [_ro("po1", "X", _bucket_date(11), 100.0)]},  # last bucket
+    )
+    gross: dict = {}  # no visible need inside the window
+    assert core.reschedule_signals(d, gross) == []
+
+
+def test_demand_just_beyond_horizon_does_not_cancel_edge_receipt():
+    """Demand exists but at a bucket >= n_buckets (out of the loaded window).
+    _need_bucket_for_receipts sees no requirement, but the receipt sits on the
+    horizon edge → the guard suppresses the phantom CANCEL."""
+    d = build_pd(
+        n_buckets=12,
+        on_hand={"X": 0},
+        sched_orders={"X": [_ro("po1", "X", _bucket_date(11), 100.0)]},
+    )
+    gross = {"X": {13: 100.0}}  # bucket 13 >= n_buckets=12 → invisible to the walk
+    assert core.reschedule_signals(d, gross) == []
+
+
+def test_surplus_well_inside_horizon_still_cancels():
+    """The edge guard is narrow: a fully-surplus receipt comfortably inside the
+    horizon (not the last bucket) still CANCELs."""
+    d = build_pd(
+        n_buckets=12,
+        on_hand={"X": 0},
+        sched_orders={"X": [_ro("po1", "X", _bucket_date(2), 100.0)]},
+    )
+    assert [s.action for s in core.reschedule_signals(d, {})] == [core.CANCEL]
+
+
+# ───────────────────────── (i) Défaut 1 — firm PlannedSupply is re-datable ───
+
+def test_firm_planned_supply_is_reschedulable():
+    """A firm PlannedSupply (FPO) mis-dated far from its need emits a reschedule
+    just like a committed PO — that is the headline case of #346. Here need=wk2,
+    the FPO lands at wk6 → RESCHEDULE_IN."""
+    d = build_pd(
+        on_hand={"X": 0},
+        sched_orders={"X": [
+            _ro("fpo1", "X", _bucket_date(6), 100.0,
+                is_firm=True, node_type="PlannedSupply"),
+        ]},
+    )
+    gross = {"X": {2: 100.0}}
+    sigs = core.reschedule_signals(d, gross)
+    assert len(sigs) == 1
+    assert sigs[0].action == core.RESCHEDULE_IN
+    assert sigs[0].node_type == "PlannedSupply"
+    assert sigs[0].is_firm is True
+
+
+# ───────────────────────── (j) bonus — node_type + is_firm carried through ───
+
+def test_signal_carries_node_type_and_is_firm():
+    """RescheduleSignal must carry node_type/is_firm verbatim from the source
+    ReceiptOrder (PR-B attribution needs them without a re-fetch)."""
+    d = build_pd(
+        on_hand={"X": 0},
+        sched_orders={"X": [
+            _ro("wo1", "X", _bucket_date(6), 100.0,
+                is_firm=True, node_type="WorkOrderSupply"),
+        ]},
+    )
+    gross = {"X": {2: 100.0}}
+    s = core.reschedule_signals(d, gross)[0]
+    assert s.node_type == "WorkOrderSupply"
+    assert s.is_firm is True
+
+
+def test_cancel_signal_carries_attribution():
+    """A CANCEL signal also carries node_type/is_firm from its source order."""
+    d = build_pd(
+        on_hand={"X": 0},
+        sched_orders={"X": [
+            _ro("fpo1", "X", _bucket_date(2), 100.0,
+                is_firm=True, node_type="PlannedSupply"),
+        ]},
+    )
+    s = core.reschedule_signals(d, {})[0]
+    assert s.action == core.CANCEL
+    assert s.node_type == "PlannedSupply"
+    assert s.is_firm is True


### PR DESCRIPTION
## Chantier #346 — PR-A (moitié moteur)

Pose la comparaison canonique **receipt-vs-besoin** dans le math core (`engine/mrp/core.py`, DB-free, golden-masterisé, consommé par les watchers + le moteur APICS) — **une seule implémentation**, jamais dupliquée entre les deux moteurs MRP.

### Blocage racine levé
Les deux chemins de chargement pré-agrégeaient les receipts par bucket (`d.sched_b[item][bucket] += qty`) → l'identité de chaque ordre perdue → re-dater un PO/WO/Transfer/FPO précis **impossible par construction**. `loader.py` charge désormais aussi `d.sched_orders` — identité préservée `(node_id, receipt_date, qty, is_firm, node_type)` — **sans toucher `sched_b`** (projection golden-master byte-identique).

### Contenu
- **migration 061** : `nodes.is_firm` (+ index partiel), CHECK `recommendations.action` étendue (DEFER/CANCEL/RESCHEDULE_IN/OUT) + colonnes `target_node_id`/`current_receipt_date`/`proposed_date`, params de dampening (baseline-only V1).
- **`reschedule_signals(d, gross)`** : pure. Date de besoin dérivée de la demande nette vs on-hand/safety (pas `sched_b` — pas de double-comptage). Need bucket = **centre de gravité** (allocation cumulée franchit 50% de la qté) → évite de tirer un gros receipt en entier vers un besoin marginal précoce. Émet RESCHEDULE_IN/OUT/CANCEL avec dampening (min_days ; CANCEL supprimé au bord d'horizon).
- **FPO** : `sched_orders` = receipts engagés (PO/WO/Transfer) + PlannedSupply `WHERE is_firm` (un PlannedSupply non-firm est régénéré → jamais re-datable).

### Invariant central prouvé
**Un plan inchangé émet ZÉRO signal** (la stabilité est le but). Golden-master 12/12 inchangé, shim 22/22, reschedule 22 tests. mypy 0/163 (bloquant), ruff clean, **unit 2124 passed**.

### Revue adversariale (4 lentilles) — 2 majeurs corrigés avant merge
Les FPO étaient **exclus** du scan (le cas d'usage phare du chantier) ; RESCHEDULE_IN **sur-tirait** les receipts entiers. Les deux corrigés + testés.

Refs #346. **PR-B** : émission gouvernée vers `recommendations` (`decision_level`) + cycle FPO (exclusion de purge + endpoint apply + netter le firm PlannedSupply comme supply engagé de façon cohérente entre les deux moteurs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)