### PR TITLE
fix(crp): scenario-scope the CRP engine and endpoints (#396)

### DIFF
--- a/docs/SCALABILITY.md
+++ b/docs/SCALABILITY.md
@@ -1,17 +1,24 @@
 # Scalability Analysis — Ootils Core
 
-> **Status:** Current system is validated for demo and pilot scale. SMB (500 items) requires Tier 1 fixes. Mid-market (5K+ items) requires architectural investment.
+> **Status:** Demo and pilot scale are validated interactively. **Batch** planning is measured as viable up to the mid-market lower edge (SMB annual ≈ 182 K nodes in ~38 s, **post-tune**; 2 000 items × 365 d ≈ 730 K nodes in ~3.8 min, **post-Tier-2 but pre-tune** — a post-tune run would be faster) after the Tier 1 + Tier 2 fixes below — all on a **2-core VM** (`scripts/bench_propagation.py`, 2026-05-23). Two caveats before reading the table: those numbers are **batch** wall-clock, not proof of **interactive** latency; and the Tier 3 SQL-window spike that would push further is a prototype, **not merged** (see "What the spike does NOT cover"). Enterprise (5K+ items) still requires architectural investment.
 
 ---
 
 ## Volume projections
 
+The **PI Nodes** column is the full-network projection (all buckets × locations).
+The **measured** propagation figures below (§ "Measured perf landscape") run on a
+narrower annual slice — e.g. SMB is benched at 500 items × 365 d ≈ 182 K nodes,
+not the ~600 K full-network figure — so read the two columns as different axes.
+All measurements are on a **2-core VM**; nothing here is proven at interactive
+latency, and the Tier 3 SQL-window path is **not merged**.
+
 | Size | Items | Locations | PI Nodes | Edges | Status |
 |------|-------|-----------|----------|-------|--------|
-| Demo | 2 | 2 | ~400 | ~800 | ✅ OK |
-| Pilot (50 items) | 50 | 5 | ~30K | ~75K | ✅ OK with latency |
-| SMB (500 items) | 500 | 10 | ~600K | ~1.5M | ⚠️ **CRITICAL — Tier 1 required** |
-| Mid-market (5K items) | 5,000 | 50 | ~50M | ~150M | 🚫 **IMPOSSIBLE — Tier 2 required** |
+| Demo | 2 | 2 | ~400 | ~800 | ✅ OK (interactive) |
+| Pilot (50 items) | 50 | 5 | ~30K | ~75K | ✅ OK (interactive, with latency) |
+| SMB (500 items) | 500 | 10 | ~600K | ~1.5M | ✅ **Viable in batch** (measured: 182 K nodes / ~38 s, post-Tier-2 + post-tune) · ⚠️ interactive unproven |
+| Mid-market (5K items) | 5,000 | 50 | ~50M | ~150M | ⚠️ **Batch-viable only up to ~2 000 items** (measured: 730 K nodes / ~3.8 min, post-Tier-2 pre-tune — not yet re-benched post-tune); 5 K items **over a 2-year horizon** ≈ 3.6 M nodes / ~19 min is **extrapolated**, needs Tier 3 (unmerged) |
 | Enterprise (50K items) | 50,000 | 200 | ~3B | ~10B | 🚫 Not feasible without architectural overhaul |
 
 ---

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1064,6 +1064,123 @@
         }
       }
     },
+    "/v1/nodes/{node_id}/firm": {
+      "post": {
+        "tags": [
+          "nodes"
+        ],
+        "summary": "Firm Node",
+        "description": "Firm a PlannedSupply into a Firm Planned Order (is_firm=TRUE, #346).\n\nA firmed PlannedSupply survives the next MRP full-regeneration purge and\nis netted as a closed/committed receipt by both MRP engines — it is no\nlonger re-planned, but stays re-datable by a RESCHEDULE_IN/OUT message.",
+        "operationId": "firm_node_v1_nodes__node_id__firm_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "node_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Node Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FirmRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirmResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "nodes"
+        ],
+        "summary": "Unfirm Node",
+        "description": "Un-firm a Firm Planned Order back into an ordinary PlannedSupply\n(is_firm=FALSE, #346).\n\nThe order becomes re-generatable again: the next MRP full-regeneration\npurge will deactivate it and, if its demand is still open, replace it.\n\n`actor` is a query parameter (not a body) — DELETE requests in this\nrepo don't carry a body (see param_overrides.py's\nclear_param_override_endpoint).",
+        "operationId": "unfirm_node_v1_nodes__node_id__firm_delete",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "node_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Node Id"
+            }
+          },
+          {
+            "name": "actor",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200,
+              "title": "Actor"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirmResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/ingest/items": {
       "post": {
         "tags": [
@@ -3696,6 +3813,190 @@
         }
       }
     },
