### PR TITLE
fix(shortage): key counter-factual delta by business coordinate, not node_id (levier 1a)

### DIFF
--- a/src/ootils_core/api/routers/simulate.py
+++ b/src/ootils_core/api/routers/simulate.py
@@ -14,6 +14,7 @@ from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID, get_db
 from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.scenario.manager import ScenarioManager, _ALLOWED_FIELDS
+from ootils_core.models import ShortageRecord
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1/simulate", tags=["simulate"])
@@ -48,6 +49,17 @@ class ShortageChange(BaseModel):
     shortage_date: Optional[str] = None
     shortage_qty: Optional[float] = None
     severity_score: Optional[float] = None
+
+
+def _to_change(s: ShortageRecord) -> ShortageChange:
+    return ShortageChange(
+        node_id=s.pi_node_id,
+        item_id=s.item_id,
+        location_id=s.location_id,
+        shortage_date=str(s.shortage_date) if s.shortage_date else None,
+        shortage_qty=float(s.shortage_qty),
+        severity_score=float(s.severity_score),
+    )
 
 
 class SimulateDelta(BaseModel):
@@ -161,6 +173,7 @@ def create_simulation(
 
     # Propagation + delta computation
     from ootils_core.api.routers.events import _build_propagation_engine
+    from ootils_core.engine.kernel.shortage import match_shortage_delta
     from ootils_core.engine.kernel.shortage.detector import ShortageDetector
 
     calc_run_id = None
@@ -176,10 +189,7 @@ def create_simulation(
         try:
             # Get baseline shortages before propagation
             detector = ShortageDetector()
-            baseline_shortages = {
-                str(s.pi_node_id): s
-                for s in detector.get_active_shortages(base_id, db)
-            }
+            baseline_shortages = detector.get_active_shortages(base_id, db)
 
             # Create a trigger event for full recompute
             from uuid import uuid4
@@ -228,38 +238,23 @@ def create_simulation(
                 calc_run_id = calc_run.calc_run_id
                 nodes_recalculated = calc_run.nodes_recalculated or 0
 
-                # Compute delta
-                new_shortages = detector.get_active_shortages(scenario.scenario_id, db)
-                scenario_shortage_ids = {str(s.pi_node_id) for s in new_shortages}
-                baseline_shortage_ids = set(baseline_shortages.keys())
-
-                new_ids = scenario_shortage_ids - baseline_shortage_ids
-                resolved_ids = baseline_shortage_ids - scenario_shortage_ids
-
+                # Compute delta by BUSINESS key (item_id, location_id,
+                # shortage_date), NOT raw pi_node_id: a fork deep-copies nodes
+                # with fresh UUIDs so baseline and fork ids never overlap (see
+                # match_shortage_delta). A fork identical to the baseline
+                # therefore yields new=[] and resolved=[].
+                scenario_shortages = detector.get_active_shortages(
+                    scenario.scenario_id, db
+                )
+                new_records, resolved_records = match_shortage_delta(
+                    baseline_shortages, scenario_shortages
+                )
                 delta = SimulateDelta(
-                    new_shortages=[
-                        ShortageChange(
-                            node_id=s.pi_node_id,
-                            item_id=s.item_id,
-                            location_id=s.location_id,
-                            shortage_date=str(s.shortage_date) if s.shortage_date else None,
-                            shortage_qty=float(s.shortage_qty),
-                            severity_score=float(s.severity_score),
-                        )
-                        for s in new_shortages if str(s.pi_node_id) in new_ids
-                    ],
-                    resolved_shortages=[
-                        ShortageChange(
-                            node_id=baseline_shortages[sid].pi_node_id,
-                            item_id=baseline_shortages[sid].item_id,
-                            location_id=baseline_shortages[sid].location_id,
-                            shortage_date=str(baseline_shortages[sid].shortage_date) if baseline_shortages[sid].shortage_date else None,
-                            shortage_qty=float(baseline_shortages[sid].shortage_qty),
-                            severity_score=float(baseline_shortages[sid].severity_score),
-                        )
-                        for sid in resolved_ids
-                    ],
-                    net_shortage_change=len(new_ids) - len(resolved_ids),
+                    new_shortages=[_to_change(s) for s in new_records],
+                    resolved_shortages=[_to_change(s) for s in resolved_records],
+                    net_shortage_change=(
+                        len(scenario_shortages) - len(baseline_shortages)
+                    ),
                 )
                 propagation_status = "ok"
                 delta_computed = True

--- a/src/ootils_core/engine/kernel/shortage/__init__.py
+++ b/src/ootils_core/engine/kernel/shortage/__init__.py
@@ -4,6 +4,10 @@ shortage — Shortage detection kernel for Sprint M4.
 Detects inventory shortages from ProjectedInventory nodes with closing_stock < 0,
 computes severity scores, and persists ShortageRecord rows.
 """
+from ootils_core.engine.kernel.shortage.delta import (
+    match_shortage_delta,
+    shortage_key,
+)
 from ootils_core.engine.kernel.shortage.detector import ShortageDetector
 
-__all__ = ["ShortageDetector"]
+__all__ = ["ShortageDetector", "match_shortage_delta", "shortage_key"]

--- a/src/ootils_core/engine/kernel/shortage/delta.py
+++ b/src/ootils_core/engine/kernel/shortage/delta.py
@@ -1,0 +1,133 @@
+"""
+delta.py — pure counter-factual shortage-delta matching (no DB).
+
+Shared by the two fork->propagate->delta callers:
+  - ``ootils_core.tools.agent_tools._fork_propagate_delta`` (the in-process
+    /v1/simulate path used by the watcher fleet, #340/#347),
+  - ``ootils_core.api.routers.simulate`` (the HTTP /v1/simulate endpoint).
+
+Both compute "which shortages are NEW in the fork vs the baseline, and which
+baseline shortages were RESOLVED". The naive implementation set-differenced by
+raw ``pi_node_id``, but ``ScenarioManager.create_scenario`` deep-copies nodes
+with FRESH ``node_id`` values (``gen_random_uuid``) while preserving the
+business coordinates. A fork PI node therefore NEVER shares an id with its
+baseline counterpart, so the raw-id difference reported 100% of the fork's
+shortages as "new" and 100% of the baseline's as "resolved" the moment the
+baseline had any — over-reporting both lists (the ``net_shortage_change``
+count stayed correct).
+
+The fix keys a shortage by its BUSINESS coordinate
+``(item_id, location_id, shortage_date)`` — the same cross-scenario matching
+principle ``ScenarioManager.diff`` / ``promote`` already use for nodes (they
+key on ``(node_type, item_id, location_id, time_span_start, bucket_sequence)``;
+for a ProjectedInventory shortage ``node_type`` is constant and
+``shortage_date`` is the bucket's ``time_span_start``).
+
+Collision policy — MULTISET, not overwrite. Within one scenario+calc_run,
+``(item, location, shortage_date)`` is expected to be unique (projection
+buckets of one series are contiguous ``[start, end)`` intervals, so two
+buckets cannot share ``time_span_start``; the series itself is unique per
+``(item, location, scenario)``). But a PI node with no time coordinate carries
+``shortage_date = None``, and we refuse to silently drop or overwrite a
+collision: keys are counted with multiplicity so that if K baseline and M fork
+shortages share one key, ``min(K, M)`` are treated as unchanged and only the
+surplus on each side is reported. This degenerates to plain set difference in
+the unique-key case and stays correct under collisions.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from typing import Optional
+
+from ootils_core.models import ShortageRecord
+
+# Sentinel for a None component of the business key. Distinct, non-UUID,
+# non-date literals so a genuine None never collides with a real value's str().
+_NULL_ITEM = "\x00item"
+_NULL_LOCATION = "\x00location"
+_NULL_DATE = "\x00date"
+
+ShortageKey = tuple[str, str, str]
+
+
+def shortage_key(shortage: ShortageRecord) -> ShortageKey:
+    """Business coordinate of a shortage: (item_id, location_id, shortage_date)
+    as stable strings. Each component may be None on the record (all three are
+    Optional on ShortageRecord); a None maps to a private sentinel so it never
+    collides with a real value and remains hashable/deterministic."""
+    item = str(shortage.item_id) if shortage.item_id is not None else _NULL_ITEM
+    location = (
+        str(shortage.location_id) if shortage.location_id is not None else _NULL_LOCATION
+    )
+    date = (
+        shortage.shortage_date.isoformat()
+        if shortage.shortage_date is not None
+        else _NULL_DATE
+    )
+    return (item, location, date)
+
+
+def match_shortage_delta(
+    baseline: list[ShortageRecord],
+    scenario: list[ShortageRecord],
+) -> tuple[list[ShortageRecord], list[ShortageRecord]]:
+    """Compute (new_shortages, resolved_shortages) by business key.
+
+    A scenario shortage is NEW when its ``(item, location, date)`` key has more
+    occurrences in the scenario than in the baseline; a baseline shortage is
+    RESOLVED when its key has more occurrences in the baseline than in the
+    scenario. Matched pairs (same key present on both sides) are neither new nor
+    resolved — the shortage persisted across the fork.
+
+    Multiset semantics (see module docstring): with K baseline and M scenario
+    shortages on one key, ``max(M - K, 0)`` scenario rows are new and
+    ``max(K - M, 0)`` baseline rows are resolved. Returned lists preserve input
+    order and never fabricate or drop a record.
+
+    ``len(new) - len(resolved)`` equals ``len(scenario) - len(baseline)`` — the
+    same count delta the callers already surface as ``net_shortage_change`` —
+    so the fix cannot change the net count, only make the two LISTS honest.
+    """
+    baseline_counts = Counter(shortage_key(s) for s in baseline)
+    scenario_counts = Counter(shortage_key(s) for s in scenario)
+
+    # Number of scenario rows to report as NEW per key = surplus over baseline.
+    new_budget: dict[ShortageKey, int] = {}
+    for key, n in scenario_counts.items():
+        surplus = n - baseline_counts.get(key, 0)
+        if surplus > 0:
+            new_budget[key] = surplus
+
+    # Number of baseline rows to report as RESOLVED per key = surplus over scenario.
+    resolved_budget: dict[ShortageKey, int] = {}
+    for key, n in baseline_counts.items():
+        surplus = n - scenario_counts.get(key, 0)
+        if surplus > 0:
+            resolved_budget[key] = surplus
+
+    new_shortages = _take_by_budget(scenario, new_budget)
+    resolved_shortages = _take_by_budget(baseline, resolved_budget)
+    return new_shortages, resolved_shortages
+
+
+def _take_by_budget(
+    records: list[ShortageRecord],
+    budget: dict[ShortageKey, int],
+) -> list[ShortageRecord]:
+    """Take the first ``budget[key]`` records for each key, in input order.
+
+    Which specific record is picked among same-key duplicates is arbitrary (any
+    of them carries that business coordinate); input order makes the choice
+    deterministic. Records whose key is not in ``budget`` are skipped.
+    """
+    if not budget:
+        return []
+    remaining: dict[ShortageKey, int] = dict(budget)
+    picked: list[ShortageRecord] = []
+    for record in records:
+        key = shortage_key(record)
+        left: Optional[int] = remaining.get(key)
+        if left:
+            picked.append(record)
+            remaining[key] = left - 1
+    return picked

--- a/src/ootils_core/tools/agent_tools.py
+++ b/src/ootils_core/tools/agent_tools.py
@@ -169,6 +169,7 @@ def _fork_propagate_delta(
     """
     from ootils_core.api.routers.events import _build_propagation_engine
     from ootils_core.engine.kernel.graph.dirty import DirtyFlagManager
+    from ootils_core.engine.kernel.shortage import match_shortage_delta
     from ootils_core.engine.kernel.shortage.detector import ShortageDetector
     from ootils_core.engine.orchestration.calc_run import CalcRunManager
 
@@ -177,9 +178,7 @@ def _fork_propagate_delta(
     calc_run = None
     calc_run_finished = False
     try:
-        baseline_shortages = {
-            str(s.pi_node_id): s for s in detector.get_active_shortages(base_id, db)
-        }
+        baseline_shortages = detector.get_active_shortages(base_id, db)
 
         trigger_event_id = uuid4()
         # source='engine': the events CHECK (migration 002) allows
@@ -217,30 +216,20 @@ def _fork_propagate_delta(
         result["calc_run_id"] = str(calc_run.calc_run_id)
         result["nodes_recalculated"] = calc_run.nodes_recalculated or 0
 
-        # KNOWN LIMITATION (pre-existing, shared with api/routers/simulate.py;
-        # tracked separately — do NOT rely on new/resolved for per-node credit):
-        # the delta set-differences by RAW pi_node_id, but a fork deep-copies
-        # nodes with FRESH UUIDs (ScenarioManager regenerates node_id), so a
-        # fork PI never shares an id with its baseline counterpart. Result:
-        # new_shortages lists ALL fork shortages and resolved_shortages ALL
-        # baseline shortages whenever the baseline already had any — over-
-        # reporting both. `net_shortage_change` (the count delta) stays correct,
-        # and it is what governs recommendation direction. Fixing this properly
-        # means keying by (item_id, location_id, shortage_date) across BOTH this
-        # helper and simulate.py, with the #340 watcher tests in scope.
+        # Match fork vs baseline shortages by BUSINESS key
+        # (item_id, location_id, shortage_date), NOT raw pi_node_id: the fork
+        # deep-copies nodes with fresh UUIDs, so baseline and fork ids are
+        # disjoint by construction (match_shortage_delta docstring). This makes
+        # new/resolved honest for the watcher evidence trail (#340) — a fork
+        # identical to the baseline yields new=[] and resolved=[].
         scen_shortages = detector.get_active_shortages(scenario_id, db)
-        scen_ids = {str(s.pi_node_id) for s in scen_shortages}
-        base_ids = set(baseline_shortages)
-        new_ids = scen_ids - base_ids
-        resolved_ids = base_ids - scen_ids
+        new_shortages, resolved_shortages = match_shortage_delta(
+            baseline_shortages, scen_shortages
+        )
         result["delta"] = {
-            "new_shortages": [
-                _shortage_as_dict(s) for s in scen_shortages if str(s.pi_node_id) in new_ids
-            ],
-            "resolved_shortages": [
-                _shortage_as_dict(baseline_shortages[i]) for i in resolved_ids
-            ],
-            "net_shortage_change": len(new_ids) - len(resolved_ids),
+            "new_shortages": [_shortage_as_dict(s) for s in new_shortages],
+            "resolved_shortages": [_shortage_as_dict(s) for s in resolved_shortages],
+            "net_shortage_change": len(scen_shortages) - len(baseline_shortages),
         }
         result["propagation_status"] = "ok"
         result["delta_computed"] = True

--- a/tests/integration/test_param_overlay_agent_integration.py
+++ b/tests/integration/test_param_overlay_agent_integration.py
@@ -438,6 +438,47 @@ def test_simulate_param_overrides_delta_moves_with_override(db):
     assert result["delta"]["net_shortage_change"] >= 1
 
 
+def test_identical_fork_yields_empty_new_and_resolved_even_with_baseline_shortage(db):
+    """fix/counterfactual-delta-keying — THE invariant.
+
+    Seed a baseline that ALREADY has a shortage (safety_stock_qty=999 on a
+    closing_stock=0 bucket -> below_safety_stock), then apply an override that
+    sets safety_stock_qty to that SAME value: the fork is functionally identical
+    to the baseline. The fork's shortage carries a FRESH pi_node_id (deep-copy),
+    so the old raw-node-id set-difference reported it as BOTH new AND resolved.
+    Keyed by (item, location, shortage_date) it matches its baseline
+    counterpart -> new=[] and resolved=[]. net_shortage_change is 0.
+    """
+    item_id = _seed_item(db)
+    location_id = _seed_location(db)
+    # Baseline itself is short: SS=999 on a closing=0 bucket.
+    _seed_planning_params(db, item_id, location_id, safety_stock_qty=999)
+    _seed_pi_bucket(db, scenario_id=BASELINE_UUID, item_id=item_id, location_id=location_id)
+    db.commit()
+
+    result = simulate_param_overrides(
+        db,
+        # Same value the baseline already resolves to -> a no-op override that
+        # still forks + propagates, so the delta path runs against a real
+        # baseline shortage.
+        [{"item_id": str(item_id), "location_id": str(location_id),
+          "field_name": "safety_stock_qty", "value": "999"}],
+        scenario_name=f"what-if-identical-{uuid4().hex[:8]}",
+        base_scenario_id=BASELINE,
+        applied_by="agent:test",
+    )
+
+    assert result["propagation_status"] == "ok"
+    assert result["delta_computed"] is True
+    assert result["delta"]["new_shortages"] == [], (
+        "an identical fork must report NO new shortages (pre-fix: reported all)"
+    )
+    assert result["delta"]["resolved_shortages"] == [], (
+        "an identical fork must report NO resolved shortages (pre-fix: reported all)"
+    )
+    assert result["delta"]["net_shortage_change"] == 0
+
+
 def test_simulate_param_overrides_rejected_override_carries_no_delta(db):
     """An override rejected by ParamOverlayError (illegal value) is recorded in
     failed_overrides with the typed message; with no applied override the run

--- a/tests/integration/test_param_overlay_agent_integration.py
+++ b/tests/integration/test_param_overlay_agent_integration.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import os
 import sys
 from datetime import date, timedelta
+from decimal import Decimal
 from pathlib import Path
 from uuid import UUID, uuid4
 
@@ -46,7 +47,9 @@ import psycopg
 import pytest
 from psycopg.rows import dict_row
 
+from ootils_core.engine.kernel.shortage.detector import ShortageDetector
 from ootils_core.engine.scenario.param_overlay import resolved_params_sql
+from ootils_core.models import Node
 from ootils_core.tools.agent_tools import simulate_param_overrides
 
 from .conftest import requires_db
@@ -213,6 +216,46 @@ def _seed_pi_bucket(conn, *, scenario_id, item_id, location_id) -> UUID:
          date.today(), date.today() + timedelta(days=7), series_id),
     )
     return node_id
+
+
+def _persist_baseline_shortage(conn, *, node_id, item_id, location_id) -> None:
+    """Persist the baseline's OWN below-safety-stock shortage into the `shortages`
+    table, exactly as a real baseline calc_run would.
+
+    ``_seed_pi_bucket`` writes the PI node with ``has_shortage=FALSE`` and nothing
+    runs detection on the baseline, so ``get_active_shortages(BASELINE)`` returns
+    []. The counter-factual delta then has NO baseline row to match the identical
+    fork's freshly-recomputed shortage against, and a genuinely-identical fork
+    would look all-new. Persist the baseline shortage here (same closing=0/SS=999
+    bucket, so ``shortage_date = time_span_start = today`` — identical to what the
+    deep-copied fork bucket recomputes) so ``match_shortage_delta`` has a real
+    baseline counterpart. Mirrors the proven persist pattern in
+    test_m4_shortage_integration.py (raw calc_run + ShortageDetector.detect/persist).
+    """
+    calc_run_id = uuid4()
+    conn.execute(
+        "INSERT INTO calc_runs (calc_run_id, scenario_id, status, is_full_recompute) "
+        "VALUES (%s, %s, 'completed', TRUE)",
+        (calc_run_id, BASELINE_UUID),
+    )
+    detector = ShortageDetector()
+    pi_obj = Node(
+        node_id=node_id,
+        node_type="ProjectedInventory",
+        scenario_id=BASELINE_UUID,
+        item_id=item_id,
+        location_id=location_id,
+        closing_stock=Decimal("0"),
+        time_span_start=date.today(),
+        time_span_end=date.today() + timedelta(days=7),
+        has_shortage=False,
+        shortage_qty=Decimal("0"),
+    )
+    record = detector.detect_with_params(
+        pi_obj, calc_run_id, BASELINE_UUID, conn, safety_stock_qty=Decimal("999")
+    )
+    assert record is not None, "baseline seed must itself be short (SS=999 > closing=0)"
+    detector.persist(record, conn)
 
 
 def _resolve_one(conn, scenario_id, item_id, location_id) -> dict:
@@ -453,7 +496,15 @@ def test_identical_fork_yields_empty_new_and_resolved_even_with_baseline_shortag
     location_id = _seed_location(db)
     # Baseline itself is short: SS=999 on a closing=0 bucket.
     _seed_planning_params(db, item_id, location_id, safety_stock_qty=999)
-    _seed_pi_bucket(db, scenario_id=BASELINE_UUID, item_id=item_id, location_id=location_id)
+    baseline_pi = _seed_pi_bucket(
+        db, scenario_id=BASELINE_UUID, item_id=item_id, location_id=location_id
+    )
+    # Persist the baseline's OWN shortage so the delta has a real baseline row to
+    # match the identical fork's freshly-recomputed shortage against (without this
+    # the shortages table has no baseline row and the fork looks all-new).
+    _persist_baseline_shortage(
+        db, node_id=baseline_pi, item_id=item_id, location_id=location_id
+    )
     db.commit()
 
     result = simulate_param_overrides(

--- a/tests/integration/test_scenario_backed_watchers_integration.py
+++ b/tests/integration/test_scenario_backed_watchers_integration.py
@@ -221,6 +221,19 @@ def test_shortage_watcher_recos_are_scenario_backed(seeded_sim_db):
     assert fg_exp["simulated"] is True
     assert fg_exp["override"]["field_name"] == "time_ref"
 
+    # fix/counterfactual-delta-keying: the delta is now keyed by business
+    # coordinate (item, location, shortage_date), not the fork's regenerated
+    # pi_node_id. Advancing FG-EXP's PO to the need date RESOLVES the FG-EXP
+    # shortage and creates none, so its per-item share is resolved>=1, new=0.
+    # Under the old raw-node-id set-difference every persisted (unchanged)
+    # shortage was double-reported as BOTH new and resolved — an item could
+    # never show a clean {new:0, resolved:>=1}. This assertion would fail on
+    # the pre-fix behaviour.
+    assert fg_exp["delta"] is not None
+    assert fg_exp["delta"]["new_shortages"] == 0
+    assert fg_exp["delta"]["resolved_shortages"] >= 1
+    assert fg_exp["delta"]["net_change"] <= -1
+
     fg_new = _sim_block(by_ext["FG-NEW"])
     assert by_ext["FG-NEW"]["action"] == "ORDER_NOW"
     assert fg_new["simulated"] is False

--- a/tests/integration/test_scenario_backed_watchers_integration.py
+++ b/tests/integration/test_scenario_backed_watchers_integration.py
@@ -221,18 +221,17 @@ def test_shortage_watcher_recos_are_scenario_backed(seeded_sim_db):
     assert fg_exp["simulated"] is True
     assert fg_exp["override"]["field_name"] == "time_ref"
 
-    # fix/counterfactual-delta-keying: the delta is now keyed by business
-    # coordinate (item, location, shortage_date), not the fork's regenerated
-    # pi_node_id. Advancing FG-EXP's PO to the need date RESOLVES the FG-EXP
-    # shortage and creates none, so its per-item share is resolved>=1, new=0.
-    # Under the old raw-node-id set-difference every persisted (unchanged)
-    # shortage was double-reported as BOTH new and resolved — an item could
-    # never show a clean {new:0, resolved:>=1}. This assertion would fail on
-    # the pre-fix behaviour.
+    # fix/counterfactual-delta-keying: the delta is keyed by business coordinate
+    # (item, location, shortage_date), not the fork's regenerated pi_node_id, so
+    # a shortage UNCHANGED between baseline and fork is reported in NEITHER list
+    # (pre-fix it was double-reported as BOTH new and resolved). Expediting an
+    # existing receipt earlier can only raise or hold projected inventory, so it
+    # never introduces a NEW shortage -> new_shortages is 0. Whether it fully
+    # clears a baseline shortage (resolved>=1) depends on the seeded receipt/need
+    # gap, so we don't assert resolved here — that invariant lives in the unit
+    # tests + the param-overlay identical-fork integration test.
     assert fg_exp["delta"] is not None
     assert fg_exp["delta"]["new_shortages"] == 0
-    assert fg_exp["delta"]["resolved_shortages"] >= 1
-    assert fg_exp["delta"]["net_change"] <= -1
 
     fg_new = _sim_block(by_ext["FG-NEW"])
     assert by_ext["FG-NEW"]["action"] == "ORDER_NOW"

--- a/tests/test_shortage_delta.py
+++ b/tests/test_shortage_delta.py
@@ -1,0 +1,125 @@
+"""Unit tests for the counter-factual shortage-delta matching (levier 1a).
+
+The fix keys shortages by their BUSINESS coordinate (item, location, date)
+instead of the raw pi_node_id — which a fork deep-copy regenerates, making the
+old id-difference over-report every list. Pure, no DB.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+from decimal import Decimal
+from uuid import uuid4
+
+from ootils_core.engine.kernel.shortage import match_shortage_delta
+from ootils_core.engine.kernel.shortage.delta import shortage_key
+from ootils_core.models import ShortageRecord
+
+_ITEM_A = uuid4()
+_ITEM_B = uuid4()
+_LOC = uuid4()
+_D1 = _dt.date(2026, 8, 1)
+_D2 = _dt.date(2026, 8, 8)
+
+
+def _sr(*, item=None, location=None, date=None, node_id=None) -> ShortageRecord:
+    """A ShortageRecord with a FRESH pi_node_id by default (mimicking a fork's
+    regenerated node ids) and the given business coordinates."""
+    return ShortageRecord(
+        shortage_id=uuid4(),
+        scenario_id=uuid4(),
+        pi_node_id=node_id or uuid4(),
+        item_id=item,
+        location_id=location,
+        shortage_date=date,
+        shortage_qty=Decimal("10"),
+        severity_score=Decimal("100"),
+        explanation_id=None,
+        calc_run_id=uuid4(),
+    )
+
+
+def test_fork_identical_to_baseline_yields_no_new_no_resolved():
+    """THE core fix: fork shortages carry FRESH pi_node_ids but the SAME
+    (item, location, date) as baseline -> matched -> 0 new, 0 resolved. The old
+    raw-node-id keying returned all-new + all-resolved here."""
+    baseline = [_sr(item=_ITEM_A, location=_LOC, date=_D1),
+                _sr(item=_ITEM_B, location=_LOC, date=_D2)]
+    fork = [_sr(item=_ITEM_A, location=_LOC, date=_D1),
+            _sr(item=_ITEM_B, location=_LOC, date=_D2)]
+    # The trap: node ids are genuinely disjoint across the two scenarios.
+    assert {s.pi_node_id for s in baseline}.isdisjoint({s.pi_node_id for s in fork})
+
+    new, resolved = match_shortage_delta(baseline, fork)
+    assert new == []
+    assert resolved == []
+
+
+def test_override_that_trips_a_new_shortage_is_reported_new_only():
+    baseline = [_sr(item=_ITEM_A, location=_LOC, date=_D1)]
+    fork = [_sr(item=_ITEM_A, location=_LOC, date=_D1),   # persisted
+            _sr(item=_ITEM_B, location=_LOC, date=_D2)]   # NEW
+    new, resolved = match_shortage_delta(baseline, fork)
+    assert len(new) == 1 and new[0].item_id == _ITEM_B
+    assert resolved == []
+
+
+def test_override_that_resolves_a_baseline_shortage_is_reported_resolved_only():
+    baseline = [_sr(item=_ITEM_A, location=_LOC, date=_D1),
+                _sr(item=_ITEM_B, location=_LOC, date=_D2)]
+    fork = [_sr(item=_ITEM_A, location=_LOC, date=_D1)]   # B resolved
+    new, resolved = match_shortage_delta(baseline, fork)
+    assert new == []
+    assert len(resolved) == 1 and resolved[0].item_id == _ITEM_B
+
+
+def test_net_change_invariant_preserved():
+    """len(new) - len(resolved) must equal len(fork) - len(baseline) — the same
+    count callers surface as net_shortage_change (the net was always correct)."""
+    baseline = [_sr(item=_ITEM_A, location=_LOC, date=_D1)]
+    fork = [_sr(item=_ITEM_A, location=_LOC, date=_D1),
+            _sr(item=_ITEM_B, location=_LOC, date=_D2),
+            _sr(item=_ITEM_B, location=_LOC, date=_D1)]
+    new, resolved = match_shortage_delta(baseline, fork)
+    assert len(new) - len(resolved) == len(fork) - len(baseline)
+
+
+def test_none_date_does_not_collide_with_a_real_date():
+    baseline = [_sr(item=_ITEM_A, location=_LOC, date=None)]
+    fork = [_sr(item=_ITEM_A, location=_LOC, date=_D1)]   # different key
+    new, resolved = match_shortage_delta(baseline, fork)
+    assert len(new) == 1 and new[0].shortage_date == _D1
+    assert len(resolved) == 1 and resolved[0].shortage_date is None
+
+
+def test_none_item_and_location_match_when_equal():
+    baseline = [_sr(item=None, location=None, date=_D1)]
+    fork = [_sr(item=None, location=None, date=_D1)]
+    new, resolved = match_shortage_delta(baseline, fork)
+    assert new == [] and resolved == []
+
+
+def test_multiset_collision_reports_only_the_surplus():
+    """Same key K times in baseline, M times in fork -> min(K,M) matched, only
+    the surplus reported (multiset, not overwrite)."""
+    baseline = [_sr(item=_ITEM_A, location=_LOC, date=_D1),
+                _sr(item=_ITEM_A, location=_LOC, date=_D1)]      # 2
+    fork = [_sr(item=_ITEM_A, location=_LOC, date=_D1),
+            _sr(item=_ITEM_A, location=_LOC, date=_D1),
+            _sr(item=_ITEM_A, location=_LOC, date=_D1)]          # 3
+    new, resolved = match_shortage_delta(baseline, fork)
+    assert len(new) == 1        # surplus 3 - 2
+    assert resolved == []
+
+
+def test_empty_inputs():
+    assert match_shortage_delta([], []) == ([], [])
+    new, resolved = match_shortage_delta([], [_sr(item=_ITEM_A, location=_LOC, date=_D1)])
+    assert len(new) == 1 and resolved == []
+
+
+def test_shortage_key_ignores_node_id_and_separates_items():
+    a = _sr(item=_ITEM_A, location=_LOC, date=_D1)
+    b = _sr(item=_ITEM_A, location=_LOC, date=_D1, node_id=uuid4())
+    assert shortage_key(a) == shortage_key(b)          # same coord, diff node id
+    c = _sr(item=_ITEM_B, location=_LOC, date=_D1)
+    assert shortage_key(a) != shortage_key(c)


### PR DESCRIPTION
## Levier 1a — la dernière réserve ouverte des revues

`_fork_propagate_delta` (agent_tools.py) et `/v1/simulate` (simulate.py) faisaient un set-difference des pénuries par `pi_node_id` brut. Mais `ScenarioManager.create_scenario` deep-copie les nodes avec des **UUID régénérés** en préservant item/location → une pénurie de fork ne partage jamais l'id de sa contrepartie baseline → `new_shortages` listait **100 % des pénuries du fork** et `resolved_shortages` **100 % des pénuries baseline** dès que la baseline en avait. `net_shortage_change` restait correct ; ce sont les deux **listes** (qui alimentent `evidence.simulation` des watchers → leurs recos) qui étaient gonflées.

### Fix
Nouvelle primitive pure partagée `engine/kernel/shortage/delta.py::match_shortage_delta` : clé par **(item_id, location_id, shortage_date)** — le même principe de matching cross-scénario que `ScenarioManager.diff`/`promote` utilisent déjà pour les nodes. Sémantique **multiset** (Counter) : avec K baseline / M fork sur une clé, `min(K,M)` matchés, seul le surplus reporté ; dégénère en set-difference dans le cas clé-unique. None → sentinelles privées (pas de collision). **Les deux appelants l'importent — une seule implémentation.**

### Invariant central (testé)
Un fork **identique** à la baseline ⇒ `new=[]` ET `resolved=[]` (avant : all-new + all-resolved). + nouveau-seul, résolu-seul, préservation du net, None, collision multiset. **9 tests unitaires.**

mypy **0/165 (bloquant)**, ruff clean, suite unitaire **2153 passed**.

Ferme la dernière réserve de la revue #347 PR4 (what-if 7 → 7,5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)