### PR TITLE
feat(reschedule): emit reschedule signals as governed recommendations (#346 PR-B)

### DIFF
--- a/scripts/agent_governance.py
+++ b/scripts/agent_governance.py
@@ -48,11 +48,22 @@ logger = logging.getLogger(__name__)
 #   L1  — DRAFT of something NEW (a new order, a parameter proposal, a
 #         disposition suggestion): nothing exists outside Ootils yet, the
 #         draft is freely reversible.
-#   L2  — EXPEDITE of an EXISTING order/receipt: approving it touches a real
-#         supplier/production commitment (a date already promised).
-#   L3+ — anything that would write to the ERP or mutate planning state.
-#         The watchers do NOT emit such actions today; that path is owned by
-#         the recommendation/approval state machine.
+#   L2  — EXPEDITE or RE-DATE of an EXISTING order/receipt: approving it
+#         touches a real supplier/production commitment (a date already
+#         promised) but is still reversible (the order moves, it is not
+#         destroyed).
+#   L3  — CANCEL of an engaged order: approving it releases a supplier /
+#         production commitment that is IRREVERSIBLE on the vendor side (a
+#         re-order later is a fresh commitment, not an undo). The reschedule
+#         emitter (agent_reschedule_watcher, #346 PR-B) is the FIRST watcher
+#         to emit an L3 DRAFT. It does NOT bypass governance: the emitter
+#         only ever writes status='DRAFT', and the recommendation/approval
+#         state machine (#341, engine/recommendation/state_machine.py) gates
+#         every L3+ promotion behind a HUMAN actor (HUMAN_ONLY_TARGETS —
+#         APPROVED/APPLIED are never reachable by a non-human actor). A
+#         watcher emitting an L3 DRAFT is therefore safe by construction: it
+#         proposes, the human disposes.
+#   L4  — reserved (irreversible + high blast radius). Not emitted.
 # ---------------------------------------------------------------------------
 _ACTION_DECISION_LEVELS: dict = {
     # shortage watcher — drafts of NEW purchase orders
@@ -60,6 +71,13 @@ _ACTION_DECISION_LEVELS: dict = {
     "ORDER_RUSH": "L1",
     # shortage + material watchers — touches an EXISTING order/receipt
     "EXPEDITE": "L2",
+    # reschedule watcher (#346) — re-date an existing order (reversible move)
+    "RESCHEDULE_IN": "L2",
+    "RESCHEDULE_OUT": "L2",
+    "DEFER": "L2",
+    # reschedule watcher (#346) — cancel an engaged order (irreversible on the
+    # supplier side => human gate mandatory, handled by the state machine)
+    "CANCEL": "L3",
     # lot policy watcher — parameter-change proposals (drafts)
     "RENEGOTIATE_MOQ": "L1",
     "REVIEW_MULTIPLE": "L1",
@@ -75,9 +93,12 @@ def decision_level(action: str) -> str:
     """Pure, deterministic mapping from a watcher action to its decision level.
 
     Single implementation for the fleet: draft of a NEW order (ORDER_NOW /
-    ORDER_RUSH) or a parameter/disposition proposal is L1; EXPEDITE of an
-    existing order is L2; ERP-touching actions would be L3+ but are not
-    emitted by the watchers today.
+    ORDER_RUSH) or a parameter/disposition proposal is L1; EXPEDITE or a
+    RE-DATE (RESCHEDULE_IN/OUT/DEFER) of an existing order is L2 (reversible
+    move); CANCEL of an engaged order is L3 (irreversible on the supplier
+    side). The reschedule watcher (#346) is the first to emit an L3 DRAFT —
+    the state machine (#341) enforces the mandatory human gate on its
+    promotion, so emitting it as a DRAFT is safe.
 
     Raises ValueError on an unknown action (fail-loudly — a silent default
     level would misclassify governance risk).

--- a/scripts/agent_reschedule_watcher.py
+++ b/scripts/agent_reschedule_watcher.py
@@ -1,0 +1,258 @@
+"""
+agent_reschedule_watcher.py — Reschedule Watcher (#346 PR-B), thin over mrp_core.
+
+Turns the deterministic reschedule action messages
+(mrp_core.reschedule_signals: RESCHEDULE_IN / RESCHEDULE_OUT / CANCEL for
+mis-dated or surplus firm receipts) into GOVERNED L2/L3 DRAFT recommendations —
+the same `recommendations` queue a planner reviews, the North Star channel.
+NEVER mrp_action_messages (architect decision: recommendations is the governed
+channel), NEVER shortages (ADR-021: that table is ShortageDetector's alone).
+
+No counter-factual fork (unlike the shortage/material watchers #340): a
+reschedule signal is a deterministic fact — "this order is mis-dated vs its
+computed need" — so the signal IS its own evidence. There is nothing to
+simulate; forking would add noise, not proof.
+
+Scenario-scoped: the watcher runs on a given scenario_id (default baseline) and
+loads the plan through that scenario (load_planning_data(scenario=...)). A fork
+with a lead-time / safety-stock overlay (#347) shifts need dates, which shifts
+the emitted signals — automatically, with no scenario branch here. The
+recommendations it writes carry that scenario_id and its own deterministic ids,
+so baseline and a fork never collide.
+
+Idempotence / stability (the whole point of #346): the recommendation_id is
+DETERMINISTIC over (scenario, target_node, action, proposed_date)
+— engine/recommendation/reschedule.reschedule_recommendation_id. Rows are
+UPSERTED with ON CONFLICT (recommendation_id) DO NOTHING, so re-running on an
+UNCHANGED plan re-derives the same ids and inserts ZERO new rows. This is
+stronger than the supersede-then-reinsert pattern of the other watchers (which
+mint a fresh UUID each run): a reschedule signal is a stable fact, not a
+re-costed proposal. Superseding is used only to EXPIRE prior DRAFTs of this
+agent/scenario whose signal no longer fires (the plan changed and the mis-date
+was resolved) — those are marked EXPIRED, the still-valid ones are re-affirmed
+by the idempotent upsert.
+
+North Star: deterministic core, DRAFT only (never applies; decision level from
+agent_governance.decision_level — RESCHEDULE_*/DEFER = L2, CANCEL = L3, the
+first watcher-emitted L3, gated to a human by the recommendation state machine
+#341), auditable (agent_runs), explainable (evidence = the signal detail),
+idempotent (deterministic id + ON CONFLICT).
+
+Usage:
+    DATABASE_URL=postgresql://... python scripts/agent_reschedule_watcher.py \
+        [--scenario <uuid>] [--horizon-days 540] [--top 15]
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from collections import defaultdict
+
+import psycopg
+from psycopg import sql
+from psycopg.types.json import Jsonb
+
+import mrp_core as core
+from agent_governance import decision_level, governed_run
+
+from ootils_core.engine.recommendation.reschedule import build_recommendation
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+logger = logging.getLogger("reschedule_watcher")
+AGENT_NAME = "reschedule_watcher"
+
+# Columns written per reschedule recommendation. The three NOT-NULL business
+# columns of migration 039 (shortage_date/deficit_qty/recommended_qty) are
+# reused per the mapping in engine/recommendation/reschedule; the three
+# reschedule columns come from migration 061.
+_COLUMNS = (
+    "recommendation_id",
+    "agent_name",
+    "agent_run_id",
+    "scenario_id",
+    "item_id",
+    "item_external_id",
+    "shortage_date",
+    "deficit_qty",
+    "recommended_qty",
+    "action",
+    "decision_level",
+    "target_node_id",
+    "current_receipt_date",
+    "proposed_date",
+    "status",
+    "confidence",
+    "evidence",
+)
+
+
+def _upsert(conn: psycopg.Connection, rows: list[tuple]) -> tuple[int, list]:
+    """Idempotent insert of reschedule recommendations.
+
+    ON CONFLICT (recommendation_id) DO NOTHING: a re-emitted identical signal
+    (same deterministic id) is a no-op. Returns (inserted_count, affirmed_ids)
+    where affirmed_ids is EVERY id we tried to write (inserted or already
+    present) — the caller uses it to NOT expire the still-valid prior DRAFTs.
+    SQL is composed via psycopg.sql (no f-strings in the SQL path).
+    """
+    if not rows:
+        return 0, []
+    col_ids = sql.SQL(", ").join(sql.Identifier(c) for c in _COLUMNS)
+    placeholders = sql.SQL(", ").join(sql.Placeholder() for _ in _COLUMNS)
+    query = sql.SQL(
+        "INSERT INTO recommendations ({cols}) VALUES ({vals}) "
+        "ON CONFLICT (recommendation_id) DO NOTHING "
+        "RETURNING recommendation_id"
+    ).format(cols=col_ids, vals=placeholders)
+    inserted = 0
+    cur = conn.cursor()
+    for r in rows:
+        got = cur.execute(query, r).fetchone()
+        if got is not None:
+            inserted += 1
+    affirmed = [r[0] for r in rows]
+    return inserted, affirmed
+
+
+def _expire_stale_drafts(
+    conn: psycopg.Connection, scenario_id: str, keep_ids: list
+) -> int:
+    """EXPIRE this agent/scenario's prior DRAFTs whose signal no longer fires.
+
+    A DRAFT that is NOT in keep_ids (the ids the current run affirmed) means the
+    mis-date it flagged was resolved (the plan changed) — mark it EXPIRED so the
+    queue reflects reality. Rows in keep_ids are left untouched (their identity
+    was just re-affirmed by the idempotent upsert). Scoped to this
+    agent + scenario so it never touches another agent's or another fork's rows.
+    """
+    if keep_ids:
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE recommendations SET status='EXPIRED', updated_at=now() "
+            "WHERE agent_name=%s AND scenario_id=%s AND status='DRAFT' "
+            "AND NOT (recommendation_id = ANY(%s))",
+            (AGENT_NAME, scenario_id, keep_ids),
+        )
+        return cur.rowcount
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE recommendations SET status='EXPIRED', updated_at=now() "
+        "WHERE agent_name=%s AND scenario_id=%s AND status='DRAFT'",
+        (AGENT_NAME, scenario_id),
+    )
+    return cur.rowcount
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(
+        description="Reschedule Watcher (#346) — governed DRAFT reschedule recommendations."
+    )
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    p.add_argument("--scenario", default=core.BASELINE,
+                   help="scenario_id to run on (default: baseline)")
+    p.add_argument("--horizon-days", type=int, default=540)
+    p.add_argument("--top", type=int, default=15)
+    p.add_argument("--allow-dev", action="store_true")
+    args = p.parse_args(argv)
+    if not args.dsn:
+        logger.error("DATABASE_URL not set")
+        return 2
+    db = core.guard_db(args.dsn, args.allow_dev)
+    scenario = args.scenario
+    logger.info("Reschedule Watcher (#346) running on DB=%s scenario=%s", db, scenario)
+    t0 = time.perf_counter()
+
+    with psycopg.connect(args.dsn) as conn:
+        d = core.load_planning_data(conn, args.horizon_days, scenario=scenario)
+        # gross = consumed independent demand (max_only + demand time fence +
+        # proration), exactly the input reschedule_signals expects — the same
+        # single demand truth the shortage watcher and the MRP cascade use.
+        gross = core.consume_demand(d)
+        signals = core.reschedule_signals(d, gross)
+
+        rows: list[tuple] = []
+        display: list[dict] = []
+        by_action: defaultdict[str, int] = defaultdict(int)
+        by_level: defaultdict[str, int] = defaultdict(int)
+
+        with governed_run(conn, AGENT_NAME, scenario, t0=t0) as run:
+            for sig in signals:
+                action = sig.action
+                reco = build_recommendation(
+                    scenario_id=scenario,
+                    item_external_id=d.names.get(sig.item_id, str(sig.item_id)[:8]),
+                    action=action,
+                    decision_level=decision_level(action),
+                    node_id=sig.node_id,
+                    item_id=sig.item_id,
+                    current_receipt_date=sig.current_receipt_date,
+                    proposed_date=sig.proposed_date,
+                    qty=sig.qty,
+                    node_type=sig.node_type,
+                    is_firm=sig.is_firm,
+                )
+                rows.append((
+                    reco.recommendation_id, AGENT_NAME, run.run_id, scenario,
+                    reco.item_id, reco.item_external_id, reco.shortage_date,
+                    reco.deficit_qty, reco.recommended_qty, reco.action,
+                    reco.decision_level, reco.target_node_id,
+                    reco.current_receipt_date, reco.proposed_date, "DRAFT",
+                    reco.confidence, Jsonb(reco.evidence),
+                ))
+                by_action[action] += 1
+                by_level[reco.decision_level] += 1
+                delta = (
+                    (sig.proposed_date - sig.current_receipt_date).days
+                    if sig.proposed_date is not None else None
+                )
+                display.append({
+                    "ext": reco.item_external_id, "action": action,
+                    "level": reco.decision_level, "cur": str(sig.current_receipt_date),
+                    "prop": str(sig.proposed_date) if sig.proposed_date else "—",
+                    "delta": delta, "qty": sig.qty,
+                })
+
+            inserted, affirmed = _upsert(conn, rows)
+            expired = _expire_stale_drafts(conn, scenario, affirmed)
+            metrics = {
+                "signals": len(signals),
+                "recommendations_affirmed": len(affirmed),
+                "recommendations_inserted": inserted,
+                "recommendations_idempotent_noop": len(affirmed) - inserted,
+                "expired_stale_drafts": expired,
+                "by_action": dict(by_action),
+                "by_decision_level": dict(by_level),
+            }
+            run.set_metrics(metrics)
+
+    m = metrics
+    elapsed = round(time.perf_counter() - t0, 2)
+    logger.info("=" * 92)
+    logger.info("RESCHEDULE WATCHER — run %s COMPLETED in %.2fs", str(run.run_id)[:8], elapsed)
+    logger.info("  Signals from mrp_core               : %d", m["signals"])
+    logger.info("  Recommendations affirmed (DRAFT)    : %d  (new: %d, idempotent no-op: %d)",
+                m["recommendations_affirmed"], m["recommendations_inserted"],
+                m["recommendations_idempotent_noop"])
+    logger.info("  Prior DRAFTs expired (signal gone)  : %d", m["expired_stale_drafts"])
+    logger.info("  By action        : %s", m["by_action"])
+    logger.info("  By decision level : %s", m["by_decision_level"])
+    logger.info("=" * 92)
+    # Sort by absolute date movement (biggest re-date first); CANCEL (delta None)
+    # sorts last within its own group.
+    display.sort(key=lambda x: (x["delta"] is None, -abs(x["delta"] or 0)))
+    logger.info("TOP %d DRAFT reschedule recommendations:", args.top)
+    logger.info("  %-14s %-14s %-4s %-11s %-11s %7s %9s",
+                "item", "action", "lvl", "current", "proposed", "delta_d", "qty")
+    for x in display[: args.top]:
+        dd = f"{x['delta']:+d}" if x["delta"] is not None else "—"
+        logger.info("  %-14s %-14s %-4s %-11s %-11s %7s %9.0f",
+                    x["ext"], x["action"], x["level"], x["cur"], x["prop"], dd, x["qty"])
+    logger.info("=" * 92)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ootils_core/engine/recommendation/__init__.py
+++ b/src/ootils_core/engine/recommendation/__init__.py
@@ -1,4 +1,11 @@
-"""Recommendation governance — state machine for the agent recommendation lifecycle."""
+"""Recommendation governance — state machine + reschedule mapping for the agent
+recommendation lifecycle."""
+from .reschedule import (
+    RESCHEDULE_ACTIONS,
+    RescheduleRecommendation,
+    build_recommendation,
+    reschedule_recommendation_id,
+)
 from .state_machine import (
     ALLOWED_TRANSITIONS,
     TERMINAL_STATUSES,
@@ -14,12 +21,16 @@ from .state_machine import (
 
 __all__ = [
     "ALLOWED_TRANSITIONS",
+    "RESCHEDULE_ACTIONS",
     "TERMINAL_STATUSES",
     "InvalidTransitionError",
     "RecommendationNotFoundError",
+    "RescheduleRecommendation",
     "TransitionResult",
     "allowed_targets",
+    "build_recommendation",
     "is_valid_transition",
+    "reschedule_recommendation_id",
     "transition_many",
     "transition_one",
     "validate_transition",

--- a/src/ootils_core/engine/recommendation/reschedule.py
+++ b/src/ootils_core/engine/recommendation/reschedule.py
@@ -1,0 +1,182 @@
+"""
+reschedule.py — pure signal->recommendation mapping for the reschedule emitter
+(#346 PR-B). DB-free, deterministic, mypy-checked.
+
+The deterministic MRP core (engine/mrp/core.py:reschedule_signals) produces a
+list of RescheduleSignal dampened action messages. This module turns ONE signal
+into ONE governed recommendation row — the typed columns that
+agent_reschedule_watcher writes into the `recommendations` table (migration 039
++ the reschedule columns of migration 061). Keeping the mapping here (not inline
+in the script) makes it unit-testable and mypy-checked; the script stays a thin
+orchestrator (load -> compute signals -> build rows -> upsert).
+
+Idempotence is the whole point of #346 (stability): the recommendation_id is a
+DETERMINISTIC uuid5 over (scenario_id, target_node_id, action, proposed_date).
+Re-running the watcher on an unchanged plan re-derives the SAME id for the same
+signal, so an ``INSERT ... ON CONFLICT (recommendation_id) DO NOTHING`` upsert
+turns a re-emitted identical signal into a no-op — zero new rows. This mirrors
+the kernel's deterministic_uuid contract for shortages (ADR-003): same input
+state, same UUID, replay-safe. It is deliberately STRONGER than the
+supersede-then-reinsert pattern of the shortage/material watchers, which mint a
+fresh UUID every run; a reschedule signal is a stable fact ("this order is
+mis-dated vs its need"), not a re-costed proposal, so the stable-identity upsert
+is the correct model and satisfies the central invariant (unchanged plan => 0
+new recommendations).
+
+The proposed_date participates in the identity on purpose: if the underlying
+need moves (e.g. a lead-time overlay in a fork shifts the need date), the signal
+is a genuinely NEW message (different proposed_date => different id => a new
+DRAFT row), not a silent mutation of the prior one. A CANCEL has proposed_date
+None, so its identity is (scenario, node, 'CANCEL', None) — a re-emitted CANCEL
+of the same node is idempotent.
+"""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+# Same fixed namespace the kernel uses for deterministic UUIDs (ADR-003,
+# engine/kernel/_ids.py). Re-declared here rather than imported so this module
+# stays free of any kernel dependency (the recommendation layer sits above the
+# kernel and must not import from it upward); the value is the invariant.
+_RECO_NAMESPACE = uuid.UUID("89e1e24e-42d7-5c31-87c7-c64e50e24131")
+
+# Reschedule actions this emitter maps. DEFER is in the migration-061 CHECK
+# vocabulary and carries an L2 decision level, but the deterministic core does
+# NOT emit it (reserved for manual/agent use — see engine/mrp/core.py); it is
+# therefore not produced here either. The mapping accepts whatever action the
+# signal carries — validation of the action string is the DB CHECK's job.
+RESCHEDULE_ACTIONS: frozenset[str] = frozenset(
+    {"RESCHEDULE_IN", "RESCHEDULE_OUT", "CANCEL", "DEFER"}
+)
+
+
+def reschedule_recommendation_id(
+    scenario_id: str,
+    target_node_id: str,
+    action: str,
+    proposed_date: Optional[date],
+) -> uuid.UUID:
+    """Stable uuid5 identity of a reschedule recommendation (idempotence key).
+
+    Same (scenario, target node, action, proposed date) => same UUID, so a
+    re-emitted identical signal upserts to a no-op. proposed_date is rendered
+    ISO (or the literal 'None' for CANCEL) inside the name so a date change is
+    a genuinely different message.
+    """
+    name = "|".join(
+        [
+            "reschedule_reco",
+            str(scenario_id),
+            str(target_node_id),
+            action,
+            proposed_date.isoformat() if proposed_date is not None else "None",
+        ]
+    )
+    return uuid.uuid5(_RECO_NAMESPACE, name)
+
+
+@dataclass(frozen=True)
+class RescheduleRecommendation:
+    """One governed recommendation row built from a RescheduleSignal.
+
+    Field names match the `recommendations` columns written by the watcher.
+    Purely a data-transfer object: no DB, no side effects. The evidence dict is
+    the forensic JSONB trail (the signal detail — the signal IS the evidence
+    for a reschedule; no counter-factual fork is needed, unlike the shortage
+    watcher #340).
+    """
+
+    recommendation_id: uuid.UUID
+    scenario_id: str
+    item_id: str
+    item_external_id: str
+    action: str
+    decision_level: str
+    target_node_id: str
+    current_receipt_date: date
+    proposed_date: Optional[date]
+    # NOT-NULL business columns of migration 039 reused for a reschedule
+    # message: shortage_date is the date at issue (the proposed need date, or
+    # the current date for a CANCEL which has no new date); deficit_qty /
+    # recommended_qty are the receipt's own quantity — the unit being re-dated
+    # or cancelled (V1 does not split a receipt).
+    shortage_date: date
+    deficit_qty: Decimal
+    recommended_qty: Decimal
+    confidence: str
+    evidence: dict
+
+
+def build_recommendation(
+    *,
+    scenario_id: str,
+    item_external_id: str,
+    action: str,
+    decision_level: str,
+    node_id: str,
+    item_id: str,
+    current_receipt_date: date,
+    proposed_date: Optional[date],
+    qty: float,
+    node_type: str,
+    is_firm: bool,
+    confidence: str = "HIGH",
+) -> RescheduleRecommendation:
+    """Map one reschedule signal's fields to a governed recommendation row.
+
+    Pure and deterministic: same inputs => byte-identical row, same
+    recommendation_id. ``decision_level`` is passed in (resolved by the caller
+    via agent_governance.decision_level(action) — never hardcoded here) so the
+    single fleet-wide ladder mapping stays the one source of truth.
+
+    ``confidence`` defaults to HIGH: a reschedule signal is a deterministic fact
+    derived from the loaded plan (this order is mis-dated vs the computed need),
+    not a probabilistic forecast — the signal itself is the evidence. The caller
+    may downgrade it (e.g. NEEDS_DATA_REVIEW on a stale demand book) by passing a
+    different value.
+    """
+    qty_dec = Decimal(str(qty))
+    # For a re-date the "date at issue" is where the order SHOULD land (the
+    # proposed need date); for a CANCEL there is no proposed date, so the
+    # non-null shortage_date column is anchored on the current receipt date.
+    shortage_date = proposed_date if proposed_date is not None else current_receipt_date
+    delta_days = (
+        (proposed_date - current_receipt_date).days if proposed_date is not None else None
+    )
+    evidence = {
+        "signal": action,
+        "target_node_id": node_id,
+        "node_type": node_type,
+        "is_firm": is_firm,
+        "qty": qty,
+        "current_receipt_date": current_receipt_date.isoformat(),
+        "proposed_date": proposed_date.isoformat() if proposed_date is not None else None,
+        "delta_days": delta_days,
+        "rule": (
+            "deterministic reschedule signal from mrp_core.reschedule_signals "
+            "(#346): receipt date vs median-unit need date, dampened by "
+            "reschedule_min_days. The signal is its own evidence — no fork."
+        ),
+    }
+    return RescheduleRecommendation(
+        recommendation_id=reschedule_recommendation_id(
+            scenario_id, node_id, action, proposed_date
+        ),
+        scenario_id=scenario_id,
+        item_id=item_id,
+        item_external_id=item_external_id,
+        action=action,
+        decision_level=decision_level,
+        target_node_id=node_id,
+        current_receipt_date=current_receipt_date,
+        proposed_date=proposed_date,
+        shortage_date=shortage_date,
+        deficit_qty=qty_dec,
+        recommended_qty=qty_dec,
+        confidence=confidence,
+        evidence=evidence,
+    )

--- a/tests/integration/test_agent_fleet_smoke.py
+++ b/tests/integration/test_agent_fleet_smoke.py
@@ -69,6 +69,7 @@ import agent_dq_watcher  # noqa: E402
 import agent_eando_watcher  # noqa: E402
 import agent_lot_policy_watcher  # noqa: E402
 import agent_material_watcher  # noqa: E402
+import agent_reschedule_watcher  # noqa: E402
 import agent_shortage_watcher  # noqa: E402
 from agent_governance import decision_level  # noqa: E402
 
@@ -87,6 +88,13 @@ WATCHERS = [
     {"name": "shortage_watcher",  "module": agent_shortage_watcher,
      "table": "recommendations",            "active": "DRAFT", "graded": "full"},
     {"name": "material_watcher",  "module": agent_material_watcher,
+     "table": "recommendations",            "active": "DRAFT", "graded": "full"},
+    # reschedule_watcher (#346): the fleet seed carries no firm receipts
+    # (no PO/WO/Transfer/FPO nodes -> sched_orders empty -> zero signals), so it
+    # emits no artifact here; it is held to the universal governed-run +
+    # idempotency contract only, like lot_policy_watcher. Its per-output
+    # behaviour is asserted in test_reschedule_watcher_integration.py.
+    {"name": "reschedule_watcher", "module": agent_reschedule_watcher,
      "table": "recommendations",            "active": "DRAFT", "graded": "full"},
     {"name": "eando_watcher",     "module": agent_eando_watcher,
      "table": "eando_recommendations",      "active": "DRAFT", "graded": "full"},

--- a/tests/integration/test_reschedule_watcher_integration.py
+++ b/tests/integration/test_reschedule_watcher_integration.py
@@ -89,10 +89,10 @@ def _drafts(dsn, scenario=BASELINE):
 
 
 def _count_recos(dsn, scenario=BASELINE):
-    with psycopg.connect(dsn) as conn:
+    with psycopg.connect(dsn, row_factory=dict_row) as conn:
         return conn.execute(
             "SELECT COUNT(*) FROM recommendations WHERE agent_name=%s AND scenario_id=%s",
-            (AGENT, str(scenario))).fetchone()[0]
+            (AGENT, str(scenario))).fetchone()["count"]
 
 
 # ---------------------------------------------------------------------------
@@ -128,17 +128,17 @@ def _seed_common(conn, today):
         "INSERT INTO locations (name, location_type, external_id) "
         "VALUES (%s, %s, %s) RETURNING location_id",
         ("Resched Plant", "plant", "LOC-RS"),
-    ).fetchone()[0]
+    ).fetchone()["location_id"]
     sup_id = conn.execute(
         "INSERT INTO suppliers (external_id, name, reliability_score, status) "
         "VALUES (%s, %s, %s, %s) RETURNING supplier_id",
         ("SUP-RS", "Resched Supplier", 0.95, "active"),
-    ).fetchone()[0]
+    ).fetchone()["supplier_id"]
     item_id = conn.execute(
         "INSERT INTO items (external_id, name, item_type, standard_cost, cost_currency) "
         "VALUES (%s, %s, %s, %s, %s) RETURNING item_id",
         ("ITM", "Reschedule Item", "component", 40.0, "EUR"),
-    ).fetchone()[0]
+    ).fetchone()["item_id"]
     conn.execute(
         "INSERT INTO item_planning_params "
         "(item_id, location_id, is_make, lead_time_sourcing_days, "
@@ -192,8 +192,8 @@ def test_emits_one_governed_draft_for_misdated_receipt(migrated_db):
     RESCHEDULE_OUT in `recommendations`, carrying the target node, both dates and
     the mapping-derived level. Never mrp_action_messages."""
     dsn = migrated_db
-    with psycopg.connect(dsn, autocommit=True) as conn:
-        today = conn.execute("SELECT CURRENT_DATE").fetchone()[0]
+    with psycopg.connect(dsn, autocommit=True, row_factory=dict_row) as conn:
+        today = conn.execute("SELECT CURRENT_DATE").fetchone()["current_date"]
         _reset_graph(conn)
         loc_id, item_id = _seed_common(conn, today)
         # Demand of 100 at week 20; on-hand 0 => need bucket 20. Receipt lands at
@@ -203,7 +203,7 @@ def test_emits_one_governed_draft_for_misdated_receipt(migrated_db):
         _receipt(conn, BASELINE, item_id, loc_id, today, 4, 100)
         node_id = conn.execute(
             "SELECT node_id FROM nodes WHERE node_type='PurchaseOrderSupply' "
-            "AND scenario_id=%s", (BASELINE,)).fetchone()[0]
+            "AND scenario_id=%s", (BASELINE,)).fetchone()["node_id"]
 
     assert _run(dsn) == 0
     rows = _drafts(dsn)
@@ -222,13 +222,16 @@ def test_emits_one_governed_draft_for_misdated_receipt(migrated_db):
 
     # It must NOT have leaked into the legacy action-message table (governed
     # channel is `recommendations`, per the watcher docstring / architect call).
-    with psycopg.connect(dsn) as conn:
+    # NB: migration 021 names the column `message_type` (CHECK IN
+    # 'EXPEDITE','DEFER','CANCEL','RELEASE','RESCHEDULE') — there is no `action`
+    # column on mrp_action_messages.
+    with psycopg.connect(dsn, row_factory=dict_row) as conn:
         exists = conn.execute(
-            "SELECT to_regclass('public.mrp_action_messages')").fetchone()[0]
+            "SELECT to_regclass('public.mrp_action_messages')").fetchone()["to_regclass"]
         if exists is not None:
             n = conn.execute(
                 "SELECT COUNT(*) FROM mrp_action_messages "
-                "WHERE action LIKE 'RESCHEDULE%%'").fetchone()[0]
+                "WHERE message_type IN ('RESCHEDULE', 'DEFER', 'CANCEL')").fetchone()["count"]
             assert n == 0, "reschedule watcher must not write mrp_action_messages"
 
 
@@ -242,8 +245,8 @@ def test_rerun_on_unchanged_plan_inserts_zero_new_rows(migrated_db):
     same plan re-derives the SAME deterministic ids; ON CONFLICT DO NOTHING
     makes the second run a no-op. Row count before run 2 == after run 2."""
     dsn = migrated_db
-    with psycopg.connect(dsn, autocommit=True) as conn:
-        today = conn.execute("SELECT CURRENT_DATE").fetchone()[0]
+    with psycopg.connect(dsn, autocommit=True, row_factory=dict_row) as conn:
+        today = conn.execute("SELECT CURRENT_DATE").fetchone()["current_date"]
         _reset_graph(conn)
         loc_id, item_id = _seed_common(conn, today)
         _onhand(conn, BASELINE, item_id, loc_id, today, 0)
@@ -341,8 +344,8 @@ def test_surplus_receipt_yields_cancel_at_l3(migrated_db):
     (not on the edge), is entirely surplus -> action=CANCEL at decision_level
     L3 (the first watcher-emitted L3), proposed_date NULL."""
     dsn = migrated_db
-    with psycopg.connect(dsn, autocommit=True) as conn:
-        today = conn.execute("SELECT CURRENT_DATE").fetchone()[0]
+    with psycopg.connect(dsn, autocommit=True, row_factory=dict_row) as conn:
+        today = conn.execute("SELECT CURRENT_DATE").fetchone()["current_date"]
         _reset_graph(conn)
         loc_id, item_id = _seed_common(conn, today)
         # No demand at all; receipt of 50 at week 10 (70 days out, far inside the
@@ -374,20 +377,20 @@ def test_watcher_never_writes_shortages(migrated_db):
     is read-only against it — the shortages row count is unchanged across a run
     that DOES emit reschedule recommendations."""
     dsn = migrated_db
-    with psycopg.connect(dsn, autocommit=True) as conn:
-        today = conn.execute("SELECT CURRENT_DATE").fetchone()[0]
+    with psycopg.connect(dsn, autocommit=True, row_factory=dict_row) as conn:
+        today = conn.execute("SELECT CURRENT_DATE").fetchone()["current_date"]
         _reset_graph(conn)
         loc_id, item_id = _seed_common(conn, today)
         _onhand(conn, BASELINE, item_id, loc_id, today, 0)
         _demand(conn, BASELINE, item_id, loc_id, today, 20, 100)
         _receipt(conn, BASELINE, item_id, loc_id, today, 4, 100)
-        before = conn.execute("SELECT COUNT(*) FROM shortages").fetchone()[0]
+        before = conn.execute("SELECT COUNT(*) FROM shortages").fetchone()["count"]
 
     assert _run(dsn) == 0
     assert _drafts(dsn), "run must actually emit a reschedule reco (else the test proves nothing)"
 
-    with psycopg.connect(dsn) as conn:
-        after = conn.execute("SELECT COUNT(*) FROM shortages").fetchone()[0]
+    with psycopg.connect(dsn, row_factory=dict_row) as conn:
+        after = conn.execute("SELECT COUNT(*) FROM shortages").fetchone()["count"]
     assert after == before == 0, "reschedule watcher must never touch `shortages` (ADR-021)"
 
 
@@ -402,8 +405,8 @@ def test_resolved_draft_is_expired_scoped_to_agent_and_scenario(migrated_db):
     the expiration must touch ONLY this agent's DRAFTs in this scenario (a
     foreign agent's DRAFT on the same scenario is left alone)."""
     dsn = migrated_db
-    with psycopg.connect(dsn, autocommit=True) as conn:
-        today = conn.execute("SELECT CURRENT_DATE").fetchone()[0]
+    with psycopg.connect(dsn, autocommit=True, row_factory=dict_row) as conn:
+        today = conn.execute("SELECT CURRENT_DATE").fetchone()["current_date"]
         _reset_graph(conn)
         loc_id, item_id = _seed_common(conn, today)
         _onhand(conn, BASELINE, item_id, loc_id, today, 0)
@@ -411,7 +414,7 @@ def test_resolved_draft_is_expired_scoped_to_agent_and_scenario(migrated_db):
         _receipt(conn, BASELINE, item_id, loc_id, today, 4, 100)
         po_node = conn.execute(
             "SELECT node_id FROM nodes WHERE node_type='PurchaseOrderSupply' "
-            "AND scenario_id=%s", (BASELINE,)).fetchone()[0]
+            "AND scenario_id=%s", (BASELINE,)).fetchone()["node_id"]
 
     assert _run(dsn) == 0
     run1_drafts = _drafts(dsn)
@@ -421,11 +424,11 @@ def test_resolved_draft_is_expired_scoped_to_agent_and_scenario(migrated_db):
     # Seed a FOREIGN agent's DRAFT on the same scenario: the expiration must not
     # touch it (scoped to agent_name + scenario_id). Reuse the run1 agent_run_id
     # FK target so the row is valid.
-    with psycopg.connect(dsn, autocommit=True) as conn:
+    with psycopg.connect(dsn, autocommit=True, row_factory=dict_row) as conn:
         foreign_run = conn.execute(
             "INSERT INTO agent_runs (agent_name, scenario_id, status) "
             "VALUES ('other_watcher', %s, 'COMPLETED') RETURNING agent_run_id",
-            (BASELINE,)).fetchone()[0]
+            (BASELINE,)).fetchone()["agent_run_id"]
         conn.execute(
             "INSERT INTO recommendations "
             "(agent_name, agent_run_id, scenario_id, item_id, item_external_id, "

--- a/tests/integration/test_reschedule_watcher_integration.py
+++ b/tests/integration/test_reschedule_watcher_integration.py
@@ -1,0 +1,460 @@
+"""
+tests/integration/test_reschedule_watcher_integration.py — chantier #346 PR-B.
+
+DB-backed coverage of the GOVERNED reschedule emitter
+(scripts/agent_reschedule_watcher.py) against a real Postgres, no mocks. The
+watcher is a thin orchestrator over the pure core (mrp_core.reschedule_signals,
+covered by tests/test_reschedule_signals.py) + the pure mapping
+(engine.recommendation.reschedule, covered by
+tests/test_reschedule_recommendation.py); this file asserts the pieces the pure
+tests cannot: the real INSERT ... ON CONFLICT idempotence, the stale-DRAFT
+expiration, scenario isolation through the #347 overlay, the ADR-021 no-write
+into `shortages`, and the L3 CANCEL path — end to end on a seeded plan.
+
+The seven invariants (one test each; STABILITY #2 is the headline):
+  1. Emission        — a mis-dated firm receipt yields ONE governed DRAFT with
+                       the right action/level/target/dates in `recommendations`
+                       (never mrp_action_messages).
+  2. Stability       — re-running on an UNCHANGED plan inserts ZERO new rows
+                       (deterministic id + ON CONFLICT DO NOTHING). THE central
+                       #346 invariant: a stable regenerative MRP never spams.
+  3. Scenario iso    — a fork with a safety_stock_qty overlay (#347) shifts the
+                       need date => a DIFFERENT message on the fork; baseline is
+                       untouched.
+  4. CANCEL => L3    — an entirely-surplus firm receipt (inside the horizon
+                       edge) yields action=CANCEL at decision_level L3.
+  5. ADR-021         — the watcher writes NOTHING into `shortages`
+                       (count-before == count-after).
+  6. Expiration      — a DRAFT whose mis-date is resolved between run 1 and run
+                       2 flips to EXPIRED, and ONLY for this agent+scenario.
+
+Determinism: every date is anchored on the DB-side CURRENT_DATE (never Python
+now()), exactly like mrp_core.load_planning_data's horizon anchor and the
+sibling watcher seeds (test_scenario_backed_watchers_integration.py). The seed
+math is verified against the pure core in tests/test_reschedule_signals.py:
+demand at bucket B with on-hand 0 gives a receipt whose need date is bucket B;
+a receipt dated far from B (>> reschedule_min_days) fires a stable RESCHEDULE.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import sys
+from pathlib import Path
+
+import pytest
+
+from .conftest import requires_db
+
+# Import seam: mrp_core + watchers live under scripts/ (outside the package).
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import agent_reschedule_watcher  # noqa: E402
+import mrp_core as core  # noqa: E402
+from agent_governance import decision_level  # noqa: E402
+
+import psycopg  # noqa: E402
+from psycopg.rows import dict_row  # noqa: E402
+
+from ootils_core.engine.scenario.param_overlay import set_param_override  # noqa: E402
+
+pytestmark = [requires_db, pytest.mark.smoke]
+
+BASELINE = core.BASELINE
+AGENT = "reschedule_watcher"
+
+# Bucket layout (weekly): a receipt whose need date lands N weeks out and whose
+# current date is M weeks out fires a RESCHEDULE when |need - current| exceeds
+# reschedule_min_days (default 3). We keep all movements ~months apart so the
+# dampening threshold is never in play (the seed is about emission, not the
+# dampening band — that band is unit-tested in test_reschedule_signals.py).
+_WEEK = 7
+
+
+def _run(dsn, scenario=None):
+    """Drive the watcher in-process (main(argv) -> int), like the fleet smoke."""
+    argv = ["--dsn", dsn, "--allow-dev"]
+    if scenario is not None:
+        argv += ["--scenario", str(scenario)]
+    return agent_reschedule_watcher.main(argv)
+
+
+def _drafts(dsn, scenario=BASELINE):
+    with psycopg.connect(dsn, row_factory=dict_row) as conn:
+        return conn.execute(
+            "SELECT * FROM recommendations WHERE agent_name=%s AND scenario_id=%s "
+            "AND status='DRAFT'",
+            (AGENT, str(scenario))).fetchall()
+
+
+def _count_recos(dsn, scenario=BASELINE):
+    with psycopg.connect(dsn) as conn:
+        return conn.execute(
+            "SELECT COUNT(*) FROM recommendations WHERE agent_name=%s AND scenario_id=%s",
+            (AGENT, str(scenario))).fetchone()[0]
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers. Each test gets a FUNCTION-scoped, freshly-truncated graph so the
+# idempotence / expiration / isolation assertions never bleed across tests.
+# ---------------------------------------------------------------------------
+
+
+def _reset_graph(conn):
+    """Wipe the per-test graph + agent artifacts. Keeps the migrated schema (and
+    the migration-002 baseline scenario) intact; only clears rows this file
+    seeds. TRUNCATE ... CASCADE so FK-linked recommendation rows go too."""
+    conn.execute(
+        "TRUNCATE nodes, edges, recommendations, agent_runs, "
+        "item_planning_params, supplier_items, items, suppliers, locations, "
+        "scenario_planning_overrides RESTART IDENTITY CASCADE"
+    )
+    # `shortages` may or may not have rows; truncate so the ADR-021 delta test
+    # starts from a known baseline. Separate statement (not all schemas link it
+    # into the graph FK web).
+    conn.execute("TRUNCATE shortages RESTART IDENTITY CASCADE")
+
+
+def _seed_common(conn, today):
+    """One location, one supplier, one bought item (ITM) with an IPP row.
+
+    Returns (loc_id, item_id). Lead time is irrelevant to reschedule need-date
+    math (need date derives from demand-vs-on-hand-vs-safety, not lead time —
+    see core._need_bucket_for_receipts), but IPP must exist so the loader reads
+    reschedule_min_days (migration-061 DEFAULT 3) and safety_stock_qty for it.
+    """
+    loc_id = conn.execute(
+        "INSERT INTO locations (name, location_type, external_id) "
+        "VALUES (%s, %s, %s) RETURNING location_id",
+        ("Resched Plant", "plant", "LOC-RS"),
+    ).fetchone()[0]
+    sup_id = conn.execute(
+        "INSERT INTO suppliers (external_id, name, reliability_score, status) "
+        "VALUES (%s, %s, %s, %s) RETURNING supplier_id",
+        ("SUP-RS", "Resched Supplier", 0.95, "active"),
+    ).fetchone()[0]
+    item_id = conn.execute(
+        "INSERT INTO items (external_id, name, item_type, standard_cost, cost_currency) "
+        "VALUES (%s, %s, %s, %s, %s) RETURNING item_id",
+        ("ITM", "Reschedule Item", "component", 40.0, "EUR"),
+    ).fetchone()[0]
+    conn.execute(
+        "INSERT INTO item_planning_params "
+        "(item_id, location_id, is_make, lead_time_sourcing_days, "
+        " lead_time_manufacturing_days, lead_time_transit_days, safety_stock_qty, "
+        " lot_size_rule, frozen_time_fence_days, slashed_time_fence_days, "
+        " forecast_consumption_strategy) "
+        "VALUES (%s,%s,FALSE,14,0,0,0,%s,0,1,%s)",
+        (item_id, loc_id, "LOTFORLOT", "max_only"),
+    )
+    conn.execute(
+        "INSERT INTO supplier_items "
+        "(supplier_id, item_id, lead_time_days, unit_cost, currency, is_preferred) "
+        "VALUES (%s,%s,14,4.0,%s,TRUE)",
+        (sup_id, item_id, "EUR"),
+    )
+    return loc_id, item_id
+
+
+def _node(conn, ntype, scenario, item_id, loc_id, today, days_out, qty, is_firm=False):
+    conn.execute(
+        "INSERT INTO nodes (node_type, scenario_id, item_id, location_id, quantity, "
+        " time_grain, time_ref, active, is_firm) "
+        "VALUES (%s, %s, %s, %s, %s, 'exact_date', %s, TRUE, %s)",
+        (ntype, str(scenario), item_id, loc_id, qty,
+         today + _dt.timedelta(days=days_out), is_firm),
+    )
+
+
+def _onhand(conn, scenario, item_id, loc_id, today, qty):
+    _node(conn, "OnHandSupply", scenario, item_id, loc_id, today, 0, qty)
+
+
+def _demand(conn, scenario, item_id, loc_id, today, weeks_out, qty):
+    _node(conn, "CustomerOrderDemand", scenario, item_id, loc_id, today, weeks_out * _WEEK, qty)
+
+
+def _receipt(conn, scenario, item_id, loc_id, today, weeks_out, qty):
+    """A firm PurchaseOrderSupply receipt (a committed order): enters
+    sched_orders (FIRM_RECEIPT_TYPES) and is re-datable."""
+    _node(conn, "PurchaseOrderSupply", scenario, item_id, loc_id, today,
+          weeks_out * _WEEK, qty, is_firm=True)
+
+
+# ===========================================================================
+# 1. Emission — one mis-dated firm receipt -> one governed DRAFT.
+# ===========================================================================
+
+
+def test_emits_one_governed_draft_for_misdated_receipt(migrated_db):
+    """A firm receipt arriving MONTHS before its need date -> a single DRAFT
+    RESCHEDULE_OUT in `recommendations`, carrying the target node, both dates and
+    the mapping-derived level. Never mrp_action_messages."""
+    dsn = migrated_db
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        today = conn.execute("SELECT CURRENT_DATE").fetchone()[0]
+        _reset_graph(conn)
+        loc_id, item_id = _seed_common(conn, today)
+        # Demand of 100 at week 20; on-hand 0 => need bucket 20. Receipt lands at
+        # week 4 => far too early => RESCHEDULE_OUT (push it to ~week 20).
+        _onhand(conn, BASELINE, item_id, loc_id, today, 0)
+        _demand(conn, BASELINE, item_id, loc_id, today, 20, 100)
+        _receipt(conn, BASELINE, item_id, loc_id, today, 4, 100)
+        node_id = conn.execute(
+            "SELECT node_id FROM nodes WHERE node_type='PurchaseOrderSupply' "
+            "AND scenario_id=%s", (BASELINE,)).fetchone()[0]
+
+    assert _run(dsn) == 0
+    rows = _drafts(dsn)
+    assert len(rows) == 1, "exactly one reschedule DRAFT expected"
+    r = rows[0]
+    assert r["action"] == "RESCHEDULE_OUT"
+    assert r["decision_level"] == decision_level("RESCHEDULE_OUT") == "L2"
+    assert str(r["target_node_id"]) == str(node_id)
+    assert r["current_receipt_date"] == today + _dt.timedelta(weeks=4)
+    assert r["proposed_date"] == today + _dt.timedelta(weeks=20)
+    assert r["proposed_date"] > r["current_receipt_date"]   # OUT = pushed later
+    assert r["status"] == "DRAFT"
+    assert r["item_external_id"] == "ITM"
+    assert r["evidence"] is not None
+    assert r["evidence"]["signal"] == "RESCHEDULE_OUT"
+
+    # It must NOT have leaked into the legacy action-message table (governed
+    # channel is `recommendations`, per the watcher docstring / architect call).
+    with psycopg.connect(dsn) as conn:
+        exists = conn.execute(
+            "SELECT to_regclass('public.mrp_action_messages')").fetchone()[0]
+        if exists is not None:
+            n = conn.execute(
+                "SELECT COUNT(*) FROM mrp_action_messages "
+                "WHERE action LIKE 'RESCHEDULE%%'").fetchone()[0]
+            assert n == 0, "reschedule watcher must not write mrp_action_messages"
+
+
+# ===========================================================================
+# 2. STABILITY — re-run on an unchanged plan inserts ZERO new rows.
+# ===========================================================================
+
+
+def test_rerun_on_unchanged_plan_inserts_zero_new_rows(migrated_db):
+    """THE headline #346 invariant. After a first run, re-running on the exact
+    same plan re-derives the SAME deterministic ids; ON CONFLICT DO NOTHING
+    makes the second run a no-op. Row count before run 2 == after run 2."""
+    dsn = migrated_db
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        today = conn.execute("SELECT CURRENT_DATE").fetchone()[0]
+        _reset_graph(conn)
+        loc_id, item_id = _seed_common(conn, today)
+        _onhand(conn, BASELINE, item_id, loc_id, today, 0)
+        _demand(conn, BASELINE, item_id, loc_id, today, 20, 100)
+        _receipt(conn, BASELINE, item_id, loc_id, today, 4, 100)
+
+    assert _run(dsn) == 0
+    after_run1 = _count_recos(dsn)
+    assert after_run1 >= 1, "run 1 must emit at least one reschedule reco"
+    drafts1 = {r["recommendation_id"] for r in _drafts(dsn)}
+
+    # --- Second run on the identical plan: no new rows, same DRAFTs still active.
+    assert _run(dsn) == 0
+    after_run2 = _count_recos(dsn)
+    assert after_run2 == after_run1, (
+        f"stability broken: {after_run2 - after_run1} new rows on an unchanged plan"
+    )
+    drafts2 = {r["recommendation_id"] for r in _drafts(dsn)}
+    assert drafts2 == drafts1, "the same DRAFTs must remain active (not superseded/re-minted)"
+
+    # The run metrics must self-report the no-op (auditable idempotence).
+    with psycopg.connect(dsn, row_factory=dict_row) as conn:
+        run = conn.execute(
+            "SELECT metrics FROM agent_runs WHERE agent_name=%s AND status='COMPLETED' "
+            "ORDER BY started_at DESC LIMIT 1", (AGENT,)).fetchone()
+        m = run["metrics"]
+        assert m["recommendations_inserted"] == 0
+        assert m["recommendations_idempotent_noop"] == m["recommendations_affirmed"]
+
+
+# ===========================================================================
+# 3. Scenario isolation — a fork overlay shifts the message; baseline unchanged.
+# ===========================================================================
+
+
+def test_fork_overlay_produces_different_message_baseline_untouched(migrated_db):
+    """A safety_stock_qty overlay (#347) on a fork pulls the need date earlier,
+    turning an on-time receipt into a RESCHEDULE_IN — a DIFFERENT message the
+    baseline never sees. safety_stock_qty (not lead_time) is the overlay knob
+    that actually moves a reschedule need date: core._need_bucket_for_receipts
+    walks demand vs on-hand vs SAFETY STOCK, and is independent of lead time.
+
+    Same nodes are seeded in BOTH scenarios (the loader reads nodes scoped by
+    scenario_id, so a fork sees only its own graph); the ONLY difference is the
+    fork's safety-stock override."""
+    dsn = migrated_db
+    with psycopg.connect(dsn, autocommit=True, row_factory=dict_row) as conn:
+        today = conn.execute("SELECT CURRENT_DATE").fetchone()["current_date"]
+        _reset_graph(conn)
+        loc_id, item_id = _seed_common(conn, today)
+
+        # Fork scenario.
+        fork_id = conn.execute(
+            "INSERT INTO scenarios (name, is_baseline, status) "
+            "VALUES ('resched-fork', FALSE, 'active') RETURNING scenario_id"
+        ).fetchone()["scenario_id"]
+
+        # Identical graph in both: demand 100 @ week 20, on-hand 0, receipt @
+        # week 20 (ON its need date when ss=0 -> baseline emits NOTHING).
+        for scen in (BASELINE, fork_id):
+            _onhand(conn, scen, item_id, loc_id, today, 0)
+            _demand(conn, scen, item_id, loc_id, today, 20, 100)
+            _receipt(conn, scen, item_id, loc_id, today, 20, 100)
+
+        # Overlay on the fork ONLY: raise safety stock so the balance dips below
+        # ss at bucket 0 -> need date is pulled to now -> receipt is now LATE ->
+        # RESCHEDULE_IN. set_param_override needs a dict_row conn (it is).
+        set_param_override(
+            conn, fork_id, item_id, "safety_stock_qty", "100", "reschedule-test",
+        )
+
+    # Run on baseline: the receipt is on its need date -> no message.
+    assert _run(dsn, scenario=BASELINE) == 0
+    assert _drafts(dsn, BASELINE) == [], "baseline receipt is on time -> no reschedule"
+
+    # Run on the fork: the overlay shifted the need -> exactly one RESCHEDULE_IN.
+    assert _run(dsn, scenario=fork_id) == 0
+    fork_rows = _drafts(dsn, fork_id)
+    assert len(fork_rows) == 1
+    assert fork_rows[0]["action"] == "RESCHEDULE_IN"
+    assert fork_rows[0]["proposed_date"] < fork_rows[0]["current_receipt_date"]
+    assert str(fork_rows[0]["scenario_id"]) == str(fork_id)
+
+    # Baseline stayed empty even after the fork run (no cross-scenario bleed).
+    assert _drafts(dsn, BASELINE) == []
+
+
+# ===========================================================================
+# 4. CANCEL => L3 — an entirely-surplus firm receipt.
+# ===========================================================================
+
+
+def test_surplus_receipt_yields_cancel_at_l3(migrated_db):
+    """A firm receipt with NO demand pulling it, sitting well inside the horizon
+    (not on the edge), is entirely surplus -> action=CANCEL at decision_level
+    L3 (the first watcher-emitted L3), proposed_date NULL."""
+    dsn = migrated_db
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        today = conn.execute("SELECT CURRENT_DATE").fetchone()[0]
+        _reset_graph(conn)
+        loc_id, item_id = _seed_common(conn, today)
+        # No demand at all; receipt of 50 at week 10 (70 days out, far inside the
+        # 540-day horizon) -> CANCEL.
+        _onhand(conn, BASELINE, item_id, loc_id, today, 0)
+        _receipt(conn, BASELINE, item_id, loc_id, today, 10, 50)
+
+    assert _run(dsn) == 0
+    rows = _drafts(dsn)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["action"] == "CANCEL"
+    assert r["decision_level"] == decision_level("CANCEL") == "L3"
+    assert r["proposed_date"] is None
+    # NOT-NULL shortage_date anchors on the current date for a CANCEL.
+    assert r["current_receipt_date"] == today + _dt.timedelta(weeks=10)
+    assert r["shortage_date"] == today + _dt.timedelta(weeks=10)
+    assert r["evidence"]["signal"] == "CANCEL"
+    assert r["evidence"]["delta_days"] is None
+
+
+# ===========================================================================
+# 5. ADR-021 — the watcher writes NOTHING into `shortages`.
+# ===========================================================================
+
+
+def test_watcher_never_writes_shortages(migrated_db):
+    """ADR-021: `shortages` is ShortageDetector's alone. The reschedule watcher
+    is read-only against it — the shortages row count is unchanged across a run
+    that DOES emit reschedule recommendations."""
+    dsn = migrated_db
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        today = conn.execute("SELECT CURRENT_DATE").fetchone()[0]
+        _reset_graph(conn)
+        loc_id, item_id = _seed_common(conn, today)
+        _onhand(conn, BASELINE, item_id, loc_id, today, 0)
+        _demand(conn, BASELINE, item_id, loc_id, today, 20, 100)
+        _receipt(conn, BASELINE, item_id, loc_id, today, 4, 100)
+        before = conn.execute("SELECT COUNT(*) FROM shortages").fetchone()[0]
+
+    assert _run(dsn) == 0
+    assert _drafts(dsn), "run must actually emit a reschedule reco (else the test proves nothing)"
+
+    with psycopg.connect(dsn) as conn:
+        after = conn.execute("SELECT COUNT(*) FROM shortages").fetchone()[0]
+    assert after == before == 0, "reschedule watcher must never touch `shortages` (ADR-021)"
+
+
+# ===========================================================================
+# 6. Expiration — a resolved DRAFT flips to EXPIRED, scoped to this agent+scen.
+# ===========================================================================
+
+
+def test_resolved_draft_is_expired_scoped_to_agent_and_scenario(migrated_db):
+    """A DRAFT emitted at run 1 whose mis-date is resolved before run 2 (the
+    receipt is re-dated onto its need date) must flip to EXPIRED at run 2 — and
+    the expiration must touch ONLY this agent's DRAFTs in this scenario (a
+    foreign agent's DRAFT on the same scenario is left alone)."""
+    dsn = migrated_db
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        today = conn.execute("SELECT CURRENT_DATE").fetchone()[0]
+        _reset_graph(conn)
+        loc_id, item_id = _seed_common(conn, today)
+        _onhand(conn, BASELINE, item_id, loc_id, today, 0)
+        _demand(conn, BASELINE, item_id, loc_id, today, 20, 100)
+        _receipt(conn, BASELINE, item_id, loc_id, today, 4, 100)
+        po_node = conn.execute(
+            "SELECT node_id FROM nodes WHERE node_type='PurchaseOrderSupply' "
+            "AND scenario_id=%s", (BASELINE,)).fetchone()[0]
+
+    assert _run(dsn) == 0
+    run1_drafts = _drafts(dsn)
+    assert len(run1_drafts) == 1
+    run1_id = run1_drafts[0]["recommendation_id"]
+
+    # Seed a FOREIGN agent's DRAFT on the same scenario: the expiration must not
+    # touch it (scoped to agent_name + scenario_id). Reuse the run1 agent_run_id
+    # FK target so the row is valid.
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        foreign_run = conn.execute(
+            "INSERT INTO agent_runs (agent_name, scenario_id, status) "
+            "VALUES ('other_watcher', %s, 'COMPLETED') RETURNING agent_run_id",
+            (BASELINE,)).fetchone()[0]
+        conn.execute(
+            "INSERT INTO recommendations "
+            "(agent_name, agent_run_id, scenario_id, item_id, item_external_id, "
+            " shortage_date, deficit_qty, recommended_qty, action, decision_level, "
+            " status, confidence, evidence) "
+            "VALUES ('other_watcher', %s, %s, %s, 'ITM', %s, 1, 1, 'EXPEDITE', 'L2', "
+            " 'DRAFT', 'HIGH', '{}'::jsonb)",
+            (foreign_run, BASELINE, item_id, today),
+        )
+        # Resolve the mis-date: re-date the firm receipt ONTO its need date
+        # (week 20). Now reschedule_signals fires nothing for it.
+        conn.execute(
+            "UPDATE nodes SET time_ref=%s WHERE node_id=%s",
+            (today + _dt.timedelta(weeks=20), po_node),
+        )
+
+    # --- Run 2: the run-1 mis-date signal is gone -> its DRAFT must EXPIRE.
+    assert _run(dsn) == 0
+    with psycopg.connect(dsn, row_factory=dict_row) as conn:
+        run1_row = conn.execute(
+            "SELECT status FROM recommendations WHERE recommendation_id=%s",
+            (run1_id,)).fetchone()
+        assert run1_row["status"] == "EXPIRED", "resolved reschedule DRAFT must flip to EXPIRED"
+
+        # The foreign agent's DRAFT on the same scenario is untouched.
+        foreign = conn.execute(
+            "SELECT status FROM recommendations WHERE agent_name='other_watcher' "
+            "AND scenario_id=%s", (BASELINE,)).fetchone()
+        assert foreign["status"] == "DRAFT", "expiration leaked onto another agent's rows"
+
+    # After resolution there is no live reschedule DRAFT left for this agent.
+    assert _drafts(dsn) == []

--- a/tests/test_reschedule_recommendation.py
+++ b/tests/test_reschedule_recommendation.py
@@ -1,0 +1,266 @@
+"""
+Unit tests for the governed reschedule EMISSION layer (#346 PR-B). DB-free.
+
+Three units are exercised, each pure and deterministic:
+
+  * agent_governance.decision_level  — the fleet-wide action->Decision-Ladder
+    mapping for the four reschedule actions (RESCHEDULE_IN/OUT/DEFER = L2,
+    CANCEL = L3, unknown => ValueError, per the existing fail-loudly contract).
+  * engine.recommendation.reschedule.reschedule_recommendation_id — the
+    deterministic uuid5 idempotence key: STABLE for an unchanged signal,
+    CHANGES when the proposed need date moves (a moved need = a new message,
+    not a mutation), CANCEL (proposed_date None) stable-and-distinct, distinct
+    per node.
+  * engine.recommendation.reschedule.build_recommendation — the signal->row
+    mapping: action/item/target/dates carried verbatim, decision_level taken
+    from the mapping (never hardcoded), evidence carries the signal detail, and
+    the NOT-NULL migration-039 columns (shortage_date / deficit_qty ==
+    recommended_qty == qty) filled per the RESCHEDULE-vs-CANCEL convention.
+
+No database, no mocks: the RescheduleSignal fields are built in memory. The
+core signal-generation logic (reschedule_signals) is PR-A's concern and is
+covered by tests/test_reschedule_signals.py — not re-tested here.
+
+decision_level lives under scripts/ (outside the package), so scripts/ is put
+on sys.path exactly as the integration harness does.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import sys
+import uuid
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+# Import seam: agent_governance lives under scripts/ (outside the package),
+# mirroring tests/integration/test_agent_fleet_smoke.py.
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from agent_governance import decision_level  # noqa: E402
+
+from ootils_core.engine.recommendation.reschedule import (  # noqa: E402
+    RESCHEDULE_ACTIONS,
+    build_recommendation,
+    reschedule_recommendation_id,
+)
+
+# A stable, non-baseline scenario id used across the identity tests.
+SCEN = "11111111-1111-1111-1111-111111111111"
+NODE_A = "aaaaaaaa-0000-0000-0000-000000000001"
+NODE_B = "bbbbbbbb-0000-0000-0000-000000000002"
+PROP = dt.date(2026, 11, 21)
+PROP2 = dt.date(2026, 12, 5)
+CUR = dt.date(2026, 8, 1)
+
+
+# ---------------------------------------------------------------------------
+# 1. decision_level — the reschedule actions on the Decision Ladder.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "action,expected",
+    [
+        ("RESCHEDULE_IN", "L2"),   # re-date an existing order: reversible move
+        ("RESCHEDULE_OUT", "L2"),
+        ("DEFER", "L2"),
+        ("CANCEL", "L3"),          # release an engaged order: irreversible on the vendor side
+    ],
+)
+def test_decision_level_for_reschedule_actions(action, expected):
+    assert decision_level(action) == expected
+
+
+def test_cancel_is_the_only_reschedule_l3():
+    """CANCEL is the single L3 among the reschedule actions — the first
+    watcher-emitted L3 (the human gate lives in the state machine, not here)."""
+    levels = {a: decision_level(a) for a in ("RESCHEDULE_IN", "RESCHEDULE_OUT", "DEFER", "CANCEL")}
+    assert levels["CANCEL"] == "L3"
+    assert [a for a, lvl in levels.items() if lvl == "L3"] == ["CANCEL"]
+
+
+def test_decision_level_unknown_action_raises():
+    """Fail-loudly: an action outside the mapping raises ValueError (no silent
+    default level would misclassify governance risk) — matches the existing
+    contract the other watchers rely on."""
+    with pytest.raises(ValueError):
+        decision_level("TELEPORT_ORDER")
+
+
+def test_reschedule_actions_constant_matches_the_mapping():
+    """Every action the emitter advertises in RESCHEDULE_ACTIONS must resolve to
+    a level (no advertised-but-unmapped action)."""
+    for action in RESCHEDULE_ACTIONS:
+        assert decision_level(action) in {"L2", "L3"}
+
+
+# ---------------------------------------------------------------------------
+# 2. reschedule_recommendation_id — deterministic uuid5 idempotence key.
+# ---------------------------------------------------------------------------
+
+
+def test_id_is_stable_for_identical_signal():
+    """Same (scenario, node, action, proposed_date) => same uuid on every call.
+    This is the idempotence key: a re-emitted identical signal upserts to a
+    no-op."""
+    a = reschedule_recommendation_id(SCEN, NODE_A, "RESCHEDULE_OUT", PROP)
+    b = reschedule_recommendation_id(SCEN, NODE_A, "RESCHEDULE_OUT", PROP)
+    assert a == b
+    assert isinstance(a, uuid.UUID)
+
+
+def test_id_changes_when_proposed_date_moves():
+    """A need that moves is a genuinely NEW message (different proposed_date =>
+    different id => a new DRAFT row), not a silent mutation of the prior one."""
+    a = reschedule_recommendation_id(SCEN, NODE_A, "RESCHEDULE_OUT", PROP)
+    b = reschedule_recommendation_id(SCEN, NODE_A, "RESCHEDULE_OUT", PROP2)
+    assert a != b
+
+
+def test_cancel_id_is_stable_and_distinct_from_reschedule():
+    """CANCEL has proposed_date None: its identity (scenario, node, 'CANCEL',
+    None) is stable across calls and never collides with a RESCHEDULE id for
+    the same node."""
+    c1 = reschedule_recommendation_id(SCEN, NODE_A, "CANCEL", None)
+    c2 = reschedule_recommendation_id(SCEN, NODE_A, "CANCEL", None)
+    assert c1 == c2
+    resched = reschedule_recommendation_id(SCEN, NODE_A, "RESCHEDULE_OUT", PROP)
+    assert c1 != resched
+
+
+def test_id_differs_per_node():
+    """Two different target nodes => two different ids, even for the same action
+    and proposed date."""
+    a = reschedule_recommendation_id(SCEN, NODE_A, "RESCHEDULE_OUT", PROP)
+    b = reschedule_recommendation_id(SCEN, NODE_B, "RESCHEDULE_OUT", PROP)
+    assert a != b
+
+
+def test_id_differs_per_action():
+    """RESCHEDULE_IN and RESCHEDULE_OUT on the same node/date are distinct
+    messages (the action is part of the identity)."""
+    a = reschedule_recommendation_id(SCEN, NODE_A, "RESCHEDULE_IN", PROP)
+    b = reschedule_recommendation_id(SCEN, NODE_A, "RESCHEDULE_OUT", PROP)
+    assert a != b
+
+
+def test_id_differs_per_scenario():
+    """The same signal in two scenarios (baseline vs a fork) gets two ids, so
+    baseline and a fork never collide in the recommendations table."""
+    other = "22222222-2222-2222-2222-222222222222"
+    a = reschedule_recommendation_id(SCEN, NODE_A, "RESCHEDULE_OUT", PROP)
+    b = reschedule_recommendation_id(other, NODE_A, "RESCHEDULE_OUT", PROP)
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# 3. build_recommendation — signal -> governed row mapping.
+# ---------------------------------------------------------------------------
+
+
+def _build(action, proposed_date, *, qty=100.0, node_id=NODE_A, node_type="PurchaseOrderSupply",
+           is_firm=True):
+    """Build a recommendation the way the watcher does: decision_level resolved
+    from the action by the shared mapping (never hardcoded)."""
+    return build_recommendation(
+        scenario_id=SCEN,
+        item_external_id="ITM-1",
+        action=action,
+        decision_level=decision_level(action),
+        node_id=node_id,
+        item_id="item-uuid-1",
+        current_receipt_date=CUR,
+        proposed_date=proposed_date,
+        qty=qty,
+        node_type=node_type,
+        is_firm=is_firm,
+    )
+
+
+def test_build_maps_reschedule_out_fields():
+    r = _build("RESCHEDULE_OUT", PROP)
+    assert r.action == "RESCHEDULE_OUT"
+    assert r.item_id == "item-uuid-1"
+    assert r.item_external_id == "ITM-1"
+    assert r.target_node_id == NODE_A          # target_node_id == node_id
+    assert r.current_receipt_date == CUR
+    assert r.proposed_date == PROP
+    # decision_level came from the mapping, not a hardcode.
+    assert r.decision_level == decision_level("RESCHEDULE_OUT") == "L2"
+    # The deterministic id matches the standalone key builder.
+    assert r.recommendation_id == reschedule_recommendation_id(SCEN, NODE_A, "RESCHEDULE_OUT", PROP)
+    assert r.confidence == "HIGH"
+
+
+def test_build_reschedule_notnull_columns_anchor_on_proposed_date():
+    """Migration-039 NOT-NULL columns for a RESCHEDULE: shortage_date is the
+    proposed need date (where the order SHOULD land); deficit_qty ==
+    recommended_qty == the receipt qty (V1 re-dates the whole receipt)."""
+    r = _build("RESCHEDULE_OUT", PROP, qty=100.0)
+    assert r.shortage_date == PROP
+    assert r.deficit_qty == Decimal("100.0")
+    assert r.recommended_qty == Decimal("100.0")
+    assert r.deficit_qty == r.recommended_qty
+
+
+def test_build_cancel_notnull_columns_anchor_on_current_date():
+    """A CANCEL has no proposed date, so the NOT-NULL shortage_date column is
+    anchored on the current receipt date instead; proposed_date is None and the
+    level is L3."""
+    r = _build("CANCEL", None, qty=50.0)
+    assert r.action == "CANCEL"
+    assert r.proposed_date is None
+    assert r.shortage_date == CUR              # anchored on current date, not proposed
+    assert r.deficit_qty == Decimal("50.0") == r.recommended_qty
+    assert r.decision_level == "L3"
+    assert r.recommendation_id == reschedule_recommendation_id(SCEN, NODE_A, "CANCEL", None)
+
+
+def test_build_evidence_carries_signal_detail():
+    """Evidence is the forensic trail: qty, delta_days, node_type, is_firm, both
+    dates, and the action — the signal IS the evidence (no fork)."""
+    r = _build("RESCHEDULE_OUT", PROP, qty=100.0, node_type="PurchaseOrderSupply", is_firm=True)
+    ev = r.evidence
+    assert ev["signal"] == "RESCHEDULE_OUT"
+    assert ev["qty"] == 100.0
+    assert ev["node_type"] == "PurchaseOrderSupply"
+    assert ev["is_firm"] is True
+    assert ev["target_node_id"] == NODE_A
+    assert ev["current_receipt_date"] == CUR.isoformat()
+    assert ev["proposed_date"] == PROP.isoformat()
+    # delta_days = proposed - current, in days.
+    assert ev["delta_days"] == (PROP - CUR).days
+    assert "rule" in ev
+
+
+def test_build_cancel_evidence_has_null_proposed_and_delta():
+    """For a CANCEL the evidence proposed_date and delta_days are null (no new
+    date), while the current date and qty still describe the surplus receipt."""
+    r = _build("CANCEL", None, qty=50.0)
+    ev = r.evidence
+    assert ev["signal"] == "CANCEL"
+    assert ev["proposed_date"] is None
+    assert ev["delta_days"] is None
+    assert ev["current_receipt_date"] == CUR.isoformat()
+    assert ev["qty"] == 50.0
+
+
+def test_build_reschedule_in_delta_is_negative():
+    """RESCHEDULE_IN pulls a receipt earlier: proposed < current => negative
+    delta_days in the evidence."""
+    earlier = dt.date(2026, 6, 1)
+    r = _build("RESCHEDULE_IN", earlier)
+    assert r.evidence["delta_days"] == (earlier - CUR).days
+    assert r.evidence["delta_days"] < 0
+
+
+def test_build_is_pure_and_deterministic():
+    """Same inputs => identical row (same id, same evidence). Purity is the
+    property the idempotent upsert leans on."""
+    a = _build("RESCHEDULE_OUT", PROP)
+    b = _build("RESCHEDULE_OUT", PROP)
+    assert a == b


### PR DESCRIPTION
## Chantier #346 — PR-B (émission gouvernée)

Transforme les `reschedule_signals` (PR-A) en **recommandations gouvernées** via la machine DRAFT→APPROVED (#341) — le canal North Star, **pas** `mrp_action_messages`.

### Contenu
- **`decision_level`** : RESCHEDULE_IN/OUT/DEFER = **L2** (re-dater un engagement existant, comme EXPEDITE) ; CANCEL = **L3** (irréversible côté fournisseur). Le reschedule emitter est le **premier watcher à émettre un DRAFT L3** — la machine d'approbation le gate derrière un humain (jamais auto-appliqué).
- **`engine/recommendation/reschedule.py`** (pur, mypy-checké) : builder signal→reco + `reschedule_recommendation_id` = **uuid5 déterministe** `(scenario|target_node|action|proposed_date)`. Réémettre un signal identique upserte le même id.
- **`scripts/agent_reschedule_watcher.py`** : watcher scenario-scopé. `INSERT ... ON CONFLICT DO NOTHING` → **un plan inchangé réémis insère ZÉRO ligne** (l'invariant de stabilité, end-to-end). `_expire_stale_drafts` passe à EXPIRED les DRAFTs résolus, scopé strictement `(agent_name, scenario_id)`. Pas de fork/simulation (un signal est déterministe) ; n'écrit jamais dans `shortages` (ADR-021).

### Note forkabilité (correction)
La date de besoin d'un reschedule dépend de la demande vs on-hand vs **safety stock** — **pas** du lead time. La valeur scenario-scopée vient donc d'un override `safety_stock_qty` (#347), pas `lead_time`. Le test d'isolation utilise `safety_stock_qty`.

### Tests
20 unit (decision_level, id déterministe, mapping) + 6 intégration : émission, **stabilité = 0 nouvelle ligne au re-run**, isolation scénario (overlay safety_stock), CANCEL=L3, aucune écriture shortages, expiration scopée. Watcher ajouté au registre fleet-smoke. **mypy 0/164 (bloquant), ruff clean, unit 2144 passed.**

Refs #346. **PR-C (closes #346)** : cycle FPO — exclusion de purge + endpoint firm + netter le firm PlannedSupply comme supply engagé de façon cohérente entre les deux moteurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)