### PR TITLE
feat(auth): étage entreprise agents PR1 — tokens/scopes/gate humain cryptographique (#392, ADR-029)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -230,6 +230,142 @@
         }
       }
     },
+    "/v1/stream": {
+      "get": {
+        "tags": [
+          "stream"
+        ],
+        "summary": "Stream Events",
+        "description": "Server-Sent Events feed of the ``events`` table for one scenario.\n\n``scenario_id`` resolves via the shared pool-free resolver (query param or\n``X-Scenario-ID`` header; default baseline). Auth requires the ``read``\nscope (#392) like every other agent-consumable read path. The kill switch\nand the concurrency budget are checked HERE, before opening any connection,\nso a disabled or saturated stream service answers 503 without touching the\nDB.",
+        "operationId": "stream_events_v1_stream_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "types",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional CSV of event_type values to include. Unknown types match nothing.",
+              "title": "Types"
+            },
+            "description": "Optional CSV of event_type values to include. Unknown types match nothing."
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Resume AFTER this stream_seq. 0 = replay full scenario history. Omit to stream from now. Takes precedence over the Last-Event-ID header.",
+              "title": "Cursor"
+            },
+            "description": "Resume AFTER this stream_seq. 0 = replay full scenario history. Omit to stream from now. Takes precedence over the Last-Event-ID header."
+          },
+          {
+            "name": "once",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Bounded catch-up mode: drain the keyset once and close, instead of LISTENing and staying open. No heartbeat in this mode. The natural mode for a cron watcher's periodic 'give me everything since my last cursor' call.",
+              "default": false,
+              "title": "Once"
+            },
+            "description": "Bounded catch-up mode: drain the keyset once and close, instead of LISTENing and staying open. No heartbeat in this mode. The natural mode for a cron watcher's periodic 'give me everything since my last cursor' call."
+          },
+          {
+            "name": "scenario_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scenario UUID or 'baseline'",
+              "title": "Scenario Id"
+            },
+            "description": "Scenario UUID or 'baseline'"
+          },
+          {
+            "name": "Last-Event-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Last-Event-Id"
+            }
+          },
+          {
+            "name": "X-Scenario-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Scenario-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/projection": {
       "get": {
         "tags": [
@@ -1898,7 +2034,7 @@
           "staging"
         ],
         "summary": "Approve",
-        "description": "Apply the validated batch to canonical tables (ADR-013 D3+D4).\n\nReturns counts (rows_inserted / rows_updated / rows_soft_deleted /\nrows_noop), the new run_id, and a list of samples per category.\nThe batch transitions from 'validated' to 'imported'; a new\n`staging.transform_runs` row is created in 'completed' state.\n\nFailure mode: if the canonical write fails for any reason, the\ntransaction is rolled back and the transform_runs row is marked\n'failed' with the error message (audit trail preserved). The\nbatch stays in 'validated' state so the operator can retry.",
+        "description": "Apply the validated batch to canonical tables (ADR-013 D3+D4).\n\nReturns counts (rows_inserted / rows_updated / rows_soft_deleted /\nrows_noop), the new run_id, and a list of samples per category.\nThe batch transitions from 'validated' to 'imported'; a new\n`staging.transform_runs` row is created in 'completed' state.\n\nFailure mode: if the canonical write fails for any reason, the\ntransaction is rolled back and the transform_runs row is marked\n'failed' with the error message (audit trail preserved). The\nbatch stays in 'validated' state so the operator can retry.\n\nDecision Ladder gate (#392 security-review follow-up): this endpoint\nUPSERTs + soft-deletes canonical master data (items/locations/suppliers)\n— an apply-to-baseline L3 action, exactly the class of decision the #392\ntoken-truth model exists to gate. A non-human principal (actor_kind\n'agent' or 'service') is refused with 403 even if it holds the `ingest`\nscope: scope says \"may operate staging\", the human gate says \"may commit\nto baseline\". This is a NEW gate (staging/approve.py had none before\n#392) — there is no pre-#392 self-declared actor_kind to preserve here\n(contrast with recommendations/scenarios, which already gated on a body\nfield and need the #392-9 legacy fallback).",
         "operationId": "approve_v1_staging_batches__batch_id__approve_post",
         "security": [
           {
@@ -3363,7 +3499,7 @@
           "recommendations"
         ],
         "summary": "Transition Recommendation",
-        "description": "Apply a governed state-machine transition to one recommendation.",
+        "description": "Apply a governed state-machine transition to one recommendation.\n\nTwo authorization floors stack (#392): a token SCOPE (recommend:approve for\nthe human-only targets APPROVED/APPLIED, recommend:draft otherwise) AND the\nDecision Ladder human gate. The SCOPE always decides on the authenticated\nPrincipal's real actor_kind (never the body). The GATE decides on\n``resolve_gate_kind`` (see auth.py, #392 defect 9): for a MINTED token, that\nis always ``principal.actor_kind`` — the body is never trusted. For the\nLEGACY token ONLY, if the body still declares an actor_kind, the gate\ndecides on THAT value — preserving the exact pre-#392 self-declared-gate\nbehaviour for the shared token during the transition window before PR2\nmints per-agent tokens (naively gating legacy on the synthetic 'human'\nPrincipal would let an honestly-declared agent on the shared token sail\nthrough a human-only transition it used to get 403 on).",
         "operationId": "transition_recommendation_v1_recommendations__recommendation_id__transition_post",
         "security": [
           {
@@ -3646,7 +3782,7 @@
           "scenarios"
         ],
         "summary": "Promote Scenario",
-        "description": "Promote a scenario's overrides onto the baseline (L3+ decision).\n\nConflict-safe (ADR-018 P2.2.c): if the baseline diverged since the\noverrides were captured, the promote aborts with 409 and the typed\nconflict list — nothing is written. Success writes the\nscenario_promotions audit row (migration 052) and emits a\n'scenario_merge' event.",
+        "description": "Promote a scenario's overrides onto the baseline (L3+ decision).\n\nConflict-safe (ADR-018 P2.2.c): if the baseline diverged since the\noverrides were captured, the promote aborts with 409 and the typed\nconflict list — nothing is written. Success writes the\nscenario_promotions audit row (migration 052) and emits a\n'scenario_merge' event.\n\nTwo authorization floors stack (#392): the token SCOPE recommend:approve\n(checked by the dependency above, always on the real token's actor_kind)\nAND the Decision Ladder human gate (checked below on ``resolve_gate_kind``\n— see auth.py, #392 defect 9). For a MINTED token the gate always decides\non the token's real actor_kind; for the LEGACY token, if the body still\ndeclares an actor_kind, the gate decides on THAT value instead — the exact\npre-#392 self-declared-gate behaviour, preserved for the shared token\nuntil PR2 mints per-agent tokens (otherwise an honestly agent-declaring\ncaller on the shared legacy token would gain the ability to promote a\nscenario to baseline, which it never had before #392).",
         "operationId": "promote_scenario_v1_scenarios__scenario_id__promote_post",
         "security": [
           {
@@ -7176,7 +7312,7 @@
         "properties": {
           "file": {
             "type": "string",
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File",
             "description": "Source file (TSV/CSV/XLSX/JSON)"
           },
@@ -7965,7 +8101,7 @@
           },
           "violations": {
             "items": {
-              "$ref": "#/components/schemas/CapacityViolationOut"
+              "$ref": "#/components/schemas/ootils_core__mps__api__CapacityViolationOut"
             },
             "type": "array",
             "title": "Violations"
@@ -7992,77 +8128,6 @@
         ],
         "title": "CapacityCheckResponse",
         "description": "Response from capacity check endpoint."
-      },
-      "CapacityViolationOut": {
-        "properties": {
-          "violation_type": {
-            "type": "string",
-            "title": "Violation Type"
-          },
-          "resource_id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Resource Id"
-          },
-          "resource_external_id": {
-            "type": "string",
-            "title": "Resource External Id"
-          },
-          "resource_name": {
-            "type": "string",
-            "title": "Resource Name"
-          },
-          "period_start": {
-            "type": "string",
-            "format": "date",
-            "title": "Period Start"
-          },
-          "period_end": {
-            "type": "string",
-            "format": "date",
-            "title": "Period End"
-          },
-          "required_capacity": {
-            "type": "string",
-            "title": "Required Capacity"
-          },
-          "available_capacity": {
-            "type": "string",
-            "title": "Available Capacity"
-          },
-          "overload_pct": {
-            "type": "string",
-            "title": "Overload Pct"
-          },
-          "affected_mps_ids": {
-            "items": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "type": "array",
-            "title": "Affected Mps Ids"
-          },
-          "severity": {
-            "type": "string",
-            "title": "Severity"
-          }
-        },
-        "type": "object",
-        "required": [
-          "violation_type",
-          "resource_id",
-          "resource_external_id",
-          "resource_name",
-          "period_start",
-          "period_end",
-          "required_capacity",
-          "available_capacity",
-          "overload_pct",
-          "affected_mps_ids",
-          "severity"
-        ],
-        "title": "CapacityViolationOut",
-        "description": "Output model for capacity violation."
       },
       "CausalStepOut": {
         "properties": {
@@ -15354,6 +15419,7 @@
               "agent"
             ],
             "title": "Actor Kind",
+            "description": "DEPRECATED (#392): ignored for the human-gate decision — the actor kind is now sourced from the authenticated token (api_tokens.actor_kind). Kept for request-shape compatibility; a value that disagrees with the token is logged as a mis-migrated client.",
             "default": "human"
           },
           "reason": {
@@ -15450,6 +15516,13 @@
           "type": {
             "type": "string",
             "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
           }
         },
         "type": "object",
@@ -15613,6 +15686,77 @@
         ],
         "title": "CapacityViolationOut",
         "description": "Capacity violation details for API response."
+      },
+      "ootils_core__mps__api__CapacityViolationOut": {
+        "properties": {
+          "violation_type": {
+            "type": "string",
+            "title": "Violation Type"
+          },
+          "resource_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Resource Id"
+          },
+          "resource_external_id": {
+            "type": "string",
+            "title": "Resource External Id"
+          },
+          "resource_name": {
+            "type": "string",
+            "title": "Resource Name"
+          },
+          "period_start": {
+            "type": "string",
+            "format": "date",
+            "title": "Period Start"
+          },
+          "period_end": {
+            "type": "string",
+            "format": "date",
+            "title": "Period End"
+          },
+          "required_capacity": {
+            "type": "string",
+            "title": "Required Capacity"
+          },
+          "available_capacity": {
+            "type": "string",
+            "title": "Available Capacity"
+          },
+          "overload_pct": {
+            "type": "string",
+            "title": "Overload Pct"
+          },
+          "affected_mps_ids": {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array",
+            "title": "Affected Mps Ids"
+          },
+          "severity": {
+            "type": "string",
+            "title": "Severity"
+          }
+        },
+        "type": "object",
+        "required": [
+          "violation_type",
+          "resource_id",
+          "resource_external_id",
+          "resource_name",
+          "period_start",
+          "period_end",
+          "required_capacity",
+          "available_capacity",
+          "overload_pct",
+          "affected_mps_ids",
+          "severity"
+        ],
+        "title": "CapacityViolationOut",
+        "description": "Output model for capacity violation."
       }
     },
     "securitySchemes": {

--- a/src/ootils_core/api/app.py
+++ b/src/ootils_core/api/app.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from uuid import uuid4
 
 from anyio import to_thread
+import psycopg
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -115,6 +116,15 @@ def _should_audit_request(request: Request) -> bool:
     return True
 
 
+_AUDIT_INSERT_SQL = """
+    INSERT INTO api_request_log (
+        correlation_id, token_prefix, method, path,
+        status_code, latency_ms, client_ip,
+        token_id, actor_kind
+    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+"""
+
+
 def _log_api_request(request: Request, status_code: int, latency_ms: int) -> None:
     if not _should_audit_request(request):
         return
@@ -123,26 +133,49 @@ def _log_api_request(request: Request, status_code: int, latency_ms: int) -> Non
     token_prefix = getattr(request.state, "client_id", None)
     correlation_id = getattr(request.state, "correlation_id", None)
 
+    # #392: stamp the authenticated principal's identity when present. Absent on
+    # an unauthenticated /health call or when a test overrides require_auth
+    # without setting a principal — both write NULL, which the migration-064
+    # columns allow.
+    principal = getattr(request.state, "principal", None)
+    token_id = getattr(principal, "token_id", None)
+    actor_kind = getattr(principal, "actor_kind", None)
+
+    params = (
+        correlation_id,
+        token_prefix,
+        request.method,
+        request.url.path,
+        status_code,
+        latency_ms,
+        client_ip,
+        token_id,
+        actor_kind,
+    )
+
     try:
         db_handle = _get_ootils_db()
         with db_handle.conn() as conn:
-            conn.execute(
-                """
-                INSERT INTO api_request_log (
-                    correlation_id, token_prefix, method, path,
-                    status_code, latency_ms, client_ip
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s)
-                """,
-                (
-                    correlation_id,
-                    token_prefix,
-                    request.method,
-                    request.url.path,
-                    status_code,
-                    latency_ms,
-                    client_ip,
-                ),
-            )
+            try:
+                conn.execute(_AUDIT_INSERT_SQL, params)
+            except psycopg.errors.ForeignKeyViolation:
+                # #392 security-review fix: token_id can reference an
+                # api_tokens row that was HARD-DELETED after the in-process
+                # principal cache (30 s TTL) authenticated this request —
+                # the cache still vouches for the token, but the FK target
+                # is gone. Losing the WHOLE audit row over a dangling
+                # token_id would erase precisely the forensic window
+                # (the last ≤30 s of a since-deleted, possibly compromised
+                # token) that matters most. Retry once with token_id=NULL —
+                # actor_kind + token_prefix are still written, so the row
+                # stays attributable ("an agent-kind call happened, prefix
+                # ootk_XXXXXXX") even though the FK link is gone. Soft
+                # revoke (api_tokens.revoked_at) is the recommended
+                # lifecycle op for exactly this reason; hard-DELETE remains
+                # supported but must never puncture the audit trail.
+                conn.rollback()
+                fallback_params = params[:7] + (None, actor_kind)
+                conn.execute(_AUDIT_INSERT_SQL, fallback_params)
     except Exception as exc:
         logger.warning(
             "audit.log_failed path=%s status=%s error=%s",

--- a/src/ootils_core/api/auth.py
+++ b/src/ootils_core/api/auth.py
@@ -1,26 +1,131 @@
 """
-auth.py — Bearer token authentication for Ootils Core API.
+auth.py — Bearer token authentication + principal resolution for Ootils Core.
 
-Token is read from env var OOTILS_API_TOKEN.
-The API stays fail-closed with no default token.
-Returns HTTP 401 if the token is absent or invalid.
+Two token flavours coexist (chantier #392 PR1):
+
+  * **Legacy single token** — the value of ``OOTILS_API_TOKEN``. Compared with
+    ``hmac.compare_digest`` exactly as before. Resolves to a synthetic
+    ``Principal`` with ``actor_kind='human'`` and the ``admin`` superset scope,
+    so every pre-#392 caller keeps working byte-for-byte. Deprecated but not
+    removed.
+  * **Minted token** (``ootk_`` prefix) — looked up in the ``api_tokens`` table
+    (migration 064). The row is the SINGLE source of truth for the caller's
+    ``actor_kind`` and ``scopes``. This closes the #350 gap where ``actor_kind``
+    was self-declared by the request body: a caller can no longer claim to be a
+    human to clear an L3 human gate — the actor kind now comes from the token.
+
+The API stays FAIL-CLOSED and there is deliberately NO optional-auth path:
+  * ``OOTILS_API_TOKEN`` is validated at import time (``_expected_token``);
+    the process refuses to start without it.
+  * A missing / malformed / unknown / revoked / expired token → 401.
+  * A minted-token lookup that cannot reach the DB → 503 (never 200).
+
+The minted-token lookup is memoised in-process for ``_CACHE_TTL_SECONDS`` (30 s)
+so the hot path stays pool-free: a token is looked up in the DB at most once
+per 30 s FOR A GIVEN TOKEN VALUE, and negative results (unknown token) are
+cached too — so a flood of *repeated* bogus tokens (the same wrong value
+retried) cannot turn into a flood of DB lookups. That guarantee does NOT
+extend to a flood of *distinct* bogus tokens (e.g. ``ootk_<random>`` probed
+once each): every unique value is still a genuine cache miss and a genuine
+lookup. The cache is therefore also SIZE-bounded (``_CACHE_MAX_ENTRIES``,
+LRU-ish eviction on overflow) so that scenario degrades to bounded memory use
+and steady-state lookup pressure, never unbounded growth, rather than being
+mistaken for a flood defense it cannot provide. ``last_used_at`` is bumped
+best-effort on a rare cache-miss and MUST NEVER fail authentication — the bump
+runs in its own try/except, isolated from the SELECT that resolves the
+Principal (see ``_lookup_minted_token_sync``): a read-only standby or a
+concurrent lock on ``api_tokens`` degrades the bump silently, never auth.
 """
 from __future__ import annotations
 
+import hashlib
 import hmac
 import logging
 import os
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Optional
+from uuid import UUID
 
-from fastapi import HTTPException, Request, Security, status
+from anyio import to_thread
+
+from fastapi import Depends, HTTPException, Request, Security, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
 
 _bearer = HTTPBearer(auto_error=False)
 
+# Minted tokens carry this prefix; anything else is treated as the legacy
+# single token. The prefix is part of the presented secret, not stripped.
+_MINTED_PREFIX = "ootk_"
+
+# Number of leading characters stored as a non-secret token_prefix (for audit
+# correlation) — kept in sync with the length the token-minting path records.
+_PREFIX_LEN = 12
+
+# In-process lookup memo TTL. A minted token is resolved against the DB at most
+# once per this many seconds FOR A GIVEN token value; negative lookups are
+# cached with the same TTL to blunt brute-force RE-ENUMERATION of the same
+# value. It does not blunt a flood of distinct values — see _CACHE_MAX_ENTRIES.
+_CACHE_TTL_SECONDS = 30.0
+
+# Hard cap on the number of memoised token hashes (positive + negative
+# combined), pre-auth reachable via _resolve_minted_principal (an attacker
+# needs no valid credential to populate a negative entry). Without a cap, a
+# flood of distinct bogus `ootk_<random>` probes — each a genuine cache miss,
+# since TTL memoisation only helps on a REPEATED value — would grow the dict
+# unboundedly (multi-GB) and, on every miss, dispatch a lookup to the shared
+# worker threadpool (the same pool sync `def` handlers use), starving it.
+# 10k entries is generously above realistic legitimate-token-churn levels
+# (single/low-hundreds of live tokens) while bounding worst-case memory to a
+# few MB. Eviction is oldest-inserted/least-recently-touched (see
+# _TokenCache.get moving an entry to the end on hit) — a plain LRU, not a
+# security control in itself, just a memory/lookup-pressure ceiling.
+_CACHE_MAX_ENTRIES = 10_000
+
+# Superset scope: a principal holding 'admin' satisfies every require_scope
+# check. The legacy token maps to this so nothing regresses.
+_ADMIN_SCOPE = "admin"
+
+# The only actor kinds a credential may carry. Kept in sync with the
+# api_tokens.actor_kind CHECK constraint (migration 064) — the token-minting
+# path (issue_agent_token.py, PR2) validates against this before insert.
+VALID_ACTOR_KINDS: frozenset[str] = frozenset({"agent", "human", "service"})
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class Principal:
+    """The authenticated caller behind one request.
+
+    ``token_id`` is None for the legacy single token (it has no DB row).
+    ``is_legacy`` distinguishes that synthetic principal from a minted one.
+    ``scopes`` is the authoritative capability set; ``'admin'`` is a superset.
+    """
+
+    token_id: Optional[UUID]
+    name: str
+    actor_kind: str  # 'agent' | 'human' | 'service'
+    scopes: frozenset[str]
+    is_legacy: bool
+
+    def has_scope(self, scope: str) -> bool:
+        return _ADMIN_SCOPE in self.scopes or scope in self.scopes
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
 
 def _expected_token() -> str:
-    """Return the configured API token or raise loudly if unset."""
+    """Return the configured legacy API token or raise loudly if unset."""
     token = os.environ.get("OOTILS_API_TOKEN")
     if not token:
         raise RuntimeError(
@@ -31,16 +136,358 @@ def _expected_token() -> str:
     return token
 
 
-async def require_auth(
-    credentials: HTTPAuthorizationCredentials | None = Security(_bearer),
-    request: Request = None,  # type: ignore[assignment]  # FastAPI injects; Union confuses dep resolver
-) -> str:
-    """
-    FastAPI dependency — validates Bearer token.
-    Raises HTTP 401 if missing or invalid.
-    Returns the token string on success.
+def _agents_enabled() -> bool:
+    """Fleet kill switch, default ON. Falsy OOTILS_AGENTS_ENABLED disables
+    every ``actor_kind='agent'`` principal (503), leaving humans/service through."""
+    return os.environ.get("OOTILS_AGENTS_ENABLED", "1").strip().lower() in _TRUTHY
 
-    Uses hmac.compare_digest to prevent timing-attack token enumeration.
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no IO, no clock of their own) — the test-writer wave targets
+# these directly.
+# ---------------------------------------------------------------------------
+
+
+def is_minted_token(presented: str) -> bool:
+    """True if the presented secret uses the minted ``ootk_`` scheme."""
+    return presented.startswith(_MINTED_PREFIX)
+
+
+def hash_token(presented: str) -> str:
+    """SHA-256 hex digest of the presented secret — the ``api_tokens.token_hash``
+    lookup key. Never store or log the raw token; the hash is what the DB holds."""
+    return hashlib.sha256(presented.encode("utf-8")).hexdigest()
+
+
+def token_prefix(presented: str) -> str:
+    """Non-secret leading slice used for audit correlation (``token_prefix``)."""
+    return presented[:_PREFIX_LEN]
+
+
+def principal_from_row(row: dict) -> Principal:
+    """Build a Principal from an ``api_tokens`` row (already filtered on
+    revoked_at IS NULL AND not-expired by the SELECT). ``scopes`` may arrive as
+    a Python list (psycopg maps ``TEXT[]``) or None → empty frozenset."""
+    raw_scopes = row.get("scopes") or []
+    return Principal(
+        token_id=UUID(str(row["token_id"])),
+        name=row["name"],
+        actor_kind=row["actor_kind"],
+        scopes=frozenset(raw_scopes),
+        is_legacy=False,
+    )
+
+
+def legacy_principal() -> Principal:
+    """The synthetic principal for the legacy single token: a human admin with
+    no DB identity. Preserves every pre-#392 behaviour (human gate passes, all
+    scopes satisfied)."""
+    return Principal(
+        token_id=None,
+        name="legacy",
+        actor_kind="human",
+        scopes=frozenset({_ADMIN_SCOPE}),
+        is_legacy=True,
+    )
+
+
+def resolve_gate_kind(
+    principal: Principal,
+    declared_actor_kind: Optional[str],
+) -> str:
+    """Return the actor_kind the Decision Ladder human gate should decide on.
+
+    #392 security-review fix (defect 9 — "the legacy window weakens the gate
+    for honest agents"): pre-#392, EVERY caller self-declared its actor_kind
+    in the request body, and the gate ran on that declared value — an agent
+    that honestly declared ``actor_kind="agent"`` got 403 on a human-only
+    transition. Post-#392, the LEGACY token resolves to a synthetic
+    ``human``/``admin`` Principal (so nothing about the single shared token
+    regresses for genuinely human callers) — but taken naively, that means
+    the SAME agent, still on the shared legacy token, now sails through
+    the same call with 200: a governance regression opened BY the fix meant
+    to close one, for the transition window before PR2 mints per-agent
+    tokens.
+
+    The fix: for a LEGACY principal ONLY, if the request body still declares
+    an ``actor_kind``, the gate decides on THAT declared value — exactly the
+    pre-#392 behaviour, preserved until the legacy token is retired. A MINTED
+    token's Principal is never second-guessed by the body: the token IS the
+    truth there, full stop; ``declared_actor_kind`` is ignored for it, which
+    is the entire point of #392.
+
+    ``declared_actor_kind`` is the request body's self-declared field
+    (deprecated) — pass ``None`` when the endpoint's body carries no such
+    field (e.g. staging's ``ApproveRequest``, which never had one — that
+    site has no pre-#392 gate to preserve, so it always decides on
+    ``principal.actor_kind``, non-legacy or not)."""
+    if principal.is_legacy and declared_actor_kind is not None:
+        return declared_actor_kind
+    return principal.actor_kind
+
+
+# ---------------------------------------------------------------------------
+# TTL cache for minted-token lookups (clock injectable for tests)
+# ---------------------------------------------------------------------------
+
+
+class _TokenCache:
+    """Small TTL + size-bounded memo mapping ``token_hash -> (Principal|None,
+    expiry)``.
+
+    Caches negatives (unknown token → None) as well as positives, which blunts
+    RE-PROBING of the same wrong value — it does NOT blunt a flood of distinct
+    wrong values (see ``_CACHE_MAX_ENTRIES``'s docstring at the module level),
+    each of which is a genuine cache miss. This class is reachable PRE-AUTH
+    (``_resolve_minted_principal`` populates a negative entry before any
+    credential has been validated), so it is also SIZE-bounded: ``put`` evicts
+    the oldest/least-recently-touched entry once ``max_entries`` is exceeded
+    (a plain LRU via ``OrderedDict``, not a security control by itself — the
+    scope check / hmac comparisons are what actually authenticate).
+
+    Guarded by a plain ``threading.Lock`` because the DB lookup on a miss runs
+    in a worker thread (``to_thread.run_sync``), so ``get``/``put`` are
+    reachable from threads other than the event loop.
+
+    The clock is injected (``time.monotonic`` by default) so tests can drive
+    TTL expiry deterministically without sleeping.
+    """
+
+    __slots__ = ("_store", "_lock", "_ttl", "_clock", "_max_entries")
+
+    def __init__(
+        self,
+        ttl_seconds: float = _CACHE_TTL_SECONDS,
+        clock: Callable[[], float] = time.monotonic,
+        max_entries: int = _CACHE_MAX_ENTRIES,
+    ) -> None:
+        self._store: OrderedDict[str, tuple[Optional[Principal], float]] = OrderedDict()
+        self._lock = threading.Lock()
+        self._ttl = ttl_seconds
+        self._clock = clock
+        self._max_entries = max_entries
+
+    def get(self, key: str) -> tuple[bool, Optional[Principal]]:
+        """Return (hit, principal). ``hit`` False means miss/expired — the
+        caller must do a DB lookup. A cached negative is a hit with None.
+
+        A hit moves the entry to the most-recently-used end, so a token under
+        active (legitimate) traffic is the last one evicted under pressure."""
+        now = self._clock()
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                return False, None
+            principal, expiry = entry
+            if now >= expiry:
+                # Lazily evict the stale entry.
+                del self._store[key]
+                return False, None
+            self._store.move_to_end(key)
+            return True, principal
+
+    def put(self, key: str, principal: Optional[Principal]) -> None:
+        """Insert/refresh one entry, then evict oldest entries (FIFO/LRU order)
+        while the store exceeds ``max_entries`` — the size ceiling that keeps a
+        flood of distinct bogus tokens from growing this dict unboundedly."""
+        expiry = self._clock() + self._ttl
+        with self._lock:
+            self._store[key] = (principal, expiry)
+            self._store.move_to_end(key)
+            while len(self._store) > self._max_entries:
+                self._store.popitem(last=False)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._store.clear()
+
+
+# Module-level cache. Not a mutable-config anti-pattern: it is an internal
+# memo with no external configuration surface, guarded by its own lock.
+_token_cache = _TokenCache()
+
+
+# ---------------------------------------------------------------------------
+# Minted-token DB lookup (rare — cache-miss only)
+# ---------------------------------------------------------------------------
+
+
+class _TokenLookupUnavailable(Exception):
+    """The DB could not be reached to resolve a minted token → surfaces as 503
+    (fail-closed: an unreachable auth backend must never fall through to 200)."""
+
+
+def _lookup_minted_token_sync(token_hash: str) -> Optional[Principal]:
+    """Resolve a minted token against ``api_tokens`` (SELECT-only).
+
+    Runs in a worker thread (see ``resolve_principal``), so it may borrow a
+    sync pool connection without blocking the event loop. Called at most once
+    per token per cache-TTL window — the hot path never reaches here.
+
+    Returns None for an unknown/revoked/expired token (→ caller raises 401).
+    Raises ``_TokenLookupUnavailable`` if the SELECT itself cannot be
+    completed (→ caller raises 503), so a down auth backend is never a
+    silent allow.
+
+    ``last_used_at`` bump-best-effort security fix: the bump runs in its OWN
+    connection/transaction (``_bump_last_used_best_effort``), AFTER this
+    function has already resolved and is about to return a Principal from a
+    SUCCESSFUL SELECT. Earlier code ran the UPDATE inside the same
+    try/except AND the same transaction as the SELECT — on a read-only
+    standby (failover) or a row lock held by a concurrent un-committed
+    revoke, the UPDATE raised, the blanket ``except Exception`` mapped it to
+    ``_TokenLookupUnavailable`` -> 503, and because a 503 is never cached
+    (see ``_resolve_minted_principal``), EVERY subsequent request for EVERY
+    minted token re-hit the same failing UPDATE: a read-only failover turned
+    into a total minted-token auth outage, even though the SELECT — the part
+    that actually decides "is this caller who they say they are" — never
+    stopped working. Isolating the bump means the read-only-standby case now
+    degrades to "auth succeeds, last_used_at silently stops advancing",
+    which is the correct blast radius for a housekeeping side-effect.
+    """
+    from ootils_core.api.dependencies import _get_ootils_db
+
+    try:
+        db = _get_ootils_db()
+        with db.conn() as conn:
+            row = _select_token_row(conn, token_hash)
+    except Exception as exc:
+        # Any driver/connection failure resolving the SELECT is treated as
+        # "auth backend down" → 503, never a fall-through to allow. Logged
+        # without the token.
+        logger.warning("auth.token_lookup_failed error=%s", exc)
+        raise _TokenLookupUnavailable from exc
+
+    if row is None:
+        return None
+
+    _bump_last_used_best_effort(row["token_id"])
+    return principal_from_row(row)
+
+
+def _bump_last_used_best_effort(token_id: UUID) -> None:
+    """Update ``api_tokens.last_used_at`` in its OWN connection/transaction,
+    isolated from the SELECT that authenticates the caller.
+
+    MUST NEVER raise and MUST NEVER affect the auth decision: any failure
+    here (read-only standby, a row lock from a concurrent revoke, a pool
+    exhaustion blip) is swallowed and logged at DEBUG — a bookkeeping
+    timestamp is not worth trading away authentication availability for.
+    Runs on the same worker thread as the caller (already off the event
+    loop via ``to_thread.run_sync``), so a second short-lived pool
+    connection here is the same cost class as the SELECT's.
+    """
+    try:
+        from ootils_core.api.dependencies import _get_ootils_db
+
+        db = _get_ootils_db()
+        with db.conn() as conn:
+            conn.execute(
+                "UPDATE api_tokens SET last_used_at = now() WHERE token_id = %s",
+                (token_id,),
+            )
+    except Exception as exc:
+        logger.debug("auth.last_used_at_bump_failed token_id=%s error=%s", token_id, exc)
+
+
+def _select_token_row(conn: DictRowConnection, token_hash: str) -> Optional[dict]:
+    """SELECT the live token row (not revoked, not expired) for a hash."""
+    return conn.execute(
+        """
+        SELECT token_id, name, actor_kind, scopes, token_prefix
+        FROM api_tokens
+        WHERE token_hash = %s
+          AND revoked_at IS NULL
+          AND (expires_at IS NULL OR expires_at > now())
+        """,
+        (token_hash,),
+    ).fetchone()
+
+
+async def _resolve_minted_principal(presented: str) -> Principal:
+    """Cache-first resolution of a minted token; DB lookup off the event loop.
+
+    Cache hit (positive or negative) is pure and instant. A miss dispatches the
+    SELECT to the bounded worker threadpool (same pool the sync ``def`` handlers
+    use, capped to the DB pool size in ``app.py``'s lifespan) so the event loop
+    is never blocked on DB IO.
+    """
+    token_hash = hash_token(presented)
+    hit, cached = _token_cache.get(token_hash)
+    if hit:
+        principal = cached
+    else:
+        try:
+            principal = await to_thread.run_sync(_lookup_minted_token_sync, token_hash)
+        except _TokenLookupUnavailable:
+            # Do NOT cache a transient unavailability as a negative — that would
+            # pin a 401/allow decision for 30 s off one blip. Surface 503.
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Authentication backend unavailable",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        _token_cache.put(token_hash, principal)
+
+    if principal is None:
+        logger.warning("auth.invalid_token kind=minted")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return principal
+
+
+# ---------------------------------------------------------------------------
+# Principal resolution (the core dependency) + kill-switch
+# ---------------------------------------------------------------------------
+
+
+def _enforce_fleet_kill_switch(principal: Principal, client_id: str) -> None:
+    """503 when the agent fleet is disabled and the caller is an agent.
+
+    Humans and service principals pass. Pool-free: a disabled fleet answers 503
+    without ever touching the DB (the decision is env-only).
+
+    ``client_id`` (the token_prefix, or ``"global_token"`` for legacy) is
+    passed in explicitly rather than read off ``request.state`` so this
+    function has no ordering dependency on WHEN the caller poses request.state
+    — it always logs identity regardless of call order."""
+    if principal.actor_kind == "agent" and not _agents_enabled():
+        # #392 security-review fix: log the BLOCKED agent's identity (name +
+        # token_id + non-secret prefix — never the raw token) — an operator
+        # who trips this kill switch mid-incident needs to see WHICH agents
+        # are still knocking, not just "some agent got a 503". The caller
+        # (resolve_principal) also poses request.state.principal/client_id
+        # BEFORE invoking this check, so the audit row for this very 503
+        # carries the same attribution.
+        logger.warning(
+            "auth.agent_fleet_disabled name=%s token_id=%s prefix=%s",
+            principal.name,
+            principal.token_id,
+            client_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Agent fleet is disabled (OOTILS_AGENTS_ENABLED).",
+        )
+
+
+async def resolve_principal(
+    credentials: HTTPAuthorizationCredentials | None = Security(_bearer),
+    request: Request = None,  # type: ignore[assignment]  # FastAPI injects; Optional confuses dep resolver
+) -> Principal:
+    """FastAPI dependency — authenticate the Bearer token and resolve the caller.
+
+    Legacy token → synthetic human/admin Principal (byte-identical to the old
+    ``require_auth`` acceptance). Minted ``ootk_`` token → the ``api_tokens``
+    row is the truth for actor_kind + scopes.
+
+    Fail-closed: missing/invalid/unknown/revoked/expired → 401; DB unreachable
+    on a minted-token cache-miss → 503. Sets ``request.state.principal`` and
+    ``request.state.client_id`` (token_prefix, or ``"global_token"`` for the
+    legacy token — preserves the existing audit key in ``app.py``).
     """
     if credentials is None:
         logger.warning("auth.missing_token")
@@ -50,18 +497,98 @@ async def require_auth(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    expected_token = _expected_token()
+    presented = credentials.credentials
 
-    # hmac.compare_digest prevents timing-based token enumeration
-    if not hmac.compare_digest(credentials.credentials, expected_token):
-        logger.warning("auth.invalid_token")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid token",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+    if is_minted_token(presented):
+        principal = await _resolve_minted_principal(presented)
+        client_id = token_prefix(presented)
+    else:
+        expected = _expected_token()
+        # hmac.compare_digest prevents timing-based token enumeration — same
+        # comparison the pre-#392 code used, unchanged.
+        if not hmac.compare_digest(presented, expected):
+            logger.warning("auth.invalid_token kind=legacy")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid token",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        # DEBUG, not INFO: a legacy token is valid but deprecated — flag it once
+        # per request at debug level, never spam INFO on the hot path.
+        logger.debug("auth.legacy_token accepted (DEPRECATED — migrate to a minted ootk_ token)")
+        principal = legacy_principal()
+        client_id = "global_token"
 
+    # #392 security-review fix: pose request.state BEFORE the kill-switch
+    # check, not after. The kill switch can itself raise (503, agent fleet
+    # disabled) — if it ran first, that 503 would be audited/logged with a
+    # blank principal/client_id, so an operator who just tripped the switch
+    # mid-incident couldn't see WHICH agent the blocked call belonged to.
+    # Posing state first means every downstream consumer (the audit INSERT
+    # in app.py, the kill-switch's own log line) has attribution regardless
+    # of whether this request goes on to succeed or gets 503'd right here.
     if request is not None:
-        request.state.client_id = "global_token"
+        request.state.principal = principal
+        request.state.client_id = client_id
 
-    return credentials.credentials
+    _enforce_fleet_kill_switch(principal, client_id)
+
+    return principal
+
+
+async def require_auth(
+    credentials: HTTPAuthorizationCredentials | None = Security(_bearer),
+    request: Request = None,  # type: ignore[assignment]
+) -> str:
+    """Backward-compatible dependency — resolves the principal (populating
+    ``request.state``) and RETURNS THE TOKEN STRING, exactly as before #392.
+
+    Every one of the ~24 ``_token: str = Depends(require_auth)`` routers keeps
+    its return contract; the new capability (principal on request.state) rides
+    alongside it. Kept as a thin alias over ``resolve_principal`` so there is a
+    single authentication implementation.
+    """
+    await resolve_principal(credentials=credentials, request=request)
+    # credentials is non-None here (resolve_principal raises 401 otherwise).
+    return credentials.credentials  # type: ignore[union-attr]
+
+
+def require_scope(scope: str) -> Callable[..., Awaitable[Principal]]:
+    """Dependency factory — require ``scope`` (or the ``admin`` superset).
+
+    Depends on ``resolve_principal`` so authentication is guaranteed to have run
+    (and ``request.state.principal`` to be set) before the scope is checked —
+    FastAPI resolves the sub-dependency first, so there is no ordering race. 401
+    if no principal could be resolved; 403 if the principal lacks the scope. The
+    legacy token holds ``admin`` and therefore satisfies every scope — no
+    regression for pre-#392 callers.
+
+    An overridden ``resolve_principal`` (as tests do for ``require_auth``) that
+    returns a Principal flows straight through; only a None/absent principal
+    yields 401.
+    """
+
+    async def _dependency(
+        principal: Optional[Principal] = Depends(resolve_principal),
+    ) -> Principal:
+        if principal is None:
+            logger.warning("auth.scope_check_without_principal scope=%s", scope)
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Missing Authorization header",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        if not principal.has_scope(scope):
+            logger.warning(
+                "auth.missing_scope scope=%s actor_kind=%s token=%s",
+                scope,
+                principal.actor_kind,
+                principal.token_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"missing scope '{scope}'",
+            )
+        return principal
+
+    return _dependency

--- a/src/ootils_core/api/routers/calc.py
+++ b/src/ootils_core/api/routers/calc.py
@@ -32,6 +32,12 @@ class CalcRunResponse(BaseModel):
     message: str
 
 
+# governance PR2: not applicable — #392 security-review audit (PR1):
+# propagation is deterministic recalculation (ADR-003), not a decision;
+# it re-derives ProjectedInventory/shortage state from events already
+# committed to the graph, it does not introduce new baseline facts. Left
+# require_auth-only; outside the L3 apply-to-baseline class this chantier
+# targets.
 @router.post("/run", response_model=CalcRunResponse)
 def trigger_calc_run(
     body: CalcRunRequest,

--- a/src/ootils_core/api/routers/dq.py
+++ b/src/ootils_core/api/routers/dq.py
@@ -74,6 +74,11 @@ class DQIssuesResponse(BaseModel):
 # ─────────────────────────────────────────────────────────────
 # POST /v1/dq/run/{batch_id}
 # ─────────────────────────────────────────────────────────────
+# governance PR2: ingest scope — deferred. #392 security-review audit
+# (PR1): this runs deterministic L1/L2 checks and writes only into
+# data_quality_issues (staging-side diagnostics), never into canonical
+# master data — not an apply-to-baseline action, unlike staging/approve.py.
+# Left require_auth-only; not the L3 class this chantier targets.
 
 @router.post(
     "/run/{batch_id}",
@@ -326,6 +331,10 @@ class AgentRunsResponse(BaseModel):
 # ─────────────────────────────────────────────────────────────
 # POST /v1/dq/agent/run/{batch_id}
 # ─────────────────────────────────────────────────────────────
+# governance PR2: ingest scope — deferred. #392 security-review audit
+# (PR1): the agent enriches data_quality_issues (impact_score, LLM
+# insights) — staging-side diagnostics only, no canonical write. Same
+# reasoning as /run/{batch_id} above. Left require_auth-only.
 
 @router.post(
     "/agent/run/{batch_id}",

--- a/src/ootils_core/api/routers/graph.py
+++ b/src/ootils_core/api/routers/graph.py
@@ -305,6 +305,10 @@ def list_nodes(
 # agent) act on a single order, not an irreversible commitment (it can be
 # reversed by DELETE) — no approval gate for V1, audited via `events` is
 # sufficient. Revisit if firm/unfirm ever needs L2+ governance.
+#
+# governance PR2: not a silent gap re-audited under #392 — this pre-existing
+# decision (reversible, event-audited, deliberately gate-free) stands. Left
+# require_auth-only; explicitly reviewed, not deferred by oversight.
 # ---------------------------------------------------------------------------
 
 class FirmRequest(BaseModel):

--- a/src/ootils_core/api/routers/recommendations.py
+++ b/src/ootils_core/api/routers/recommendations.py
@@ -28,11 +28,12 @@ from uuid import UUID, uuid4
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope, resolve_gate_kind, resolve_principal
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
 from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.recommendation.state_machine import (
     ALLOWED_TRANSITIONS,
+    HUMAN_ONLY_TARGETS,
     HumanGateError,
     InvalidTransitionError,
     RecommendationNotFoundError,
@@ -50,9 +51,11 @@ VALID_ACTIONS = frozenset({"EXPEDITE", "ORDER_RUSH", "ORDER_NOW"})
 # decisions — humans only. The rule itself lives in the state machine
 # (state_machine.HUMAN_ONLY_TARGETS / enforce_human_gate) so every consumer
 # — this router, the CLI, any future in-process caller — hits the same gate;
-# the router only maps HumanGateError to a 403. Transitional until per-token
-# agent scopes land (#350): actor_kind is self-declared, and once token
-# scopes exist an agent token will be structurally unable to claim 'human'.
+# the router only maps HumanGateError to a 403. As of #392 the actor_kind fed
+# to the gate is sourced from the authenticated Principal (the api_tokens row),
+# NOT the request body — an agent token cannot claim 'human'. Two independent
+# floors now stack: the token scope (recommend:approve for APPROVED/APPLIED)
+# AND the human gate on actor_kind.
 
 
 # ---------------------------------------------------------------------------
@@ -112,7 +115,15 @@ class RecommendationDetailOut(RecommendationOut):
 class TransitionRequest(BaseModel):
     to_status: Literal["DRAFT", "REVIEWED", "APPROVED", "REJECTED", "APPLIED", "EXPIRED"]
     actor: str = Field(min_length=1, max_length=200, description="Username or agent name")
-    actor_kind: Literal["human", "agent"] = "human"
+    actor_kind: Literal["human", "agent"] = Field(
+        default="human",
+        description=(
+            "DEPRECATED (#392): ignored for the human-gate decision — the actor "
+            "kind is now sourced from the authenticated token (api_tokens.actor_kind). "
+            "Kept for request-shape compatibility; a value that disagrees with the "
+            "token is logged as a mis-migrated client."
+        ),
+    )
     reason: Optional[str] = None
 
 
@@ -171,7 +182,7 @@ def _to_out(row: dict) -> RecommendationOut:
 @router.get("", response_model=RecommendationsListResponse)
 def list_recommendations(
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
     scenario_id: UUID = Depends(resolve_scenario_id),
     status_filter: Optional[str] = Query(default=None, alias="status"),
     action: Optional[str] = Query(default=None),
@@ -232,7 +243,7 @@ def list_recommendations(
 def get_recommendation(
     recommendation_id: UUID,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> RecommendationDetailOut:
     """Recommendation detail: evidence trail (explainability) + full transition history."""
     row = db.execute(
@@ -278,23 +289,72 @@ def transition_recommendation(
     recommendation_id: UUID,
     body: TransitionRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    principal: Principal = Depends(resolve_principal),
 ) -> TransitionResponse:
-    """Apply a governed state-machine transition to one recommendation."""
+    """Apply a governed state-machine transition to one recommendation.
+
+    Two authorization floors stack (#392): a token SCOPE (recommend:approve for
+    the human-only targets APPROVED/APPLIED, recommend:draft otherwise) AND the
+    Decision Ladder human gate. The SCOPE always decides on the authenticated
+    Principal's real actor_kind (never the body). The GATE decides on
+    ``resolve_gate_kind`` (see auth.py, #392 defect 9): for a MINTED token, that
+    is always ``principal.actor_kind`` — the body is never trusted. For the
+    LEGACY token ONLY, if the body still declares an actor_kind, the gate
+    decides on THAT value — preserving the exact pre-#392 self-declared-gate
+    behaviour for the shared token during the transition window before PR2
+    mints per-agent tokens (naively gating legacy on the synthetic 'human'
+    Principal would let an honestly-declared agent on the shared token sail
+    through a human-only transition it used to get 403 on).
+    """
+    # Scope floor — required scope depends on the target (runtime), so it is
+    # enforced here rather than as a static route dependency. approve is a
+    # superset of draft for this router's purposes; admin (legacy token) passes
+    # both via Principal.has_scope. The scope ALWAYS decides on the real
+    # token's actor_kind (resolve_gate_kind's legacy fallback applies to the
+    # human GATE only, never to scope — a legacy caller declaring 'agent' in
+    # the body still holds 'admin' and passes every scope check, unchanged).
+    required_scope = "recommend:approve" if body.to_status in HUMAN_ONLY_TARGETS else "recommend:draft"
+    if not principal.has_scope(required_scope):
+        logger.warning(
+            "recommendation.transition.missing_scope scope=%s to=%s actor_kind=%s token=%s",
+            required_scope,
+            body.to_status,
+            principal.actor_kind,
+            principal.token_id,
+        )
+        raise HTTPException(
+            status_code=403,
+            detail=f"missing scope '{required_scope}'",
+        )
+
+    gate_kind = resolve_gate_kind(principal, body.actor_kind)
+    if not principal.is_legacy and body.actor_kind != principal.actor_kind:
+        # A MINTED token's body disagreeing with its own token is a
+        # mis-migrated client signal (the token is the truth regardless, but
+        # this is worth surfacing). A LEGACY principal disagreeing is NOT an
+        # anomaly here — it is resolve_gate_kind's intended fallback, so no
+        # warning for that case.
+        logger.warning(
+            "recommendation.transition.actor_kind_mismatch body=%s token=%s reco=%s",
+            body.actor_kind,
+            principal.actor_kind,
+            recommendation_id,
+        )
+
     try:
         result = transition_one(
             db,
             recommendation_id,
             body.to_status,
             body.actor,
-            actor_kind=body.actor_kind,
+            actor_kind=gate_kind,
             reason=body.reason,
         )
     except HumanGateError as e:
         # Decision Ladder gate — enforced by the state machine itself (single
-        # source of truth); the router only maps it to HTTP. Transitional
-        # until per-token agent scopes land (#350): actor_kind is
-        # self-declared.
+        # source of truth); the router only maps it to HTTP. Since #392 the
+        # actor_kind reaching the gate is the token's, so an agent token that
+        # cleared the draft scope still cannot reach a human-only target.
         raise HTTPException(
             status_code=403,
             detail=(

--- a/src/ootils_core/api/routers/scenarios.py
+++ b/src/ootils_core/api/routers/scenarios.py
@@ -36,7 +36,7 @@ from psycopg import sql
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_auth, require_scope, resolve_gate_kind
 from ootils_core.api.dependencies import get_db, BASELINE_SCENARIO_ID
 from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.recommendation.state_machine import (
@@ -293,7 +293,7 @@ def promote_scenario(
     scenario_id: UUID,
     body: PromoteRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    principal: Principal = Depends(require_scope("recommend:approve")),
 ) -> PromoteResponse:
     """Promote a scenario's overrides onto the baseline (L3+ decision).
 
@@ -302,15 +302,36 @@ def promote_scenario(
     conflict list — nothing is written. Success writes the
     scenario_promotions audit row (migration 052) and emits a
     'scenario_merge' event.
+
+    Two authorization floors stack (#392): the token SCOPE recommend:approve
+    (checked by the dependency above, always on the real token's actor_kind)
+    AND the Decision Ladder human gate (checked below on ``resolve_gate_kind``
+    — see auth.py, #392 defect 9). For a MINTED token the gate always decides
+    on the token's real actor_kind; for the LEGACY token, if the body still
+    declares an actor_kind, the gate decides on THAT value instead — the exact
+    pre-#392 self-declared-gate behaviour, preserved for the shared token
+    until PR2 mints per-agent tokens (otherwise an honestly agent-declaring
+    caller on the shared legacy token would gain the ability to promote a
+    scenario to baseline, which it never had before #392).
     """
+    gate_kind = resolve_gate_kind(principal, body.actor_kind)
+    if not principal.is_legacy and body.actor_kind != principal.actor_kind:
+        # A MINTED token's body disagreeing with its own token is a
+        # mis-migrated client signal. A LEGACY principal disagreeing is NOT
+        # an anomaly — it's resolve_gate_kind's intended fallback.
+        logger.warning(
+            "scenario.promote.actor_kind_mismatch body=%s token=%s scenario_id=%s",
+            body.actor_kind,
+            principal.actor_kind,
+            scenario_id,
+        )
     # Decision Ladder gate — promoting IS applying a scenario to the
     # baseline, i.e. the 'APPLIED' human-only action class. The rule lives
     # in engine/recommendation/state_machine (single source of truth,
     # shared with the recommendation router/CLI); this router only maps
-    # HumanGateError to a 403. Transitional until per-token agent scopes
-    # land (#350): actor_kind is self-declared.
+    # HumanGateError to a 403.
     try:
-        enforce_human_gate("APPLIED", body.actor_kind)
+        enforce_human_gate("APPLIED", gate_kind)
     except HumanGateError:
         raise HTTPException(
             status_code=403,

--- a/src/ootils_core/api/routers/staging.py
+++ b/src/ootils_core/api/routers/staging.py
@@ -25,6 +25,19 @@ Endpoint:
 
 ADR-013 D4 mandates approval; this endpoint only enqueues the upload —
 batches sit in `pending` until /v1/staging/batches/{id}/approve lands.
+
+Authorization (#392 security-review follow-up): every staging write
+(upload, diff-preview, reject, approve) requires the `ingest` scope — the
+legacy token holds `admin` (a superset) so nothing pre-#392 regresses.
+`approve` additionally applies the same UPSERT + soft-delete to canonical
+master data (items/locations/suppliers) that `staging/approve.py` describes
+below — an apply-to-baseline L3 action — so it ALSO requires the Decision
+Ladder human gate on top of the scope: a non-human principal (agent/service)
+is refused with 403 regardless of scope. The approver identity written to
+`staging.transform_runs.approved_by` is the request body's `approved_by`
+field (kept for the human-readable name a bearer token doesn't carry), but
+the *governance decision* (human vs not) is the authenticated principal's
+`actor_kind`, never self-declared.
 """
 from __future__ import annotations
 
@@ -44,7 +57,7 @@ from fastapi import (
 
 from pydantic import BaseModel, Field
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db
 from ootils_core.db.types import DictRowConnection
 from ootils_core.staging.approve import ApprovalError, approve_batch
@@ -85,7 +98,7 @@ _MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 @router.post(
     "/upload",
     status_code=status.HTTP_202_ACCEPTED,
-    dependencies=[Depends(require_auth)],
+    dependencies=[Depends(require_scope("ingest"))],
 )
 def upload_file(
     file: Annotated[UploadFile, File(description="Source file (TSV/CSV/XLSX/JSON)")],
@@ -206,17 +219,18 @@ def upload_file(
 def _extract_submitter() -> str | None:
     """Placeholder for pulling the authenticated identity off the request.
 
-    The current `require_auth` dependency only validates the bearer
-    token (no subject extraction yet). When ADR-013's audit story
-    needs real identities (OIDC subject, API-key owner, etc.) this
-    function is the single place to wire it up.
+    `resolve_principal` (#392) now extracts a name/actor_kind from a minted
+    token, but `upload_file` above only depends on the `ingest` scope check
+    (not the Principal itself) — wiring `principal.name` in here as the
+    submitter is a small follow-up, not yet done. This function stays the
+    single place to do it.
     """
     return None
 
 
 @router.get(
     "/batches/{batch_id}/diff",
-    dependencies=[Depends(require_auth)],
+    dependencies=[Depends(require_scope("ingest"))],
 )
 def get_batch_diff(
     batch_id: UUID,
@@ -295,12 +309,12 @@ class ApproveRequest(BaseModel):
 
 @router.post(
     "/batches/{batch_id}/approve",
-    dependencies=[Depends(require_auth)],
 )
 def approve(
     batch_id: UUID,
     body: ApproveRequest,
     db: DictRowConnection = Depends(get_db),
+    principal: Principal = Depends(require_scope("ingest")),
 ) -> dict:
     """Apply the validated batch to canonical tables (ADR-013 D3+D4).
 
@@ -313,7 +327,34 @@ def approve(
     transaction is rolled back and the transform_runs row is marked
     'failed' with the error message (audit trail preserved). The
     batch stays in 'validated' state so the operator can retry.
+
+    Decision Ladder gate (#392 security-review follow-up): this endpoint
+    UPSERTs + soft-deletes canonical master data (items/locations/suppliers)
+    — an apply-to-baseline L3 action, exactly the class of decision the #392
+    token-truth model exists to gate. A non-human principal (actor_kind
+    'agent' or 'service') is refused with 403 even if it holds the `ingest`
+    scope: scope says "may operate staging", the human gate says "may commit
+    to baseline". This is a NEW gate (staging/approve.py had none before
+    #392) — there is no pre-#392 self-declared actor_kind to preserve here
+    (contrast with recommendations/scenarios, which already gated on a body
+    field and need the #392-9 legacy fallback).
     """
+    if principal.actor_kind != "human":
+        logger.warning(
+            "staging.approve.human_gate_rejected batch=%s actor_kind=%s token=%s",
+            batch_id,
+            principal.actor_kind,
+            principal.token_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Approving a staging batch commits to canonical baseline data "
+                "and is an L3/L4 decision reserved to human actors (Decision "
+                "Ladder, strategy doc §5)."
+            ),
+        )
+
     try:
         result = approve_batch(
             db,
@@ -372,7 +413,7 @@ class RejectRequest(BaseModel):
 
 @router.post(
     "/batches/{batch_id}/reject",
-    dependencies=[Depends(require_auth)],
+    dependencies=[Depends(require_scope("ingest"))],
 )
 def reject(
     batch_id: UUID,

--- a/src/ootils_core/api/routers/stream.py
+++ b/src/ootils_core/api/routers/stream.py
@@ -60,7 +60,7 @@ import psycopg
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
 from starlette.responses import StreamingResponse
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import resolve_scenario_id
 from ootils_core.db.connection import DEFAULT_DATABASE_URL
 from ootils_core.db.types import AsyncDictRowConnection
@@ -533,15 +533,16 @@ async def stream_events(
         "since my last cursor' call.",
     ),
     last_event_id: Optional[str] = Header(default=None, alias="Last-Event-ID"),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> StreamingResponse:
     """Server-Sent Events feed of the ``events`` table for one scenario.
 
     ``scenario_id`` resolves via the shared pool-free resolver (query param or
-    ``X-Scenario-ID`` header; default baseline). Auth is required like every
-    other ``/v1/*`` endpoint. The kill switch and the concurrency budget are
-    checked HERE, before opening any connection, so a disabled or saturated
-    stream service answers 503 without touching the DB.
+    ``X-Scenario-ID`` header; default baseline). Auth requires the ``read``
+    scope (#392) like every other agent-consumable read path. The kill switch
+    and the concurrency budget are checked HERE, before opening any connection,
+    so a disabled or saturated stream service answers 503 without touching the
+    DB.
     """
     if not _stream_enabled():
         raise HTTPException(

--- a/src/ootils_core/db/migrations/064_api_tokens_and_scopes.sql
+++ b/src/ootils_core/db/migrations/064_api_tokens_and_scopes.sql
@@ -1,0 +1,255 @@
+-- ============================================================
+-- Migration 064 — API tokens registry + scopes, audit binding (#392)
+-- ============================================================
+-- Chantier #392 "agent enterprise floor" PR1. ADR-029 (à venir):
+-- "Cryptographic actor identity — the Decision Ladder's actor_kind is
+-- derived from the presented token, never self-declared by the request
+-- body."
+--
+-- THE GOVERNANCE HOLE THIS CLOSES: today auth (api/auth.py) validates a
+-- single shared OOTILS_API_TOKEN and any caller asserts its own actor
+-- kind (agent / human / service) in the request payload. That means the
+-- #341 approval state machine — which gates L3+ actions on "a human, not
+-- an agent, approved this" — trusts a self-declared field. A compromised
+-- or buggy agent could stamp itself 'human' and walk an irreversible
+-- CANCEL past the human-only gate. api_tokens makes actor_kind a property
+-- of the CREDENTIAL: it is set once, by an operator, at token-issue time
+-- (scripts/issue_agent_token.py, PR2) and read back cryptographically from
+-- the presented token's hash. The request body can no longer influence
+-- who the caller is. This is the substrate the #341 machine and the
+-- Decision Ladder (L0-L4) become genuinely enforceable on.
+--
+-- WHY SHA-256 WITH NO KDF (deliberate, not an oversight): a password KDF
+-- (bcrypt/argon2/scrypt) exists to slow brute force against LOW-entropy
+-- human secrets. Our tokens are NOT human secrets — issue_agent_token.py
+-- (PR2) mints them from 32 bytes of os.urandom (256 bits of entropy),
+-- rendered as `ootk_<base>`. A 256-bit random string is not brute-forceable
+-- regardless of hash speed, so a slow KDF buys zero security here while
+-- adding per-request CPU on the hot auth path (every API call hashes the
+-- bearer to look it up). Plain SHA-256 hex is the correct, standard choice
+-- for high-entropy API keys (same rationale GitHub/Stripe-class keys use a
+-- fast hash + a prefix). The CLEARTEXT token is shown exactly ONCE at
+-- issuance and never stored — only token_hash (lookup key) and
+-- token_prefix (human-readable, non-secret) live in the DB. A leak of this
+-- table therefore leaks no usable credential.
+--
+-- WHY scopes IS TEXT[] (not JSONB, not a join table):
+--   * NOT JSONB — the repo doctrine (CLAUDE.md, "no JSONB for business
+--     data") reserves JSONB for unbounded-shape diagnostic payloads. A
+--     scope set is a flat list of short enum-like strings with a KNOWN
+--     shape; that is exactly what a native TEXT[] models, with real
+--     array operators (`'shortage:read' = ANY(scopes)`) and GIN-indexable
+--     containment. TEXT[] is a typed column, not a JSONB carve-out.
+--   * NOT a token_scopes join table — a scope grant has no attributes of
+--     its own (no grant time, no grantor, no per-scope expiry in V1); it
+--     is pure set membership on the token. A join table would add a second
+--     table, a second FK, and a multi-row read on the hot auth path to
+--     reconstruct a set we can carry inline. If scopes ever grow
+--     attributes, promoting to a join table is a clean forward migration;
+--     V1 does not pay that cost.
+--   * NO CHECK ON THE ARRAY CONTENTS — the set of valid scope strings is
+--     validated in APPLICATION code (the auth layer's whitelist), NOT by a
+--     SQL CHECK. A `CHECK (scopes <@ ARRAY[...])` would FREEZE the whole
+--     scope vocabulary into the schema: every new capability scope would
+--     require a new migration to widen the CHECK, coupling scope evolution
+--     to DDL and to the migration runner's ordering. Keeping the whitelist
+--     in Python lets scopes evolve with the code that enforces them, at
+--     the same review boundary, with no schema churn. The DB stores the
+--     grant; the app decides what a grant is allowed to contain.
+--
+-- WHY actor_kind IS DENORMALISED INTO api_request_log: the audit trail
+-- must stay readable FOREVER, including after a token is hard-deleted. The
+-- FK api_request_log.token_id → api_tokens is ON DELETE SET NULL (audit
+-- rows survive token deletion, they are not cascaded away), so token_id
+-- alone cannot answer "was this call made by an agent or a human?" once
+-- the token row is gone. Copying actor_kind onto each audit row at write
+-- time freezes that fact at the moment of the call — the historically
+-- correct value, immune to later token deletion OR to a token being
+-- re-issued with a different kind under a recycled id. Denormalisation is
+-- the right call for an immutable audit log: the log records what was true
+-- then, not what the live registry says now.
+--
+-- WHY recommendation_transitions.actor_kind IS ALSO WIDENED HERE (security-
+-- review defect #6): 'service' becomes a first-class api_tokens.actor_kind
+-- in THIS migration, but recommendation_transitions (migration 040) still
+-- CHECKs actor_kind IN ('human', 'agent') only. Without this fix, a fully
+-- authorised 'service' token performing a legitimate transition (e.g.
+-- REVIEWED) would trip that stale CHECK on INSERT and surface as a raw
+-- CheckViolation -> opaque 500 on a request that should have succeeded.
+-- The migration that introduces a new actor_kind value is the correct,
+-- single place to keep every actor_kind CHECK across the schema in sync —
+-- see section (3) below for the introspection-based, name-safe widening
+-- (mirrors migration 034's pattern for retiring an anonymous CHECK).
+--
+-- Idempotence (repo migration policy — the runner in db/connection.py
+-- wraps each file in its own transaction and, on ANY error, ROLLS BACK and
+-- ABORTS; it does NOT swallow "already exists"): every statement is
+-- written to re-run as a clean no-op.
+--   * CREATE TABLE IF NOT EXISTS       — skips the table on re-run.
+--   * ADD COLUMN IF NOT EXISTS         — skips each audit column on re-run.
+--   * CREATE INDEX IF NOT EXISTS       — no-op on re-run.
+--   * DO $$ ... pg_constraint lookup + DROP CONSTRAINT IF EXISTS + ADD —
+--     section (3): finds the OLD (possibly anonymous) actor_kind CHECK by
+--     introspection rather than assuming its auto-generated name, drops it,
+--     then (re)creates the canonically-named, widened CHECK. The
+--     introspection query itself excludes the canonical name from its
+--     match, so once the widened CHECK is in place a re-run finds nothing
+--     left to drop — a clean no-op, exactly like section (1) and (2).
+-- No JSONB. Typed columns and a native TEXT[] only.
+--
+-- ref: ADR-029 (cryptographic actor identity), #392.
+-- ============================================================
+
+BEGIN;
+
+-- ------------------------------------------------------------
+-- (1) API tokens registry
+-- ------------------------------------------------------------
+-- One row per issued credential. The cleartext token is NEVER stored: only
+-- its SHA-256 hex (lookup + uniqueness) and a non-secret human-readable
+-- prefix. actor_kind is the cryptographic source of the Decision Ladder —
+-- set at issuance, never taken from a request body.
+CREATE TABLE IF NOT EXISTS api_tokens (
+    token_id      UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    name          TEXT        NOT NULL,                      -- human label: "shortage-watcher", "pilote-ngo"
+    actor_kind    TEXT        NOT NULL CHECK (actor_kind IN ('agent', 'human', 'service')),
+    token_hash    TEXT        NOT NULL UNIQUE,               -- SHA-256 hex of the full token; cleartext never stored
+    token_prefix  TEXT        NOT NULL,                      -- ~12 leading chars in clear ("ootk_XXXXXXX") for lookup + readable audit
+    scopes        TEXT[]      NOT NULL DEFAULT '{}',         -- native array; valid values whitelisted in app code (see header: no CHECK on contents)
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at    TIMESTAMPTZ,                               -- NULL = no expiry
+    revoked_at    TIMESTAMPTZ,                               -- NULL = live; set = kill-switched
+    last_used_at  TIMESTAMPTZ,                               -- NULL = never presented
+    rate_per_min  INTEGER     CHECK (rate_per_min IS NULL OR rate_per_min > 0)  -- NULL = no per-token rate cap
+);
+
+COMMENT ON TABLE api_tokens IS
+    'Issued API credentials registry (#392, ADR-029). Cleartext token is '
+    'never stored — only token_hash (SHA-256 hex, lookup/uniqueness) and '
+    'token_prefix (non-secret, readable). actor_kind is the cryptographic '
+    'source of the Decision Ladder actor identity, set at issuance by an '
+    'operator, never self-declared by a request body — the #341 human-only '
+    'approval gate becomes enforceable on it.';
+
+COMMENT ON COLUMN api_tokens.actor_kind IS
+    'agent | human | service. Cryptographically bound to the credential at '
+    'issuance; the #341 approval state machine and the Decision Ladder '
+    '(L0-L4) derive the caller''s kind from this, NOT from the request '
+    'payload. Kept in sync with the auth layer''s VALID_ACTOR_KINDS.';
+
+COMMENT ON COLUMN api_tokens.token_hash IS
+    'SHA-256 hex of the full cleartext token. No KDF by design: tokens are '
+    '256-bit os.urandom (issue_agent_token.py, PR2), not low-entropy human '
+    'secrets, so a fast hash is both sufficient and correct on the hot auth '
+    'path. Cleartext is shown once at issuance and never persisted.';
+
+COMMENT ON COLUMN api_tokens.token_prefix IS
+    'First ~12 chars of the token in clear ("ootk_XXXXXXX"). Non-secret: '
+    'safe to log and display for lookup + human-readable audit. Not unique '
+    '(collisions on the short prefix are possible); token_hash is the '
+    'unique identity.';
+
+COMMENT ON COLUMN api_tokens.scopes IS
+    'Granted scopes as a native TEXT[] (not JSONB, not a join table — see '
+    'migration header). The set of valid scope strings is validated in '
+    'application code, never by a SQL CHECK, so scopes evolve with the code '
+    'that enforces them without schema churn.';
+
+-- Lookup / audit index on the readable prefix. NON-unique on purpose:
+-- token_hash carries uniqueness; two tokens may share a short prefix.
+CREATE INDEX IF NOT EXISTS idx_api_tokens_prefix
+    ON api_tokens (token_prefix);
+
+-- ------------------------------------------------------------
+-- (2) Bind the audit log (migration 023) to the issuing token
+-- ------------------------------------------------------------
+-- Both columns are NULLABLE and default-free: pre-existing api_request_log
+-- rows keep NULL, and the current INSERT in api/app.py (which names its
+-- columns explicitly) is unaffected — a strictly additive, rolling-deploy-
+-- safe extension. The backend-dev wires the values in api/ separately.
+--
+-- token_id → api_tokens(token_id) ON DELETE SET NULL: the audit trail must
+-- OUTLIVE a hard-deleted token. Deleting a token nulls the reference on old
+-- audit rows rather than cascading them away — the record of "a call
+-- happened" is never erased by credential lifecycle.
+ALTER TABLE api_request_log
+    ADD COLUMN IF NOT EXISTS token_id UUID
+        REFERENCES api_tokens (token_id) ON DELETE SET NULL;
+
+-- actor_kind is DENORMALISED here on purpose (see header): once token_id is
+-- nulled by a token delete, this frozen copy still answers "agent or human
+-- made this call?" — the historically correct value, immune to later token
+-- deletion or id recycling. No FK, no CHECK: this mirrors whatever
+-- api_tokens.actor_kind was at call time; it is an immutable audit fact,
+-- not a live-validated field.
+ALTER TABLE api_request_log
+    ADD COLUMN IF NOT EXISTS actor_kind TEXT;
+
+COMMENT ON COLUMN api_request_log.token_id IS
+    'Issuing api_tokens.token_id for this request (#392). ON DELETE SET '
+    'NULL — audit rows survive a hard token delete; the reference is '
+    'cleared, the audit row is kept.';
+
+COMMENT ON COLUMN api_request_log.actor_kind IS
+    'Denormalised copy of the token''s actor_kind at call time (#392). '
+    'Frozen so the audit stays answerable ("agent vs human") even after '
+    'token_id is nulled by a token delete. No FK / no CHECK: it is an '
+    'immutable audit fact, not a live-validated field.';
+
+-- ------------------------------------------------------------
+-- (3) Align recommendation_transitions.actor_kind with the new vocabulary
+-- ------------------------------------------------------------
+-- Security-review defect #6: this migration makes 'service' a first-class
+-- api_tokens.actor_kind (whitelisted in code, allowed through the kill
+-- switch), but recommendation_transitions (migration 040) still CHECKs
+-- actor_kind IN ('human', 'agent') only. A valid 'service' token
+-- performing an authorised transition (e.g. REVIEWED) hits transition_one's
+-- INSERT, trips that stale CHECK, and surfaces as a raw CheckViolation ->
+-- opaque 500 on a request that should have succeeded. Fix at the source:
+-- the migration that introduces 'service' as a valid actor is the correct
+-- place to widen every actor_kind CHECK to accept it.
+--
+-- The migration 040 constraint is an UNNAMED inline CHECK
+-- (`actor_kind TEXT ... CHECK (actor_kind IN ('human', 'agent'))`), so
+-- Postgres auto-assigned it a name. Rather than hardcode the assumed
+-- `<table>_<column>_check` auto-name (recommendation_transitions_
+-- actor_kind_check) and risk a silent no-op DROP IF EXISTS on a
+-- differently-named constraint, we discover it by INTROSPECTION —
+-- pg_constraint filtered on this table + contype='c' (CHECK) + the
+-- constraint definition mentioning actor_kind — the same robust pattern
+-- migration 034 uses to retire an anonymous CHECK on resources.resource_
+-- type. The `conname <> 'recommendation_transitions_actor_kind_check'`
+-- guard makes this loop-safe on re-run: once the canonical name is in
+-- place, the introspection finds nothing left to drop (the one match IS
+-- the named constraint we just added) and the block is a clean no-op —
+-- matching 034's own idempotence guard exactly.
+DO $$
+DECLARE
+    old_constraint_name TEXT;
+BEGIN
+    SELECT conname INTO old_constraint_name
+    FROM pg_constraint
+    WHERE conrelid = 'recommendation_transitions'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) LIKE '%actor_kind%'
+      AND conname <> 'recommendation_transitions_actor_kind_check'
+    LIMIT 1;
+
+    IF old_constraint_name IS NOT NULL THEN
+        EXECUTE 'ALTER TABLE recommendation_transitions DROP CONSTRAINT '
+            || quote_ident(old_constraint_name);
+    END IF;
+END $$;
+
+ALTER TABLE recommendation_transitions DROP CONSTRAINT IF EXISTS recommendation_transitions_actor_kind_check;
+ALTER TABLE recommendation_transitions ADD CONSTRAINT recommendation_transitions_actor_kind_check
+    CHECK (actor_kind IN ('human', 'agent', 'service'));
+
+COMMENT ON COLUMN recommendation_transitions.actor_kind IS
+    'human | agent | service (#392). Widened from the migration-040 '
+    'human/agent-only CHECK so a valid service-actor_kind api_tokens '
+    'credential (#392) can record a governed transition without tripping a '
+    'stale CheckViolation. Kept in sync with api_tokens.actor_kind''s '
+    'vocabulary.';
+
+COMMIT;

--- a/src/ootils_core/engine/recommendation/state_machine.py
+++ b/src/ootils_core/engine/recommendation/state_machine.py
@@ -55,9 +55,12 @@ TERMINAL_STATUSES: frozenset[str] = frozenset(
 # Decision Ladder gate (North Star L3+): approving or applying a
 # recommendation is a human decision. Enforced HERE — the single source of
 # truth of the machine — so no in-process caller (router, CLI, future
-# watcher/orchestrator import) can bypass it. actor_kind is self-declared
-# until per-token agent scopes land (#350); this gate is the transitional
-# floor, not the final authentication story.
+# watcher/orchestrator import) can bypass it. As of #392, actor_kind is no
+# longer self-declared: the REST callers source it from the authenticated
+# Principal (the api_tokens row behind the Bearer token), so an agent token is
+# structurally unable to claim 'human' at this gate. The CLI still passes an
+# explicit actor_kind (a trusted local operator context). This function only
+# decides; it never trusts a request body.
 HUMAN_ONLY_TARGETS: frozenset[str] = frozenset({"APPROVED", "APPLIED"})
 
 

--- a/src/ootils_core/mps/api.py
+++ b/src/ootils_core/mps/api.py
@@ -790,6 +790,13 @@ class ApproveMPSResponse(BaseModel):
     notes: Optional[str]
 
 
+# governance PR2: recommend:approve or a dedicated mps:approve scope —
+# deferred. #392 security-review audit (PR1): this transitions an MPS node
+# DRAFT/REVIEWED -> APPROVED, gating entry into /promote-to-mrp below. It does
+# NOT itself write canonical master data (unlike staging/approve.py, which is
+# gated in this same PR1) — the write-to-baseline happens one step later, at
+# promote-to-mrp. Scoped as require_auth-only for now; not a silent gap, an
+# explicitly deferred one, tracked alongside promote-to-mrp below.
 @router.post(
     "/{mps_id}/approve",
     response_model=ApproveMPSResponse,
@@ -925,6 +932,17 @@ class PromoteToMRPResponse(BaseModel):
     crp_peak_load_date: Optional[date] = Field(None, description="Date of peak load (if CRP triggered)")
 
 
+# governance PR2: recommend:approve or a dedicated mps:approve scope +
+# Decision Ladder human gate — deferred. #392 security-review audit (PR1):
+# this DOES write to baseline (creates PlannedSupply nodes on the baseline
+# scenario — see the CRP-integration comment below confirming
+# "promote_to_mrp writes planned_supply on baseline") and flips the MPS node
+# to the terminal RELEASED status, an apply-to-baseline action in the same
+# family as staging/approve.py (gated in this PR1) and scenarios/promote
+# (gated in PR1's prior pass). Left require_auth-only here deliberately:
+# closing it needs the same scope+human-gate stacking pattern already
+# applied to staging/scenarios/recommendations, tracked as PR2 follow-up
+# rather than folded silently into this pass.
 @router.post(
     "/{mps_id}/promote-to-mrp",
     response_model=PromoteToMRPResponse,

--- a/tests/integration/test_agent_floor_integration.py
+++ b/tests/integration/test_agent_floor_integration.py
@@ -1,0 +1,755 @@
+"""
+Integration tests for the agent enterprise floor (chantier #392 PR1) against a
+real PostgreSQL database (no mocks). Migration 064 (api_tokens + the
+api_request_log.token_id/actor_kind audit columns) is applied by the
+``migrated_db`` fixture the same way production applies it (OotilsDB startup).
+
+THE SECURITY CONTRACT under test — a minted token's ``actor_kind`` comes from
+the ``api_tokens`` row, NOT the request body, so the #341 human-only approval
+gate becomes genuinely enforceable:
+
+  1. An AGENT token cannot approve an L3 (APPROVED) — 403 on the scope floor,
+     and ALSO 403 on the human gate even when the agent is (abnormally) minted
+     with recommend:approve AND the body lies actor_kind="human". This is the
+     defence-in-depth that proves the self-declaration hole is closed.
+  2. A HUMAN token approves — 200; the audit row records the TOKEN's actor_kind.
+  3. Revocation takes effect within the cache TTL (forced here by clearing the
+     process cache, never by a wall-clock sleep) — a revoked token -> 401.
+  4. Legacy global-token behaviour is byte-unchanged (admin, approves, and its
+     api_request_log.token_id stays NULL).
+  5. Audit attributability: a minted call stamps token_id + actor_kind on the
+     last api_request_log row.
+  6. Stream requires the read scope (403 without, 200 with; ``once=true`` for a
+     bounded response).
+  7. Generic missing-scope: a {read}-only token cannot even move to REVIEWED.
+
+Plus the #392 security-review fixes:
+  8. Staging L3 gate (defect: staging/approve.py had NO gate at all before
+     #392 — an agent token with the `ingest` scope could apply canonical
+     master-data changes). An agent token WITH `ingest` -> 403 on the human
+     gate; an agent token WITHOUT `ingest` -> 403 on the scope floor first
+     (never reaches the gate); a human token WITH `ingest` clears both floors.
+  9. The legacy-window gate fallback (defect 9, ``resolve_gate_kind``) proven
+     end-to-end: the shared legacy token honours a body-declared actor_kind
+     for the HUMAN GATE ONLY (pre-#392 behaviour, preserved on purpose) —
+     legacy + body declares 'agent' -> 403; legacy + no declaration/'human'
+     -> 200. This is the transition-window compromise, not a reopened hole:
+     a MINTED token never gets this fallback (see TestAgentCannotApproveL3
+     above, which already proves the token always wins for minted callers).
+  10. Audit FK fallback (defect 5): a hard-DELETEd api_tokens row must not
+      erase the audit trail of calls the (still process-cached) token
+      authenticated in its final ≤TTL window — the INSERT retries with
+      token_id=NULL, keeping actor_kind/prefix.
+  11. A `service` token (defect 6: migration 064's CHECK now allows it end to
+      end) can draft-transition a recommendation with no CHECK violation, and
+      the audit trail correctly attributes actor_kind='service'.
+
+Tokens are inserted DIRECTLY in SQL: only the test knows the cleartext; the DB
+holds ``hash_token(clear)``. Each test seeds its own uuid4-suffixed tokens so
+there are no inter-test collisions. No wall-clock timing assertions anywhere.
+"""
+from __future__ import annotations
+
+import io
+import os
+from uuid import uuid4
+
+import pytest
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+BASELINE = "00000000-0000-0000-0000-000000000001"
+LEGACY_TOKEN = "integration-test-token"
+
+
+# ---------------------------------------------------------------------------
+# App fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def api_client(migrated_db):
+    """TestClient with get_db overridden onto the test DB.
+
+    Mirrors test_recommendations_api_integration.py. NOTE: because get_db is
+    overridden, _should_audit_request() returns False, so this client does NOT
+    write api_request_log rows — the audit-attribution assertions use the
+    ``audit_client`` fixture below instead.
+    """
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = LEGACY_TOKEN
+
+    from fastapi.testclient import TestClient
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="module")
+def audit_client(migrated_db):
+    """TestClient WITHOUT a get_db override so the api_request_log middleware
+    actually runs (audit attribution tests). Binds to the real DB via
+    DATABASE_URL, exactly as the app resolves its pool in production."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = LEGACY_TOKEN
+
+    from fastapi.testclient import TestClient
+
+    from ootils_core.api.app import create_app
+
+    app = create_app()
+    with TestClient(app) as client:
+        yield client
+
+
+@pytest.fixture(autouse=True)
+def _clear_token_cache():
+    """The minted-token lookup is memoised in-process; clear it around every
+    test so a seed/revoke in one test never leaks a cached decision into
+    another (and so revocation is observable without a TTL sleep)."""
+    import ootils_core.api.auth as auth
+
+    auth._token_cache.clear()
+    yield
+    auth._token_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Direct DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _db_conn(dsn):
+    import psycopg
+    from psycopg.rows import dict_row
+
+    return psycopg.connect(dsn, row_factory=dict_row, autocommit=True)
+
+
+def _mint_token(
+    dsn,
+    *,
+    actor_kind: str,
+    scopes: list[str],
+    expires_at: str | None = None,
+    revoked_at: str | None = None,
+) -> tuple[str, str]:
+    """Insert one api_tokens row; return (cleartext_token, token_id).
+
+    The cleartext exists ONLY here in the test — the DB stores its SHA-256 via
+    the same hash_token the auth layer uses on lookup.
+    """
+    from ootils_core.api.auth import hash_token, token_prefix
+
+    clear = f"ootk_{actor_kind}_{uuid4().hex}"
+    token_id = uuid4()
+    with _db_conn(dsn) as conn:
+        conn.execute(
+            """
+            INSERT INTO api_tokens (
+                token_id, name, actor_kind, token_hash, token_prefix,
+                scopes, expires_at, revoked_at
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                token_id,
+                f"test-{actor_kind}-{token_id}",
+                actor_kind,
+                hash_token(clear),
+                token_prefix(clear),
+                scopes,
+                expires_at,
+                revoked_at,
+            ),
+        )
+    return clear, str(token_id)
+
+
+def _revoke(dsn, token_id: str) -> None:
+    with _db_conn(dsn) as conn:
+        conn.execute(
+            "UPDATE api_tokens SET revoked_at = now() WHERE token_id = %s",
+            (token_id,),
+        )
+
+
+def _insert_recommendation(
+    dsn,
+    *,
+    scenario_id: str = BASELINE,
+    status: str = "DRAFT",
+    action: str = "EXPEDITE",
+    agent_name: str = "shortage_watcher",
+) -> tuple[str, str]:
+    run_id = uuid4()
+    reco_id = uuid4()
+    with _db_conn(dsn) as conn:
+        conn.execute(
+            "INSERT INTO agent_runs (agent_run_id, agent_name, scenario_id, status) "
+            "VALUES (%s, %s, %s, 'COMPLETED')",
+            (run_id, agent_name, scenario_id),
+        )
+        conn.execute(
+            """
+            INSERT INTO recommendations (
+                recommendation_id, agent_name, agent_run_id, scenario_id,
+                item_id, item_external_id, shortage_date,
+                deficit_qty, recommended_qty, estimated_cost, currency,
+                lead_time_days, runway_days, margin_days,
+                action, status, confidence
+            ) VALUES (
+                %s, %s, %s, %s,
+                %s, 'PUMP-01', '2026-08-15',
+                100, 120, 4800, 'EUR',
+                14, 30, 16,
+                %s, %s, 'HIGH'
+            )
+            """,
+            (reco_id, agent_name, run_id, scenario_id, uuid4(), action, status),
+        )
+    return str(reco_id), str(run_id)
+
+
+def _upload_and_validate_batch(api_client, source_system: str) -> str:
+    """Upload a minimal single-row items TSV via the LEGACY (admin) token,
+    then force the batch into 'validated' so it is approve-ready — mirrors
+    tests/integration/test_staging_approve.py::_upload_and_validate.
+
+    Deliberately a PURE INSERT (0% deletion ratio) so approval never needs
+    force=true — the point of these tests is the auth floor, not the diff
+    guard. Uses the LEGACY token for setup (admin holds every scope,
+    including `ingest`) so the fabricated test tokens are reserved for the
+    actual assertions under test.
+    """
+    external_id = f"AGENTFLOOR-{uuid4().hex[:8]}"
+    lines = [
+        "external_id\tname\titem_type\tuom\tstatus",
+        f"{external_id}\tAgent Floor Item\tcomponent\tEA\tactive",
+    ]
+    data = ("\n".join(lines) + "\n").encode("utf-8")
+    resp = api_client.post(
+        "/v1/staging/upload",
+        headers=_bearer(LEGACY_TOKEN),
+        files={"file": ("items.tsv", io.BytesIO(data), "text/plain")},
+        data={"entity_type": "items", "source_system": source_system},
+    )
+    assert resp.status_code == 202, resp.text
+    batch_id = resp.json()["batch_id"]
+    with _db_conn(os.environ["DATABASE_URL"]) as conn:
+        conn.execute(
+            "UPDATE ingest_batches SET status = 'validated', dq_status = 'validated' "
+            "WHERE batch_id = %s",
+            (batch_id,),
+        )
+    return batch_id
+
+
+# ---------------------------------------------------------------------------
+# Per-test cleanup tracker
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tracker(migrated_db):
+    created = {"recos": [], "runs": [], "tokens": []}
+
+    def _reco(**kwargs) -> str:
+        reco_id, run_id = _insert_recommendation(migrated_db, **kwargs)
+        created["recos"].append(reco_id)
+        created["runs"].append(run_id)
+        return reco_id
+
+    def _token(**kwargs) -> tuple[str, str]:
+        clear, token_id = _mint_token(migrated_db, **kwargs)
+        created["tokens"].append(token_id)
+        return clear, token_id
+
+    ns = type("NS", (), {"reco": staticmethod(_reco), "token": staticmethod(_token)})
+    yield ns
+
+    with _db_conn(migrated_db) as conn:
+        if created["recos"]:
+            conn.execute(
+                "DELETE FROM recommendation_transitions WHERE recommendation_id = ANY(%s::uuid[])",
+                (created["recos"],),
+            )
+            conn.execute(
+                "DELETE FROM recommendations WHERE recommendation_id = ANY(%s::uuid[])",
+                (created["recos"],),
+            )
+        if created["runs"]:
+            conn.execute(
+                "DELETE FROM agent_runs WHERE agent_run_id = ANY(%s::uuid[])",
+                (created["runs"],),
+            )
+        if created["tokens"]:
+            # Null the audit FK first is unnecessary (ON DELETE SET NULL), but
+            # scrub the audit rows we generated so the table stays tidy.
+            conn.execute(
+                "DELETE FROM api_request_log WHERE token_id = ANY(%s::uuid[])",
+                (created["tokens"],),
+            )
+            conn.execute(
+                "DELETE FROM api_tokens WHERE token_id = ANY(%s::uuid[])",
+                (created["tokens"],),
+            )
+        conn.execute("DELETE FROM events WHERE event_type = 'recommendation_transition'")
+
+
+def _bearer(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ===========================================================================
+# 1. Agent token cannot approve an L3 (both floors)
+# ===========================================================================
+
+
+class TestAgentCannotApproveL3:
+    def _reviewed_reco(self, tracker) -> str:
+        """A recommendation moved DRAFT -> REVIEWED (via legacy admin), so the
+        only thing standing between it and APPROVED is the caller's identity."""
+        return tracker.reco(status="REVIEWED")
+
+    def test_scope_floor_blocks_agent_without_approve(self, api_client, tracker):
+        reco_id = self._reviewed_reco(tracker)
+        clear, _ = tracker.token(actor_kind="agent", scopes=["read", "recommend:draft"])
+
+        resp = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={"to_status": "APPROVED", "actor": "shortage_watcher", "actor_kind": "agent"},
+            headers=_bearer(clear),
+        )
+        assert resp.status_code == 403, resp.text
+        # It failed on the SCOPE floor, not the human gate.
+        assert "scope" in resp.json()["detail"].lower()
+
+    def test_human_gate_blocks_agent_even_with_approve_scope_and_lying_body(
+        self, api_client, tracker
+    ):
+        """DEFENCE IN DEPTH: an agent token abnormally minted WITH
+        recommend:approve clears the scope floor — but the human gate reads the
+        TOKEN's actor_kind ('agent'), not the body, so a body claiming
+        actor_kind='human' still gets 403. This is the test that proves the
+        self-declaration hole is closed."""
+        reco_id = self._reviewed_reco(tracker)
+        clear, _ = tracker.token(actor_kind="agent", scopes=["recommend:approve"])
+
+        resp = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={"to_status": "APPROVED", "actor": "rogue", "actor_kind": "human"},
+            headers=_bearer(clear),
+        )
+        assert resp.status_code == 403, resp.text
+        # The human gate message (not the scope message) — the body lie was ignored.
+        assert "human" in resp.json()["detail"].lower()
+
+        # And the recommendation was NOT approved.
+        with _db_conn(os.environ["DATABASE_URL"]) as conn:
+            row = conn.execute(
+                "SELECT status FROM recommendations WHERE recommendation_id = %s",
+                (reco_id,),
+            ).fetchone()
+        assert row["status"] == "REVIEWED"
+
+
+# ===========================================================================
+# 2. Human token approves; audit records the token's actor_kind
+# ===========================================================================
+
+
+class TestHumanApproves:
+    def test_human_token_approves_and_audit_kind_is_from_token(self, api_client, tracker):
+        reco_id = tracker.reco(status="REVIEWED")
+        # Body deliberately claims 'agent' — the TOKEN is human, and the token wins.
+        clear, _ = tracker.token(actor_kind="human", scopes=["recommend:approve"])
+
+        resp = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={"to_status": "APPROVED", "actor": "ngoineau", "actor_kind": "agent"},
+            headers=_bearer(clear),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["actor_kind"] == "human"  # response echoes the token's kind
+
+        with _db_conn(os.environ["DATABASE_URL"]) as conn:
+            reco = conn.execute(
+                "SELECT status FROM recommendations WHERE recommendation_id = %s",
+                (reco_id,),
+            ).fetchone()
+            assert reco["status"] == "APPROVED"
+            audit = conn.execute(
+                "SELECT actor, actor_kind FROM recommendation_transitions "
+                "WHERE recommendation_id = %s ORDER BY created_at DESC LIMIT 1",
+                (reco_id,),
+            ).fetchone()
+        # The audit trail records the TOKEN's kind, not the body's.
+        assert audit["actor_kind"] == "human"
+        assert audit["actor"] == "ngoineau"
+
+
+# ===========================================================================
+# 3. Revocation observed within the cache TTL (cache cleared, no sleep)
+# ===========================================================================
+
+
+class TestRevocationWithinTtl:
+    def test_valid_then_revoked_is_401(self, api_client, tracker):
+        clear, token_id = tracker.token(actor_kind="agent", scopes=["read"])
+
+        ok = api_client.get("/v1/recommendations", headers=_bearer(clear))
+        assert ok.status_code == 200, ok.text
+
+        _revoke(os.environ["DATABASE_URL"], token_id)
+        # Purge the process cache so the next lookup re-hits the DB (models the
+        # <=TTL window elapsing, without a 30 s wall-clock wait).
+        import ootils_core.api.auth as auth
+
+        auth._token_cache.clear()
+
+        revoked = api_client.get("/v1/recommendations", headers=_bearer(clear))
+        assert revoked.status_code == 401
+
+
+# ===========================================================================
+# 4. Legacy global token unchanged
+# ===========================================================================
+
+
+class TestLegacyUnchanged:
+    def test_legacy_reads_and_approves_as_admin(self, api_client, tracker):
+        reco_id = tracker.reco(status="REVIEWED")
+        headers = _bearer(LEGACY_TOKEN)
+
+        listed = api_client.get("/v1/recommendations", headers=headers)
+        assert listed.status_code == 200, listed.text
+
+        approved = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={"to_status": "APPROVED", "actor": "ngoineau", "actor_kind": "human"},
+            headers=headers,
+        )
+        assert approved.status_code == 200, approved.text
+
+    def test_legacy_audit_row_has_null_token_id(self, audit_client, tracker):
+        # audit_client writes api_request_log (no get_db override).
+        resp = audit_client.get("/v1/recommendations", headers=_bearer(LEGACY_TOKEN))
+        assert resp.status_code == 200, resp.text
+
+        with _db_conn(os.environ["DATABASE_URL"]) as conn:
+            row = conn.execute(
+                """
+                SELECT token_id, token_prefix, actor_kind
+                FROM api_request_log
+                WHERE path = '/v1/recommendations'
+                ORDER BY created_at DESC
+                LIMIT 1
+                """
+            ).fetchone()
+        assert row is not None
+        assert row["token_id"] is None  # legacy token has no DB identity
+        assert row["token_prefix"] == "global_token"
+
+
+# ===========================================================================
+# 5. Audit attributability for a minted call
+# ===========================================================================
+
+
+class TestAuditAttribution:
+    def test_minted_call_stamps_token_id_and_actor_kind(self, audit_client, tracker):
+        clear, token_id = tracker.token(actor_kind="agent", scopes=["read"])
+
+        resp = audit_client.get("/v1/recommendations", headers=_bearer(clear))
+        assert resp.status_code == 200, resp.text
+
+        with _db_conn(os.environ["DATABASE_URL"]) as conn:
+            row = conn.execute(
+                """
+                SELECT token_id, actor_kind
+                FROM api_request_log
+                WHERE token_id = %s
+                ORDER BY created_at DESC
+                LIMIT 1
+                """,
+                (token_id,),
+            ).fetchone()
+        assert row is not None
+        assert str(row["token_id"]) == token_id
+        assert row["actor_kind"] == "agent"
+
+
+# ===========================================================================
+# 6. Stream scope
+# ===========================================================================
+
+
+class TestStreamScope:
+    def test_stream_without_read_scope_is_403(self, api_client, tracker):
+        # A token with a non-read scope only — stream requires 'read'.
+        clear, _ = tracker.token(actor_kind="agent", scopes=["recommend:draft"])
+        resp = api_client.get("/v1/stream?once=true", headers=_bearer(clear))
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["detail"] == "missing scope 'read'"
+
+    def test_stream_with_read_scope_is_200(self, api_client, tracker):
+        clear, _ = tracker.token(actor_kind="agent", scopes=["read"])
+        # once=true -> bounded catch-up drain, so the TestClient does not hang
+        # waiting on an open-ended SSE stream.
+        resp = api_client.get("/v1/stream?once=true", headers=_bearer(clear))
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"].startswith("text/event-stream")
+
+
+# ===========================================================================
+# 7. Generic missing-scope on a transition
+# ===========================================================================
+
+
+class TestGenericMissingScope:
+    def test_read_only_token_cannot_review(self, api_client, tracker):
+        reco_id = tracker.reco(status="DRAFT")
+        clear, _ = tracker.token(actor_kind="agent", scopes=["read"])
+
+        resp = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={"to_status": "REVIEWED", "actor": "shortage_watcher", "actor_kind": "agent"},
+            headers=_bearer(clear),
+        )
+        assert resp.status_code == 403, resp.text
+        # DRAFT -> REVIEWED needs recommend:draft, which this token lacks.
+        assert resp.json()["detail"] == "missing scope 'recommend:draft'"
+
+
+# ===========================================================================
+# 8. Staging L3 gate (#392 security-review — staging/approve.py had NO gate
+#    at all before #392)
+# ===========================================================================
+
+
+class TestStagingApproveGate:
+    def test_agent_with_ingest_scope_blocked_by_human_gate(self, api_client, tracker):
+        """An agent token holding `ingest` clears the scope floor -> reaches
+        the NEW human gate added by the security review -> 403."""
+        batch_id = _upload_and_validate_batch(
+            api_client, source_system=f"AGENTFLOOR-GATE-{uuid4().hex[:6]}"
+        )
+        clear, _ = tracker.token(actor_kind="agent", scopes=["ingest"])
+
+        resp = api_client.post(
+            f"/v1/staging/batches/{batch_id}/approve",
+            headers=_bearer(clear),
+            json={"approved_by": "shortage_watcher"},
+        )
+        assert resp.status_code == 403, resp.text
+        assert "human" in resp.json()["detail"].lower()
+
+        # Nothing was committed to canonical: the batch is still 'validated'.
+        with _db_conn(os.environ["DATABASE_URL"]) as conn:
+            row = conn.execute(
+                "SELECT status FROM ingest_batches WHERE batch_id = %s",
+                (batch_id,),
+            ).fetchone()
+        assert row["status"] == "validated"
+
+    @pytest.mark.parametrize("endpoint_suffix", ["approve", "reject", "diff"])
+    def test_agent_without_ingest_scope_blocked_by_scope_floor(
+        self, api_client, tracker, endpoint_suffix
+    ):
+        """Without `ingest` at all, the SCOPE floor fires first — the request
+        never even reaches the (approve-only) human gate."""
+        batch_id = _upload_and_validate_batch(
+            api_client, source_system=f"AGENTFLOOR-NOSCOPE-{uuid4().hex[:6]}"
+        )
+        clear, _ = tracker.token(actor_kind="agent", scopes=["read"])
+
+        if endpoint_suffix == "diff":
+            resp = api_client.get(
+                f"/v1/staging/batches/{batch_id}/diff", headers=_bearer(clear)
+            )
+        elif endpoint_suffix == "approve":
+            resp = api_client.post(
+                f"/v1/staging/batches/{batch_id}/approve",
+                headers=_bearer(clear),
+                json={"approved_by": "shortage_watcher"},
+            )
+        else:  # reject
+            resp = api_client.post(
+                f"/v1/staging/batches/{batch_id}/reject",
+                headers=_bearer(clear),
+                json={"rejected_by": "shortage_watcher", "reason": "test"},
+            )
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["detail"] == "missing scope 'ingest'"
+
+    def test_human_with_ingest_scope_clears_both_floors(self, api_client, tracker):
+        """A human token holding `ingest` passes the scope floor AND the human
+        gate — the request reaches the real approval logic. Assert it is NOT
+        an auth/gate 403 (the batch is a clean pure-insert, so this resolves
+        as 200; asserting 'not 403' first keeps the test robust to any
+        unrelated business-logic wrinkle in approve_batch)."""
+        batch_id = _upload_and_validate_batch(
+            api_client, source_system=f"AGENTFLOOR-HUMANOK-{uuid4().hex[:6]}"
+        )
+        clear, _ = tracker.token(actor_kind="human", scopes=["ingest"])
+
+        resp = api_client.post(
+            f"/v1/staging/batches/{batch_id}/approve",
+            headers=_bearer(clear),
+            json={"approved_by": "ngoineau"},
+        )
+        assert resp.status_code != 403, resp.text
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["counts"]["rows_inserted"] == 1
+
+
+# ===========================================================================
+# 9. Legacy-window gate fallback (#392 defect 9, resolve_gate_kind)
+#    proven end-to-end on the recommendations transition endpoint.
+# ===========================================================================
+
+
+class TestLegacyGateFallbackEndToEnd:
+    def test_legacy_with_declared_agent_is_403(self, api_client, tracker):
+        """The shared legacy token, with the body still declaring
+        actor_kind='agent', is gated on THAT declared value (pre-#392
+        behaviour preserved on purpose for the transition window) -> 403,
+        exactly as an honestly-declaring agent got before #392."""
+        reco_id = tracker.reco(status="REVIEWED")
+        resp = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={"to_status": "APPROVED", "actor": "shortage_watcher", "actor_kind": "agent"},
+            headers=_bearer(LEGACY_TOKEN),
+        )
+        assert resp.status_code == 403, resp.text
+        assert "human" in resp.json()["detail"].lower()
+
+        with _db_conn(os.environ["DATABASE_URL"]) as conn:
+            row = conn.execute(
+                "SELECT status FROM recommendations WHERE recommendation_id = %s",
+                (reco_id,),
+            ).fetchone()
+        assert row["status"] == "REVIEWED"  # not approved
+
+    def test_legacy_with_declared_human_is_200(self, api_client, tracker):
+        """Same shared legacy token, body now declares (or defaults to)
+        'human' -> the gate decides on that declared value -> 200. Proves the
+        transition window does not regress the ordinary human-approves path."""
+        reco_id = tracker.reco(status="REVIEWED")
+        resp = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={"to_status": "APPROVED", "actor": "ngoineau", "actor_kind": "human"},
+            headers=_bearer(LEGACY_TOKEN),
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_legacy_with_no_declared_actor_kind_is_200(self, api_client, tracker):
+        """actor_kind omitted entirely -> TransitionRequest defaults it to
+        'human' -> resolve_gate_kind's legacy fallback sees 'human' -> 200.
+        Distinct from the explicit-'human' case above: this exercises the
+        Pydantic default path, not an explicit client declaration."""
+        reco_id = tracker.reco(status="REVIEWED")
+        resp = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={"to_status": "APPROVED", "actor": "ngoineau"},
+            headers=_bearer(LEGACY_TOKEN),
+        )
+        assert resp.status_code == 200, resp.text
+
+
+# ===========================================================================
+# 10. Audit FK fallback (#392 defect 5) — a hard-DELETEd api_tokens row must
+#     not erase the audit trail of a call it authenticated while cached.
+# ===========================================================================
+
+
+class TestAuditFkFallback:
+    def test_hard_deleted_token_audit_row_falls_back_to_null_token_id(
+        self, audit_client, tracker
+    ):
+        """audit_client (no get_db override) so _log_api_request actually
+        runs. Sequence: mint -> authenticate once (populates the process
+        cache) -> hard-DELETE the api_tokens row WITHOUT clearing the cache
+        (models the token's final ≤TTL window after a hard delete) ->
+        authenticate again -> the SELECT the cache still vouches for
+        succeeds, but the audit INSERT's token_id FK now points at nothing.
+        _log_api_request must retry with token_id=NULL rather than losing the
+        row (migration-064 ForeignKeyViolation carve-out in app.py)."""
+        clear, token_id = tracker.token(actor_kind="agent", scopes=["read"])
+
+        warm = audit_client.get("/v1/recommendations", headers=_bearer(clear))
+        assert warm.status_code == 200, warm.text  # populates the process cache
+
+        with _db_conn(os.environ["DATABASE_URL"]) as conn:
+            conn.execute("DELETE FROM api_tokens WHERE token_id = %s", (token_id,))
+        # Deliberately NOT clearing auth._token_cache — the whole point is
+        # that the in-process cache still vouches for the (now-deleted) token
+        # for the remainder of its TTL window.
+
+        resp = audit_client.get("/v1/recommendations", headers=_bearer(clear))
+        assert resp.status_code == 200, resp.text  # cache hit -> still authenticates
+
+        with _db_conn(os.environ["DATABASE_URL"]) as conn:
+            row = conn.execute(
+                """
+                SELECT token_id, actor_kind, token_prefix
+                FROM api_request_log
+                WHERE token_prefix = %s
+                ORDER BY created_at DESC
+                LIMIT 1
+                """,
+                (clear[:12],),
+            ).fetchone()
+        assert row is not None
+        assert row["token_id"] is None  # FK target gone -> NULL fallback, row kept
+        assert row["actor_kind"] == "agent"  # denormalised kind still stamped
+        assert row["token_prefix"] == clear[:12]
+        # tracker's own teardown DELETEs api_tokens WHERE token_id = ANY(...);
+        # this row is already gone, so that DELETE is a harmless no-op here.
+
+
+# ===========================================================================
+# 11. service token (#392 defect 6 — migration 064's CHECK now permits it
+#     end to end, no CheckViolation on transition_one's INSERT)
+# ===========================================================================
+
+
+class TestServiceActorKind:
+    def test_service_token_drafts_transition_with_no_check_violation(
+        self, api_client, tracker
+    ):
+        reco_id = tracker.reco(status="DRAFT")
+        clear, _ = tracker.token(actor_kind="service", scopes=["recommend:draft"])
+
+        resp = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={"to_status": "REVIEWED", "actor": "billing-sync", "actor_kind": "service"},
+            headers=_bearer(clear),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["actor_kind"] == "service"
+
+        with _db_conn(os.environ["DATABASE_URL"]) as conn:
+            audit = conn.execute(
+                "SELECT actor_kind FROM recommendation_transitions "
+                "WHERE recommendation_id = %s ORDER BY created_at DESC LIMIT 1",
+                (reco_id,),
+            ).fetchone()
+        assert audit["actor_kind"] == "service"

--- a/tests/integration/test_agent_floor_integration.py
+++ b/tests/integration/test_agent_floor_integration.py
@@ -738,9 +738,13 @@ class TestServiceActorKind:
         reco_id = tracker.reco(status="DRAFT")
         clear, _ = tracker.token(actor_kind="service", scopes=["recommend:draft"])
 
+        # No actor_kind in the body: the field is a deprecated Literal['human','agent']
+        # and is ignored for minted tokens. 'service' comes from the TOKEN — that is
+        # exactly the contract this test proves (the widened migration-064 CHECK lets
+        # the transition record actor_kind='service' without a CheckViolation).
         resp = api_client.post(
             f"/v1/recommendations/{reco_id}/transition",
-            json={"to_status": "REVIEWED", "actor": "billing-sync", "actor_kind": "service"},
+            json={"to_status": "REVIEWED", "actor": "billing-sync"},
             headers=_bearer(clear),
         )
         assert resp.status_code == 200, resp.text

--- a/tests/test_auth_principal.py
+++ b/tests/test_auth_principal.py
@@ -1,0 +1,859 @@
+"""
+Unit tests for auth.py principal resolution + the enterprise-floor helpers
+(chantier #392 PR1, plus the #392 security-review fixes). PURE — no
+PostgreSQL, no live pool.
+
+Layers exercised:
+  * Pure helpers (is_minted_token / hash_token / token_prefix /
+    principal_from_row / legacy_principal / Principal.has_scope /
+    resolve_gate_kind — security-review defect 9).
+  * _TokenCache with an INJECTED clock (deterministic TTL expiry — no sleep)
+    AND a size bound (defect 2 — LRU eviction via OrderedDict).
+  * resolve_principal, with the minted-token DB lookup monkeypatched out
+    (_lookup_minted_token_sync) and the env driven via monkeypatch: legacy
+    vs minted, unknown/revoked/expired -> 401, DB-down -> 503 (and NOT cached),
+    the OOTILS_AGENTS_ENABLED fleet kill switch.
+  * _bump_last_used_best_effort (defects 3+4): must never raise, and a
+    SELECT-ok/bump-ko lookup must still yield a Principal.
+  * require_scope, driven through a file-local FastAPI app + TestClient so the
+    401/403 mapping and the exact `missing scope '<scope>'` detail are covered
+    end to end.
+
+No pytest-asyncio in this repo: async coroutines are driven with
+``asyncio.run()`` inside sync tests (same pattern as test_mps_approve.py).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from uuid import UUID, uuid4
+
+import pytest
+
+# auth.py validates OOTILS_API_TOKEN at IMPORT time — set it before importing.
+os.environ.setdefault("OOTILS_API_TOKEN", "unit-legacy-token")
+
+import ootils_core.api.auth as auth  # noqa: E402
+from ootils_core.api.auth import (  # noqa: E402
+    Principal,
+    _CACHE_TTL_SECONDS,
+    _MINTED_PREFIX,
+    _TokenCache,
+    _TokenLookupUnavailable,
+    VALID_ACTOR_KINDS,
+    hash_token,
+    is_minted_token,
+    legacy_principal,
+    principal_from_row,
+    require_scope,
+    resolve_gate_kind,
+    resolve_principal,
+    token_prefix,
+)
+
+_LEGACY = "unit-legacy-token-value-abc123"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_auth(monkeypatch):
+    """Every test gets a known legacy token, the fleet enabled, and a clean
+    module-level token cache (so cross-test state never leaks)."""
+    monkeypatch.setenv("OOTILS_API_TOKEN", _LEGACY)
+    monkeypatch.delenv("OOTILS_AGENTS_ENABLED", raising=False)
+    auth._token_cache.clear()
+    yield
+    auth._token_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers for driving the async dependency from sync tests
+# ---------------------------------------------------------------------------
+
+
+class _Creds:
+    """Stand-in for HTTPAuthorizationCredentials (only .credentials is read)."""
+
+    def __init__(self, token: str) -> None:
+        self.scheme = "Bearer"
+        self.credentials = token
+
+
+class _FakeState:
+    pass
+
+
+class _FakeRequest:
+    def __init__(self) -> None:
+        self.state = _FakeState()
+
+
+def _resolve(token: str | None):
+    """Run resolve_principal for a bearer token (or None) and return the
+    Principal. Raises the HTTPException verbatim for the caller to inspect."""
+    creds = _Creds(token) if token is not None else None
+    request = _FakeRequest()
+    return asyncio.run(resolve_principal(credentials=creds, request=request)), request
+
+
+# ===========================================================================
+# 1. Pure helpers
+# ===========================================================================
+
+
+class TestIsMintedToken:
+    def test_minted_prefix_is_minted(self):
+        assert is_minted_token(_MINTED_PREFIX + "abc") is True
+
+    def test_legacy_value_is_not_minted(self):
+        assert is_minted_token("plain-legacy-token") is False
+
+    def test_empty_string_is_not_minted(self):
+        assert is_minted_token("") is False
+
+    def test_prefix_must_be_leading(self):
+        # The prefix only counts when it leads the string.
+        assert is_minted_token("x" + _MINTED_PREFIX) is False
+
+
+class TestHashToken:
+    def test_is_deterministic(self):
+        assert hash_token("ootk_abc") == hash_token("ootk_abc")
+
+    def test_is_64_hex_chars(self):
+        digest = hash_token("ootk_whatever")
+        assert len(digest) == 64
+        assert all(c in "0123456789abcdef" for c in digest)
+
+    def test_differs_from_the_raw_token(self):
+        raw = "ootk_secret"
+        assert hash_token(raw) != raw
+
+    def test_distinct_inputs_distinct_hashes(self):
+        assert hash_token("ootk_a") != hash_token("ootk_b")
+
+    def test_matches_hashlib_sha256(self):
+        import hashlib
+
+        raw = "ootk_reference"
+        assert hash_token(raw) == hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+class TestTokenPrefix:
+    def test_length_capped(self):
+        # Long token -> a short, fixed-length non-secret slice.
+        pfx = token_prefix("ootk_" + "z" * 100)
+        assert len(pfx) == auth._PREFIX_LEN
+
+    def test_stable_for_same_input(self):
+        assert token_prefix("ootk_stable_abc") == token_prefix("ootk_stable_abc")
+
+    def test_is_a_leading_slice(self):
+        token = "ootk_abcdefghijklmnop"
+        assert token.startswith(token_prefix(token))
+
+    def test_short_token_returned_whole(self):
+        assert token_prefix("ootk") == "ootk"
+
+
+class TestPrincipalFromRow:
+    def test_scopes_list_becomes_frozenset(self):
+        tid = uuid4()
+        p = principal_from_row(
+            {
+                "token_id": tid,
+                "name": "shortage-watcher",
+                "actor_kind": "agent",
+                "scopes": ["read", "recommend:draft"],
+                "token_prefix": "ootk_abc",
+            }
+        )
+        assert p.token_id == tid
+        assert p.name == "shortage-watcher"
+        assert p.actor_kind == "agent"
+        assert p.scopes == frozenset({"read", "recommend:draft"})
+        assert isinstance(p.scopes, frozenset)
+        assert p.is_legacy is False
+
+    def test_none_scopes_becomes_empty_frozenset(self):
+        p = principal_from_row(
+            {
+                "token_id": uuid4(),
+                "name": "svc",
+                "actor_kind": "service",
+                "scopes": None,
+                "token_prefix": "ootk_svc",
+            }
+        )
+        assert p.scopes == frozenset()
+
+    def test_empty_scopes_list_becomes_empty_frozenset(self):
+        p = principal_from_row(
+            {
+                "token_id": uuid4(),
+                "name": "svc",
+                "actor_kind": "service",
+                "scopes": [],
+                "token_prefix": "ootk_svc",
+            }
+        )
+        assert p.scopes == frozenset()
+
+    def test_token_id_string_is_coerced_to_uuid(self):
+        tid = uuid4()
+        p = principal_from_row(
+            {
+                "token_id": str(tid),
+                "name": "n",
+                "actor_kind": "human",
+                "scopes": ["admin"],
+                "token_prefix": "ootk_n",
+            }
+        )
+        assert p.token_id == tid
+        assert isinstance(p.token_id, UUID)
+
+    def test_actor_kind_carried_through(self):
+        for kind in VALID_ACTOR_KINDS:
+            p = principal_from_row(
+                {
+                    "token_id": uuid4(),
+                    "name": "n",
+                    "actor_kind": kind,
+                    "scopes": [],
+                    "token_prefix": "ootk_n",
+                }
+            )
+            assert p.actor_kind == kind
+
+
+class TestLegacyPrincipal:
+    def test_is_human_admin_legacy(self):
+        p = legacy_principal()
+        assert p.actor_kind == "human"
+        assert p.is_legacy is True
+        assert p.token_id is None
+        assert p.name == "legacy"
+
+    def test_holds_admin_scope(self):
+        assert legacy_principal().has_scope("admin")
+
+    def test_admin_satisfies_any_scope(self):
+        p = legacy_principal()
+        assert p.has_scope("read")
+        assert p.has_scope("recommend:approve")
+        assert p.has_scope("anything:at:all")
+
+
+class TestHasScope:
+    def _agent(self, scopes):
+        return Principal(
+            token_id=uuid4(),
+            name="a",
+            actor_kind="agent",
+            scopes=frozenset(scopes),
+            is_legacy=False,
+        )
+
+    def test_exact_scope_present(self):
+        assert self._agent({"read"}).has_scope("read") is True
+
+    def test_absent_scope_is_false(self):
+        assert self._agent({"read"}).has_scope("recommend:approve") is False
+
+    def test_admin_is_superset(self):
+        assert self._agent({"admin"}).has_scope("recommend:approve") is True
+
+    def test_empty_scopes_never_satisfy(self):
+        assert self._agent(set()).has_scope("read") is False
+
+
+# ===========================================================================
+# 2. _TokenCache — injected clock, deterministic TTL
+# ===========================================================================
+
+
+class _FakeClock:
+    """Manually advanced monotonic-like clock."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+def _principal(token_id=None):
+    return Principal(
+        token_id=token_id or uuid4(),
+        name="cached",
+        actor_kind="agent",
+        scopes=frozenset({"read"}),
+        is_legacy=False,
+    )
+
+
+class TestTokenCache:
+    def test_miss_then_put_then_hit(self):
+        clock = _FakeClock()
+        cache = _TokenCache(ttl_seconds=30.0, clock=clock)
+
+        hit, value = cache.get("h1")
+        assert hit is False and value is None
+
+        p = _principal()
+        cache.put("h1", p)
+
+        hit, value = cache.get("h1")
+        assert hit is True
+        assert value is p
+
+    def test_expiry_is_strict_after_ttl(self):
+        clock = _FakeClock()
+        cache = _TokenCache(ttl_seconds=30.0, clock=clock)
+        cache.put("h1", _principal())
+
+        # Just before TTL: still a hit.
+        clock.advance(29.999)
+        hit, _ = cache.get("h1")
+        assert hit is True
+
+        # AT the TTL boundary the entry is expired (get uses now >= expiry).
+        clock.advance(0.001)  # total 30.0
+        hit, value = cache.get("h1")
+        assert hit is False
+        assert value is None
+
+    def test_negative_entry_is_cached(self):
+        clock = _FakeClock()
+        cache = _TokenCache(ttl_seconds=30.0, clock=clock)
+
+        cache.put("bogus", None)  # cache a NEGATIVE lookup
+
+        hit, value = cache.get("bogus")
+        assert hit is True  # a cached negative is a HIT, not a miss
+        assert value is None
+
+    def test_negative_entry_also_expires(self):
+        clock = _FakeClock()
+        cache = _TokenCache(ttl_seconds=10.0, clock=clock)
+        cache.put("bogus", None)
+
+        clock.advance(10.0)
+        hit, value = cache.get("bogus")
+        assert hit is False
+        assert value is None
+
+    def test_clear_drops_all_entries(self):
+        cache = _TokenCache(ttl_seconds=30.0, clock=_FakeClock())
+        cache.put("h1", _principal())
+        cache.put("h2", None)
+
+        cache.clear()
+
+        assert cache.get("h1") == (False, None)
+        assert cache.get("h2") == (False, None)
+
+    def test_default_ttl_is_module_constant(self):
+        # The parameter defaults to the documented module constant.
+        cache = _TokenCache(clock=_FakeClock())
+        assert cache._ttl == _CACHE_TTL_SECONDS
+
+
+# ===========================================================================
+# 2b. _TokenCache size bound (#392 security-review defect 2) — LRU eviction
+# ===========================================================================
+
+
+class TestTokenCacheSizeBound:
+    """A flood of DISTINCT bogus ``ootk_<random>`` tokens is, by definition,
+    all cache MISSES (TTL memoisation only helps on a REPEATED value) — so the
+    size bound, not the TTL, is what keeps the store from growing unboundedly.
+    Reachable pre-auth: ``_resolve_minted_principal`` populates a negative
+    entry before any credential has been validated."""
+
+    def test_put_beyond_max_entries_evicts_oldest(self):
+        clock = _FakeClock()
+        cache = _TokenCache(ttl_seconds=30.0, clock=clock, max_entries=3)
+
+        cache.put("k1", _principal())
+        cache.put("k2", _principal())
+        cache.put("k3", _principal())
+        cache.put("k4", _principal())  # over budget -> evicts k1 (oldest)
+
+        assert cache.get("k1") == (False, None)  # evicted
+        assert cache.get("k2")[0] is True
+        assert cache.get("k3")[0] is True
+        assert cache.get("k4")[0] is True
+
+    def test_store_never_exceeds_max_entries(self):
+        clock = _FakeClock()
+        cache = _TokenCache(ttl_seconds=30.0, clock=clock, max_entries=5)
+
+        for i in range(50):  # N + K distinct keys, N=5
+            cache.put(f"flood-{i}", None)  # a flood of NEGATIVE entries
+            assert len(cache._store) <= 5
+
+        assert len(cache._store) == 5
+
+    def test_negative_entries_count_toward_the_bound(self):
+        """A flood of unknown ootk_ tokens (all negative lookups) must evict
+        just like positive entries — the bound is on ENTRY COUNT, not on
+        'real' (positive) principals only."""
+        clock = _FakeClock()
+        cache = _TokenCache(ttl_seconds=30.0, clock=clock, max_entries=2)
+
+        cache.put("bogus-1", None)
+        cache.put("bogus-2", None)
+        cache.put("bogus-3", None)  # evicts bogus-1
+
+        assert cache.get("bogus-1") == (False, None)
+        assert cache.get("bogus-2") == (True, None)
+        assert cache.get("bogus-3") == (True, None)
+
+    def test_get_hit_moves_entry_to_end_protecting_it_from_eviction(self):
+        """A `get` hit must move the entry to the MRU end, so a token under
+        active legitimate traffic is not the one evicted when the cache is
+        under flood pressure from distinct bogus tokens."""
+        clock = _FakeClock()
+        cache = _TokenCache(ttl_seconds=30.0, clock=clock, max_entries=3)
+
+        cache.put("k1", _principal())
+        cache.put("k2", _principal())
+        cache.put("k3", _principal())
+        # Touch k1 (a "real" hit) — it becomes the MRU entry.
+        hit, _ = cache.get("k1")
+        assert hit is True
+
+        cache.put("k4", _principal())  # over budget: evicts the NOW-oldest, k2
+
+        assert cache.get("k1")[0] is True  # protected by the touch above
+        assert cache.get("k2") == (False, None)  # evicted instead of k1
+        assert cache.get("k3")[0] is True
+        assert cache.get("k4")[0] is True
+
+    def test_default_max_entries_is_module_constant(self):
+        cache = _TokenCache(clock=_FakeClock())
+        assert cache._max_entries == auth._CACHE_MAX_ENTRIES
+
+
+# ===========================================================================
+# 3. resolve_principal — legacy / minted / kill switch, lookup monkeypatched
+# ===========================================================================
+
+
+class TestResolveLegacy:
+    def test_correct_legacy_token_is_human_admin(self):
+        principal, request = _resolve(_LEGACY)
+        assert principal.is_legacy is True
+        assert principal.actor_kind == "human"
+        assert principal.has_scope("admin")
+        # client_id audit key preserved for the legacy token.
+        assert request.state.client_id == "global_token"
+        assert request.state.principal is principal
+
+    def test_wrong_legacy_token_is_401(self):
+        with pytest.raises(auth.HTTPException) as ei:
+            _resolve("not-the-legacy-token")
+        assert ei.value.status_code == 401
+
+    def test_missing_header_is_401(self):
+        with pytest.raises(auth.HTTPException) as ei:
+            _resolve(None)
+        assert ei.value.status_code == 401
+
+
+class TestResolveMinted:
+    def _install_lookup(self, monkeypatch, mapping, *, raises=None, counter=None):
+        """Replace the DB lookup with an in-memory dict; optionally raise, and
+        optionally count invocations."""
+
+        def _fake(token_hash):
+            if counter is not None:
+                counter.append(token_hash)
+            if raises is not None:
+                raise raises
+            return mapping.get(token_hash)
+
+        monkeypatch.setattr(auth, "_lookup_minted_token_sync", _fake)
+
+    def test_valid_minted_token_reflects_row(self, monkeypatch):
+        token = _MINTED_PREFIX + "agentsecret"
+        row_principal = Principal(
+            token_id=uuid4(),
+            name="shortage-watcher",
+            actor_kind="agent",
+            scopes=frozenset({"read", "recommend:draft"}),
+            is_legacy=False,
+        )
+        self._install_lookup(monkeypatch, {hash_token(token): row_principal})
+
+        principal, request = _resolve(token)
+        assert principal is row_principal
+        assert principal.actor_kind == "agent"
+        assert principal.scopes == frozenset({"read", "recommend:draft"})
+        assert principal.is_legacy is False
+        # client_id audit key is the non-secret token prefix, not the raw token.
+        assert request.state.client_id == token_prefix(token)
+
+    def test_unknown_minted_token_is_401(self, monkeypatch):
+        token = _MINTED_PREFIX + "ghost"
+        self._install_lookup(monkeypatch, {})  # lookup returns None
+        with pytest.raises(auth.HTTPException) as ei:
+            _resolve(token)
+        assert ei.value.status_code == 401
+
+    def test_revoked_or_expired_lookup_none_is_401(self, monkeypatch):
+        # The SELECT filters revoked/expired -> returns None -> 401, identical
+        # to the unknown-token path (auth cannot tell them apart, by design).
+        token = _MINTED_PREFIX + "revoked"
+        self._install_lookup(monkeypatch, {})
+        with pytest.raises(auth.HTTPException) as ei:
+            _resolve(token)
+        assert ei.value.status_code == 401
+
+    def test_db_down_is_503(self, monkeypatch):
+        token = _MINTED_PREFIX + "dbdown"
+        self._install_lookup(monkeypatch, {}, raises=_TokenLookupUnavailable())
+        with pytest.raises(auth.HTTPException) as ei:
+            _resolve(token)
+        assert ei.value.status_code == 503
+
+    def test_db_down_503_is_not_cached(self, monkeypatch):
+        """A transient 503 must NOT be memoised as a negative — the very next
+        request re-attempts the DB lookup instead of serving a cached failure."""
+        token = _MINTED_PREFIX + "flaky"
+        calls: list[str] = []
+        self._install_lookup(
+            monkeypatch, {}, raises=_TokenLookupUnavailable(), counter=calls
+        )
+
+        with pytest.raises(auth.HTTPException) as ei1:
+            _resolve(token)
+        assert ei1.value.status_code == 503
+
+        with pytest.raises(auth.HTTPException) as ei2:
+            _resolve(token)
+        assert ei2.value.status_code == 503
+
+        # Two independent lookups: the failure was never cached.
+        assert len(calls) == 2
+
+    def test_positive_lookup_is_cached_single_db_hit(self, monkeypatch):
+        """Sanity counterpart to the 503 test: a SUCCESSFUL lookup is memoised,
+        so a second resolve within the TTL does not re-hit the DB."""
+        token = _MINTED_PREFIX + "cached"
+        calls: list[str] = []
+        row_principal = _principal()
+        self._install_lookup(
+            monkeypatch, {hash_token(token): row_principal}, counter=calls
+        )
+
+        p1, _ = _resolve(token)
+        p2, _ = _resolve(token)
+        assert p1 is row_principal and p2 is row_principal
+        assert len(calls) == 1  # second call served from the process cache
+
+
+class TestFleetKillSwitch:
+    def _install_agent(self, monkeypatch, actor_kind, scopes=("read",)):
+        token = _MINTED_PREFIX + "k-" + actor_kind
+        principal = Principal(
+            token_id=uuid4(),
+            name=actor_kind,
+            actor_kind=actor_kind,
+            scopes=frozenset(scopes),
+            is_legacy=False,
+        )
+        monkeypatch.setattr(
+            auth,
+            "_lookup_minted_token_sync",
+            lambda h, _p=principal: _p,
+        )
+        return token
+
+    def test_agent_blocked_when_fleet_disabled(self, monkeypatch):
+        monkeypatch.setenv("OOTILS_AGENTS_ENABLED", "0")
+        token = self._install_agent(monkeypatch, "agent")
+        with pytest.raises(auth.HTTPException) as ei:
+            _resolve(token)
+        assert ei.value.status_code == 503
+
+    def test_human_passes_when_fleet_disabled(self, monkeypatch):
+        monkeypatch.setenv("OOTILS_AGENTS_ENABLED", "0")
+        token = self._install_agent(monkeypatch, "human")
+        principal, _ = _resolve(token)
+        assert principal.actor_kind == "human"
+
+    def test_service_passes_when_fleet_disabled(self, monkeypatch):
+        monkeypatch.setenv("OOTILS_AGENTS_ENABLED", "0")
+        token = self._install_agent(monkeypatch, "service")
+        principal, _ = _resolve(token)
+        assert principal.actor_kind == "service"
+
+    def test_legacy_human_passes_when_fleet_disabled(self, monkeypatch):
+        # The legacy token maps to actor_kind='human' -> the agent kill switch
+        # never touches it.
+        monkeypatch.setenv("OOTILS_AGENTS_ENABLED", "0")
+        principal, _ = _resolve(_LEGACY)
+        assert principal.actor_kind == "human"
+        assert principal.is_legacy is True
+
+    def test_agent_passes_when_fleet_enabled(self, monkeypatch):
+        monkeypatch.setenv("OOTILS_AGENTS_ENABLED", "1")
+        token = self._install_agent(monkeypatch, "agent")
+        principal, _ = _resolve(token)
+        assert principal.actor_kind == "agent"
+
+
+# ===========================================================================
+# 3b. resolve_gate_kind — #392 security-review defect 9
+#
+# Pre-#392: EVERY caller self-declared actor_kind, and the gate decided on
+# that declared value. Post-#392: a MINTED token's Principal is the sole
+# truth (declared value ignored) — but the LEGACY token resolves to a
+# synthetic human/admin Principal, so naively gating on principal.actor_kind
+# would let an agent that HONESTLY declares 'agent' on the shared legacy
+# token now sail past a human-only gate it used to get 403 on. The fix: for
+# a LEGACY principal ONLY, an explicit declared_actor_kind overrides;
+# declared_actor_kind is IGNORED for every minted (non-legacy) principal.
+# ===========================================================================
+
+
+class TestResolveGateKind:
+    def _legacy(self) -> Principal:
+        return legacy_principal()
+
+    def _minted(self, actor_kind: str = "agent") -> Principal:
+        return Principal(
+            token_id=uuid4(),
+            name="minted",
+            actor_kind=actor_kind,
+            scopes=frozenset({"read"}),
+            is_legacy=False,
+        )
+
+    def test_legacy_with_declared_agent_returns_agent(self):
+        # (a) pre-#392 behaviour preserved: an honest agent declaration on the
+        # shared legacy token still gates as 'agent'.
+        assert resolve_gate_kind(self._legacy(), "agent") == "agent"
+
+    def test_legacy_with_no_declaration_returns_principal_kind(self):
+        # (b) no body field at all (e.g. staging's ApproveRequest) -> falls
+        # back to the legacy principal's synthetic 'human'.
+        assert resolve_gate_kind(self._legacy(), None) == "human"
+
+    def test_minted_with_declared_human_lie_returns_token_kind(self):
+        # (c) THE #392 closure: a minted token's body claiming 'human' is
+        # ignored outright — the token's real kind always wins.
+        minted = self._minted("agent")
+        assert resolve_gate_kind(minted, "human") == "agent"
+
+    def test_minted_with_no_declaration_returns_principal_kind(self):
+        # (d) minted + no body field -> principal.actor_kind, same as (c).
+        minted = self._minted("service")
+        assert resolve_gate_kind(minted, None) == "service"
+
+    def test_legacy_with_declared_human_returns_human(self):
+        # Sanity: an explicit 'human' declaration on legacy is a no-op change
+        # (still 'human'), not a special case that skips the fallback branch.
+        assert resolve_gate_kind(self._legacy(), "human") == "human"
+
+    def test_minted_human_token_with_declared_agent_lie_returns_human(self):
+        # Symmetric to (c): the token wins regardless of which direction the
+        # body's lie points.
+        minted = self._minted("human")
+        assert resolve_gate_kind(minted, "agent") == "human"
+
+
+# ===========================================================================
+# 3c. _bump_last_used_best_effort — #392 security-review defects 3+4
+#
+# The last_used_at UPDATE must be isolated from the SELECT that authenticates
+# the caller: a read-only standby / a concurrent row lock from a revoke must
+# degrade to "auth succeeds, last_used_at silently stops advancing", never to
+# an auth outage.
+# ===========================================================================
+
+
+class TestBumpLastUsedBestEffort:
+    def test_never_raises_when_the_update_connection_fails(self, monkeypatch):
+        class _ExplodingConn:
+            def __enter__(self):
+                raise RuntimeError("read-only standby: cannot UPDATE")
+
+            def __exit__(self, *exc_info):
+                return False
+
+        class _FakeDb:
+            def conn(self):
+                return _ExplodingConn()
+
+        monkeypatch.setattr(
+            "ootils_core.api.dependencies._get_ootils_db",
+            lambda: _FakeDb(),
+        )
+
+        # Must swallow the failure and simply return — no exception escapes.
+        auth._bump_last_used_best_effort(uuid4())
+
+    def test_lookup_returns_principal_even_when_bump_fails(self, monkeypatch):
+        """SELECT-ok + bump-ko (a REAL failure inside the bump's own DB call,
+        not a stand-in that raises past it) must still resolve a Principal —
+        the bump is isolated INSIDE _bump_last_used_best_effort's own
+        try/except (auth.py), not by the caller catching anything: note that
+        _lookup_minted_token_sync's own try/except wraps ONLY the SELECT, so
+        this only holds together because the bump swallows its own failure
+        (see test_never_raises_when_the_update_connection_fails above) —
+        this test proves the end-to-end consequence of that contract."""
+        token_id = uuid4()
+        row = {
+            "token_id": token_id,
+            "name": "watcher",
+            "actor_kind": "agent",
+            "scopes": ["read"],
+            "token_prefix": "ootk_watch",
+        }
+
+        select_calls: list[str] = []
+
+        class _SelectCursorResult:
+            def fetchone(self_inner):
+                return row
+
+        class _SelectConn:
+            def execute(self_inner, *args, **kwargs):
+                select_calls.append("select")
+                return _SelectCursorResult()
+
+        class _SelectConnCtx:
+            def __enter__(self_inner):
+                return _SelectConn()
+
+            def __exit__(self_inner, *exc_info):
+                return False
+
+        class _BumpConnCtx:
+            """The bump's OWN connection — opening it fails, exactly the
+            read-only-standby scenario _bump_last_used_best_effort's
+            docstring describes."""
+
+            def __enter__(self_inner):
+                raise RuntimeError("read-only standby: cannot UPDATE")
+
+            def __exit__(self_inner, *exc_info):
+                return False
+
+        class _FakeDb:
+            """Same SINGLETON instance serves BOTH call sites (SELECT then
+            bump — each site calls _get_ootils_db() independently, so the
+            patched function must return the SAME object both times); the
+            SELECT succeeds, the bump's connection acquisition fails."""
+
+            def __init__(self_inner):
+                self_inner._calls = 0
+
+            def conn(self_inner):
+                self_inner._calls += 1
+                return _SelectConnCtx() if self_inner._calls == 1 else _BumpConnCtx()
+
+        shared_db = _FakeDb()
+        monkeypatch.setattr(
+            "ootils_core.api.dependencies._get_ootils_db",
+            lambda: shared_db,
+        )
+
+        # No exception escapes — the bump swallows its own connection failure
+        # (real bump code path, not a stand-in), and a Principal comes back.
+        principal = auth._lookup_minted_token_sync("irrelevant-hash")
+        assert select_calls == ["select"]
+        assert principal is not None
+        assert principal.token_id == token_id
+        assert principal.actor_kind == "agent"
+
+
+# ===========================================================================
+# 4. require_scope — driven through a file-local FastAPI app
+# ===========================================================================
+
+
+def _scope_app():
+    """A tiny app whose one route requires the 'recommend:approve' scope.
+
+    resolve_principal is overridden per-test via dependency_overrides so the
+    scope check runs against a Principal we control, with no DB and no bearer
+    parsing."""
+    from fastapi import Depends, FastAPI
+
+    app = FastAPI()
+
+    @app.get("/guarded")
+    async def guarded(
+        principal: Principal = Depends(require_scope("recommend:approve")),
+    ):
+        return {"actor_kind": principal.actor_kind}
+
+    return app
+
+
+def _override_principal(app, principal):
+    # require_scope depends on resolve_principal; override THAT so the sub-dep
+    # returns our principal (or None) without any bearer/DB work.
+    async def _fake():
+        return principal
+
+    app.dependency_overrides[resolve_principal] = _fake
+
+
+class TestRequireScope:
+    def _client(self, principal):
+        from fastapi.testclient import TestClient
+
+        app = _scope_app()
+        _override_principal(app, principal)
+        return TestClient(app)
+
+    def test_no_principal_is_401(self):
+        client = self._client(None)
+        resp = client.get("/guarded")
+        assert resp.status_code == 401
+
+    def test_missing_scope_is_403_with_exact_detail(self):
+        agent = Principal(
+            token_id=uuid4(),
+            name="watcher",
+            actor_kind="agent",
+            scopes=frozenset({"read"}),  # lacks recommend:approve
+            is_legacy=False,
+        )
+        client = self._client(agent)
+        resp = client.get("/guarded")
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "missing scope 'recommend:approve'"
+
+    def test_present_scope_passes(self):
+        human = Principal(
+            token_id=uuid4(),
+            name="ngo",
+            actor_kind="human",
+            scopes=frozenset({"recommend:approve"}),
+            is_legacy=False,
+        )
+        client = self._client(human)
+        resp = client.get("/guarded")
+        assert resp.status_code == 200
+        assert resp.json()["actor_kind"] == "human"
+
+    def test_admin_superset_passes(self):
+        admin = Principal(
+            token_id=None,
+            name="legacy",
+            actor_kind="human",
+            scopes=frozenset({"admin"}),
+            is_legacy=True,
+        )
+        client = self._client(admin)
+        resp = client.get("/guarded")
+        assert resp.status_code == 200


### PR DESCRIPTION
Réf #392 (PR1/2) — **vague A2 du plan AI-native (épique #397) : le fossé n°3, celui qui conditionne tout pilote où des agents écrivent.**

## Le trou fermé
`actor_kind` était **auto-déclaré dans le body** (« until per-token agent scopes land #350 ») — n'importe quel appelant pouvait se dire `human` et approuver un L3. La Decision Ladder n'était pas cryptographiquement opposable. Désormais **`actor_kind` vient du token authentifié**.

## Livré
- **Migration 064** : `api_tokens` (hash SHA-256, `actor_kind` CHECK, scopes `TEXT[]`, expiration/révocation, `rate_per_min`) + audit `api_request_log.token_id/actor_kind` + CHECK transitions élargi à `service`. Zéro JSONB, rolling-safe.
- **`resolve_principal`** : legacy (=admin/human, DEPRECATED) ou token `ootk_` → cache LRU borné TTL 30 s → lookup DB déporté. **Fail-closed** (DB down → 503 jamais caché). `require_scope`, kill-switch flotte `OOTILS_AGENTS_ENABLED` (agent→503, humains passent).
- **Gate humain à deux étages** sur les writes L3 (recommendations approve, scenarios promote, **staging approve**) : scope du token ET `actor_kind='human'` dérivé du token.
- **`last_used_at`** best-effort en transaction séparée (un standby read-only n'interrompt jamais l'auth). **`resolve_gate_kind`** : le legacy préserve le gate self-déclaré pré-#392 (pas de régression dans la fenêtre de transition).

## Revue sécurité grade-attaquant (15 agents) : 9 défauts, tous corrigés avant merge
Escalade L3 via `/staging/approve` · DoS mémoire (cache négatif non borné) · `last_used_at` load-bearing (503 flotte) · audit troué au hard-delete · `service`→500 · kill-switch sans attribution · fenêtre legacy · openapi périmé · +1 en relecture d'orchestration. Les autres routes apply-candidates (mps promote #398, firm, dq, calc) auditées et **déférées-avec-commentaire** — aucun trou L3 silencieux.

## Rétro-compat = la preuve
Bearer legacy valide, 6 watchers en-process (hors périmètre), démo + **~2300 tests passent sans modification**.

## Tests
62 unitaires + 20 intégration — dont **le test d'escalade** (token agent + scope anormal + body menteur → 403 au gate) et le gate legacy bout-en-bout. openapi.json régénéré. Suite : 2322 passed, mypy 0/169.

**PR2** : budgets par token, `/metrics` Prometheus, émission/révocation, scopes read-only restants, ADR-029.

🤖 Generated with [Claude Code](https://claude.com/claude-code)