+    "/v1/scenarios/{scenario_id}/param-overrides": {
+      "post": {
+        "tags": [
+          "param-overrides"
+        ],
+        "summary": "Set Param Override Endpoint",
+        "description": "Set (upsert) a scenario-scoped planning-param overlay override.\n\nL0 simulation-only write — no Decision Ladder gate, never promoted onto\nbaseline (ADR-025 §5). Refused on the baseline scenario, on a\nnon-whitelisted field, on an out-of-bounds value, or on an item/location\nwith no current planning-params row — all via ParamOverlayError -> 422.",
+        "operationId": "set_param_override_endpoint_v1_scenarios__scenario_id__param_overrides_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "scenario_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Scenario Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ParamOverrideIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ParamOverrideOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "param-overrides"
+        ],
+        "summary": "List Param Overrides Endpoint",
+        "description": "List every planning-param overlay override for a scenario.\n\nA baseline scenario_id (or any scenario with no overrides) returns 200\nwith an empty list — a baseline can never carry an override\n(set_param_override refuses it), so this is a legitimate empty result,\nnot an error.",
+        "operationId": "list_param_overrides_endpoint_v1_scenarios__scenario_id__param_overrides_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "scenario_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Scenario Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ParamOverridesListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/scenarios/{scenario_id}/param-overrides/{field_name}": {
+      "delete": {
+        "tags": [
+          "param-overrides"
+        ],
+        "summary": "Clear Param Override Endpoint",
+        "description": "Clear a scenario-scoped planning-param overlay override.\n\nIdempotent: a missing override is a no-op (still 204) — only an unknown\nfield_name or an unknown scenario_id raises (422). No baseline special\ncase: clearing on baseline is simply the no-op path (baseline can never\nhold an override).",
+        "operationId": "clear_param_override_endpoint_v1_scenarios__scenario_id__param_overrides__field_name__delete",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "scenario_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Scenario Id"
+            }
+          },
+          {
+            "name": "field_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Field Name"
+            }
+          },
+          {
+            "name": "item_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Item Id"
+            }
+          },
+          {
+            "name": "location_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Location Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/calc/run": {
       "post": {
         "tags": [
@@ -5474,15 +5775,56 @@
         "summary": "Calculate CRP",
         "description": "Perform Capacity Requirements Planning calculation.\n\nExplodes planned orders into operations via routings, computes load per work center per day using backward scheduling, and detects overloads (infinite loading).",
         "operationId": "calculate_crp_v1_crp_calculate_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "scenario_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scenario UUID or 'baseline'",
+              "title": "Scenario Id"
+            },
+            "description": "Scenario UUID or 'baseline'"
+          },
+          {
+            "name": "X-Scenario-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Scenario-Id"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/CRPCalculateRequest"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -5505,12 +5847,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ]
+        }
       }
     },
     "/v1/crp/load-profile/{work_center_id}": {
@@ -5552,6 +5889,40 @@
               "title": "Horizon Days"
             },
             "description": "Planning horizon in days"
+          },
+          {
+            "name": "scenario_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scenario UUID or 'baseline'",
+              "title": "Scenario Id"
+            },
+            "description": "Scenario UUID or 'baseline'"
+          },
+          {
+            "name": "X-Scenario-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Scenario-Id"
+            }
           }
         ],
         "responses": {
@@ -5623,6 +5994,40 @@
               "title": "Work Center Ids"
             },
             "description": "Comma-separated list of work center IDs to filter"
+          },
+          {
+            "name": "scenario_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scenario UUID or 'baseline'",
+              "title": "Scenario Id"
+            },
+            "description": "Scenario UUID or 'baseline'"
+          },
+          {
+            "name": "X-Scenario-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Scenario-Id"
+            }
           }
         ],
         "responses": {
@@ -5657,15 +6062,56 @@
         "summary": "Suggest Resolutions for Overloads",
         "description": "Analyze detected overloads and suggest order date shifts to resolve them.\n\nStrategy: For each overload, identifies planned orders contributing to the overload and suggests shifting them to the next available capacity slot.",
         "operationId": "suggest_resolutions_v1_crp_suggest_resolutions_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "scenario_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scenario UUID or 'baseline'",
+              "title": "Scenario Id"
+            },
+            "description": "Scenario UUID or 'baseline'"
+          },
+          {
+            "name": "X-Scenario-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Scenario-Id"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/CRPSuggestResolutionsRequest"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -5688,12 +6134,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ]
+        }
       }
     }
   },
@@ -6830,23 +7271,12 @@
             ],
             "title": "Work Center Ids",
             "description": "Optional list of work center IDs to include"
