### PR TITLE
feat(drp): moteur de transfert inter-site minimal — core pur + loader scenario-paramétré (#395 PR1)

### DIFF
--- a/src/ootils_core/engine/drp/__init__.py
+++ b/src/ootils_core/engine/drp/__init__.py
@@ -1,0 +1,28 @@
+"""
+DRP (Distribution Requirements Planning) engine — the distribution echelon of
+the single netting cascade (ADR-020 §Unité de planification / ADR-028).
+
+core  : pure, DB-free, deterministic transfer-signal maths, keyed by
+        (item, location) — the per-site echelon (mrp/core is the item-level
+        make/buy echelon).
+loader: SELECT-only, scenario-parameterized load into DRPData (safety stock
+        overlay-resolved via #347, so the plan is forkable).
+"""
+from ootils_core.engine.drp.core import (
+    TransferLink,
+    TransferSignal,
+    excess_by_location,
+    projected_deficits,
+    transfer_signals,
+)
+from ootils_core.engine.drp.loader import DRPData, load_drp_data
+
+__all__ = [
+    "DRPData",
+    "TransferLink",
+    "TransferSignal",
+    "excess_by_location",
+    "load_drp_data",
+    "projected_deficits",
+    "transfer_signals",
+]

--- a/src/ootils_core/engine/drp/core.py
+++ b/src/ootils_core/engine/drp/core.py
@@ -1,0 +1,400 @@
+"""
+Canonical packaged DRP math core (ADR-020 §Unité de planification / ADR-028).
+DB-free, pure, deterministic — the distribution echelon of the single netting
+cascade (MRP is the make/buy echelon; both share the same gross-to-net maths
+applied to different graph arcs: distribution arcs here, BOM arcs in mrp/core).
+
+Planning key = (item, location). This is the ONE structural difference from the
+MRP math core (engine/mrp/core.py), which plans item-level (pooled across
+locations). Every projection, excess and signal below is scoped to a single
+(item, location) coordinate; a transfer link moves a deficit at one location's
+coordinate against another location's excess.
+
+SCOPE — V1 (checkpoint pilote, business defaults LOCKED):
+  * Single-hop transfers only. Multi-hop (source -> hub -> dest) is OUT of scope
+    — a deficit is served directly from a linked source's excess, never relayed.
+  * Greedy priority allocation, NOT fair-share and NOT network optimisation: a
+    source's excess is consumed link-by-link in (priority, source) order; the
+    first eligible destinations drain it. Fair-share splitting of a scarce
+    source across competing destinations is a PR2+ refinement.
+  * Net demand per (item, location) per bucket = simple max(orders, forecast)
+    (see projected_deficits / DRPData construction in loader.py). The per-item
+    forecast-consumption WINDOW of #349 (backward-before-forward cross-bucket
+    consumption) is item-level machinery living in mrp/core.consume_demand; a
+    per-location windowed variant is a PR2+ refinement, deliberately not
+    reimplemented here. window==0 is exactly the golden-master max semantics.
+
+Determinism: every public function returns results in a fully sorted order and
+never relies on dict iteration order. Ties in link selection resolve by
+(priority, source_location) so the plan is reproducible run-to-run.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TransferLink:
+    """A single active distribution lane between two locations.
+
+    Sourced from distribution_links (migration 029) by the loader.
+    lead_buckets is the transit lead time expressed in WEEKLY buckets
+    (ceil(transit_lead_time_days / 7)) — the DRP core works in the same weekly
+    bucket grid as the MRP core. min_qty / max_qty mirror the link's
+    minimum_shipment_qty / maximum_shipment_qty (max_qty None => uncapped).
+    priority is the sourcing preference (1 = highest), used to order candidate
+    sources for a destination in deficit.
+
+    item is None for a GENERIC lane (distribution_links.item_id NULL — usable by
+    any item on that (source, dest) pair) or an item key for an ITEM-SPECIFIC
+    lane.
+
+    link_ref is a stable per-row discriminant (the loader populates it from
+    distribution_links.distribution_link_id, stringified) used ONLY as a final,
+    last-resort determinism tie-break (#395 F6) when two link rows are
+    otherwise identical for sorting purposes — same source, same dest, same
+    priority (e.g. two genuinely duplicate lanes on the same pair at the same
+    priority). Without it, such a tie would be broken by physical scan/list
+    order, which is not a business signal and would make the emitted plan
+    depend on incidental row order. An empty string (the default — no known
+    row identity, e.g. a hand-built test link) still participates in the sort
+    key like any other value; it does not special-case anything.
+
+    Field order/default matter for BOTH new fields: item and link_ref are
+    appended LAST, each with a default, specifically so every pre-existing
+    6-positional-argument construction site (TransferLink(source, dest,
+    lead_buckets, min_qty, max_qty, priority)) keeps working unchanged and
+    resolves to a generic (item=None) lane with no ref — backward compatible
+    by construction, not by convention.
+    """
+
+    source_location: str
+    dest_location: str
+    lead_buckets: int
+    min_qty: float
+    max_qty: float | None
+    priority: int
+    item: str | None = None
+    link_ref: str = ""
+
+
+@dataclass(frozen=True)
+class TransferSignal:
+    """A proposed inter-site transfer with its evidence embedded (explainability,
+    ADR-004): the deficit it covers, the source excess that funded it, and the
+    ship/arrival timing.
+
+    arrival_bucket may be AT OR AFTER deficit_bucket when ship_bucket floored to
+    0 (the transit lead time does not fit before the deficit). The signal is
+    STILL emitted — that is the honest state of the plan (the transfer is the
+    best available action even though it lands late); a consumer reads
+    arrival_bucket > deficit_bucket as "covered late". Never silently dropped.
+    """
+
+    item: str
+    source_location: str
+    dest_location: str
+    qty: float
+    ship_bucket: int
+    arrival_bucket: int
+    deficit_bucket: int
+    deficit_qty: float
+    source_excess_before: float
+
+
+def _projected_deficit_for_coord(
+    demand: dict[int, float],
+    on_hand: float,
+    safety: float,
+    horizon_buckets: int,
+) -> tuple[int, float] | None:
+    """First bucket where projected on-hand at ONE (item, location) coordinate
+    drops below safety stock, and the quantity needed to climb back to safety.
+
+    Variant of mrp/core.first_shortage scoped to a single coordinate (that
+    function keys by item and reads a PlanningData; here demand/on_hand/safety
+    are already the per-coordinate values, and the DRP deficit projection has NO
+    scheduled receipts — the whole point of the pass is to discover the transfer
+    receipts the coordinate needs). Semantics are otherwise IDENTICAL to
+    first_shortage:
+
+      * walk weekly buckets accumulating on top of on_hand;
+      * each bucket subtracts that bucket's net demand;
+      * trigger at the SAFETY threshold (pa < safety), not at stockout — safety
+        is the reorder trigger that leaves lead time to recover, matching the
+        MRP projection; for a coordinate with safety==0 this reduces to the
+        first negative (stockout) bucket;
+      * deficit = safety - pa, i.e. the quantity that restores safety (consumers
+        must NOT add safety again).
+
+    Returns (deficit_bucket, deficit_qty) or None if the coordinate never breaks
+    safety over the horizon.
+    """
+    pa = on_hand
+    for t in range(horizon_buckets):
+        pa -= demand.get(t, 0.0)
+        if pa < safety:
+            return t, safety - pa
+    return None
+
+
+def projected_deficits(
+    demand_by_loc: dict[tuple[str, str], dict[int, float]],
+    on_hand_by_loc: dict[tuple[str, str], float],
+    safety_by_loc: dict[tuple[str, str], float],
+    horizon_buckets: int,
+) -> dict[tuple[str, str], tuple[int, float]]:
+    """First-shortage projection per (item, location) coordinate.
+
+    For every coordinate carrying demand OR on-hand OR safety, run the
+    single-coordinate safety-threshold projection (see
+    _projected_deficit_for_coord, the per-location variant of
+    mrp/core.first_shortage). Returns {(item, location): (deficit_bucket,
+    deficit_qty)} for the coordinates that DO break safety on the horizon;
+    coordinates that stay at or above safety are omitted (no deficit, no key).
+
+    Deterministic: independent of dict iteration order (each coordinate is
+    projected in isolation; the result dict carries no ordering semantics — the
+    caller, transfer_signals, sorts).
+    """
+    coords = set(demand_by_loc) | set(on_hand_by_loc) | set(safety_by_loc)
+    out: dict[tuple[str, str], tuple[int, float]] = {}
+    for coord in coords:
+        demand = demand_by_loc.get(coord, {})
+        on_hand = on_hand_by_loc.get(coord, 0.0)
+        safety = safety_by_loc.get(coord, 0.0)
+        hit = _projected_deficit_for_coord(demand, on_hand, safety, horizon_buckets)
+        if hit is not None:
+            out[coord] = hit
+    return out
+
+
+def excess_by_location(
+    demand_by_loc: dict[tuple[str, str], dict[int, float]],
+    on_hand_by_loc: dict[tuple[str, str], float],
+    safety_by_loc: dict[tuple[str, str], float],
+    horizon_buckets: int,
+) -> dict[tuple[str, str], float]:
+    """Distributable excess per (item, location) coordinate.
+
+    excess = on_hand - (total net demand over the horizon + safety), floored at
+    0. Conservative BY DESIGN: a source never offers stock it needs to cover its
+    own horizon demand or to hold its own safety buffer — only the surplus above
+    both is transferable. A coordinate with no surplus (or unknown) yields 0.
+
+    This is intentionally a horizon-total test, NOT a time-phased one: V1 answers
+    "does this location hold more than it will ever need on the horizon", which
+    is the safe lower bound on what it can give away. A time-phased "excess as of
+    the ship bucket" refinement (a source may hold transient early-horizon excess
+    it consumes later) is PR2+.
+
+    The horizon window here is IDENTICAL to projected_deficits': demand is
+    summed over `t < horizon_buckets` only (bucket keys at or beyond the horizon
+    ceiling are ignored). One shared window for both functions is deliberate —
+    a demand line that lands past the loaded horizon is not visible to either
+    the deficit projection or the excess calculation, so a source's excess
+    figure is never deflated by out-of-window demand the deficit side would
+    never have seen either (see the loader for the matching clip on the
+    customer-order side).
+
+    Only coordinates present in on_hand_by_loc can carry excess (no stock =>
+    nothing to give); the result omits coordinates with excess <= 0.
+    """
+    out: dict[tuple[str, str], float] = {}
+    for coord, on_hand in on_hand_by_loc.items():
+        total_demand = sum(
+            q for t, q in demand_by_loc.get(coord, {}).items() if t < horizon_buckets
+        )
+        safety = safety_by_loc.get(coord, 0.0)
+        excess = float(on_hand) - (total_demand + safety)
+        if excess > 0:
+            out[coord] = excess
+    return out
+
+
+def _resolve_candidate_links(
+    dest_links: list[TransferLink], item: str
+) -> list[TransferLink]:
+    """Resolve the candidate links for ONE (item, destination) pair out of every
+    active link landing at that destination, applying item scoping and
+    SPECIFICITY-REFINEMENT de-duplication (#395 F2/F3, revised).
+
+    Scoping: a link with item is None is GENERIC (any item may use it); a link
+    with item set is usable ONLY by that exact item. A candidate for `item` is
+    therefore every dest_link where `link.item is None or link.item == item`.
+
+    Dedup is a REFINEMENT relation ACROSS specificity levels ONLY — it is NOT a
+    single-winner-per-pair eviction, and it NEVER compares two links of the SAME
+    specificity against each other to pick one:
+
+      * If ONE OR MORE item-specific lanes exist for a (source, dest) pair, they
+        REPLACE every generic lane on that SAME pair for this item — a
+        specific lane is the master-data statement "route THIS item on THIS
+        pair THIS way", which supersedes the generic default. This is the only
+        case where a lane is excluded.
+      * Two (or more) lanes of the SAME specificity on the same pair — two
+        generic lanes, or two lanes both specific to this item — are NEVER
+        deduped against each other. Both stay candidates: this is declared
+        capacity from the master data (e.g. two genuinely parallel lanes on
+        one physical lane, or a duplicate row), and the engine does not
+        silently second-guess which one "wins" — that would make a capacity
+        figure or a priority ordering depend on an arbitrary tie-break
+        (upstream: comparing link_ref, a stringified UUID with no business
+        order, previously picked a "winner" by lexical accident — dropping a
+        real max_qty capacity or letting a lower-priority duplicate evict a
+        higher-priority one). Lane-duplicate hygiene is a data-quality
+        concern, not something this pure function arbitrates.
+      * Same-specificity duplicates are therefore ALL kept as candidates and
+        served SEQUENTIALLY by the existing deterministic order (priority ASC,
+        source_location, link_ref — see below): the determinism guarantee
+        (#395 F6) comes from that STABLE ordering, not from evicting one of
+        them. A caller draining a deficit against two same-priority same-pair
+        lanes (one capped, one uncapped) drains the FIRST in that order up to
+        its cap, then falls through to the next.
+
+    This refinement-only contract is a business default, documented and
+    🎯-adjustable — a future revision could add real dedup of TRUE duplicate
+    rows (same source, dest, item, priority, min/max — an actual data-entry
+    accident), but that requires a positive signal this function does not have
+    ("these two rows are the same lane recorded twice" vs "these are two
+    genuinely parallel lanes"), so V1 never guesses.
+
+    Implementation: partition item-eligible links by (source, dest) pair; a
+    pair keeps ONLY its item-specific links if it has at least one, otherwise
+    ONLY its generic links — no link-vs-link comparison, no per-pair single
+    winner. Flatten and sort ONCE (priority ASC, source_location, link_ref) —
+    the existing determinism contract, with link_ref (#395 F6) as the final
+    tie-break for two rows that would otherwise compare equal (same source
+    into the same dest at the same priority).
+    """
+    eligible = [lk for lk in dest_links if lk.item is None or lk.item == item]
+
+    specific_by_pair: dict[tuple[str, str], list[TransferLink]] = {}
+    generic_by_pair: dict[tuple[str, str], list[TransferLink]] = {}
+    for link in eligible:
+        pair = (link.source_location, link.dest_location)
+        bucket = specific_by_pair if link.item is not None else generic_by_pair
+        bucket.setdefault(pair, []).append(link)
+
+    resolved: list[TransferLink] = []
+    for pair, generics in generic_by_pair.items():
+        if pair not in specific_by_pair:
+            resolved.extend(generics)
+    for specifics in specific_by_pair.values():
+        resolved.extend(specifics)
+
+    return sorted(resolved, key=lambda lk: (lk.priority, lk.source_location, lk.link_ref))
+
+
+def transfer_signals(
+    demand_by_loc: dict[tuple[str, str], dict[int, float]],
+    on_hand_by_loc: dict[tuple[str, str], float],
+    safety_by_loc: dict[tuple[str, str], float],
+    links: list[TransferLink],
+    horizon_buckets: int,
+) -> list[TransferSignal]:
+    """Canonical DRP transfer signal generation. PURE, DB-free, deterministic.
+
+    For every (item, destination) coordinate in deficit (see projected_deficits),
+    source the deficit from linked locations' distributable excess (see
+    excess_by_location), greedily by link priority:
+
+      * Candidate links for a destination = active links whose dest_location is
+        that coordinate's location, scoped to links generic (item is None) OR
+        specific to that coordinate's item, resolved by specificity-refinement
+        per (source, dest) pair (see _resolve_candidate_links — a specific
+        lane replaces every generic on its OWN pair; same-specificity
+        duplicates are NEVER evicted against each other, both stay candidates)
+        — and whose source_location holds excess of the SAME item — sorted
+        (priority ASC, source_location, link_ref) for determinism.
+      * qty = min(remaining deficit, remaining source excess, link.max_qty if
+        not None).
+      * MINIMUM-SHIPMENT RULE (business default, LOCKED but adjustable): if the
+        computed qty is below link.min_qty, NO signal is emitted on that link.
+        The deficit is neither inflated up to the minimum (we do not ship stock
+        the destination does not need just to clear a lane minimum) nor served
+        below the minimum (the lane physically cannot). The remaining deficit
+        then falls through to the next-priority link. A deficit that no link can
+        satisfy at or above its minimum is left uncovered (no signal) — honest.
+      * GREEDY SHARED EXCESS: each source coordinate's excess is a single running
+        counter decremented as links draw on it, so one unit of excess never
+        funds two destinations (same shared-counter discipline as remaining_fc
+        in mrp/core #349). Sources are drawn in the order destinations are
+        processed (sorted, below), which makes the allocation reproducible.
+
+    Timing per signal:
+      * ship_bucket   = max(0, deficit_bucket - link.lead_buckets)
+      * arrival_bucket = ship_bucket + link.lead_buckets
+    When the deficit is closer than the transit lead time, ship_bucket floors at
+    0 and arrival_bucket lands AT/AFTER deficit_bucket — the signal is still
+    emitted (covered late is the truth of the plan; see TransferSignal).
+
+    Output is sorted (item, dest_location, deficit_bucket, priority,
+    source_location, link_ref) — a total order, so the signal list is
+    byte-stable even across two genuinely duplicate lanes on the same pair at
+    the same priority (#395 F6; link_ref is "" when unset, a no-op tie-break).
+
+    NOTE (deliberately out of scope, V1): multi-hop relay, fair-share splitting
+    of a scarce source across competing destinations, and network cost
+    optimisation. See the module docstring.
+    """
+    deficits = projected_deficits(demand_by_loc, on_hand_by_loc, safety_by_loc, horizon_buckets)
+    excess = excess_by_location(demand_by_loc, on_hand_by_loc, safety_by_loc, horizon_buckets)
+
+    # Index active links by destination location ONLY as a first cheap filter
+    # (independent of item). The item scoping + specificity-refinement dedup
+    # happens per (item, dest) below via _resolve_candidate_links, since which
+    # links are eligible now depends on the deficit's item, not just its
+    # destination.
+    links_by_dest: dict[str, list[TransferLink]] = {}
+    for link in links:
+        links_by_dest.setdefault(link.dest_location, []).append(link)
+
+    # Carry the emitting link's priority and link_ref alongside each signal so
+    # the output sort can key on (item, dest, deficit_bucket, priority, source,
+    # link_ref) without a reverse lookup — priority/link_ref are not part of
+    # TransferSignal's public shape (they are link-level evidence, not
+    # signal-level), so they live only in this local sort-key tuple.
+    keyed: list[tuple[str, str, int, int, str, str, TransferSignal]] = []
+    # Process deficits in a deterministic coordinate order so the greedy draw on
+    # shared source excess is reproducible (item, then dest_location).
+    for (item, dest_location) in sorted(deficits):
+        deficit_bucket, deficit_qty = deficits[(item, dest_location)]
+        remaining_deficit = deficit_qty
+        candidates = _resolve_candidate_links(links_by_dest.get(dest_location, []), item)
+        for link in candidates:
+            if remaining_deficit <= 0:
+                break
+            source_coord = (item, link.source_location)
+            avail = excess.get(source_coord, 0.0)
+            if avail <= 0:
+                continue
+            qty = min(remaining_deficit, avail)
+            if link.max_qty is not None:
+                qty = min(qty, link.max_qty)
+            if qty < link.min_qty:
+                # Below the lane minimum: emit nothing on this link, leave the
+                # deficit for the next-priority link (see docstring).
+                continue
+            ship_bucket = max(0, deficit_bucket - link.lead_buckets)
+            arrival_bucket = ship_bucket + link.lead_buckets
+            signal = TransferSignal(
+                item=item,
+                source_location=link.source_location,
+                dest_location=dest_location,
+                qty=qty,
+                ship_bucket=ship_bucket,
+                arrival_bucket=arrival_bucket,
+                deficit_bucket=deficit_bucket,
+                deficit_qty=deficit_qty,
+                source_excess_before=avail,
+            )
+            keyed.append((
+                item, dest_location, deficit_bucket, link.priority,
+                link.source_location, link.link_ref, signal,
+            ))
+            excess[source_coord] = avail - qty
+            remaining_deficit -= qty
+
+    keyed.sort(key=lambda k: (k[0], k[1], k[2], k[3], k[4], k[5]))
+    return [k[6] for k in keyed]

--- a/src/ootils_core/engine/drp/loader.py
+++ b/src/ootils_core/engine/drp/loader.py
@@ -1,0 +1,314 @@
+"""
+DB loading layer for DRP (distribution) planning data (ADR-020 / ADR-028).
+SELECT-only; core.py is DB-free. Mirrors engine/mrp/loader.py's style — one
+scenario-scoped scan per source, tuple-row cursor, `_spread_period` forecast
+proration — with ONE structural difference: everything is keyed by
+(item, location) instead of pooled to item level. The distribution echelon
+plans per-site; the MRP echelon pools. See ADR-020 §Unité de planification.
+
+Scenario-parameterized like the MRP loader: `scenario` scopes the node reads
+(a fork sees its own on-hand / demand nodes) and drives the planning-param
+overlay (#347), so a fork's safety-stock override is visible to the DRP
+projection — which is what makes the distribution plan forkable (agents can
+test a safety-stock counter-factual per site without forking master data).
+
+This module NEVER writes and NEVER commits (SELECT-only; the caller owns the
+transaction, same contract as the MRP loader and ScenarioManager).
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import math
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+from psycopg.rows import tuple_row
+
+from ootils_core.engine.drp.core import TransferLink
+from ootils_core.engine.mrp.core import BASELINE, _spread_period
+from ootils_core.engine.scenario.param_overlay import resolved_params_sql
+
+# Independent-demand node types the DRP echelon nets, mirroring
+# mrp/core.DEMAND_TYPES. Kept as a local constant (not imported) so a future
+# change to the MRP demand vocabulary is a conscious cross-echelon decision.
+DRP_DEMAND_TYPES = ["CustomerOrderDemand", "ForecastDemand"]
+
+# Planning-key convention (#395 F4): items.external_id and locations.external_id
+# are BOTH nullable (migration 007's backfill was one-shot; the UNIQUE
+# constraint tolerates any number of NULLs), and the repo's OWN seed pipeline
+# (seed/master/locations.py, seed/master/items.py) inserts rows WITHOUT
+# external_id. Keying purely on external_id would therefore collapse every
+# never-backfilled item (or location) onto the single string "None" for that
+# column, and — because Python's f"{None}" == "None" for every row alike, not a
+# per-row unique value — every site with a NULL external_id would silently pool
+# onto ONE shared coordinate. That is exactly the per-site separation this
+# module exists to preserve, so it must never depend on external_id alone.
+#
+# The fix is a deterministic fallback: COALESCE(external_id, <uuid>::text).
+# When external_id is set, the coordinate carries the readable business key
+# (unchanged from before — no behavioural difference on a fully-backfilled
+# dataset). When it is NULL, the coordinate falls back to the row's OWN UUID
+# stringified — unique and stable per row (the same item/location always
+# yields the same fallback key across calls, since UUIDs don't change), so
+# per-site separation holds even on an un-backfilled dataset. This convention
+# is applied to EVERY query in this loader (on-hand, customer orders, forecast,
+# safety stock, distribution links) — one rule, no exceptions, so a coordinate
+# computed from one query always matches the same coordinate from another.
+#
+# Parameterized by table alias (not hardcoded to `i`/`l`) because the
+# distribution-links query joins TWO location aliases (su/du, upstream/
+# downstream) and needs the SAME convention applied to each independently —
+# a plain module-level string constant could only ever name one alias, so a
+# tiny function is the correct shape here, not a fixed literal.
+def _item_key_sql(alias: str) -> str:
+    return f"COALESCE({alias}.external_id, {alias}.item_id::text)"
+
+
+def _loc_key_sql(alias: str) -> str:
+    return f"COALESCE({alias}.external_id, {alias}.location_id::text)"
+
+
+@dataclass
+class DRPData:
+    """Loaded, scenario-resolved inputs for the DRP core, all keyed by the
+    (item, location) planning coordinate.
+
+    Key convention (#395 F4): each coordinate component is
+    COALESCE(external_id, <uuid>::text) — the item/location's business
+    external_id when it is set, or the row's own UUID stringified when it is
+    NULL. NEVER the bare external_id: that column is nullable on BOTH items
+    and locations, and this repo's own seed pipeline inserts rows without one,
+    so a bare-external_id key would silently pool every un-backfilled site onto
+    one shared "None" coordinate — the exact per-site collapse this module
+    exists to prevent. See _item_key_sql / _loc_key_sql below for the single
+    fragment implementing this, applied identically to every query.
+
+    demand_by_loc : {(item, location): {bucket: net_demand}} — per-bucket
+        max(orders, forecast) (see the loader; the #349 windowed consumption is
+        item-level and a per-location variant is PR2+).
+    on_hand_by_loc: {(item, location): qty} — summed OnHandSupply of the scenario.
+    safety_by_loc : {(item, location): qty} — overlay-resolved safety_stock_qty
+        (#347), NOT pooled across locations.
+    links         : active distribution_links as TransferLink compute records.
+    horizon_start / n_buckets carried for callers that need to date a bucket
+        back to a calendar date (parallel to PlanningData.horizon_start).
+    """
+
+    horizon_start: _dt.date
+    n_buckets: int
+    demand_by_loc: dict[tuple[str, str], dict[int, float]] = field(default_factory=dict)
+    on_hand_by_loc: dict[tuple[str, str], float] = field(default_factory=dict)
+    safety_by_loc: dict[tuple[str, str], float] = field(default_factory=dict)
+    links: list[TransferLink] = field(default_factory=list)
+
+
+def load_drp_data(conn, horizon_days: int = 180, scenario: str = BASELINE) -> DRPData:
+    # tuple_row for positional access regardless of the connection's configured
+    # row_factory (a scenario-aware caller hands us the app's dict_row
+    # connection — same reason as the MRP loader).
+    cur = conn.cursor(row_factory=tuple_row)
+    horizon_start = cur.execute("SELECT CURRENT_DATE").fetchone()[0]
+    n_buckets = math.ceil(horizon_days / 7) + 1
+    horizon_end = horizon_start + _dt.timedelta(days=horizon_days)
+
+    def bucket(d: _dt.date) -> int:
+        return max(0, (d - horizon_start).days // 7)
+
+    d = DRPData(horizon_start=horizon_start, n_buckets=n_buckets)
+
+    # --- on-hand per (item, location) ---------------------------------------
+    # OnHandSupply of the scenario, summed per coordinate. A node with a NULL
+    # location_id is skipped: an un-located on-hand has no place in a per-site
+    # distribution plan (the MRP echelon, which pools, is where an un-located
+    # quantity still counts). Scenario-scoped like the MRP loader's nodes scan.
+    on_hand: defaultdict[tuple[str, str], float] = defaultdict(float)
+    for item, loc, qty in cur.execute(
+        f"SELECT {_item_key_sql('i')}, {_loc_key_sql('l')}, n.quantity "
+        "FROM nodes n "
+        "JOIN items i ON i.item_id = n.item_id "
+        "JOIN locations l ON l.location_id = n.location_id "
+        "WHERE n.scenario_id = %(b)s AND n.active "
+        "AND n.node_type = 'OnHandSupply' "
+        "AND n.quantity IS NOT NULL",
+        {"b": scenario},
+    ).fetchall():
+        on_hand[(item, loc)] += float(qty)
+    d.on_hand_by_loc = dict(on_hand)
+
+    # --- customer-order demand per (item, location), weekly buckets ----------
+    # #395 F1: clipped to [horizon_start, horizon_end] — SYMMETRIC with the
+    # forecast side below, which _spread_period already confines to
+    # [horizon_start, horizon_end). Before this fix only the lower bound was
+    # enforced (tref >= horizon_start) and a customer order dated well beyond
+    # the loaded horizon (e.g. horizon_days=180 but tref at +400 days) still
+    # landed in bucket((tref)) — a bucket FAR past n_buckets, invisible to
+    # excess_by_location's now-windowed sum (see core.py's matching F1 fix) and
+    # to projected_deficits' `range(horizon_buckets)` walk, but silently present
+    # in co_b/demand_by_loc's raw dict — a discarded-looking key that could
+    # still leak into a future consumer iterating demand_by_loc directly. The
+    # upper clip keeps demand_by_loc itself confined to the SAME window the
+    # core functions actually see, so the loader and the core never disagree
+    # about what "the horizon" contains.
+    co_b: defaultdict[tuple[str, str], defaultdict[int, float]] = defaultdict(
+        lambda: defaultdict(float)
+    )
+    for item, loc, tref, qty in cur.execute(
+        f"SELECT {_item_key_sql('i')}, {_loc_key_sql('l')}, n.time_ref, n.quantity "
+        "FROM nodes n "
+        "JOIN items i ON i.item_id = n.item_id "
+        "JOIN locations l ON l.location_id = n.location_id "
+        "WHERE n.scenario_id = %(b)s AND n.active "
+        "AND n.node_type = 'CustomerOrderDemand' "
+        "AND n.time_ref IS NOT NULL AND n.quantity IS NOT NULL",
+        {"b": scenario},
+    ).fetchall():
+        if horizon_start <= tref <= horizon_end:
+            co_b[(item, loc)][bucket(tref)] += float(qty)
+
+    # --- forecast demand per (item, location), prorated to weekly buckets ----
+    # Same proration as the MRP loader (each line spread from its date to the
+    # NEXT forecast date for the SAME series), but the series key is
+    # (item, location) — NOT pooled to item. Aggregate by (item, location, date)
+    # first so duplicate dates collapse and the period-to-next-date span is never
+    # zero-length (which would silently drop volume — the MRP loader guards the
+    # same way, there against multi-location dupes it is intentionally pooling;
+    # here the location is part of the key, so we only collapse true same-site
+    # duplicate-date lines).
+    raw_fc: defaultdict[tuple[str, str], defaultdict[_dt.date, float]] = defaultdict(
+        lambda: defaultdict(float)
+    )
+    for item, loc, tref, qty in cur.execute(
+        f"SELECT {_item_key_sql('i')}, {_loc_key_sql('l')}, n.time_ref, n.quantity "
+        "FROM nodes n "
+        "JOIN items i ON i.item_id = n.item_id "
+        "JOIN locations l ON l.location_id = n.location_id "
+        "WHERE n.scenario_id = %(b)s AND n.active "
+        "AND n.node_type = 'ForecastDemand' "
+        "AND n.time_ref IS NOT NULL AND n.quantity IS NOT NULL",
+        {"b": scenario},
+    ).fetchall():
+        raw_fc[(item, loc)][tref] += float(qty)
+
+    fc_b: defaultdict[tuple[str, str], defaultdict[int, float]] = defaultdict(
+        lambda: defaultdict(float)
+    )
+    for coord, datemap in raw_fc.items():
+        rows = sorted(datemap.items())
+        gaps = [
+            (rows[i + 1][0] - rows[i][0]).days
+            for i in range(len(rows) - 1)
+            if (rows[i + 1][0] - rows[i][0]).days > 0
+        ]
+        default_span = sorted(gaps)[len(gaps) // 2] if gaps else 7  # median gap, else weekly
+        for i, (tref, qty) in enumerate(rows):
+            end = rows[i + 1][0] if i + 1 < len(rows) else tref + _dt.timedelta(days=default_span)
+            _spread_period(qty, tref, end, horizon_start, horizon_end, n_buckets, fc_b[coord])
+
+    # --- net demand = per-bucket max(orders, forecast) per coordinate --------
+    # DRP echelon V1 net-demand rule: for each coordinate and bucket, the net
+    # independent demand is max(customer orders, forecast) — exactly what
+    # mrp/core.consume_demand reduces to under the default max_only strategy with
+    # a ZERO consumption window (the golden-master semantics). The forecast-
+    # consumption WINDOW of #349 (a booking consuming a neighbouring bucket's
+    # forecast, backward-before-forward) and the demand time fence are per-item
+    # machinery in consume_demand that need PlanningData; a per-location variant
+    # is a deliberate PR2+ refinement (module docstring of core.py). Summing
+    # orders + forecast here instead of maxing would double-count the forecast a
+    # booking already consumes.
+    demand_by_loc: dict[tuple[str, str], dict[int, float]] = {}
+    empty: dict[int, float] = {}
+    for coord in set(co_b) | set(fc_b):
+        orders: dict[int, float] = co_b.get(coord, empty)
+        forecast: dict[int, float] = fc_b.get(coord, empty)
+        merged: dict[int, float] = {}
+        for t in set(orders) | set(forecast):
+            v = max(orders.get(t, 0.0), forecast.get(t, 0.0))
+            if v:
+                merged[t] = v
+        if merged:
+            demand_by_loc[coord] = merged
+    d.demand_by_loc = demand_by_loc
+
+    # --- safety stock per (item, location), overlay-resolved (#347) ----------
+    # resolved_params_sql() yields ONE row per (item_id, location_id) with
+    # safety_stock_qty already COALESCEd against any scenario override — so a
+    # fork's per-site safety override is visible here WITHOUT pooling (the MRP
+    # loader pools SUM(safety) across locations for its item-level key; the DRP
+    # echelon keeps the per-location value, which is the whole point). Baseline
+    # (scenario == BASELINE) passes scenario_id=None so every LATERAL override
+    # join degrades to "no row" and the base column flows through unchanged.
+    resolved = resolved_params_sql("ipp")
+    overlay_scenario_id = scenario if scenario != BASELINE else None
+    safety: dict[tuple[str, str], float] = {}
+    for item, loc, ss in cur.execute(
+        f"""
+        SELECT {_item_key_sql('i')}, {_loc_key_sql('l')}, rp.safety_stock_qty
+        FROM ({resolved}) rp
+        JOIN items i ON i.item_id = rp.item_id
+        JOIN locations l ON l.location_id = rp.location_id
+        """,
+        {"scenario_id": overlay_scenario_id},
+    ).fetchall():
+        if ss is not None:
+            safety[(item, loc)] = float(ss)
+    d.safety_by_loc = safety
+
+    # --- active distribution links -> TransferLink ---------------------------
+    # lead_buckets = ceil(transit_lead_time_days / 7). Locations resolved to the
+    # same COALESCE(external_id, uuid::text) key convention as everywhere else
+    # in this loader (#395 F4 — see _loc_key_sql's docstring above); su/du are
+    # the upstream/downstream location aliases, so the same alias-parameterized
+    # helper is invoked once per alias rather than the shared `l` used by the
+    # other queries. max_qty is None when the column is NULL (uncapped). min_qty
+    # defaults to the column DEFAULT (1) via NOT NULL; read straight.
+    # distribution_links is NOT scenario-scoped (network topology is master
+    # data, shared across scenarios) — a fork overlays parametric fields
+    # (safety), not topology, per ADR-025's whitelist.
+    #
+    # item_id (#395 F2/F3): distribution_links.item_id is NULLABLE — NULL means
+    # a GENERIC lane (any item may use it), a set value means the lane is
+    # scoped to that one item. LEFT JOIN items (not an inner JOIN) because a
+    # generic link's item_id is NULL and must NOT be dropped by the join; the
+    # resolved item key is itself NULL when item_id IS NULL (COALESCE only
+    # applies once ii.item_id is present — a NULL LEFT JOIN miss propagates
+    # through COALESCE(ii.external_id, ii.item_id::text) as NULL, which is
+    # exactly TransferLink.item's None-means-generic contract, so no special
+    # casing is needed in the loop below beyond checking `is not None`).
+    #
+    # ORDER BY / link_ref (#395 F6): without a fixed order, two distribution_
+    # links rows on the SAME (source, dest) pair at the SAME priority would
+    # have their relative order decided by physical scan order — not a
+    # business signal, and it would make the emitted plan depend on
+    # incidental table/index layout. ORDER BY (priority, source, dest,
+    # distribution_link_id) fixes that ordering deterministically at the SQL
+    # layer; link_ref (the stringified distribution_link_id) is carried onto
+    # TransferLink as the final, last-resort tie-break the core sorts by (see
+    # core.py's _resolve_candidate_links / transfer_signals) — belt AND
+    # braces: the loader emits a stable order, and the core's own sort keys
+    # never depend on it holding.
+    links: list[TransferLink] = []
+    for src, dst, lt_days, min_q, max_q, prio, item_key, link_id in cur.execute(
+        f"SELECT {_loc_key_sql('su')}, {_loc_key_sql('du')}, "
+        "dl.transit_lead_time_days, dl.minimum_shipment_qty, "
+        "dl.maximum_shipment_qty, dl.priority, "
+        "COALESCE(ii.external_id, ii.item_id::text), dl.distribution_link_id "
+        "FROM distribution_links dl "
+        "JOIN locations su ON su.location_id = dl.upstream_location_id "
+        "JOIN locations du ON du.location_id = dl.downstream_location_id "
+        "LEFT JOIN items ii ON ii.item_id = dl.item_id "
+        "WHERE dl.active "
+        "ORDER BY dl.priority, su.location_id, du.location_id, dl.distribution_link_id"
+    ).fetchall():
+        links.append(TransferLink(
+            source_location=src,
+            dest_location=dst,
+            lead_buckets=math.ceil(float(lt_days) / 7),
+            min_qty=float(min_q),
+            max_qty=float(max_q) if max_q is not None else None,
+            priority=int(prio),
+            item=item_key,
+            link_ref=str(link_id),
+        ))
+    d.links = links
+
+    return d

--- a/tests/integration/test_drp_loader_integration.py
+++ b/tests/integration/test_drp_loader_integration.py
@@ -1,0 +1,607 @@
+"""
+tests/integration/test_drp_loader_integration.py — DB-backed tests for
+ootils_core.engine.drp.loader.load_drp_data against real Postgres (#395 PR1).
+
+The loader is SELECT-only and strictly (item, location)-keyed and strictly
+scenario-scoped (no baseline fallback — a fork sees ONLY the nodes carrying its
+own scenario_id). These tests lock:
+  1. per-(item, location) grouping is NOT pooled across locations,
+  2. lead_buckets = ceil(transit_lead_time_days / 7) off the real column,
+  3. the #347 forkability guarantee: a safety-stock override in a fork is
+     visible to the DRP load of that fork and invisible to baseline,
+  4. scenario-scoping of on-hand: a node seeded only on a fork is absent from
+     the baseline load,
+  5. distribution_links min/max/priority surface into TransferLink (max NULL
+     -> None).
+
+Fixture + seed style mirrors tests/integration/test_param_overlay_integration.py
+(function-scoped `conn`, direct-SQL seeding via _seed_item / _seed_location /
+_seed_planning_params / _seed_scenario) and the explicit-scenario_id node
+seeding of tests/integration/test_param_overlay_propagation_integration.py (the
+loader is scenario-scoped, so every node carries an explicit scenario_id — no
+ScenarioManager deep-copy needed). No mocks — CLAUDE.md.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from uuid import UUID, uuid4
+
+from ootils_core.engine.drp.loader import load_drp_data
+from ootils_core.engine.scenario.param_overlay import set_param_override
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+# Seeded by migration 002 (is_baseline=TRUE) — the only baseline scenario.
+BASELINE = UUID("00000000-0000-0000-0000-000000000001")
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers (calqued on test_param_overlay_integration.py)
+# ---------------------------------------------------------------------------
+
+
+def _seed_item(conn, name: str = "drp-item") -> UUID:
+    return conn.execute(
+        "INSERT INTO items (item_id, external_id, name) VALUES (%s, %s, %s) RETURNING item_id",
+        (uuid4(), f"{name}-{uuid4()}", name),
+    ).fetchone()["item_id"]
+
+
+def _seed_location(conn, name: str = "drp-loc") -> UUID:
+    return conn.execute(
+        "INSERT INTO locations (location_id, external_id, name) "
+        "VALUES (%s, %s, %s) RETURNING location_id",
+        (uuid4(), f"{name}-{uuid4()}", name),
+    ).fetchone()["location_id"]
+
+
+def _seed_scenario(conn, name: str = "drp-fork") -> UUID:
+    """A non-baseline scenario (a fork). The DRP loader is scenario-scoped by
+    node.scenario_id; the override overlay is keyed by this scenario_id too, so
+    a plain fork row (no ScenarioManager deep-copy) is all we need."""
+    return conn.execute(
+        "INSERT INTO scenarios (scenario_id, name, is_baseline, status) "
+        "VALUES (%s, %s, FALSE, 'active') RETURNING scenario_id",
+        (uuid4(), f"{name}-{uuid4()}"),
+    ).fetchone()["scenario_id"]
+
+
+def _seed_planning_params(conn, item_id, location_id, **overrides) -> None:
+    """One CURRENT (effective_to NULL) item_planning_params row. Default
+    safety_stock_qty=0 so a fork override to a large value is an unambiguous
+    signal in the forkability test."""
+    defaults = dict(
+        lead_time_sourcing_days=14,
+        lead_time_manufacturing_days=0,
+        lead_time_transit_days=0,
+        safety_stock_qty=0,
+        min_order_qty=None,
+        lot_size_rule="LOTFORLOT",
+    )
+    defaults.update(overrides)
+    conn.execute(
+        """
+        INSERT INTO item_planning_params (
+            item_id, location_id, effective_from, effective_to,
+            lead_time_sourcing_days, lead_time_manufacturing_days, lead_time_transit_days,
+            safety_stock_qty, min_order_qty, lot_size_rule
+        ) VALUES (
+            %(item_id)s, %(location_id)s, %(effective_from)s, NULL,
+            %(lead_time_sourcing_days)s, %(lead_time_manufacturing_days)s, %(lead_time_transit_days)s,
+            %(safety_stock_qty)s, %(min_order_qty)s, %(lot_size_rule)s
+        )
+        """,
+        {"item_id": item_id, "location_id": location_id, "effective_from": date.today(), **defaults},
+    )
+
+
+def _seed_on_hand(conn, *, scenario_id, item_id, location_id, qty) -> UUID:
+    """An OnHandSupply node explicitly scoped to `scenario_id` (the DRP loader
+    is strictly scenario-scoped — see the #349/#347 seeding pattern)."""
+    node_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO nodes (
+            node_id, node_type, scenario_id, item_id, location_id,
+            quantity, time_grain, time_ref, active
+        ) VALUES (%s, 'OnHandSupply', %s, %s, %s, %s, 'exact_date', CURRENT_DATE, TRUE)
+        """,
+        (node_id, scenario_id, item_id, location_id, qty),
+    )
+    return node_id
+
+
+def _seed_customer_order(conn, *, scenario_id, item_id, location_id, qty, days_out) -> UUID:
+    """A CustomerOrderDemand node dated CURRENT_DATE + days_out, scenario-scoped.
+    Customer orders map straight to bucket((tref)) = days_out // 7 (no
+    _spread_period proration), which keeps the bucket arithmetic exact and
+    hand-checkable in these tests."""
+    node_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO nodes (
+            node_id, node_type, scenario_id, item_id, location_id,
+            quantity, time_grain, time_ref, active
+        ) VALUES (
+            %s, 'CustomerOrderDemand', %s, %s, %s, %s, 'exact_date',
+            CURRENT_DATE + %s, TRUE
+        )
+        """,
+        (node_id, scenario_id, item_id, location_id, qty, timedelta(days=days_out)),
+    )
+    return node_id
+
+
+def _seed_link(
+    conn,
+    *,
+    upstream_location_id,
+    downstream_location_id,
+    transit_lead_time_days,
+    minimum_shipment_qty=1,
+    maximum_shipment_qty=None,
+    priority=100,
+    active=True,
+) -> UUID:
+    """A distribution_links row (migration 029). Columns/defaults read straight
+    off the real schema: minimum_shipment_qty NOT NULL DEFAULT 1, priority NOT
+    NULL DEFAULT 100 (CHECK >= 1), maximum_shipment_qty NULLABLE."""
+    return conn.execute(
+        """
+        INSERT INTO distribution_links (
+            distribution_link_id, upstream_location_id, downstream_location_id,
+            transit_lead_time_days, minimum_shipment_qty, maximum_shipment_qty,
+            priority, active
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        RETURNING distribution_link_id
+        """,
+        (
+            uuid4(),
+            upstream_location_id,
+            downstream_location_id,
+            transit_lead_time_days,
+            minimum_shipment_qty,
+            maximum_shipment_qty,
+            priority,
+            active,
+        ),
+    ).fetchone()["distribution_link_id"]
+
+
+# ---------------------------------------------------------------------------
+# 1. Per-(item, location) grouping is NOT pooled across locations
+# ---------------------------------------------------------------------------
+
+
+def test_demand_keyed_per_location_not_pooled(conn):
+    """One item, two locations, different demands in different buckets: the
+    loader yields TWO distinct (item, location) demand keys, each with its own
+    bucket — proving the DRP echelon keys per-site rather than pooling to item
+    level (the ONE structural difference from the MRP loader)."""
+    item_id = _seed_item(conn)
+    east = _seed_location(conn, "drp-east")
+    west = _seed_location(conn, "drp-west")
+    _seed_planning_params(conn, item_id, east)
+    _seed_planning_params(conn, item_id, west)
+
+    item_ext = conn.execute(
+        "SELECT external_id FROM items WHERE item_id = %s", (item_id,)
+    ).fetchone()["external_id"]
+    east_ext = conn.execute(
+        "SELECT external_id FROM locations WHERE location_id = %s", (east,)
+    ).fetchone()["external_id"]
+    west_ext = conn.execute(
+        "SELECT external_id FROM locations WHERE location_id = %s", (west,)
+    ).fetchone()["external_id"]
+
+    # EAST: 8 units at CURRENT_DATE+15 -> bucket 15//7 = 2.
+    _seed_customer_order(conn, scenario_id=BASELINE, item_id=item_id, location_id=east, qty=8, days_out=15)
+    # WEST: 20 units at CURRENT_DATE+3 -> bucket 3//7 = 0.
+    _seed_customer_order(conn, scenario_id=BASELINE, item_id=item_id, location_id=west, qty=20, days_out=3)
+    conn.commit()
+
+    d = load_drp_data(conn, horizon_days=180, scenario=str(BASELINE))
+
+    assert (item_ext, east_ext) in d.demand_by_loc
+    assert (item_ext, west_ext) in d.demand_by_loc
+    assert d.demand_by_loc[(item_ext, east_ext)] == {2: 8.0}
+    assert d.demand_by_loc[(item_ext, west_ext)] == {0: 20.0}
+    # Not pooled: the two coordinates are separate keys, never summed to one.
+    assert (item_ext, east_ext) != (item_ext, west_ext)
+
+
+# ---------------------------------------------------------------------------
+# 2. lead_buckets = ceil(transit_lead_time_days / 7)
+# ---------------------------------------------------------------------------
+
+
+def test_lead_buckets_is_ceil_of_transit_days_over_seven(conn):
+    """The real formula in loader.py is math.ceil(transit_lead_time_days / 7):
+    14d -> 2, 10d -> 2 (ceil(1.43)), 7d -> 1. Three links, three sources into
+    one dest, asserted by source location."""
+    item_id = _seed_item(conn)
+    dest = _seed_location(conn, "drp-dest")
+    src14 = _seed_location(conn, "drp-src14")
+    src10 = _seed_location(conn, "drp-src10")
+    src7 = _seed_location(conn, "drp-src7")
+    _seed_planning_params(conn, item_id, dest)
+
+    _seed_link(conn, upstream_location_id=src14, downstream_location_id=dest, transit_lead_time_days=14)
+    _seed_link(conn, upstream_location_id=src10, downstream_location_id=dest, transit_lead_time_days=10)
+    _seed_link(conn, upstream_location_id=src7, downstream_location_id=dest, transit_lead_time_days=7)
+    conn.commit()
+
+    d = load_drp_data(conn, horizon_days=180, scenario=str(BASELINE))
+
+    ext = {}
+    for loc in (dest, src14, src10, src7):
+        ext[loc] = conn.execute(
+            "SELECT external_id FROM locations WHERE location_id = %s", (loc,)
+        ).fetchone()["external_id"]
+
+    by_source = {lk.source_location: lk for lk in d.links}
+    assert by_source[ext[src14]].lead_buckets == 2, "14 / 7 = 2.0 -> ceil 2"
+    assert by_source[ext[src10]].lead_buckets == 2, "10 / 7 = 1.43 -> ceil 2"
+    assert by_source[ext[src7]].lead_buckets == 1, "7 / 7 = 1.0 -> ceil 1"
+
+
+# ---------------------------------------------------------------------------
+# 3. Forkability (#347) — THE critical DRP guarantee
+# ---------------------------------------------------------------------------
+
+
+def test_safety_stock_override_forkable_and_baseline_unchanged(conn):
+    """THE forkability test. Base safety_stock_qty=0 for (item, location). An
+    override to 999 inside a fork must be visible in that fork's DRP load
+    (safety_by_loc[(item, loc)] == 999) AND baseline must still resolve to 0.
+    This is the guarantee that "DRP is forkable" (#347): an agent tests a
+    per-site safety-stock counter-factual without forking master data."""
+    item_id = _seed_item(conn)
+    location_id = _seed_location(conn)
+    _seed_planning_params(conn, item_id, location_id, safety_stock_qty=0)
+    fork = _seed_scenario(conn)
+    set_param_override(
+        conn, fork, item_id, "safety_stock_qty", "999", "drp-test",
+        location_id=location_id,
+    )
+    conn.commit()
+
+    item_ext = conn.execute(
+        "SELECT external_id FROM items WHERE item_id = %s", (item_id,)
+    ).fetchone()["external_id"]
+    loc_ext = conn.execute(
+        "SELECT external_id FROM locations WHERE location_id = %s", (location_id,)
+    ).fetchone()["external_id"]
+
+    forked = load_drp_data(conn, horizon_days=180, scenario=str(fork))
+    baseline = load_drp_data(conn, horizon_days=180, scenario=str(BASELINE))
+
+    assert forked.safety_by_loc[(item_ext, loc_ext)] == 999.0, "fork reads its SS override"
+    assert baseline.safety_by_loc[(item_ext, loc_ext)] == 0.0, "baseline stays at base SS"
+
+
+# ---------------------------------------------------------------------------
+# 4. Scenario-scoping of on-hand — fork-only node invisible to baseline
+# ---------------------------------------------------------------------------
+
+
+def test_on_hand_seeded_on_fork_only_absent_from_baseline(conn):
+    """The loader is strictly scenario-scoped (WHERE n.scenario_id = %(b)s, no
+    baseline fallback). An OnHandSupply seeded ONLY on the fork is visible in
+    the fork's load and ABSENT from baseline's."""
+    item_id = _seed_item(conn)
+    location_id = _seed_location(conn)
+    _seed_planning_params(conn, item_id, location_id)
+    fork = _seed_scenario(conn)
+    _seed_on_hand(conn, scenario_id=fork, item_id=item_id, location_id=location_id, qty=42)
+    conn.commit()
+
+    item_ext = conn.execute(
+        "SELECT external_id FROM items WHERE item_id = %s", (item_id,)
+    ).fetchone()["external_id"]
+    loc_ext = conn.execute(
+        "SELECT external_id FROM locations WHERE location_id = %s", (location_id,)
+    ).fetchone()["external_id"]
+
+    forked = load_drp_data(conn, horizon_days=180, scenario=str(fork))
+    baseline = load_drp_data(conn, horizon_days=180, scenario=str(BASELINE))
+
+    assert forked.on_hand_by_loc[(item_ext, loc_ext)] == 42.0
+    assert (item_ext, loc_ext) not in baseline.on_hand_by_loc
+
+
+# ---------------------------------------------------------------------------
+# 5. Link min/max/priority surface into TransferLink (max NULL -> None)
+# ---------------------------------------------------------------------------
+
+
+def test_link_min_max_priority_surface_into_transferlink(conn):
+    """distribution_links minimum_shipment_qty / maximum_shipment_qty /
+    priority land on TransferLink; a NULL maximum_shipment_qty becomes
+    max_qty=None (uncapped)."""
+    item_id = _seed_item(conn)
+    dest = _seed_location(conn, "drp-dest")
+    src_capped = _seed_location(conn, "drp-src-capped")
+    src_uncapped = _seed_location(conn, "drp-src-uncapped")
+    _seed_planning_params(conn, item_id, dest)
+
+    _seed_link(
+        conn, upstream_location_id=src_capped, downstream_location_id=dest,
+        transit_lead_time_days=7, minimum_shipment_qty=5, maximum_shipment_qty=50, priority=1,
+    )
+    _seed_link(
+        conn, upstream_location_id=src_uncapped, downstream_location_id=dest,
+        transit_lead_time_days=7, minimum_shipment_qty=2, maximum_shipment_qty=None, priority=3,
+    )
+    conn.commit()
+
+    d = load_drp_data(conn, horizon_days=180, scenario=str(BASELINE))
+
+    capped_ext = conn.execute(
+        "SELECT external_id FROM locations WHERE location_id = %s", (src_capped,)
+    ).fetchone()["external_id"]
+    uncapped_ext = conn.execute(
+        "SELECT external_id FROM locations WHERE location_id = %s", (src_uncapped,)
+    ).fetchone()["external_id"]
+
+    by_source = {lk.source_location: lk for lk in d.links}
+
+    capped = by_source[capped_ext]
+    assert capped.min_qty == 5.0
+    assert capped.max_qty == 50.0
+    assert capped.priority == 1
+
+    uncapped = by_source[uncapped_ext]
+    assert uncapped.min_qty == 2.0
+    assert uncapped.max_qty is None, "NULL maximum_shipment_qty -> None (uncapped)"
+    assert uncapped.priority == 3
+
+
+def test_inactive_link_excluded(conn):
+    """Belt on the WHERE dl.active filter: an inactive link never surfaces as a
+    TransferLink."""
+    item_id = _seed_item(conn)
+    dest = _seed_location(conn, "drp-dest")
+    src = _seed_location(conn, "drp-src")
+    _seed_planning_params(conn, item_id, dest)
+
+    _seed_link(
+        conn, upstream_location_id=src, downstream_location_id=dest,
+        transit_lead_time_days=7, active=False,
+    )
+    conn.commit()
+
+    src_ext = conn.execute(
+        "SELECT external_id FROM locations WHERE location_id = %s", (src,)
+    ).fetchone()["external_id"]
+
+    d = load_drp_data(conn, horizon_days=180, scenario=str(BASELINE))
+    assert src_ext not in {lk.source_location for lk in d.links}
+
+
+# ---------------------------------------------------------------------------
+# #395 review fixes: fallback key, CO clip, item-specific lanes, ORDER BY
+# ---------------------------------------------------------------------------
+
+
+def _seed_item_no_external_id(conn, name: str = "drp-item-null") -> UUID:
+    """An item row with external_id explicitly NULL. The UNIQUE constraint on
+    items.external_id (migration 007) is a plain UNIQUE, not a NOT NULL — SQL
+    NULLs are never equal to each other under UNIQUE, so any number of rows may
+    carry a NULL external_id without collision. This is what the loader's F4
+    fallback-key fix (COALESCE(external_id, item_id::text)) exists to handle."""
+    return conn.execute(
+        "INSERT INTO items (item_id, external_id, name) VALUES (%s, NULL, %s) "
+        "RETURNING item_id",
+        (uuid4(), name),
+    ).fetchone()["item_id"]
+
+
+def _seed_location_no_external_id(conn, name: str = "drp-loc-null") -> UUID:
+    """A location row with external_id explicitly NULL — same NULL-tolerant
+    UNIQUE rationale as _seed_item_no_external_id."""
+    return conn.execute(
+        "INSERT INTO locations (location_id, external_id, name) VALUES (%s, NULL, %s) "
+        "RETURNING location_id",
+        (uuid4(), name),
+    ).fetchone()["location_id"]
+
+
+def test_fallback_key_used_when_external_id_is_null(conn):
+    """#395 F4, THE critical case: an item AND a location seeded with NO
+    external_id (NULL) must NOT collapse onto a shared "None" coordinate — the
+    loader keys them by COALESCE(external_id, <uuid>::text), i.e. the row's own
+    stringified UUID as a stable fallback. We seed one on-hand node for this
+    (item, location) pair with NO external_id anywhere and confirm the loader's
+    on_hand_by_loc key is the (item_id, location_id) UUIDs stringified — never
+    the literal strings "None"/"None" that a naive f"{external_id}" key would
+    have produced for every un-backfilled row alike."""
+    item_id = _seed_item_no_external_id(conn)
+    location_id = _seed_location_no_external_id(conn)
+    _seed_planning_params(conn, item_id, location_id)
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_id, location_id=location_id, qty=7)
+    conn.commit()
+
+    d = load_drp_data(conn, horizon_days=180, scenario=str(BASELINE))
+
+    expected_key = (str(item_id), str(location_id))
+    assert expected_key in d.on_hand_by_loc, (
+        "the (item, location) coordinate must key by the stringified UUIDs when "
+        "external_id is NULL, not by a literal 'None' placeholder"
+    )
+    assert d.on_hand_by_loc[expected_key] == 7.0
+    assert ("None", "None") not in d.on_hand_by_loc
+
+
+def test_fallback_key_two_items_without_external_id_on_same_location_stay_distinct(conn):
+    """#395 F4: TWO items, BOTH with a NULL external_id, sharing the SAME
+    location (which DOES carry an external_id) — a naive f"{None}" key would
+    collapse both items' on-hand onto ONE coordinate ("None", loc_ext) and sum
+    their quantities together. The UUID fallback keeps them on two DISTINCT
+    coordinates, each with its own quantity."""
+    item_a = _seed_item_no_external_id(conn, "drp-item-null-a")
+    item_b = _seed_item_no_external_id(conn, "drp-item-null-b")
+    location_id = _seed_location(conn, "drp-shared-loc")  # has a real external_id
+    _seed_planning_params(conn, item_a, location_id)
+    _seed_planning_params(conn, item_b, location_id)
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_a, location_id=location_id, qty=11)
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_b, location_id=location_id, qty=22)
+    conn.commit()
+
+    loc_ext = conn.execute(
+        "SELECT external_id FROM locations WHERE location_id = %s", (location_id,)
+    ).fetchone()["external_id"]
+
+    d = load_drp_data(conn, horizon_days=180, scenario=str(BASELINE))
+
+    key_a = (str(item_a), loc_ext)
+    key_b = (str(item_b), loc_ext)
+    assert key_a != key_b, "two NULL-external_id items must never resolve to the same coordinate"
+    assert d.on_hand_by_loc[key_a] == 11.0
+    assert d.on_hand_by_loc[key_b] == 22.0
+    # Neither quantity is silently summed onto a shared "None" coordinate.
+    assert d.on_hand_by_loc[key_a] + d.on_hand_by_loc[key_b] == 33.0
+
+
+def test_fallback_key_item_with_and_without_external_id_coexist(conn):
+    """#395 F4: one item WITH a real external_id and one item WITHOUT (NULL),
+    same location, coexist without collision — the business-key item resolves
+    to its readable external_id, the NULL one falls back to its UUID, and
+    neither shadows the other."""
+    item_named = _seed_item(conn, "drp-item-named")
+    item_null = _seed_item_no_external_id(conn, "drp-item-anon")
+    location_id = _seed_location(conn, "drp-coexist-loc")
+    _seed_planning_params(conn, item_named, location_id)
+    _seed_planning_params(conn, item_null, location_id)
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_named, location_id=location_id, qty=5)
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_null, location_id=location_id, qty=9)
+    conn.commit()
+
+    item_named_ext = conn.execute(
+        "SELECT external_id FROM items WHERE item_id = %s", (item_named,)
+    ).fetchone()["external_id"]
+    loc_ext = conn.execute(
+        "SELECT external_id FROM locations WHERE location_id = %s", (location_id,)
+    ).fetchone()["external_id"]
+
+    d = load_drp_data(conn, horizon_days=180, scenario=str(BASELINE))
+
+    assert d.on_hand_by_loc[(item_named_ext, loc_ext)] == 5.0
+    assert d.on_hand_by_loc[(str(item_null), loc_ext)] == 9.0
+
+
+def test_customer_order_beyond_horizon_end_is_clipped(conn):
+    """#395 F1 (loader side): a CustomerOrderDemand dated horizon_start + 400
+    days, loaded with horizon_days=180 (horizon_end = start + 180), must be
+    ABSENT from demand_by_loc entirely — clipped by the upper bound
+    `horizon_start <= tref <= horizon_end`, symmetric with the forecast side's
+    _spread_period confinement. Before the fix only the lower bound was
+    enforced and this order would have landed in a bucket far past n_buckets,
+    invisible to the core's windowed excess/deficit but still lingering in the
+    raw dict."""
+    item_id = _seed_item(conn)
+    location_id = _seed_location(conn)
+    _seed_planning_params(conn, item_id, location_id)
+    _seed_customer_order(
+        conn, scenario_id=BASELINE, item_id=item_id, location_id=location_id,
+        qty=99, days_out=400,
+    )
+    conn.commit()
+
+    item_ext = conn.execute(
+        "SELECT external_id FROM items WHERE item_id = %s", (item_id,)
+    ).fetchone()["external_id"]
+    loc_ext = conn.execute(
+        "SELECT external_id FROM locations WHERE location_id = %s", (location_id,)
+    ).fetchone()["external_id"]
+
+    d = load_drp_data(conn, horizon_days=180, scenario=str(BASELINE))
+    assert (item_ext, loc_ext) not in d.demand_by_loc, (
+        "a customer order 400 days out on a 180-day horizon must be clipped, "
+        "not silently carried into demand_by_loc"
+    )
+
+
+def test_link_item_id_resolves_to_item_key_null_stays_none(conn):
+    """#395 F2/F3 (loader side): distribution_links.item_id, when set, resolves
+    onto TransferLink.item as the SAME (item, location) key convention used
+    everywhere else in the loader; when NULL, TransferLink.item is None (a
+    generic lane) — the LEFT JOIN items must NOT drop the link row just
+    because item_id is NULL."""
+    item_id = _seed_item(conn, "drp-lane-item")
+    src = _seed_location(conn, "drp-lane-src")
+    generic_src = _seed_location(conn, "drp-lane-generic-src")
+    dest = _seed_location(conn, "drp-lane-dest")
+    _seed_planning_params(conn, item_id, dest)
+
+    specific_link_id = conn.execute(
+        """
+        INSERT INTO distribution_links (
+            distribution_link_id, upstream_location_id, downstream_location_id,
+            item_id, transit_lead_time_days, priority
+        ) VALUES (%s, %s, %s, %s, %s, %s)
+        RETURNING distribution_link_id
+        """,
+        (uuid4(), src, dest, item_id, 7, 1),
+    ).fetchone()["distribution_link_id"]
+    generic_link_id = conn.execute(
+        """
+        INSERT INTO distribution_links (
+            distribution_link_id, upstream_location_id, downstream_location_id,
+            item_id, transit_lead_time_days, priority
+        ) VALUES (%s, %s, %s, NULL, %s, %s)
+        RETURNING distribution_link_id
+        """,
+        (uuid4(), generic_src, dest, 7, 2),
+    ).fetchone()["distribution_link_id"]
+    conn.commit()
+
+    item_ext = conn.execute(
+        "SELECT external_id FROM items WHERE item_id = %s", (item_id,)
+    ).fetchone()["external_id"]
+
+    d = load_drp_data(conn, horizon_days=180, scenario=str(BASELINE))
+    links_by_ref = {lk.link_ref: lk for lk in d.links}
+
+    specific = links_by_ref[str(specific_link_id)]
+    generic = links_by_ref[str(generic_link_id)]
+    assert specific.item == item_ext, "item_id set -> TransferLink.item resolves to its key"
+    assert generic.item is None, (
+        "item_id NULL -> TransferLink.item is None (generic); the LEFT JOIN "
+        "must not drop the row"
+    )
+
+
+def test_links_order_by_is_stable_across_calls(conn):
+    """#395 F6 (loader side): two links on the SAME (priority, source, dest)
+    triple, differing only by distribution_link_id, must come back in the SAME
+    relative order on every call — the loader's ORDER BY (priority, source,
+    dest, distribution_link_id) makes that order deterministic (the smaller
+    UUID sorts first), never physical scan order."""
+    item_id = _seed_item(conn)
+    src = _seed_location(conn, "drp-dup-src")
+    dest = _seed_location(conn, "drp-dup-dest")
+    _seed_planning_params(conn, item_id, dest)
+
+    link_a = _seed_link(
+        conn, upstream_location_id=src, downstream_location_id=dest,
+        transit_lead_time_days=7, priority=5,
+    )
+    link_b = _seed_link(
+        conn, upstream_location_id=src, downstream_location_id=dest,
+        transit_lead_time_days=7, priority=5,
+    )
+    conn.commit()
+
+    expected_ref_order = sorted([str(link_a), str(link_b)])
+
+    d1 = load_drp_data(conn, horizon_days=180, scenario=str(BASELINE))
+    d2 = load_drp_data(conn, horizon_days=180, scenario=str(BASELINE))
+
+    refs1 = [lk.link_ref for lk in d1.links if lk.link_ref in {str(link_a), str(link_b)}]
+    refs2 = [lk.link_ref for lk in d2.links if lk.link_ref in {str(link_a), str(link_b)}]
+
+    assert refs1 == expected_ref_order, "ORDER BY ... distribution_link_id sorts the smaller UUID first"
+    assert refs1 == refs2, "the relative order must be stable across two separate calls"

--- a/tests/test_drp_core_golden.py
+++ b/tests/test_drp_core_golden.py
@@ -1,0 +1,762 @@
+"""
+Golden-master for the DRP (distribution) engine (engine/drp/core.py).
+
+Same discipline as tests/test_mrp_core_golden.py: a tiny hand-computed dataset
+whose expected outputs are derived STEP BY STEP in the comments, so any future
+change that deviates from the documented arithmetic fails CI instead of silently
+shifting a distribution plan. Every number below is derived by hand from the
+documented semantics of core.py (module + function docstrings) BEFORE running —
+none is copied back from an execution. If the engine ever disagrees with a
+derivation here, the derivation is the contract and the divergence is a bug to
+investigate, not a golden to "fix".
+
+core.py's functions are pure (they operate on plain dict/list inputs, not the
+DB), so this runs with no database — just the engine math.
+
+Planning key throughout = (item, location) tuples; quantities are floats;
+buckets are 0-indexed weekly integers.
+"""
+from __future__ import annotations
+
+import pytest
+
+from ootils_core.engine.drp import core
+from ootils_core.engine.drp.core import TransferLink, TransferSignal
+
+# A generous horizon so no case is truncated by the bucket ceiling; every
+# derivation below reasons about the FIRST safety-breaking bucket, well inside.
+H = 12
+
+
+# ───────────────────────── projected_deficits ─────────────────────────
+
+
+def test_deficit_simple_below_safety():
+    """Case 1 — the simplest deficit.
+    (A, EAST): on_hand=10, safety=5, demand 8 @bucket 2.
+    Projection walk (pa starts at on_hand=10):
+      bucket 0: pa -= 0  -> 10  (>= safety 5, no trigger)
+      bucket 1: pa -= 0  -> 10  (>= 5)
+      bucket 2: pa -= 8  -> 2   (< safety 5) -> TRIGGER
+    deficit = safety - pa = 5 - 2 = 3.0, at deficit_bucket 2.
+    """
+    out = core.projected_deficits(
+        demand_by_loc={("A", "EAST"): {2: 8.0}},
+        on_hand_by_loc={("A", "EAST"): 10.0},
+        safety_by_loc={("A", "EAST"): 5.0},
+        horizon_buckets=H,
+    )
+    assert out == {("A", "EAST"): (2, 3.0)}
+
+
+def test_deficit_triggers_at_safety_threshold_not_stockout():
+    """Case 2 — the trigger is the SAFETY threshold, NOT stockout.
+    (A, EAST): on_hand=30, safety=20, demand 15 @bucket 2 then 20 @bucket 4.
+      bucket 2: pa = 30 - 15 = 15  -> 15 < safety 20 -> TRIGGER (still POSITIVE,
+                nowhere near stockout — this is the whole point of the case).
+    deficit = 20 - 15 = 5.0 at bucket 2. The later bucket-4 demand is never
+    reached because the first breach already returned.
+    """
+    out = core.projected_deficits(
+        demand_by_loc={("A", "EAST"): {2: 15.0, 4: 20.0}},
+        on_hand_by_loc={("A", "EAST"): 30.0},
+        safety_by_loc={("A", "EAST"): 20.0},
+        horizon_buckets=H,
+    )
+    assert out == {("A", "EAST"): (2, 5.0)}
+    # Explicit: the balance at trigger (15) is strictly positive — safety, not
+    # stockout, fired. deficit_qty (5) restores safety (15 + 5 == 20).
+    deficit_bucket, deficit_qty = out[("A", "EAST")]
+    assert deficit_bucket == 2
+    assert deficit_qty == pytest.approx(5.0)
+
+
+def test_deficit_zero_safety_is_first_negative_bucket():
+    """Case 3 — safety=0 reduces to the first NEGATIVE (stockout) bucket.
+    (A, EAST): on_hand=10, safety=0, demand 4 @bucket 1 then 9 @bucket 2.
+      bucket 1: pa = 10 - 4 = 6   -> 6 < 0? no.
+      bucket 2: pa = 6  - 9 = -3  -> -3 < 0 -> TRIGGER (first negative).
+    deficit = safety - pa = 0 - (-3) = 3.0 at bucket 2.
+    (safety absent from the map => default 0.0 in the projection.)
+    """
+    out = core.projected_deficits(
+        demand_by_loc={("A", "EAST"): {1: 4.0, 2: 9.0}},
+        on_hand_by_loc={("A", "EAST"): 10.0},
+        safety_by_loc={},
+        horizon_buckets=H,
+    )
+    assert out == {("A", "EAST"): (2, 3.0)}
+
+
+def test_deficit_absent_when_never_below_safety():
+    """Case 4 — a coordinate that never breaks safety is ABSENT from the dict.
+    (A, EAST): on_hand=100, safety=5, demand 10 @bucket 2.
+      lowest projection over the horizon = 100 - 10 = 90, always >= safety 5.
+    No breach => no key. The dict is empty (this is the ONLY coordinate).
+    """
+    out = core.projected_deficits(
+        demand_by_loc={("A", "EAST"): {2: 10.0}},
+        on_hand_by_loc={("A", "EAST"): 100.0},
+        safety_by_loc={("A", "EAST"): 5.0},
+        horizon_buckets=H,
+    )
+    assert out == {}
+    assert ("A", "EAST") not in out
+
+
+# ───────────────────────── excess_by_location ─────────────────────────
+
+
+def test_excess_floor_zero_when_exactly_demand_plus_safety():
+    """Case 5 — excess is floored at 0: a source holding EXACTLY demand+safety
+    yields NO key (excess must be strictly > 0 to appear).
+    (A, WEST): on_hand=25, safety=5, demand total = 20 (8 @b0 + 12 @b3).
+      excess = 25 - (20 + 5) = 0 -> floored, NOT strictly positive -> no key.
+    """
+    out = core.excess_by_location(
+        demand_by_loc={("A", "WEST"): {0: 8.0, 3: 12.0}},
+        on_hand_by_loc={("A", "WEST"): 25.0},
+        safety_by_loc={("A", "WEST"): 5.0},
+        horizon_buckets=H,
+    )
+    assert out == {}
+
+
+def test_excess_positive_uses_horizon_total_demand():
+    """Companion to case 5/6 — the excess formula, made explicit.
+    (A, WEST): on_hand=100, safety=5, demand total 20 (all @bucket 0).
+      excess = 100 - (20 total demand + 5 safety) = 75.0.
+    A location with stock but with NO entry in on_hand_by_loc can never carry
+    excess — only coordinates present in on_hand_by_loc are scanned.
+    """
+    out = core.excess_by_location(
+        demand_by_loc={("A", "WEST"): {0: 20.0}},
+        on_hand_by_loc={("A", "WEST"): 100.0},
+        safety_by_loc={("A", "WEST"): 5.0},
+        horizon_buckets=H,
+    )
+    assert out == {("A", "WEST"): 75.0}
+
+
+# ───────────────────────── transfer_signals ─────────────────────────
+
+
+def test_transfer_nominal_single_signal():
+    """Case 6 — the nominal transfer (the dev's smoke case).
+    WEST (source): on_hand=100, safety=5, demand 20 @bucket 0
+        -> excess = 100 - (20 + 5) = 75.
+    EAST (dest):   on_hand=10, safety=5, demand 8 @bucket 2
+        -> projection bucket 2 = 10 - 8 = 2 < 5 -> deficit (bucket 2, qty 3).
+    Link WEST->EAST, lead_buckets=2, min_qty=1 (default), max_qty=None, prio=1.
+      qty          = min(remaining deficit 3, source excess 75) = 3
+                     (max_qty None => no cap); 3 >= min_qty 1 -> emit.
+      ship_bucket  = max(0, deficit_bucket 2 - lead 2) = 0
+      arrival      = ship 0 + lead 2 = 2 (lands exactly at the deficit bucket).
+      source_excess_before = 75 (the excess seen BEFORE this draw).
+    Exactly ONE signal.
+    """
+    signals = core.transfer_signals(
+        demand_by_loc={("A", "WEST"): {0: 20.0}, ("A", "EAST"): {2: 8.0}},
+        on_hand_by_loc={("A", "WEST"): 100.0, ("A", "EAST"): 10.0},
+        safety_by_loc={("A", "WEST"): 5.0, ("A", "EAST"): 5.0},
+        links=[TransferLink("WEST", "EAST", 2, 1.0, None, 1)],
+        horizon_buckets=H,
+    )
+    assert signals == [
+        TransferSignal(
+            item="A",
+            source_location="WEST",
+            dest_location="EAST",
+            qty=3.0,
+            ship_bucket=0,
+            arrival_bucket=2,
+            deficit_bucket=2,
+            deficit_qty=3.0,
+            source_excess_before=75.0,
+        )
+    ]
+
+
+def test_min_shipment_blocks_single_link_no_signal():
+    """Case 7a — the minimum-shipment rule blocks a lane below its minimum.
+    EAST deficit (bucket 2, qty 3) exactly as case 6.
+    Link WEST->EAST has min_qty=10 > the needed 3:
+      qty = min(3, excess 75) = 3; 3 < min_qty 10 -> emit NOTHING on this link.
+    No other link exists -> the deficit is left uncovered -> ZERO signals.
+    (Honest: we neither ship 3 below the lane minimum nor inflate to 10 units
+    the destination does not need.)
+    """
+    signals = core.transfer_signals(
+        demand_by_loc={("A", "WEST"): {0: 20.0}, ("A", "EAST"): {2: 8.0}},
+        on_hand_by_loc={("A", "WEST"): 100.0, ("A", "EAST"): 10.0},
+        safety_by_loc={("A", "WEST"): 5.0, ("A", "EAST"): 5.0},
+        links=[TransferLink("WEST", "EAST", 2, 10.0, None, 1)],
+        horizon_buckets=H,
+    )
+    assert signals == []
+
+
+def test_min_shipment_falls_through_to_secondary_link():
+    """Case 7b — a deficit blocked at the priority link's minimum FALLS THROUGH
+    to the next-priority link, which serves it.
+    EAST deficit (bucket 2, qty 3).
+    Two candidate links into EAST, both sources holding excess:
+      - WEST->EAST : priority 1, min_qty=10  (BLOCKS: 3 < 10)
+      - NORTH->EAST: priority 2, min_qty=1   (serves)
+    Sources' excess:
+      WEST : on_hand 100, dem 20, ss 5 -> 75.
+      NORTH: on_hand  50, dem 10, ss 5 -> 35.
+    Greedy over EAST's candidates in (priority, source) order = [WEST(1), NORTH(2)]:
+      WEST link: qty = min(3, 75) = 3 < min_qty 10 -> skip (remaining stays 3).
+      NORTH link: qty = min(3, 35) = 3 >= min_qty 1 -> EMIT.
+        ship = max(0, 2 - lead 2) = 0, arrival = 0 + 2 = 2.
+        source_excess_before = 35 (NORTH's excess, untouched by the skipped WEST).
+    Exactly ONE signal, sourced from NORTH.
+    """
+    signals = core.transfer_signals(
+        demand_by_loc={
+            ("A", "WEST"): {0: 20.0},
+            ("A", "NORTH"): {0: 10.0},
+            ("A", "EAST"): {2: 8.0},
+        },
+        on_hand_by_loc={("A", "WEST"): 100.0, ("A", "NORTH"): 50.0, ("A", "EAST"): 10.0},
+        safety_by_loc={("A", "WEST"): 5.0, ("A", "NORTH"): 5.0, ("A", "EAST"): 5.0},
+        links=[
+            TransferLink("WEST", "EAST", 2, 10.0, None, 1),
+            TransferLink("NORTH", "EAST", 2, 1.0, None, 2),
+        ],
+        horizon_buckets=H,
+    )
+    assert len(signals) == 1
+    sig = signals[0]
+    assert sig.source_location == "NORTH"
+    assert sig.qty == pytest.approx(3.0)
+    assert sig.ship_bucket == 0
+    assert sig.arrival_bucket == 2
+    assert sig.deficit_bucket == 2
+    assert sig.source_excess_before == pytest.approx(35.0)
+
+
+def test_shared_source_excess_decremented_across_destinations():
+    """Case 8 — one source's excess is a single running counter shared greedily
+    across destinations; the SECOND destination sees it decremented.
+    Source WEST: on_hand=100, safety=0, no demand -> excess = 100.
+    Two destinations, each with its own deficit, both linked to WEST only:
+      DEST_A (label 'EAST'):  on_hand 0, ss 0, demand 30 @bucket 1
+          -> bucket 1: pa = 0 - 30 = -30 < 0 -> deficit (bucket 1, qty 30).
+      DEST_B (label 'SOUTH'): on_hand 0, ss 0, demand 40 @bucket 1
+          -> deficit (bucket 1, qty 40).
+    Destinations are processed in sorted (item, dest) order = EAST, then SOUTH.
+      EAST : qty = min(30, excess 100) = 30 -> emit, source_excess_before = 100.
+             WEST excess now 100 - 30 = 70.
+      SOUTH: qty = min(40, excess 70) = 40 -> emit, source_excess_before = 70
+             (DECREMENTED — the EAST draw already consumed 30).
+    Total transferred 30 + 40 = 70 <= initial excess 100 (never over-drawn).
+    Links have lead 0, so ship = deficit_bucket = 1, arrival = 1.
+    """
+    signals = core.transfer_signals(
+        demand_by_loc={("A", "EAST"): {1: 30.0}, ("A", "SOUTH"): {1: 40.0}},
+        on_hand_by_loc={("A", "WEST"): 100.0, ("A", "EAST"): 0.0, ("A", "SOUTH"): 0.0},
+        safety_by_loc={},
+        links=[
+            TransferLink("WEST", "EAST", 0, 1.0, None, 1),
+            TransferLink("WEST", "SOUTH", 0, 1.0, None, 1),
+        ],
+        horizon_buckets=H,
+    )
+    by_dest = {s.dest_location: s for s in signals}
+    assert by_dest["EAST"].source_excess_before == pytest.approx(100.0)
+    assert by_dest["EAST"].qty == pytest.approx(30.0)
+    assert by_dest["SOUTH"].source_excess_before == pytest.approx(70.0)
+    assert by_dest["SOUTH"].qty == pytest.approx(40.0)
+    # Conservation: total drawn from WEST <= its initial excess.
+    assert by_dest["EAST"].qty + by_dest["SOUTH"].qty <= 100.0
+
+
+def test_max_qty_caps_partial_coverage():
+    """Case 9 — max_qty caps a single transfer (honest partial coverage).
+    EAST deficit: on_hand 0, ss 0, demand 10 @bucket 2 -> deficit (bucket 2, 10).
+    Source WEST excess 100 (on_hand 100, no demand, ss 0). Link max_qty=4:
+      qty = min(remaining 10, excess 100) = 10, then capped by max_qty -> 4.
+      4 >= min_qty 1 -> emit qty=4 (covers 4 of the 10; the rest stays open,
+      and no further link exists to cover it).
+    ship = max(0, 2 - lead 1) = 1, arrival = 1 + 1 = 2.
+    """
+    signals = core.transfer_signals(
+        demand_by_loc={("A", "EAST"): {2: 10.0}},
+        on_hand_by_loc={("A", "WEST"): 100.0, ("A", "EAST"): 0.0},
+        safety_by_loc={},
+        links=[TransferLink("WEST", "EAST", 1, 1.0, 4.0, 1)],
+        horizon_buckets=H,
+    )
+    assert len(signals) == 1
+    assert signals[0].qty == pytest.approx(4.0)
+    assert signals[0].deficit_qty == pytest.approx(10.0)  # full deficit recorded
+    assert signals[0].ship_bucket == 1
+    assert signals[0].arrival_bucket == 2
+
+
+def test_no_excess_anywhere_yields_no_signal():
+    """Case 10 — a source with no distributable excess never funds a transfer
+    (never starve the source to feed a peer).
+    EAST deficit: on_hand 0, ss 0, demand 10 @bucket 2 -> deficit (bucket 2, 10).
+    Source WEST holds on_hand 20 but its OWN demand is 20 @bucket 0
+        -> excess = 20 - (20 + 0) = 0 -> no excess key.
+    Candidate link WEST->EAST finds avail=0 -> continue -> ZERO signals.
+    """
+    signals = core.transfer_signals(
+        demand_by_loc={("A", "WEST"): {0: 20.0}, ("A", "EAST"): {2: 10.0}},
+        on_hand_by_loc={("A", "WEST"): 20.0, ("A", "EAST"): 0.0},
+        safety_by_loc={},
+        links=[TransferLink("WEST", "EAST", 1, 1.0, None, 1)],
+        horizon_buckets=H,
+    )
+    assert signals == []
+
+
+def test_ship_bucket_floors_at_zero_arrival_after_deficit():
+    """Case 11 — when the deficit is nearer than the transit lead time, ship
+    floors at 0 and arrival lands AFTER the deficit; the signal is STILL emitted.
+    EAST deficit: on_hand 0, ss 0, demand 5 @bucket 1 -> deficit (bucket 1, 5).
+    Link WEST->EAST lead_buckets=3 (> deficit_bucket 1):
+      ship    = max(0, 1 - 3) = 0
+      arrival = 0 + 3 = 3, which is > deficit_bucket 1 -> "covered late".
+      qty = min(5, excess 100) = 5 >= min 1 -> emit (NOT dropped).
+    Source WEST excess 100 (on_hand 100, no demand).
+    """
+    signals = core.transfer_signals(
+        demand_by_loc={("A", "EAST"): {1: 5.0}},
+        on_hand_by_loc={("A", "WEST"): 100.0, ("A", "EAST"): 0.0},
+        safety_by_loc={},
+        links=[TransferLink("WEST", "EAST", 3, 1.0, None, 1)],
+        horizon_buckets=H,
+    )
+    assert len(signals) == 1
+    sig = signals[0]
+    assert sig.ship_bucket == 0
+    assert sig.arrival_bucket == 3
+    assert sig.deficit_bucket == 1
+    assert sig.arrival_bucket > sig.deficit_bucket  # late, but present
+    assert sig.qty == pytest.approx(5.0)
+
+
+def test_determinism_insertion_order_independent_and_output_sorted():
+    """Case 12 — determinism + the output sort key (item, dest, deficit_bucket,
+    priority, source).
+
+    THREE signals engineered so a naive dict-order emission would NOT match the
+    documented sort, then asserted byte-identical under two DIFFERENT input
+    insertion orders.
+
+    Setup (single item 'A'):
+      Destinations & deficits (all on_hand 0, ss 0):
+        DEPOT: demand 5 @bucket 0  -> deficit (bucket 0, 5)
+        EAST : demand 10 @bucket 2 -> deficit (bucket 2, 10)
+        SOUTH: demand 20 @bucket 1 -> deficit (bucket 1, 20)
+      Sources (both plenty of excess, no own demand, ss 0):
+        WEST : on_hand 100 -> excess 100
+        NORTH: on_hand 100 -> excess 100
+      Links (all lead 0, min 1, uncapped):
+        DEPOT <- WEST  priority 1
+        EAST  <- WEST  priority 1
+        EAST  <- NORTH priority 2   (redundant on EAST — WEST already covers 10)
+        SOUTH <- NORTH priority 1
+
+    #395 F7 review fix: the REAL service order is NOT insertion/label order — it
+    is `sorted(deficits)` on the (item, dest) key, i.e. plain alphabetical dest
+    order: DEPOT < EAST < SOUTH. So DEPOT is served FIRST, not EAST — the
+    previous docstring here had this backwards (it asserted "WEST excess after
+    EAST draw = 90" as if EAST went first) and the test PASSED anyway only
+    because it never checked source_excess_before. Corrected order below, with
+    source_excess_before now asserted on all three signals so a future
+    regression to the wrong order fails loudly instead of passing silently.
+
+    Per-destination greedy resolution, in the REAL processed order:
+      DEPOT (deficit 5, processed 1st): WEST(p1) covers all 5 -> signal
+           WEST->DEPOT, source_excess_before=100 (WEST untouched so far).
+           WEST excess drops 100 -> 95.
+      EAST (deficit 10, processed 2nd): WEST(p1) covers all 10 -> signal
+           WEST->EAST, source_excess_before=95 (WEST AFTER the DEPOT draw, NOT
+           100). WEST excess drops 95 -> 85. NORTH(p2) then sees
+           remaining_deficit 0 -> break, NO second EAST signal.
+      SOUTH (deficit 20, processed 3rd): NORTH(p1) covers 20 -> signal
+           NORTH->SOUTH, source_excess_before=100 (NORTH untouched by anything
+           before it — DEPOT/EAST only ever drew on WEST).
+
+    Expected emitted signals, already in the documented output sort order
+    (item, dest, deficit_bucket, priority, source) since dest is alphabetical:
+        ('A', 'DEPOT', 0, 1, 'WEST',  qty=5,  source_excess_before=100)
+        ('A', 'EAST',  2, 1, 'WEST',  qty=10, source_excess_before=95)
+        ('A', 'SOUTH', 1, 1, 'NORTH', qty=20, source_excess_before=100)
+    'DEPOT' < 'EAST' < 'SOUTH' alphabetically -> that IS the output order.
+    """
+    demand = {
+        ("A", "EAST"): {2: 10.0},
+        ("A", "SOUTH"): {1: 20.0},
+        ("A", "DEPOT"): {0: 5.0},
+    }
+    on_hand = {
+        ("A", "WEST"): 100.0,
+        ("A", "NORTH"): 100.0,
+        ("A", "EAST"): 0.0,
+        ("A", "SOUTH"): 0.0,
+        ("A", "DEPOT"): 0.0,
+    }
+    links = [
+        TransferLink("WEST", "EAST", 0, 1.0, None, 1),
+        TransferLink("NORTH", "EAST", 0, 1.0, None, 2),
+        TransferLink("NORTH", "SOUTH", 0, 1.0, None, 1),
+        TransferLink("WEST", "DEPOT", 0, 1.0, None, 1),
+    ]
+
+    first = core.transfer_signals(demand, on_hand, {}, links, H)
+
+    # Rebuild every input dict/list in a DIFFERENT insertion order — a correct,
+    # order-independent engine must return a byte-identical list.
+    demand_shuffled = {
+        ("A", "DEPOT"): {0: 5.0},
+        ("A", "SOUTH"): {1: 20.0},
+        ("A", "EAST"): {2: 10.0},
+    }
+    on_hand_shuffled = {
+        ("A", "DEPOT"): 0.0,
+        ("A", "SOUTH"): 0.0,
+        ("A", "EAST"): 0.0,
+        ("A", "NORTH"): 100.0,
+        ("A", "WEST"): 100.0,
+    }
+    links_shuffled = [
+        TransferLink("WEST", "DEPOT", 0, 1.0, None, 1),
+        TransferLink("NORTH", "SOUTH", 0, 1.0, None, 1),
+        TransferLink("NORTH", "EAST", 0, 1.0, None, 2),
+        TransferLink("WEST", "EAST", 0, 1.0, None, 1),
+    ]
+    second = core.transfer_signals(demand_shuffled, on_hand_shuffled, {}, links_shuffled, H)
+
+    assert first == second, "output must be independent of input insertion order"
+
+    # The documented total order AND the source_excess_before evidence on every
+    # signal — this is the F7 fix: the previous version of this test asserted
+    # only (dest, bucket, qty, source) and so never caught that its own
+    # docstring had the service order (and therefore the WEST excess trail)
+    # backwards. WEST's excess is 100 for DEPOT (first draw), then 95 for EAST
+    # (AFTER DEPOT's draw of 5) — never 90, which would only be true if EAST
+    # were served before DEPOT. NORTH is untouched by either WEST draw, so
+    # SOUTH sees NORTH's full initial 100.
+    assert [
+        (s.dest_location, s.deficit_bucket, s.qty, s.source_location, s.source_excess_before)
+        for s in first
+    ] == [
+        ("DEPOT", 0, 5.0, "WEST", 100.0),
+        ("EAST", 2, 10.0, "WEST", 95.0),
+        ("SOUTH", 1, 20.0, "NORTH", 100.0),
+    ]
+
+
+# ─────────────── #395 review fixes: excess window, item scoping, dedup ───────────────
+
+
+def test_excess_window_bounded_to_horizon_buckets():
+    """#395 F1 — the excess window is IDENTICAL to projected_deficits': demand
+    at or beyond horizon_buckets is invisible to BOTH functions, not just the
+    deficit side.
+    (A, WEST): on_hand=100, safety=0, demand {bucket 50: 50.0}, horizon_buckets=12.
+      excess_by_location only sums `t < horizon_buckets` (t=50 is NOT < 12) ->
+      total_demand = 0.0 (the out-of-window 50 units are never summed).
+      excess = 100 - (0 + 0) = 100.0 — NOT 100 - 50 = 50, which is what a
+      time-unbounded sum would have produced.
+    Companion check: projected_deficits' walk is `range(horizon_buckets)`
+    (0..11), so it never reaches bucket 50 either — WEST itself carries no
+    deficit (it is a pure source in this setup, consistent either way).
+    """
+    demand = {("A", "WEST"): {50: 50.0}}
+    on_hand = {("A", "WEST"): 100.0}
+    excess = core.excess_by_location(demand, on_hand, {}, horizon_buckets=H)
+    assert excess == {("A", "WEST"): 100.0}
+    deficits = core.projected_deficits(demand, on_hand, {}, horizon_buckets=H)
+    assert ("A", "WEST") not in deficits
+
+
+def test_excess_window_end_to_end_full_transfer():
+    """#395 F1 end-to-end: the windowed excess (100.0, see above) funds a
+    same-item deficit INSIDE the horizon in full.
+    WEST: on_hand=100, safety=0, demand {50: 50.0} (out of window) -> excess 100.0.
+    EAST: on_hand=0, safety=0, demand 80 @bucket 3 (inside window)
+        -> bucket 3: pa = 0 - 80 = -80 < 0 -> deficit (bucket 3, 80.0).
+    Link WEST->EAST, lead=0, min=1, uncapped:
+      qty = min(80, 100) = 80.0 (the full deficit, entirely funded).
+      ship = max(0, 3-0) = 3, arrival = 3+0 = 3.
+    """
+    demand = {("A", "WEST"): {50: 50.0}, ("A", "EAST"): {3: 80.0}}
+    on_hand = {("A", "WEST"): 100.0, ("A", "EAST"): 0.0}
+    links = [TransferLink("WEST", "EAST", 0, 1.0, None, 1)]
+    signals = core.transfer_signals(demand, on_hand, {}, links, horizon_buckets=H)
+    assert signals == [
+        TransferSignal(
+            item="A",
+            source_location="WEST",
+            dest_location="EAST",
+            qty=80.0,
+            ship_bucket=3,
+            arrival_bucket=3,
+            deficit_bucket=3,
+            deficit_qty=80.0,
+            source_excess_before=100.0,
+        )
+    ]
+
+
+def test_item_specific_lane_never_serves_a_different_item():
+    """#395 F2 — item scoping: a lane with item="A" set is usable ONLY by item
+    A; item B's SAME-shaped deficit at the SAME destination, with excess on the
+    SAME source, gets ZERO signals because the only candidate link is scoped
+    away from it.
+    WEST: excess 100.0 for BOTH item A (on_hand 100, no demand, ss 0) and item B
+        (on_hand 100, no demand, ss 0) — so lack of excess is never the reason B
+        goes unserved.
+    EAST: deficit (bucket 1, 20.0) for BOTH A and B (demand 20 @bucket 1 each,
+        on_hand 0, ss 0).
+    ONE link WEST->EAST with item="A" (lead 0, min 1, uncapped, prio 1):
+      _resolve_candidate_links(dest_links, "B") filters `link.item is None or
+      link.item == item` -> "A" is neither None nor == "B" -> EXCLUDED ->
+      candidates for B = [] -> deficit is left uncovered, NO signal for B.
+      For item A the same link passes the filter (item == "A") -> ONE signal,
+      qty = min(20, 100) = 20.
+    """
+    demand = {("A", "EAST"): {1: 20.0}, ("B", "EAST"): {1: 20.0}}
+    on_hand = {
+        ("A", "WEST"): 100.0, ("B", "WEST"): 100.0,
+        ("A", "EAST"): 0.0, ("B", "EAST"): 0.0,
+    }
+    links = [TransferLink("WEST", "EAST", 0, 1.0, None, 1, item="A")]
+    signals = core.transfer_signals(demand, on_hand, {}, links, horizon_buckets=H)
+    assert len(signals) == 1, "item B must get ZERO signals — the only link is scoped to A"
+    assert signals[0].item == "A"
+    assert signals[0].qty == pytest.approx(20.0)
+
+
+def test_most_specific_wins_single_signal_not_double_capacity():
+    """#395 F3 — specificity-refinement: a generic lane and an item-specific
+    lane on the SAME (source, dest) physical pair are NOT two independent lanes
+    with summed capacity — the specific lane REPLACES every generic lane on
+    that SAME pair for this item (the ONLY case _resolve_candidate_links ever
+    excludes a lane; see its docstring), so exactly ONE signal is emitted,
+    never two (30 then 50) that would double the pair's real physical
+    capacity. Contrast with F6 below: this dedup applies ACROSS specificity
+    levels only — two lanes of the SAME specificity on a pair (e.g. two
+    generic duplicates) are never evicted this way; they are both kept as
+    candidates instead (F6's scenario).
+    EAST: deficit (bucket 2, 80.0) for item A (demand 80 @bucket 2, on_hand 0, ss 0).
+    WEST: excess 100.0 for item A (on_hand 100, no demand, ss 0).
+    TWO links on the SAME pair (WEST, EAST), same priority 1:
+      generic       max_qty=30,  item=None
+      item-specific max_qty=100, item="A"
+    _resolve_candidate_links("A"): both pass the item filter (generic always
+    passes; specific matches "A"); the pair (WEST, EAST) has at least one
+    item-specific link -> ONLY the item="A" link (max_qty=100) survives as a
+    candidate for this pair, REGARDLESS of which link was inserted first
+    (asserted both ways below) — the generic one is discarded outright, not
+    summed alongside it.
+      qty = min(remaining 80, excess 100) = 80, capped by max_qty 100 -> stays 80.
+    ONE signal, qty=80 — never two signals (e.g. 30 via generic + 50 via
+    specific) that would imply 130 units of capacity on one physical lane.
+    """
+    demand = {("A", "EAST"): {2: 80.0}}
+    on_hand = {("A", "WEST"): 100.0, ("A", "EAST"): 0.0}
+
+    generic = TransferLink("WEST", "EAST", 0, 1.0, 30.0, 1, item=None)
+    specific = TransferLink("WEST", "EAST", 0, 1.0, 100.0, 1, item="A")
+
+    for links in ([generic, specific], [specific, generic]):
+        signals = core.transfer_signals(demand, on_hand, {}, links, horizon_buckets=H)
+        assert len(signals) == 1, "generic + specific on the same pair must yield ONE signal"
+        assert signals[0].qty == pytest.approx(80.0)
+        assert signals[0].source_excess_before == pytest.approx(100.0)
+
+
+def test_different_pairs_with_different_item_scoping_are_independent():
+    """#395 F4 — pair independence: an item-specific lane on (WEST, EAST) and a
+    generic lane on (SOUTH, EAST) are two DIFFERENT physical pairs, so the
+    specificity-refinement dedup (which only compares candidates on the SAME
+    pair) never touches them — each pair resolves on its own.
+    Item A: deficit (bucket 1, 10.0) at EAST; excess 100.0 at WEST (own item-A
+        coordinate). Link WEST->EAST scoped item="A" serves it.
+    Item B: deficit (bucket 1, 15.0) at EAST; excess 100.0 at SOUTH (own item-B
+        coordinate) — NOTE item B has NO excess at WEST at all (no on_hand
+        entry for (B, WEST)), so B could only ever be served via SOUTH.
+    Link SOUTH->EAST is GENERIC (item=None) -> eligible for B (and would be
+    eligible for A too, but A is already fully served by the more specific
+    WEST link before SOUTH is even considered for A's deficit).
+    Result: TWO independent signals — A via WEST->EAST, B via SOUTH->EAST.
+    """
+    demand = {("A", "EAST"): {1: 10.0}, ("B", "EAST"): {1: 15.0}}
+    on_hand = {
+        ("A", "WEST"): 100.0,
+        ("B", "SOUTH"): 100.0,
+        ("A", "EAST"): 0.0,
+        ("B", "EAST"): 0.0,
+    }
+    links = [
+        TransferLink("WEST", "EAST", 0, 1.0, None, 1, item="A"),
+        TransferLink("SOUTH", "EAST", 0, 1.0, None, 1, item=None),
+    ]
+    signals = core.transfer_signals(demand, on_hand, {}, links, horizon_buckets=H)
+    by_item = {s.item: s for s in signals}
+    assert set(by_item) == {"A", "B"}
+    assert by_item["A"].source_location == "WEST"
+    assert by_item["A"].qty == pytest.approx(10.0)
+    assert by_item["B"].source_location == "SOUTH"
+    assert by_item["B"].qty == pytest.approx(15.0)
+
+
+def test_duplicate_generic_lanes_same_pair_deterministic_link_ref_tiebreak():
+    """#395 F6 — determinism for two lanes on the SAME (source, dest) pair at
+    the SAME priority, both GENERIC (item=None): _resolve_candidate_links'
+    dedup is a SPECIFICITY-REFINEMENT relation ACROSS specificity levels only
+    (specific replaces generic on the SAME pair, per F3 above) — it NEVER
+    compares two links of EQUAL specificity against each other to evict one.
+    Two generic duplicates on the same pair are therefore BOTH kept as
+    candidates (see the function's own docstring: "Same-specificity duplicates
+    are ... ALL kept as candidates and served SEQUENTIALLY"), and determinism
+    comes from the stable sort (priority ASC, source_location, link_ref) that
+    decides which one is drained FIRST, not from evicting either.
+
+    Setup: EAST deficit (bucket 2, 100.0); WEST excess 100.0. Two links WEST->
+    EAST, same priority 1: link_ref="1" (max_qty=30), link_ref="2" (max_qty=None).
+      Both pass item scoping (generic, item=None, eligible for any item).
+      Both survive _resolve_candidate_links (same specificity -> no eviction),
+      sorted (priority 1, source "WEST", link_ref) -> "1" before "2" (same
+      priority, same source, "1" < "2" lexically) REGARDLESS of the order the
+      two links were constructed/passed in.
+      Greedy drain, in that fixed order:
+        link_ref "1" (max_qty=30): qty = min(remaining 100, excess 100) = 100,
+          capped by max_qty 30 -> 30. 30 >= min_qty 1 -> EMIT.
+          source_excess_before = 100 (untouched so far).
+          excess[WEST] -> 100 - 30 = 70. remaining_deficit -> 100 - 30 = 70.
+        link_ref "2" (max_qty=None): qty = min(remaining 70, excess 70) = 70
+          (no cap). 70 >= min_qty 1 -> EMIT.
+          source_excess_before = 70 (AFTER link "1"'s draw, not 100).
+          excess[WEST] -> 0. remaining_deficit -> 0.
+      TWO signals, TOTAL 30 + 70 = 100 == the full deficit (fully covered by
+      the two duplicate lanes together, never double-counted since excess is
+      one shared running counter across both draws).
+      ship = max(0, 2-0) = 2, arrival = 2 for both (same lead_buckets=0).
+    Determinism asserted both ways: insertion order [ref1, ref2] and
+    [ref2, ref1] give the IDENTICAL two-signal list.
+    """
+    demand = {("A", "EAST"): {2: 100.0}}
+    on_hand = {("A", "WEST"): 100.0, ("A", "EAST"): 0.0}
+
+    ref1 = TransferLink("WEST", "EAST", 0, 1.0, 30.0, 1, item=None, link_ref="1")
+    ref2 = TransferLink("WEST", "EAST", 0, 1.0, None, 1, item=None, link_ref="2")
+
+    expected = [
+        TransferSignal(
+            item="A",
+            source_location="WEST",
+            dest_location="EAST",
+            qty=30.0,
+            ship_bucket=2,
+            arrival_bucket=2,
+            deficit_bucket=2,
+            deficit_qty=100.0,
+            source_excess_before=100.0,
+        ),
+        TransferSignal(
+            item="A",
+            source_location="WEST",
+            dest_location="EAST",
+            qty=70.0,
+            ship_bucket=2,
+            arrival_bucket=2,
+            deficit_bucket=2,
+            deficit_qty=100.0,
+            source_excess_before=70.0,
+        ),
+    ]
+
+    signals_order1 = core.transfer_signals(demand, on_hand, {}, [ref1, ref2], horizon_buckets=H)
+    signals_order2 = core.transfer_signals(demand, on_hand, {}, [ref2, ref1], horizon_buckets=H)
+
+    assert signals_order1 == expected
+    assert signals_order2 == expected
+    assert sum(s.qty for s in signals_order1) == pytest.approx(100.0), (
+        "the two duplicate lanes together cover the full deficit exactly once"
+    )
+    assert signals_order1 == signals_order2, "dedup outcome must not depend on link insertion order"
+
+
+def test_empty_inputs_yield_empty_signal_list():
+    """Case 13 — no coordinates, no links -> [] (not None, no error)."""
+    assert core.transfer_signals({}, {}, {}, [], H) == []
+    # Links present but zero demand/on-hand is still empty.
+    assert core.transfer_signals(
+        {}, {}, {}, [TransferLink("WEST", "EAST", 1, 1.0, None, 1)], H
+    ) == []
+
+
+def test_conservation_combined_multi_source_multi_dest():
+    """Case 14 — conservation invariants on a combined multi-source/-dest run:
+      (i)  per destination: sum of qty transferred IN <= that dest's deficit_qty.
+      (ii) per source: sum of qty drawn OUT <= that source's INITIAL excess.
+
+    Setup (item 'A'):
+      Sources (no own demand, ss 0):
+        WEST : on_hand 50  -> excess 50
+        NORTH: on_hand 30  -> excess 30
+      Destinations (on_hand 0, ss 0):
+        EAST : demand 60 @bucket 2 -> deficit (bucket 2, 60)
+        SOUTH: demand 10 @bucket 3 -> deficit (bucket 3, 10)
+      Links (lead 0, min 1, uncapped):
+        EAST  <- WEST  priority 1
+        EAST  <- NORTH priority 2
+        SOUTH <- NORTH priority 1
+
+    Greedy (dest order EAST then SOUTH):
+      EAST (60): WEST(p1) gives min(60, 50)=50 (WEST excess -> 0);
+                 NORTH(p2) gives min(10, 30)=10 (NORTH excess -> 20).
+                 EAST covered 60 total == its deficit (bound (i) tight).
+      SOUTH (10): NORTH(p1) gives min(10, 20)=10 (NORTH excess -> 10).
+    Draws: WEST out = 50 (== initial 50, bound (ii) tight);
+           NORTH out = 10 + 10 = 20 (<= initial 30).
+    """
+    demand = {("A", "EAST"): {2: 60.0}, ("A", "SOUTH"): {3: 10.0}}
+    on_hand = {
+        ("A", "WEST"): 50.0,
+        ("A", "NORTH"): 30.0,
+        ("A", "EAST"): 0.0,
+        ("A", "SOUTH"): 0.0,
+    }
+    links = [
+        TransferLink("WEST", "EAST", 0, 1.0, None, 1),
+        TransferLink("NORTH", "EAST", 0, 1.0, None, 2),
+        TransferLink("NORTH", "SOUTH", 0, 1.0, None, 1),
+    ]
+    signals = core.transfer_signals(demand, on_hand, {}, links, H)
+
+    # Independently recompute the initial excess and the deficits to bound against.
+    initial_excess = core.excess_by_location(demand, on_hand, {}, H)
+    deficits = core.projected_deficits(demand, on_hand, {}, H)
+
+    in_by_dest: dict[tuple[str, str], float] = {}
+    out_by_source: dict[tuple[str, str], float] = {}
+    for s in signals:
+        in_by_dest[(s.item, s.dest_location)] = (
+            in_by_dest.get((s.item, s.dest_location), 0.0) + s.qty
+        )
+        out_by_source[(s.item, s.source_location)] = (
+            out_by_source.get((s.item, s.source_location), 0.0) + s.qty
+        )
+
+    # (i) never transfer more into a destination than it is short.
+    for coord, received in in_by_dest.items():
+        assert received <= deficits[coord][1] + 1e-9, f"{coord} over-served"
+
+    # (ii) never draw more out of a source than its initial distributable excess.
+    for coord, drawn in out_by_source.items():
+        assert drawn <= initial_excess[coord] + 1e-9, f"{coord} over-drawn"
+
+    # Tight-bound spot checks from the derivation above.
+    assert in_by_dest[("A", "EAST")] == pytest.approx(60.0)
+    assert out_by_source[("A", "WEST")] == pytest.approx(50.0)
+    assert out_by_source[("A", "NORTH")] == pytest.approx(20.0)


### PR DESCRIPTION
Réf #395 (PR1/2) — **vague B2 du plan AI-native (épique #397) : le fossé fonctionnel n°1 commence à se refermer.** `distribution_links` (migration 029) était morte depuis sa création ; pour un métier distribution, aucune recommandation de transfert inter-site n'était possible.

## Ce que ça livre
- **`engine/drp/core.py`** — moteur de transfert pur, DB-free, déterministe (style math core MRP) : déficits projetés par `(item, location)` (seuil safety), excès source conservateur borné à l'horizon, greedy priorisé avec excès **décrémenté globalement** (un excédent ne sert jamais deux destinations), min/max shipment du lien, ship date par lead time du lien, **évidence embarquée** par signal.
- **Scoping item des lanes** : une lane spécifique à un item ne sert que lui ; **specificity-refinement** (la spécifique remplace les génériques de sa paire — philosophie du résolveur overlay) ; les doublons de même spécificité restent de la capacité déclarée, servis en ordre stable.
- **`engine/drp/loader.py`** — SELECT-only, scenario-paramétré : demande par `(item, location)` **non poolée** (LA différence avec le loader MRP), safety **overlay-résolu #347 sans pooling** → **le DRP est forkable par construction** (un override de fork est visible dans sa projection), clé `COALESCE(external_id, uuid::text)` (le seed du repo omet external_id — sans repli, effondrement per-site), CO clippés à l'horizon, ORDER BY déterministe.

## Qualité (3 couches)
- **Revue adversariale 11 agents : 6 défauts uniques confirmés, tous corrigés** (fenêtre d'excès non bornée, item_id ignoré + capacité doublée, clés NULLABLE, CO non clippés, doublons non déterministes, dérivation de golden fausse).
- **+1 défaut attrapé en relecture d'orchestration** : dédup sur-généralisé violant la priorité via tie-break UUID.
- **22 goldens dérivés à la main** (l'arithmétique commentée est le contrat) + **12 tests d'intégration Postgres** (dont LE test de forkabilité : override safety visible dans le fork seul). Suite : 2196 passed, mypy 0/168.

## PR2 (à venir)
Recommandations `TRANSFER` gouvernées L1 (migration 064 : action CHECK + colonnes location), watcher `agent_transfer_watcher`, `POST /v1/drp/run`, seed démo (transfert ATL→LAX), ADR-028. 🎯 Checkpoint pilote ouvert : politiques de transfert (défauts actés : min_qty du lien, priority ASC, greedy, lead du lien, pas de push spéculatif).

🤖 Generated with [Claude Code](https://claude.com/claude-code)