-          },
-          "scenario_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Scenario Id",
-            "description": "Optional scenario ID to filter planned orders"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "title": "CRPCalculateRequest",
-        "description": "Request for CRP calculation."
+        "description": "Request for CRP calculation.\n\nscenario_id is NOT a body field: it is resolved from the ``scenario_id`` query\nparam or the ``X-Scenario-ID`` header (see resolve_scenario_id), consistent with\nATP/RCCP. Defaults to baseline."
       },
       "CRPCalculateResponse": {
         "properties": {
@@ -8962,6 +9392,73 @@
           "components_with_shortage"
         ],
         "title": "ExplodeResponse"
+      },
+      "FirmRequest": {
+        "properties": {
+          "actor": {
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Actor"
+          }
+        },
+        "type": "object",
+        "required": [
+          "actor"
+        ],
+        "title": "FirmRequest",
+        "description": "Body of POST /v1/nodes/{node_id}/firm.\n\nIdentity of the actor. The current auth layer doesn't extract subjects\nfrom the bearer token (single shared token, see api/auth.py), so callers\npass it explicitly for now — same carve-out as staging.py's\napproved_by/rejected_by."
+      },
+      "FirmResponse": {
+        "properties": {
+          "node_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Node Id"
+          },
+          "is_firm": {
+            "type": "boolean",
+            "title": "Is Firm"
+          },
+          "scenario_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Scenario Id"
+          },
+          "item_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Item Id"
+          },
+          "location_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "node_id",
+          "is_firm",
+          "scenario_id",
+          "item_id",
+          "location_id"
+        ],
+        "title": "FirmResponse"
       },
       "ForecastAdjustRequest": {
         "properties": {
@@ -11513,6 +12010,137 @@
           "new_value"
         ],
         "title": "OverrideIn"
+      },
+      "ParamOverrideIn": {
+        "properties": {
+          "item_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Item Id"
+          },
+          "location_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location Id"
+          },
+          "field_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Field Name"
+          },
+          "value": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Value"
+          },
+          "applied_by": {
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Applied By"
+          }
+        },
+        "type": "object",
+        "required": [
+          "item_id",
+          "field_name",
+          "value",
+          "applied_by"
+        ],
+        "title": "ParamOverrideIn",
+        "description": "Body of POST .../param-overrides — one scenario-scoped field override."
+      },
+      "ParamOverrideOut": {
+        "properties": {
+          "override_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Override Id"
+          },
+          "scenario_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Scenario Id"
+          },
+          "item_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Item Id"
+          },
+          "location_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location Id"
+          },
+          "field_name": {
+            "type": "string",
+            "title": "Field Name"
+          },
+          "value": {
+            "type": "string",
+            "title": "Value"
+          },
+          "applied_at": {
+            "type": "string",
+            "title": "Applied At"
+          },
+          "applied_by": {
+            "type": "string",
+            "title": "Applied By"
+          }
+        },
+        "type": "object",
+        "required": [
+          "override_id",
+          "scenario_id",
+          "item_id",
+          "field_name",
+          "value",
+          "applied_at",
+          "applied_by"
+        ],
+        "title": "ParamOverrideOut"
+      },
+      "ParamOverridesListResponse": {
+        "properties": {
+          "scenario_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Scenario Id"
+          },
+          "overrides": {
+            "items": {
+              "$ref": "#/components/schemas/ParamOverrideOut"
+            },
+            "type": "array",
+            "title": "Overrides"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "scenario_id",
+          "overrides",
+          "total"
+        ],
+        "title": "ParamOverridesListResponse"
       },
       "PeggingNode": {
         "properties": {

--- a/src/ootils_core/crp/engine.py
+++ b/src/ootils_core/crp/engine.py
@@ -25,6 +25,7 @@ from decimal import Decimal
 from typing import Dict, List, Optional, Tuple, Any
 from uuid import UUID
 
+from ootils_core.constants import BASELINE_SCENARIO_ID
 from ootils_core.crp.models import WorkCenter, Routing, Operation
 from ootils_core.db.types import DictRowConnection
 
@@ -320,19 +321,21 @@ class CRPEngine:
         self,
         horizon_days: int = 90,
         work_centers: Optional[List[UUID]] = None,
-        scenario_id: Optional[UUID] = None,
+        scenario_id: UUID = BASELINE_SCENARIO_ID,
     ) -> CRPResult:
         """
         Perform CRP calculation.
-        
+
         Args:
             horizon_days: Number of days to plan ahead (default: 90)
             work_centers: Optional list of work center IDs to include (default: all active)
-            scenario_id: Optional scenario ID to filter planned orders
-        
+            scenario_id: Scenario to read planned orders from (default: baseline).
+                A fork that wrote planned supply must not contaminate the baseline
+                load; every planned-order read is filtered by this scenario.
+
         Returns:
             CRPResult with load profiles and overloads
-        
+
         Raises:
             ValueError: If no database connection is set
             RuntimeError: If calculation fails
@@ -350,9 +353,9 @@ class CRPEngine:
         horizon_end = horizon_start + timedelta(days=horizon_days)
         
         logger.info(
-            "CRP calculation started: horizon=%s to %s (%s days), work_centers=%s",
+            "CRP calculation started: horizon=%s to %s (%s days), work_centers=%s, scenario=%s",
             horizon_start, horizon_end, horizon_days,
-            len(work_centers) if work_centers else "all"
+            len(work_centers) if work_centers else "all", scenario_id,
         )
         
         result = CRPResult(calculation_id, horizon_start, horizon_end)
@@ -551,16 +554,17 @@ class CRPEngine:
         self,
         start_date: date,
         end_date: date,
-        scenario_id: Optional[UUID] = None,
+        scenario_id: UUID = BASELINE_SCENARIO_ID,
     ) -> List[Dict[str, Any]]:
         """
         Fetch planned orders from MRP/MPS.
-        
+
         Args:
             start_date: Start of horizon
             end_date: End of horizon
-            scenario_id: Optional scenario filter
-        
+            scenario_id: Scenario to read from (default: baseline). Always applied —
+                a baseline read must never see a fork's planned supply (and vice-versa).
+
         Returns:
             List of planned orders with item_id, due_date, quantity
         """
@@ -570,38 +574,25 @@ class CRPEngine:
             raise ValueError("Database connection not set")
 
         with self._conn.cursor() as cur:
-            if scenario_id:
-                cur.execute("""
-                    SELECT 
-                        planned_supply_id,
-                        item_id,
-                        location_id,
-                        quantity,
-                        due_date,
-                        status
-                    FROM planned_supply
-                    WHERE due_date >= %s
-                      AND due_date < %s
-                      AND scenario_id = %s
-                      AND status IN ('RELEASED', 'APPROVED', 'PLANNED')
-                    ORDER BY due_date
-                """, (start_date, end_date, scenario_id))
-            else:
-                cur.execute("""
-                    SELECT 
-                        planned_supply_id,
-                        item_id,
-                        location_id,
-                        quantity,
-                        due_date,
-                        status
-                    FROM planned_supply
-                    WHERE due_date >= %s
-                      AND due_date < %s
-                      AND status IN ('RELEASED', 'APPROVED', 'PLANNED')
-                    ORDER BY due_date
-                """, (start_date, end_date))
-            
+            # Scenario isolation: planned_supply is scenario-scoped (migration 030),
+            # so the load is read from exactly one scenario. `scenario_id` defaults
+            # to baseline but is never omitted from the predicate.
+            cur.execute("""
+                SELECT
+                    planned_supply_id,
+                    item_id,
+                    location_id,
+                    quantity,
+                    due_date,
+                    status
+                FROM planned_supply
+                WHERE due_date >= %s
+                  AND due_date < %s
+                  AND scenario_id = %s
+                  AND status IN ('RELEASED', 'APPROVED', 'PLANNED')
+                ORDER BY due_date
+            """, (start_date, end_date, scenario_id))
+
             for row in cur.fetchall():
                 ps_id, item_id, loc_id, qty, due_date, status = _row_values(
                     row,
@@ -722,36 +713,48 @@ class CRPEngine:
         self,
         work_center_id: UUID,
         horizon_days: int = 90,
+        scenario_id: UUID = BASELINE_SCENARIO_ID,
     ) -> Optional[LoadProfile]:
         """
         Get load profile for a specific work center.
-        
+
         Args:
             work_center_id: The work center to get profile for
             horizon_days: Number of days in the horizon
-        
+            scenario_id: Scenario to read planned orders from (default: baseline)
+
         Returns:
             LoadProfile for the work center, or None if not found
         """
-        result = self.calculate(horizon_days=horizon_days, work_centers=[work_center_id])
+        result = self.calculate(
+            horizon_days=horizon_days,
+            work_centers=[work_center_id],
+            scenario_id=scenario_id,
+        )
         return result.load_profiles.get(work_center_id)
-    
+
     def get_overloads(
         self,
         horizon_days: int = 90,
         work_centers: Optional[List[UUID]] = None,
+        scenario_id: UUID = BASELINE_SCENARIO_ID,
     ) -> List[Overload]:
         """
         Get all overloads in the planning horizon.
-        
+
         Args:
             horizon_days: Number of days in the horizon
             work_centers: Optional list of work centers to check
-        
+            scenario_id: Scenario to read planned orders from (default: baseline)
+
         Returns:
             List of Overload objects
         """
-        result = self.calculate(horizon_days=horizon_days, work_centers=work_centers)
+        result = self.calculate(
+            horizon_days=horizon_days,
+            work_centers=work_centers,
+            scenario_id=scenario_id,
+        )
         return result.overloads
     
     def suggest_resolutions(
@@ -759,18 +762,20 @@ class CRPEngine:
         horizon_days: int = 90,
         work_centers: Optional[List[UUID]] = None,
         max_shift_days: int = 14,
+        scenario_id: UUID = BASELINE_SCENARIO_ID,
     ) -> List[Dict[str, Any]]:
         """
         Suggest resolutions for detected overloads by shifting order dates.
-        
+
         Strategy: For each overload, find planned orders contributing to that day
         and suggest shifting them to the next available capacity slot.
-        
+
         Args:
             horizon_days: Planning horizon in days
             work_centers: Optional list of work centers to analyze
             max_shift_days: Maximum days to suggest shifting (default: 14)
-        
+            scenario_id: Scenario to read planned orders from (default: baseline)
+
         Returns:
             List of resolution suggestions with:
             - work_center_id, work_center_code
@@ -780,22 +785,26 @@ class CRPEngine:
         """
         if self._conn is None:
             raise ValueError("Database connection not set")
-        
+
         # First get all overloads
-        overloads = self.get_overloads(horizon_days=horizon_days, work_centers=work_centers)
-        
+        overloads = self.get_overloads(
+            horizon_days=horizon_days,
+            work_centers=work_centers,
+            scenario_id=scenario_id,
+        )
+
         if not overloads:
             return []
-        
+
         suggestions: List[Dict[str, Any]] = []
         horizon_start = date.today()
         horizon_end = horizon_start + timedelta(days=horizon_days)
-        
+
         # Group overloads by work center and date for efficient processing
         overload_map: Dict[Tuple[UUID, date], Overload] = {}
         for ol in overloads:
             overload_map[(ol.work_center_id, ol.overload_date)] = ol
-        
+
         # For each overloaded work center, find contributing orders
         for (wc_id, ol_date), overload in overload_map.items():
             suggestion = self._suggest_resolution_for_overload(
@@ -805,12 +814,13 @@ class CRPEngine:
                 horizon_start=horizon_start,
                 horizon_end=horizon_end,
                 max_shift_days=max_shift_days,
+                scenario_id=scenario_id,
             )
             if suggestion:
                 suggestions.append(suggestion)
-        
+
         return suggestions
-    
+
     def _suggest_resolution_for_overload(
         self,
         work_center_id: UUID,
@@ -819,6 +829,7 @@ class CRPEngine:
         horizon_start: date,
         horizon_end: date,
         max_shift_days: int,
+        scenario_id: UUID = BASELINE_SCENARIO_ID,
     ) -> Optional[Dict[str, Any]]:
         """
         Suggest resolution for a single overload by finding orders to shift.
@@ -838,6 +849,10 @@ class CRPEngine:
             # The alias `wc` and the SQL column alias `work_center_code`
             # are kept so downstream Python (suggestion dict keys) is
             # untouched.
+            # Scenario isolation: `planned_supply` is scenario-scoped — the join
+            # is filtered on ps.scenario_id so a fork's orders never leak into a
+            # baseline resolution (the master-data legs — items/routings/resources
+            # — are not scenario-scoped and are joined unfiltered).
             cur.execute("""
                 SELECT
                     ps.planned_supply_id,
@@ -859,9 +874,10 @@ class CRPEngine:
                 WHERE ps.due_date >= %s
                   AND ps.due_date <= %s
                   AND wc.resource_id = %s
+                  AND ps.scenario_id = %s
                   AND ps.status IN ('RELEASED', 'APPROVED', 'PLANNED')
                 ORDER BY ps.due_date DESC, op.sequence DESC
-            """, (horizon_start, horizon_end, work_center_id))
+            """, (horizon_start, horizon_end, work_center_id, scenario_id))
             
             rows = cur.fetchall()
         

--- a/src/ootils_core/crp/routers.py
+++ b/src/ootils_core/crp/routers.py
@@ -14,10 +14,10 @@ from typing import List, Optional, Dict, Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status, Path
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from ootils_core.api.auth import require_auth
-from ootils_core.api.dependencies import get_db
+from ootils_core.api.dependencies import get_db, resolve_scenario_id
 from ootils_core.crp.engine import CRPEngine
 from ootils_core.db.types import DictRowConnection
 
@@ -31,10 +31,22 @@ router = APIRouter(prefix="/v1/crp", tags=["crp"])
 # ─────────────────────────────────────────────────────────────
 
 class CRPCalculateRequest(BaseModel):
-    """Request for CRP calculation."""
+    """Request for CRP calculation.
+
+    scenario_id is NOT a body field: it is resolved from the ``scenario_id`` query
+    param or the ``X-Scenario-ID`` header (see resolve_scenario_id), consistent with
+    ATP/RCCP. Defaults to baseline.
+    """
+    # extra="forbid": scenario_id used to be a body field and moved to
+    # query/header. Without this, an old client (or one following a stale
+    # openapi.json) POSTing scenario_id in the body would have it silently
+    # dropped by Pydantic's default extra="ignore" — landing on baseline with
+    # a 200 OK, the exact silent-fallback bug this module was fixed to avoid.
+    # A stray body field must fail loudly (422), not disappear.
+    model_config = ConfigDict(extra="forbid")
+
     horizon_days: int = Field(default=90, ge=1, le=365, description="Planning horizon in days")
     work_center_ids: Optional[List[str]] = Field(None, description="Optional list of work center IDs to include")
-    scenario_id: Optional[str] = Field(None, description="Optional scenario ID to filter planned orders")
 
 
 class LoadBucketOut(BaseModel):
@@ -106,16 +118,17 @@ class CRPOverloadsResponse(BaseModel):
 )
 async def calculate_crp(
     body: CRPCalculateRequest,
+    scenario_id: UUID = Depends(resolve_scenario_id),
     db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> CRPCalculateResponse:
     """
     Calculate CRP load profiles and detect overloads.
-    
+
     - **horizon_days**: Planning horizon in days (default: 90, max: 365)
     - **work_center_ids**: Optional list of work center IDs to include (default: all active)
-    - **scenario_id**: Optional scenario ID to filter planned orders
-    
+    - **scenario_id**: Scenario to read from (query param or X-Scenario-ID header; default: baseline)
+
     Returns:
     - **calculation_id**: Unique identifier for this calculation
     - **horizon_start/end**: Date range of the planning horizon
@@ -139,25 +152,14 @@ async def calculate_crp(
                     detail=f"Invalid work center ID format: {wc_id}",
                 )
     
-    # Convert scenario ID from string to UUID
-    scenario_uuid: Optional[UUID] = None
-    if body.scenario_id:
-        try:
-            scenario_uuid = UUID(body.scenario_id)
-        except ValueError:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Invalid scenario ID format: {body.scenario_id}",
-            )
-    
     # Initialize CRP engine and calculate
     engine = CRPEngine(db_conn=db)
-    
+
     try:
         result = engine.calculate(
             horizon_days=body.horizon_days,
             work_centers=work_center_uuids,
-            scenario_id=scenario_uuid,
+            scenario_id=scenario_id,
         )
     except Exception as e:
         logger.exception("CRP calculation failed: %s", e)
@@ -231,15 +233,17 @@ async def calculate_crp(
 async def get_load_profile(
     work_center_id: UUID = Path(..., description="Work center UUID"),
     horizon_days: int = Query(default=90, ge=1, le=365, description="Planning horizon in days"),
+    scenario_id: UUID = Depends(resolve_scenario_id),
     db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> LoadProfileOut:
     """
     Get load profile for a specific work center.
-    
+
     - **work_center_id**: UUID of the work center
     - **horizon_days**: Planning horizon in days (default: 90)
-    
+    - **scenario_id**: Scenario to read from (query param or X-Scenario-ID header; default: baseline)
+
     Returns:
     - **work_center_id**: UUID of the work center
     - **work_center_code**: Human-readable code
@@ -249,11 +253,12 @@ async def get_load_profile(
     - **overload_count**: Number of days with overloads
     """
     engine = CRPEngine(db_conn=db)
-    
+
     try:
         profile = engine.get_load_profile(
             work_center_id=work_center_id,
             horizon_days=horizon_days,
+            scenario_id=scenario_id,
         )
     except Exception as e:
         logger.exception("Failed to get load profile: %s", e)
@@ -306,15 +311,17 @@ async def get_load_profile(
 async def get_overloads(
     horizon_days: int = Query(default=90, ge=1, le=365, description="Planning horizon in days"),
     work_center_ids: Optional[str] = Query(None, description="Comma-separated list of work center IDs to filter"),
+    scenario_id: UUID = Depends(resolve_scenario_id),
     db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> CRPOverloadsResponse:
     """
     List all detected overloads.
-    
+
     - **horizon_days**: Planning horizon in days (default: 90)
     - **work_center_ids**: Optional comma-separated list of work center IDs to filter
-    
+    - **scenario_id**: Scenario to read from (query param or X-Scenario-ID header; default: baseline)
+
     Returns:
     - **horizon_start/end**: Date range of the planning horizon
     - **total_overloads**: Total number of overloads
@@ -343,6 +350,7 @@ async def get_overloads(
         overloads = engine.get_overloads(
             horizon_days=horizon_days,
             work_centers=work_center_uuids,
+            scenario_id=scenario_id,
         )
     except Exception as e:
         logger.exception("Failed to get overloads: %s", e)
@@ -424,16 +432,18 @@ class CRPSuggestResolutionsResponse(BaseModel):
 )
 async def suggest_resolutions(
     body: CRPSuggestResolutionsRequest,
+    scenario_id: UUID = Depends(resolve_scenario_id),
     db: DictRowConnection = Depends(get_db),
     _token: str = Depends(require_auth),
 ) -> CRPSuggestResolutionsResponse:
     """
     Suggest resolutions for CRP overloads.
-    
+
     - **horizon_days**: Planning horizon in days (default: 90)
     - **work_center_ids**: Optional list of work center IDs to analyze
     - **max_shift_days**: Maximum days to suggest shifting (default: 14)
-    
+    - **scenario_id**: Scenario to read from (query param or X-Scenario-ID header; default: baseline)
+
     Returns:
     - **horizon_start/end**: Date range of the planning horizon
     - **total_suggestions**: Number of resolution suggestions
@@ -459,6 +469,7 @@ async def suggest_resolutions(
             horizon_days=body.horizon_days,
             work_centers=work_center_uuids,
             max_shift_days=body.max_shift_days,
+            scenario_id=scenario_id,
         )
     except Exception as e:
         logger.exception("Failed to suggest resolutions: %s", e)

--- a/src/ootils_core/demo/phase1.py
+++ b/src/ootils_core/demo/phase1.py
@@ -178,10 +178,12 @@ def _execute_phase1_demo(database_url: str, token: str) -> dict:
             conn.execute("UPDATE planned_supply SET status = 'RELEASED' WHERE source_id = %s", (mps_id,))
             conn.commit()
 
+        # scenario_id is not a CRPCalculateRequest body field (it resolves from
+        # the query param / X-Scenario-ID header, and the model now forbids
+        # unknown body keys) — the demo runs on baseline, the default.
         crp = _post(client, "/v1/crp/calculate", auth, {
             "horizon_days": 30,
             "work_center_ids": [str(work_center_id)],
-            "scenario_id": BASELINE_SCENARIO_ID,
         })
 
         atp = _post(client, "/v1/atp/check", auth, {

--- a/src/ootils_core/mps/api.py
+++ b/src/ootils_core/mps/api.py
@@ -997,7 +997,11 @@ async def promote_to_mrp(
     if body.run_crp and not body.dry_run:
         try:
             from ootils_core.crp.engine import CRPEngine
-            
+
+            # promote_to_mrp writes planned_supply on baseline (the INSERT does not
+            # carry the MPS scenario_id), so CRP reads baseline — reading the MPS
+            # fork here would find zero promoted orders. CRP now always scenario-
+            # scopes its planned-order read; baseline is the explicit default.
             crp_engine = CRPEngine(db_conn=db)
             crp_result = crp_engine.calculate(horizon_days=body.crp_horizon_days)
             

--- a/tests/integration/test_phase1_e2e.py
+++ b/tests/integration/test_phase1_e2e.py
@@ -184,10 +184,13 @@ def test_phase1_forecast_mps_crp_atp_rest_e2e(api_client, auth, seeded_db):
         )
         conn.commit()
 
+    # scenario_id is not a CRPCalculateRequest body field (query param /
+    # X-Scenario-ID header only; the model now forbids unknown body keys) —
+    # this test runs on baseline, the default.
     crp_resp = api_client.post(
         "/v1/crp/calculate",
         headers=auth,
-        json={"horizon_days": 30, "scenario_id": BASELINE_SCENARIO_ID},
+        json={"horizon_days": 30},
     )
     assert crp_resp.status_code == 200, crp_resp.text
     crp = crp_resp.json()

--- a/tests/integration/test_scenario_isolation_crp_integration.py
+++ b/tests/integration/test_scenario_isolation_crp_integration.py
@@ -1,0 +1,394 @@
+"""
+Scenario-isolation integration test for CRP (#396).
+
+Before the fix, ``CRPEngine._fetch_planned_orders`` fell back to an
+*unfiltered* ``planned_supply`` query whenever ``scenario_id`` was ``None``
+(and the ``/v1/crp/*`` endpoints never resolved a scenario at all). A fork that
+wrote planned supply therefore contaminated the baseline CRP load, and vice-
+versa. CRP now always scenario-scopes its planned-order read and every
+``/v1/crp/*`` endpoint resolves ``scenario_id`` (query param or
+``X-Scenario-ID`` header, default baseline) — matching ATP (#…) and RCCP (#338).
+
+This test seeds a baseline dataset plus a fork scenario with an *extra*
+planned supply and asserts:
+
+  (a) the baseline response counts / loads only the baseline order (the fork's
+      order is invisible);
+  (b) the response with ``?scenario_id=<fork>`` (or ``X-Scenario-ID`` header)
+      reflects the fork order only;
+  (c) reading the fork does not contaminate a subsequent baseline read.
+
+Mechanics (fixtures, seeding shape, dict_row-by-name access, CURRENT_DATE-
+relative dates, per-test teardown) are copied from
+``tests/integration/test_scenario_isolation_atp_rccp_integration.py`` — a
+passing pattern. Runs against a real PostgreSQL database (no mocks) on a fresh
+migrated DB; every row is created and cleaned up locally.
+"""
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+AUTH_HEADERS = {"Authorization": "Bearer integration-test-token"}
+BASELINE_SCENARIO_ID = "00000000-0000-0000-0000-000000000001"
+
+
+# ---------------------------------------------------------------------------
+# Shared module-scoped fixtures (mirror the ATP/RCCP isolation module)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def api_client(migrated_db):
+    """Module-scoped FastAPI TestClient bound to the real test DB."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = "integration-test-token"
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+    from fastapi.testclient import TestClient
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="module")
+def auth():
+    return AUTH_HEADERS
+
+
+@pytest.fixture(scope="module")
+def fork_scenario_id(migrated_db) -> str:
+    """Create a fork scenario row (parent = baseline), return its id."""
+    import psycopg
+    from psycopg.rows import dict_row
+
+    scenario_id = uuid4()
+    with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        conn.execute(
+            """
+            INSERT INTO scenarios (scenario_id, name, parent_scenario_id)
+            VALUES (%s, %s, %s::UUID)
+            """,
+            (scenario_id, "crp-isolation-fork", BASELINE_SCENARIO_ID),
+        )
+        conn.commit()
+    return str(scenario_id)
+
+
+# ---------------------------------------------------------------------------
+# Seeding helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_item_and_location(conn) -> tuple[UUID, UUID]:
+    """Create a unique item + location, return their ids."""
+    item_id = uuid4()
+    location_id = uuid4()
+    conn.execute(
+        "INSERT INTO items (item_id, name) VALUES (%s, %s)",
+        (item_id, f"CRP Iso Item {item_id}"),
+    )
+    conn.execute(
+        "INSERT INTO locations (location_id, name) VALUES (%s, %s)",
+        (location_id, f"CRP Iso Loc {location_id}"),
+    )
+    return item_id, location_id
+
+
+def _insert_work_center(conn) -> UUID:
+    """Insert a work-center-flavoured row in the unified ``resources`` table.
+
+    Master data — NOT scenario-scoped (shared by baseline and the fork).
+    """
+    wc_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO resources (
+            resource_id, external_id, name, resource_type,
+            capacity_per_day, capacity_unit, efficiency, active
+        ) VALUES (%s, %s, 'CRP Iso WC', 'work_center', 80, 'unit', 1.0, TRUE)
+        """,
+        (wc_id, f"WC-CRP-ISO-{wc_id.hex[:8]}"),
+    )
+    return wc_id
+
+
+def _insert_routing_with_operation(conn, *, item_id: UUID, work_center_id: UUID) -> tuple[UUID, UUID]:
+    """Insert a routing + a single operation on the work center (master data)."""
+    routing_id = uuid4()
+    operation_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO routings (routing_id, item_id, sequence, description, active)
+        VALUES (%s, %s, 1, 'CRP Iso routing', TRUE)
+        """,
+        (routing_id, item_id),
+    )
+    conn.execute(
+        """
+        INSERT INTO routing_operations (
+            operation_id, routing_id, sequence, resource_id,
+            setup_time, run_time_per_unit, description, active
+        ) VALUES (%s, %s, 10, %s, 0, 0.5, 'CRP Iso op', TRUE)
+        """,
+        (operation_id, routing_id, work_center_id),
+    )
+    return routing_id, operation_id
+
+
+def _seed_planned_supply(
+    conn, *, item_id, location_id, quantity, due_date, scenario_id=BASELINE_SCENARIO_ID
+) -> UUID:
+    ps_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO planned_supply
+            (planned_supply_id, item_id, location_id, scenario_id, quantity, due_date, status, priority)
+        VALUES (%s, %s, %s, %s::UUID, %s, %s, 'RELEASED', 0)
+        """,
+        (ps_id, item_id, location_id, scenario_id, quantity, due_date),
+    )
+    return ps_id
+
+
+def _teardown_crp_rows(conn, *, item_id, location_id, work_center_id, routing_id) -> None:
+    """Delete every CRP row written for this item/location/work center."""
+    conn.execute("DELETE FROM routing_operations WHERE routing_id = %s", (routing_id,))
+    conn.execute("DELETE FROM routings WHERE routing_id = %s", (routing_id,))
+    conn.execute("DELETE FROM planned_supply WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM resources WHERE resource_id = %s", (work_center_id,))
+    conn.execute("DELETE FROM items WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM locations WHERE location_id = %s", (location_id,))
+
+
+def _stable(body: dict) -> dict:
+    """Strip per-call noise so two identical calculations compare equal.
+
+    ``calculation_id`` is a fresh uuid4 on every call and ``calculation_time_ms``
+    is timing — both differ run-to-run even for an identical order set.
+    """
+    return {
+        k: v for k, v in body.items()
+        if k not in ("calculation_time_ms", "calculation_id")
+    }
+
+
+def _total_load(body: dict, work_center_id: str) -> float:
+    """Sum the load across the buckets of one work center's profile (0.0 if absent)."""
+    profile = body["load_profiles"].get(work_center_id)
+    if profile is None:
+        return 0.0
+    return float(profile["total_load_hours"])
+
+
+# ---------------------------------------------------------------------------
+# CRP — baseline vs fork isolation
+# ---------------------------------------------------------------------------
+
+
+class TestCRPScenarioIsolation:
+    """POST /v1/crp/calculate planned-order aggregation must be scenario-scoped."""
+
+    def _seed(self, migrated_db, fork_scenario_id):
+        """Baseline: WC + routing + PlannedSupply 100. Fork: +PlannedSupply 40 (fork-only).
+
+        Both orders are due inside the CRP horizon (CURRENT_DATE-relative). The
+        work center, routing and operation are shared master data — the ONLY
+        scenario-scoped row is ``planned_supply``.
+        """
+        import psycopg
+        from psycopg.rows import dict_row
+
+        due_date = date.today() + timedelta(days=7)
+        with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+            item_id, location_id = _insert_item_and_location(conn)
+            work_center_id = _insert_work_center(conn)
+            routing_id, _op_id = _insert_routing_with_operation(
+                conn, item_id=item_id, work_center_id=work_center_id
+            )
+            # Baseline order (must NOT leak into the fork answer)
+            _seed_planned_supply(
+                conn, item_id=item_id, location_id=location_id,
+                quantity=Decimal("100"), due_date=due_date,
+            )
+            # Fork-only order (must NOT leak into the baseline answer)
+            _seed_planned_supply(
+                conn, item_id=item_id, location_id=location_id,
+                quantity=Decimal("40"), due_date=due_date,
+                scenario_id=fork_scenario_id,
+            )
+            conn.commit()
+        return item_id, location_id, work_center_id, routing_id
+
+    def test_crp_baseline_ignores_fork_and_fork_sees_own_rows(
+        self, api_client, auth, migrated_db, fork_scenario_id
+    ):
+        import psycopg
+        from psycopg.rows import dict_row
+
+        item_id, location_id, work_center_id, routing_id = self._seed(
+            migrated_db, fork_scenario_id
+        )
+        wc = str(work_center_id)
+        payload = {"horizon_days": 30, "work_center_ids": [wc]}
+        try:
+            # (a) Baseline (no scenario param): only the baseline order (qty 100)
+            # is counted; the fork's qty-40 order must be invisible.
+            resp = api_client.post("/v1/crp/calculate", json=payload, headers=auth)
+            assert resp.status_code == 200, resp.text
+            baseline = resp.json()
+            assert baseline["planned_orders_count"] == 1
+            baseline_load = _total_load(baseline, wc)
+            assert baseline_load > 0.0
+
+            # (b) Fork: only the fork order (qty 40) is counted; the baseline
+            # qty-100 order must be invisible. Different qty ⇒ different load.
+            resp = api_client.post(
+                "/v1/crp/calculate", json=payload,
+                params={"scenario_id": fork_scenario_id}, headers=auth,
+            )
+            assert resp.status_code == 200, resp.text
+            fork = resp.json()
+            assert fork["planned_orders_count"] == 1
+            fork_load = _total_load(fork, wc)
+            assert fork_load > 0.0
+            # The fork order is smaller (40 < 100) ⇒ strictly less load. This
+            # proves the two scenarios are computed from disjoint order sets.
+            assert fork_load < baseline_load
+
+            # (c) X-Scenario-ID header is equivalent to the query param
+            # (calculation_time_ms is timing noise — excluded from comparison).
+            resp = api_client.post(
+                "/v1/crp/calculate", json=payload,
+                headers={**auth, "X-Scenario-ID": fork_scenario_id},
+            )
+            assert resp.status_code == 200, resp.text
+            assert _stable(resp.json()) == _stable(fork)
+
+            # (d) Baseline answer is unchanged after fork reads (no contamination).
+            resp = api_client.post("/v1/crp/calculate", json=payload, headers=auth)
+            assert resp.status_code == 200, resp.text
+            assert _stable(resp.json()) == _stable(baseline)
+        finally:
+            with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+                _teardown_crp_rows(
+                    conn, item_id=item_id, location_id=location_id,
+                    work_center_id=work_center_id, routing_id=routing_id,
+                )
+                conn.commit()
+
+    def test_crp_overloads_endpoint_is_scenario_scoped(
+        self, api_client, auth, migrated_db, fork_scenario_id
+    ):
+        """GET /v1/crp/overloads must count overloads from its own scenario only.
+
+        A bare 200-on-both-sides assertion has no teeth: FastAPI ignores an
+        unknown query param, and the ``_seed()`` loads (50 h baseline / 20 h
+        fork, capacity 80 h/day) never cross the capacity ceiling, so both
+        sides report zero overloads whether or not the scenario filter is
+        applied. This test forces an overload on the baseline side only, and
+        asserts the *counts* — a revert of the CRP scenario-scoping fix (i.e.
+        the fork read falling back to seeing the unfiltered baseline order)
+        would make the fork side see the overload too, and the assertion
+        below would fail.
+
+        Arithmetic, verified against CRPEngine.calculate() (read the code,
+        not assumed):
+          - capacity_per_day=80, efficiency=1.0 => effective capacity 80 h/day.
+          - Operation: setup_time=0, run_time_per_unit=0.5.
+          - A SINGLE large order does NOT work here: CRPEngine spreads any one
+            order's total_hours evenly across days_needed=ceil(total_hours /
+            80) days (engine.py calculate(), the "Distribute load across the
+            days" block) — hours_per_day = total_hours / days_needed is, by
+            that construction, always <= capacity (e.g. qty=1000 => 500 h =>
+            days_needed=ceil(500/80)=7 => ~71.43 h/day < 80 h/day => NO
+            overload, however large the single order's quantity).
+          - Overload therefore requires several orders whose per-order load
+            lands on the SAME day. Each extra order below has
+            quantity=100 => total_hours=50 h => days_needed=ceil(50/80)=1
+            (single-day, no spreading ambiguity), due on the same due_date as
+            the existing baseline order (also 50 h, from ``_seed()``).
+            10 extra orders + the existing one: 11 x 50 h = 550 h on that one
+            day versus an 80 h/day ceiling => excess ~470 h (~6.9x capacity) —
+            a massive, arithmetic-detail-insensitive margin.
+          - The fork side is untouched: its lone 40-qty order (20 h) stays
+            far under 80 h/day => 0 overloads, both before and after the
+            baseline-side seeding above.
+        """
+        import psycopg
+        from psycopg.rows import dict_row
+
+        item_id, location_id, work_center_id, routing_id = self._seed(
+            migrated_db, fork_scenario_id
+        )
+        wc = str(work_center_id)
+        due_date = date.today() + timedelta(days=7)  # matches _seed()'s due_date
+        try:
+            with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+                for _ in range(10):
+                    _seed_planned_supply(
+                        conn, item_id=item_id, location_id=location_id,
+                        quantity=Decimal("100"), due_date=due_date,
+                    )
+                conn.commit()
+
+            params_base = {"horizon_days": 30, "work_center_ids": wc}
+
+            # Baseline: 11 orders (550 h) on one day vs. 80 h/day capacity —
+            # at least one overload must be reported.
+            resp = api_client.get("/v1/crp/overloads", params=params_base, headers=auth)
+            assert resp.status_code == 200, resp.text
+            baseline_overloads = resp.json()["overloads"]
+            assert len(baseline_overloads) >= 1
+            assert any(o["work_center_id"] == wc for o in baseline_overloads)
+
+            # Fork: only its own 20 h order — no overload. Pre-fix (unfiltered
+            # planned_supply fallback), the fork read would also see the
+            # baseline's 550 h order and report >= 1 overload here.
+            resp = api_client.get(
+                "/v1/crp/overloads",
+                params={**params_base, "scenario_id": fork_scenario_id},
+                headers=auth,
+            )
+            assert resp.status_code == 200, resp.text
+            fork_overloads = resp.json()["overloads"]
+            assert len(fork_overloads) == 0
+        finally:
+            with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+                # _teardown_crp_rows deletes planned_supply by item_id, which
+                # covers the 10 extra orders seeded above (same item_id).
+                _teardown_crp_rows(
+                    conn, item_id=item_id, location_id=location_id,
+                    work_center_id=work_center_id, routing_id=routing_id,
+                )
+                conn.commit()
+
+    def test_crp_invalid_scenario_id_is_422(self, api_client, auth):
+        resp = api_client.post(
+            "/v1/crp/calculate",
+            json={"horizon_days": 30},
+            params={"scenario_id": "not-a-uuid"},
+            headers=auth,
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
Closes #396 (quick win du plan AI-native, épique #397).

## Problème
CRP était le **dernier module en infraction** avec la doctrine « every read path accepts scenario_id » : `_fetch_planned_orders` tournait **sans filtre scénario** sur le chemin des routers, et `_suggest_resolution_for_overload` ne filtrait jamais sa jambe `planned_supply`. Un fork qui écrit des ordres planifiés contaminait les réponses CRP baseline (et réciproquement) — le défaut corrigé pour ATP/RCCP par #338.

## Fix
- **Moteur** : `scenario_id: UUID = BASELINE_SCENARIO_ID` propagé partout, les 2 sites toujours filtrés ; jambes master-data légitimement non filtrées (pas de colonne scenario_id).
- **Routers** : `Depends(resolve_scenario_id)` sur les 4 endpoints (query param ou `X-Scenario-ID`, défaut baseline) ; `scenario_id` retiré du body + `extra="forbid"` (**fail-loudly** : un client spec-périmé prend un 422 explicite, jamais du baseline silencieux).
- **openapi.json régénéré** (89 paths) — les 4 endpoints CRP documentent `X-Scenario-ID` ; ramasse aussi la staleness pré-existante (`/firm`, `param-overrides`).
- **Test d'intégration** calqué sur le pattern d'isolation ATP/RCCP : isolation `calculate` par charges disjointes (50 h vs 20 h) + **garde-fou de régression** sur `overloads` (11 ordres empilés → 550 h vs 80 h/j : baseline ≥ 1 overload, fork 0 ; pré-fix, la lecture fork voyait les ordres baseline et échouait). L'étalement de charge du moteur rend tout ordre *unique* incapable de créer un overload — documenté dans le docstring.
- **SCALABILITY.md** : en-tête remis à la vérité mesurée (batch-viable vs interactif-non-prouvé, provenance post-tune corrigée, extrapolation re-qualifiée « 2-year »).

Hors scope, ouvert séparément : #398 (promote MPS → baseline).

**Revue adversariale multi-agents : 4 constats (1 majeur — le contrat OpenAPI mentait ; 3 mineurs) — tous corrigés.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)