### PR TITLE
feat(drp): fair-share proportionnel + arrondi logistique (#395 PR2a, ADR-028)

### DIFF
--- a/docs/ADR-028-drp-fair-share-rounding.md
+++ b/docs/ADR-028-drp-fair-share-rounding.md
@@ -1,0 +1,136 @@
+# ADR-028 — DRP fair-share proportionnel + arrondi logistique descendant
+
+**Statut :** Accepté — chantier #395 **PR2a CLOSE** (le cœur `engine/drp/core.py` et la migration 065 sont mergés ; PR2b — recommandations gouvernées, watcher, endpoint, seed — reste à venir, cf. §Suite). Les deux règles métier tranchées par le pilote (fair-share, arrondi descendant) et les trois choix d'implémentation de l'architecte sont gravés ici.
+**Date :** 2026-07-06
+**Contexte mesuré :** décision pilote du 2026-07-06 ; docstrings du cœur DRP (`engine/drp/core.py` §SCOPE, `transfer_signals`, `_fair_share_round`) et migration `065_distribution_links_transfer_multiple.sql`, qui référencent tous cet ADR.
+
+---
+
+## Contexte
+
+L'échelon DRP (ADR-020 §Unité de planification) déplace du stock **fini** entre sites : une source excédentaire couvre le déficit d'un ou plusieurs sites qu'elle dessert. La première version du cœur DRP répartissait cet excédent en **greedy priorisé, dest-first** : le premier site (dans l'ordre de priorité) vidait la source jusqu'à saturation de son besoin, puis le suivant se servait sur le reste.
+
+Ce comportement a un défaut métier grave, remonté par le pilote (expert métier mondial de son domaine) : la **famine des dealers B**. Quand une source ne peut pas couvrir tous les sites en déficit qu'elle dessert, un site basse-priorité en pénurie prolongée reste à **zéro** run après run, pendant qu'un site prioritaire est servi à **100 %**. Le greedy dest-first traduit « préférence de sourcing » en « exclusivité de sourcing » — ce qui n'est pas ce que veut le métier : une priorité doit *incliner* le partage, pas *affamer* le palier inférieur.
+
+Second point : le greedy travaillait en quantités continues, alors qu'un transfert physique se fait par **unités logistiques** (colis, palette, camion complet). Rien dans le modèle ne permettait de dire « on expédie des colis entiers, pas des fractions », ni de choisir le sens d'arrondi — question d'autant plus sensible qu'un transfert DRP a une contrainte de conservation que le MRP n'a pas (voir Décision, point 5).
+
+Deux règles métier sont donc tranchées par le pilote (fair-share proportionnel ; arrondi à un multiple logistique configurable), et trois choix d'implémentation par l'architecte (algorithme exact et ordre déterministe ; interaction priorité × fair-share ; sens et gestion du reliquat de l'arrondi). Le cœur `engine/drp/core.py` implémente déjà la totalité ; cet ADR fige les décisions.
+
+## Décision
+
+### 1. Fair-share proportionnel remplace le greedy priorisé — décision **PILOTE**
+
+Quand une source ne peut pas couvrir tous les sites en déficit qu'elle dessert, son excédent est réparti au **prorata des déficits résiduels** de ces sites, au lieu que le premier draine la source. Raison métier : tuer la **famine des dealers B** — un site basse-priorité ne doit plus rester à zéro pendant qu'un site prioritaire est à 100 %. La règle vit en un seul endroit (`transfer_signals`) :
+
+```python
+part_dest = avail_snapshot * (residual_deficit_dest / Σ residual_deficits)
+```
+
+`avail_snapshot` est l'excédent de la source figé au **début** du palier de priorité traité, de sorte que la répartition est une vraie proportion (la somme des parts idéales égale le snapshot) ; le compteur d'excédent **vivant** est ce qui est réellement décrémenté, donc aucun jeu d'arrondi ou de reliquat n'est jamais sur-tiré.
+
+### 2. Arrondi à un multiple logistique configurable — décision **PILOTE**
+
+Chaque lane porte un multiple d'expédition : `distribution_links.transfer_multiple` (migration 065, `NUMERIC(18,6)`, `CHECK > 0`, **DEFAULT 1 = pas d'arrondi**). Toute lane antérieure à la colonne, ou tout link de test construit à la main, garde donc exactement le comportement continu pré-arrondi. La quantité transférée est arrondie à un multiple entier de cette valeur (sens et reliquat : point 5).
+
+### 3. Algorithme fair-share = **option (a) par source, ordre total figé** — architecte
+
+L'itération est **source-first** : boucle externe sur le palier de priorité (ascendant), puis sur les **sources** actives à ce palier dans l'ordre total figé `(priority_min(source), source_location, item)`, chaque source répartissant son excédent restant au prorata des déficits résiduels des destinations qu'elle dessert à ce palier. La **destination est la dimension interne** — l'exact opposé de l'ancien drain dest-first. L'ordre de traitement (palier → sources → destinations triées) est entièrement déterministe, et la clé de tri de **sortie** est logiquement inchangée (`item, dest_location, deficit_bucket, priority, source_location, link_ref, …`), donc le plan émis est **byte-stable** run-to-run, indépendant de l'ordre d'insertion des dicts/listes d'entrée.
+
+> **Le déterminisme run-to-run est l'invariant dur.** C'est le critère qui a écarté les alternatives (voir §Alternatives rejetées) : toute variante dont la stabilité byte-à-byte serait non triviale à prouver est refusée.
+
+**Déterminisme désormais INCONDITIONNEL (revue adversariale #395 PR2a, fix MINOR).** La clé initiale `(priority, source_location, link_ref)` n'était une clé de tri **totale** qu'en pratique, pas par construction : `link_ref` est unique pour toute lane réellement chargée par le loader (il vient de `distribution_links.distribution_link_id`, une UUID PRIMARY KEY), mais un `TransferLink` construit à la main (tests, ou tout futur appelant) laissé à la valeur par défaut `""` peut entrer en collision avec un autre — à ce point, la clé n'était plus totale et l'issue retombait silencieusement sur l'ordre d'insertion, qui n'est pas un signal métier. Le fix ajoute un tie-break final sur les champs discriminants restants de la lane : la clé unique et partagée `_sort_key(link)` est désormais **`(priority, source_location, link_ref, max_qty, min_qty, transfer_multiple)`**, avec `max_qty=None` mappé à `+inf` (une lane non plafonnée trie après toute lane plafonnée à parité des champs précédents — choix arbitraire mais fixe, seule l'existence d'un ordre total déterministe compte, pas un sens particulier). Cette clé est désormais **la seule** utilisée aux trois sites où un ensemble de lanes candidates est ordonné (`_resolve_candidate_links`, la boucle interne de répartition fair-share, le tri de sortie de `transfer_signals`) — un seul endroit de définition, plus de dérive possible entre les trois. Deux lanes identiques sur **tous** ces champs sont désormais véritablement interchangeables : même sortie quel que soit l'ordre d'appel. Deux lanes différant sur un seul champ, aussi mineur soit-il, trient de façon déterministe par cette différence — jamais par accident de site d'appel.
+
+### 4. Interaction priorité × fair-share = **greedy ENTRE paliers, fair-share À priorité égale**
+
+Les lanes sont servies par palier de priorité **ascendant** ; le fair-share ne s'applique **qu'entre lanes de priorité égale**. Entre paliers, le comportement est **greedy** : un déficit qu'une lane p1 couvre voit son résiduel **rétrécir avant qu'aucune lane p2 ne soit même considérée**, et ce **globalement à travers toutes les sources** (c'est pourquoi la boucle externe est le palier de priorité, pas la source : c'est le seul ordre sous lequel toute lane p1, quelle que soit sa source, agit avant toute lane p2 — c'est le sens de « priorité » ici).
+
+L'interrupteur module `_FAIR_SHARE_RESPECTS_PRIORITY` (constante, **défaut `True`**) gouverne ce comportement. À `False`, tous les candidats s'effondrent en **un seul palier virtuel** : fair-share pur sur toutes les lanes, priorité **ignorée** pour la stratification (la priorité réelle de la lane reste émise sur le signal et reste dans la clé de tri de sortie). Le pilote peut basculer tout le comportement trivialement.
+
+> ### 🎯 Arbitrage métier OUVERT — ajustable par le pilote
+>
+> **Tension à documenter explicitement.** Le défaut (`True`) tue la famine entre dealers du **même palier** — c'est exactement le cas remonté par le pilote et ce que la V1 corrige. **Mais** un dealer sur une lane **basse-priorité** peut encore être servi **après** un dealer premium (greedy entre paliers) : le défaut n'élimine donc pas toute forme d'attente inter-palier, seulement la famine intra-palier.
+>
+> Si le pilote veut du **fair-share pur** — priorité entièrement ignorée, tous les dealers partagés au prorata quel que soit le palier — il bascule `_FAIR_SHARE_RESPECTS_PRIORITY` à `False`. Le choix entre « priorité respectée entre paliers » et « fair-share plat » est un **arbitrage métier ouvert**, laissé à la main du pilote, pas un invariant technique.
+
+### 5. Arrondi **INFÉRIEUR (floor) borné**, reliquat reversé — architecte
+
+Chaque part fair-share est arrondie **vers le bas** au multiple entier le plus proche, bornée par le besoin réel (`_fair_share_round`) :
+
+```python
+qty_brute = min(raw_part, avail, max_qty if not None)   # besoin borné
+qty       = floor(qty_brute / mult) * mult              # DESCENDANT
+```
+
+C'est une divergence **VOLONTAIRE** du `lot_size` MRP, qui fait `ceil` (`engine/mrp/core.py:34`, `math.ceil(qty / mult) * mult`). Justification : le **MRP fabrique / achète** — sur-commander pour atteindre un multiple est acceptable (on satisfait le besoin et on porte un petit surplus). Le **DRP DÉPLACE du stock fini** — sur-transférer **PRIVE la source** de stock qu'elle peut encore avoir besoin. Le floor est donc la borne conservatrice : on expédie des colis entiers, jamais plus que le besoin. Même idée « respecter un multiple », **sens d'arrondi opposé**, parce qu'un moteur crée de la supply et l'autre ne fait que la relocaliser — divergence assumée, pas une incohérence à réconcilier.
+
+Le **reliquat** de l'arrondi (`qty_brute - qty`) n'est **jamais consommé** : il reste dans l'excédent vivant de la source, disponible pour la destination suivante / le palier suivant (jamais perdu — c'est la propriété `rounding_remnant` portée sur chaque `TransferSignal`, preuve d'explicabilité ADR-004).
+
+Deux règles de bord, business defaults verrouillés mais **🎯 ajustables** :
+
+- **Sous le minimum de lane → 0.** Si la quantité arrondie est `< min_qty`, aucun transfert sur cette lane (règle minimum-shipment existante) : la lane ne peut physiquement pas expédier sous son minimum, et on ne gonfle jamais le besoin jusqu'à lui. Le déficit reste pour la lane suivante.
+- **Déficit résiduel dégénéré `< multiple` → 0.** Quand `qty_brute < mult`, le floor vaut déjà 0 : pas de micro-transfert d'un colis pour un besoin sous le colis — couvert par le floor lui-même, sans cas spécial.
+
+### 6. Passe de balayage du reliquat (« remnant sweep ») — architecte, revue adversariale #395 PR2a (fix MAJOR)
+
+**Défaut découvert :** le fair-share proportionnel **seul** (points 1+5 ci-dessus, sans ce point 6) peut bloquer un excédent entier à zéro alors qu'il pourrait servir quelqu'un. Exemple qui casse la répartition proportionnelle nue : excès de la source = 12, `transfer_multiple` = 12, **deux** destinations de même palier chacune en déficit de 20. La part idéale proportionnelle est 6/6 ; `_fair_share_round` arrondit **chacune** des deux parts à 0 (une demi-palette ne tient pas) → **aucune des deux destinations n'est servie**, et les 12 unités d'excédent réel restent inertes. C'est **strictement pire** que l'ancien greedy dest-first, qui aurait au moins expédié une palette entière à la première destination rencontrée — et une violation directe de l'intention anti-famine du fair-share (une source rare ne doit jamais finir par ne servir **personne** alors qu'au moins un multiple entier est expédiable à **quelqu'un**).
+
+**Correction :** après la passe de répartition proportionnelle d'une source à un palier donné (points 1+5), une **passe de balayage** répète : tant que l'excédent vivant de la source peut encore expédier **≥ 1 multiple entier** à une destination de ce palier dont le résiduel est `> 0`, servir la destination **la plus nécessiteuse** — résiduel restant le plus grand, tie-break `dest_location` alphabétique — avec la plus grande quantité de multiple entier qui tient (`floor(min(résiduel, excédent, max_qty restant) / multiple) * multiple`), essayée lane par lane dans l'ordre `_sort_key`. Une destination qu'aucune de ses lanes ne peut servir (bloquée par `min_qty`, un `max_qty` restant épuisé, ou un résiduel réellement `< 1` multiple) est marquée **épuisée pour ce (source, palier)** et n'est jamais retentée — l'excédent vivant ne fait que décroître pendant le balayage, donc une destination non servable maintenant ne peut jamais le redevenir plus tard dans le même balayage (borne la boucle : chaque itération soit expédie un multiple, soit épuise définitivement une destination — deux quantités strictement décroissantes et finies).
+
+> ### 🎯 Arbitrage métier OUVERT — ajustable par le pilote
+>
+> **« Le plus nécessiteux d'abord » n'est PAS le seul choix défendable.** V1 sert la destination au plus grand résiduel restant en premier — c'est le correctif anti-famine le plus conservateur (servir en priorité celui qui est le plus loin d'être couvert). L'alternative explicite et tout aussi défendable est le **ROUND-ROBIN** entre destinations à égalité : étaler les palettes disponibles entre les dealers plutôt que concentrer chaque palette entière sur le seul dealer le plus en manque. Le choix entre « le plus nécessiteux d'abord » et « round-robin » est un **arbitrage métier ouvert** — le pilote tranchera ; ce n'est pas un invariant technique, et une future révision peut rendre ce choix aussi trivialement bascule-able que l'interrupteur du point 4.
+
+`transfer_multiple` = 1 (le défaut) n'est **jamais affecté en pratique** par cette passe : la répartition proportionnelle couvre déjà tout résiduel jusqu'à l'unité entière, donc il ne reste jamais de multiple entier non tiré à trouver — la boucle de balayage ne trouve rien à faire et sort immédiatement.
+
+## Alternatives rejetées
+
+- **Greedy priorisé dest-first (l'existant).** Rejeté par le pilote : traduit une préférence de sourcing en exclusivité de sourcing → **famine des dealers B**. C'est la motivation même de #395 PR2a.
+- **(b) Water-filling global.** Rejeté : convergence **non triviale à prouver byte-stable** run-to-run — l'invariant dur (§Décision point 3) exclut toute variante dont on ne peut garantir trivialement la stabilité byte-à-byte. Sur-ingénierie pour une démo.
+- **(c) Deux passes (allocation continue puis passe d'arrondi séparée).** Rejeté : complexité **reliquat × arrondi** — deux couches de résiduel à réconcilier, alors que l'option (a) traite l'arrondi et le report du reliquat dans la même passe source-first.
+- **Arrondi supérieur (`ceil`, aligné sur le `lot_size` MRP).** Rejeté : sur-transférerait du stock fini et **priverait la source** (violation de l'invariant de conservation) — le MRP peut sur-commander parce qu'il crée de la supply, le DRP ne le peut pas parce qu'il la déplace (§Décision point 5).
+- **Priorité entièrement ignorée par défaut (fair-share plat).** Non rejeté sur le principe — c'est précisément l'autre position de l'interrupteur `_FAIR_SHARE_RESPECTS_PRIORITY`. Le **défaut** est « priorité respectée entre paliers » ; le fair-share plat reste à un flip du pilote (§Décision point 4, encart 🎯).
+
+## Conséquences
+
+- **Positif :** la famine des dealers du même palier est éliminée ; les transferts respectent une granularité logistique par lane sans jamais sur-transférer ; le plan reste déterministe et explicable (chaque signal porte `deficit_qty`, `source_excess_before`, `fair_share_qty`, `rounding_remnant`).
+
+- **Invariants garantis (à vérifier en test — voir §Suite / test-writer #395 PR2a) :**
+
+  | Invariant | Énoncé |
+  |---|---|
+  | Conservation source | Σ des quantités sortant d'une source ≤ son excédent |
+  | Conservation dest | Σ des quantités reçues par une destination ≤ son déficit |
+  | Déterminisme total | plan byte-stable run-to-run, indépendant de l'ordre d'insertion des entrées |
+  | Anti-blocage palette | aucune palette (multiple) entière d'excédent ne reste bloquée tant qu'une destination reliée peut la recevoir — corrigé par la passe de balayage (point 6) |
+  | `min_qty` préservé | aucun transfert sous le minimum de lane ; une quantité arrondie `< min_qty` → 0 |
+  | Cœur DB-free | `core.py` reste pur, sans I/O ; le chargement DB vit dans `loader.py` (SELECT-only) |
+
+  **⚠ L'invariant « anti-blocage palette » n'est PAS « toute destination reçoit `> 0` ».** Cette formulation plus forte est **mathématiquement inatteignable** sous arrondi palette dès qu'une source ne peut expédier qu'**un seul** multiple entier à **plusieurs** destinations en déficit du même palier (excès=12, multiple=12, deux destinations : une seule palette tient, donc l'une des deux reçoit forcément 0 — on ne coupe pas une palette). L'invariant réellement garanti est plus précis et plus vrai : **aucun multiple entier expédiable à SOMEONE ne reste inerte dans l'excédent d'une source** — c'est-à-dire que si la source peut expédier ≥ 1 multiple entier à une destination dont le résiduel est ≥ ce multiple, ce transfert **est émis**, sur SOMEONE (le point 6). Sans la passe de balayage (fair-share proportionnel **seul**, points 1+5), une part fractionnaire peut être rognée sous le multiple pour **chaque** destination du palier simultanément (0,5 palette chacune, dans l'exemple 12/12/deux-dests) → **zéro transfert émis du tout**, un résultat strictement pire que l'ancien greedy dest-first (qui aurait au moins servi la première destination). La passe de balayage (point 6) est ce qui restaure l'anti-famine réelle après le fair-share proportionnel.
+
+- **Négatif / dette assumée en V1 :**
+  - La passe de balayage (point 6) ajoute une boucle et un état (`shipped_by_link` par identité de lane, `exhausted_dests`) au-dessus de la passe proportionnelle simple — complexité assumée pour fermer un vrai trou anti-famine (0/0 sur toutes les destinations d'un palier), pas une fonctionnalité de confort.
+  - Le choix « le plus nécessiteux d'abord » dans la passe de balayage reste un **arbitrage métier ouvert** (round-robin est l'alternative défendable) — encart 🎯 du point 6.
+  - Le défaut `_FAIR_SHARE_RESPECTS_PRIORITY=True` n'élimine pas l'attente inter-palier (un dealer basse-priorité peut être servi après un dealer premium) — **arbitrage métier ouvert**, à la main du pilote (encart 🎯).
+  - **Single-hop uniquement** : un déficit est servi directement depuis l'excédent d'une source reliée, jamais relayé (source → hub → dest hors scope).
+  - **Excédent = test horizon-total**, pas time-phased : borne basse sûre de ce qu'une source peut céder ; un excédent transitoire en début d'horizon qu'elle consomme plus tard n'est pas offert. Raffinement PR2+.
+  - **Demande nette = `max(orders, forecast)` par bucket** : la fenêtre de consommation de prévision #349 (backward-before-forward, cross-bucket) est de la machinerie item-level dans `mrp/core.consume_demand` ; une variante per-location est un raffinement PR2+ délibérément non réimplémenté (`window==0` reproduit exactement la sémantique golden-master `max`).
+  - Pas d'émission `StreamChanges` au niveau du cœur — cohérent avec le reste du chemin de calcul (le cœur est pur) ; l'émission gouvernée arrive avec PR2b.
+
+- **Reste à faire :** voir §Suite. Cet ADR ne sera référençable comme « chantier #395 clos » qu'une fois PR2b mergée.
+
+## Suite (hors scope PR2a)
+
+- **PR2b :** recommandations **TRANSFER gouvernées L1** (canal `recommendations`, machine d'états #341, jamais une table de faits non-gouvernée — même principe qu'ADR-021/ADR-026) + **watcher scenario-backed** (fork contre-factuel, à l'image de #340) + endpoint **`POST /v1/drp/run`** + **seed démo** DRP + `agent_governance` action **TRANSFER** (`decision_level`) + **CHECK vocabulaire** de l'action. Aucun de ces éléments n'existe encore — la PR2a livre uniquement le cœur math + la colonne.
+- **ADR-020 « per-site → DRP → central » :** cet ADR-028 est une **brique** de la cascade à deux échelons décidée en ADR-020 §Unité de planification (DRP per-site → MRP central, même maths de netting sur des arcs de graphe différents). La dépendance amont d'ADR-020 tient : la fusion utile suppose que Pyramide livre la demande **per-site** ; tant que la demande pilote est mono-location, l'échelon DRP tourne à vide.
+
+## Références
+
+- **#395** — chantier DRP fair-share (PR2a : cœur + migration 065).
+- **Décision pilote du 2026-07-06** — fair-share proportionnel (anti-famine dealers B) + arrondi à un multiple logistique configurable.
+- `src/ootils_core/engine/drp/core.py` — cœur pur : `transfer_signals`, `projected_deficits`, `excess_by_location`, `_fair_share_round`, `_resolve_candidate_links`, `_FAIR_SHARE_RESPECTS_PRIORITY`, dataclasses `TransferLink` / `TransferSignal`.
+- `src/ootils_core/engine/drp/loader.py` — chargement SELECT-only, scenario-parameterized (safety stock overlay-resolved #347) → `DRPData`.
+- `src/ootils_core/db/migrations/065_distribution_links_transfer_multiple.sql` — `distribution_links.transfer_multiple` (`NUMERIC(18,6)`, `CHECK > 0`, DEFAULT 1).
+- `src/ootils_core/db/migrations/029_drp_models.sql` — table `distribution_links` d'origine.
+- `src/ootils_core/engine/mrp/core.py:34` — `lot_size` (`math.ceil`), le **contraste** revendiqué du sens d'arrondi (MRP crée de la supply → `ceil` ; DRP la déplace → `floor`).
+- `docs/ADR-020-mrp-consolidation.md` — §Unité de planification (per-site → DRP → central) dont ceci est une brique.
+- `docs/ADR-021-shortage-truth.md`, `docs/ADR-026-reschedule-fpo.md` — précédents « les watchers émettent des DRAFT gouvernés, jamais dans une table de faits non-gouvernée » (à appliquer en PR2b).

--- a/src/ootils_core/db/migrations/065_distribution_links_transfer_multiple.sql
+++ b/src/ootils_core/db/migrations/065_distribution_links_transfer_multiple.sql
@@ -1,0 +1,84 @@
+-- ============================================================
+-- Migration 065 — distribution_links.transfer_multiple (DRP fair-share, #395 PR2a)
+-- ============================================================
+-- Chantier #395 DRP fair-share. ADR-028 (à venir): "DRP transfer rounding —
+-- a per-lane logistics shipment multiple, rounded DOWN".
+--
+-- WHAT: one additive, typed column on distribution_links (migration 029) —
+-- transfer_multiple, the logistics shipment multiple of a lane (case /
+-- pallet / full-truck unit). The pilot has decided replenishment transfers
+-- must respect a per-lane logistical rounding: you ship whole cases, not
+-- fractional units. DEFAULT 1 means "no rounding", so every existing lane
+-- keeps its current continuous behaviour untouched (rolling-deploy safe,
+-- fully backward-compatible) until an operator sets a real multiple.
+--
+-- WHY ROUNDED DOWN (the load-bearing semantic, and a DELIBERATE divergence
+-- from MRP lot sizing): DRP MOVES already-finished stock between locations;
+-- it does not create it. Rounding a transfer UP would ship MORE finished
+-- goods downstream than the true net requirement — starving the source
+-- location and over-committing physical inventory it may still need. So the
+-- DRP rounding is the CONSERVATIVE floor: round the transfer DOWN to the
+-- nearest whole multiple (bounded by what is actually needed), never up.
+-- This is intentionally OPPOSITE to MRP lot sizing (engine/mrp/lot_sizing),
+-- where lot_size does a CEIL: MRP MAKES or BUYS supply, so rounding a
+-- production/purchase order UP to a lot multiple is correct (you satisfy the
+-- need and carry a little extra). Same "respect a multiple" idea, opposite
+-- rounding direction, because one engine creates supply and the other only
+-- relocates it. This divergence is assumed and documented (ADR-028), not an
+-- inconsistency to reconcile with lot_size.
+--
+-- TYPING: NUMERIC(18,6), matching every other quantity on distribution_links
+-- (minimum_shipment_qty, maximum_shipment_qty, transit_cost_per_unit/fixed
+-- are all NUMERIC(18,6) in migration 029) — no FLOAT/REAL on a quantity.
+-- CHECK (transfer_multiple > 0): a multiple must be strictly positive (a
+-- zero or negative "case size" is meaningless and would make the DOWN-round
+-- ill-defined / divide-by-zero). Strictly > 0, not >= 0, unlike the
+-- migration-029 minimum_shipment_qty >= 0 (a zero MINIMUM is a legitimate
+-- "no floor"; a zero MULTIPLE is not a legitimate "no rounding" — that is
+-- what DEFAULT 1 expresses).
+--
+-- Idempotence (repo migration policy — the runner in db/connection.py wraps
+-- each file in its own transaction and, on ANY error, ROLLS BACK and ABORTS;
+-- it does NOT swallow "already exists"): every statement re-runs as a clean
+-- no-op.
+--   * ADD COLUMN IF NOT EXISTS          — skips the column on re-run.
+--   * DROP CONSTRAINT IF EXISTS + ADD   — deterministic re-create; the only
+--     replay-safe way to (re)assert a named CHECK, since PG has no CREATE OR
+--     REPLACE / ALTER for a CHECK constraint (matching migrations 061/064).
+-- The constraint is added out-of-line with an explicit canonical name
+-- (distribution_links_transfer_multiple_check) precisely so DROP IF EXISTS +
+-- ADD is name-deterministic on replay.
+--
+-- No index: transfer_multiple is a per-lane parameter read alongside the
+-- lane row, never a filter/join predicate.
+-- No JSONB. Typed column only.
+--
+-- ref: ADR-028 (DRP transfer rounding), #395 PR2a.
+-- ============================================================
+
+BEGIN;
+
+-- ------------------------------------------------------------
+-- Per-lane logistics shipment multiple (rounded DOWN by the DRP planner)
+-- ------------------------------------------------------------
+ALTER TABLE distribution_links
+    ADD COLUMN IF NOT EXISTS transfer_multiple NUMERIC(18,6) NOT NULL DEFAULT 1;
+
+-- Named, out-of-line CHECK asserted idempotently (DROP IF EXISTS + ADD) so a
+-- partial-then-replayed migration re-creates it deterministically.
+ALTER TABLE distribution_links
+    DROP CONSTRAINT IF EXISTS distribution_links_transfer_multiple_check;
+ALTER TABLE distribution_links
+    ADD CONSTRAINT distribution_links_transfer_multiple_check
+    CHECK (transfer_multiple > 0);
+
+COMMENT ON COLUMN distribution_links.transfer_multiple IS
+    'Logistics shipment multiple of this lane — case/pallet size in item '
+    'units (#395 PR2a, ADR-028). The DRP planner rounds each transfer DOWN '
+    'to the nearest whole multiple, bounded by the true net requirement: '
+    'DRP MOVES finished stock, so it stays conservative and never '
+    'over-transfers (deliberately the OPPOSITE of MRP lot_size, which CEILs '
+    'because MRP creates supply). 1 (default) = no rounding, continuous '
+    'transfers. Must be > 0.';
+
+COMMIT;

--- a/src/ootils_core/engine/drp/core.py
+++ b/src/ootils_core/engine/drp/core.py
@@ -13,10 +13,47 @@ coordinate against another location's excess.
 SCOPE — V1 (checkpoint pilote, business defaults LOCKED):
   * Single-hop transfers only. Multi-hop (source -> hub -> dest) is OUT of scope
     — a deficit is served directly from a linked source's excess, never relayed.
-  * Greedy priority allocation, NOT fair-share and NOT network optimisation: a
-    source's excess is consumed link-by-link in (priority, source) order; the
-    first eligible destinations drain it. Fair-share splitting of a scarce
-    source across competing destinations is a PR2+ refinement.
+  * FAIR-SHARE proportional allocation (#395 PR2a, ADR-028), NOT the earlier
+    dest-first greedy and NOT network optimisation. A scarce source is split
+    PROPORTIONALLY across the destinations it feeds instead of the first
+    destination draining it (which starved its peers). The rule, in one place:
+      - SOURCE-FIRST, priority-stratified. The outer loop is the PRIORITY level
+        (ascending), then within a level the SOURCES in the fixed total order
+        (priority_min of the source, source_location, item), each source
+        splitting its remaining excess across the destinations it serves AT
+        THAT level. Destinations are the inner dimension — the opposite of the
+        old dest-first drain.
+      - Proportional to RESIDUAL deficits: for one source at one level,
+        part_dest = avail_source * (residual_deficit_dest / Σ residual_deficits)
+        over the destinations it serves at that level whose residual is still
+        > 0. avail_source is snapshotted at the start of the level so the split
+        stays a true proportion (Σ of the ideal parts == the snapshot); the
+        live counter is what is actually decremented, so no rounding/residual
+        slack is ever over-drawn.
+      - Priority x fair-share interaction: served by ASCENDING priority level,
+        fair-share only AMONG lanes of EQUAL priority, greedy BETWEEN levels — a
+        deficit a p1 lane covers is reduced (its residual shrinks) BEFORE any p2
+        lane is even considered, GLOBALLY across sources, not just within one
+        source. That is why the priority level, not the source, is the outer
+        loop: it is the only ordering under which every p1 lane (any source)
+        acts before any p2 lane, which is what "priority" means here.
+      - Switch _FAIR_SHARE_RESPECTS_PRIORITY (module constant, default True,
+        🎯 pilot-adjustable): False collapses every candidate into ONE virtual
+        level — pure fair-share across all lanes, priority ignored. The pilot
+        can flip the whole behaviour trivially.
+  * LOGISTICS ROUNDING — rounded DOWN, remnant returned (#395 PR2a, ADR-028).
+    Each lane carries a transfer_multiple (case/pallet unit, migration 065,
+    DEFAULT 1 == no rounding). The transferred qty is FLOORED to the nearest
+    whole multiple, bounded by the true need: qty = floor(min(part, avail,
+    max_qty) / mult) * mult. This is a DELIBERATE divergence from MRP lot
+    sizing (mrp/lot_sizing CEILs): the DRP MOVES finished stock, so
+    over-transferring would strip the source — the conservative floor never
+    ships more than needed. The DOWN-round remnant (qty_brute - qty_rounded) is
+    NOT consumed: it stays in avail_source, available to the next destination /
+    the next level (no remnant is ever lost). A rounded qty below the lane's
+    min_qty yields 0 on that lane (the existing minimum-shipment rule, fall
+    through to the next lane); a residual smaller than one multiple therefore
+    also yields 0 (no micro-transfer). See _fair_share_round.
   * Net demand per (item, location) per bucket = simple max(orders, forecast)
     (see projected_deficits / DRPData construction in loader.py). The per-item
     forecast-consumption WINDOW of #349 (backward-before-forward cross-bucket
@@ -25,11 +62,15 @@ SCOPE — V1 (checkpoint pilote, business defaults LOCKED):
     reimplemented here. window==0 is exactly the golden-master max semantics.
 
 Determinism: every public function returns results in a fully sorted order and
-never relies on dict iteration order. Ties in link selection resolve by
-(priority, source_location) so the plan is reproducible run-to-run.
+never relies on dict iteration order. The fair-share PROCESSING order (priority
+level, then sources by (priority_min, source_location, item), then destinations
+sorted) is fully figé; the OUTPUT sort key is unchanged (item, dest_location,
+deficit_bucket, priority, source_location, link_ref) so the emitted plan is
+byte-stable run-to-run and independent of input dict/list insertion order.
 """
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 
@@ -50,8 +91,8 @@ class TransferLink:
     lane.
 
     link_ref is a stable per-row discriminant (the loader populates it from
-    distribution_links.distribution_link_id, stringified) used ONLY as a final,
-    last-resort determinism tie-break (#395 F6) when two link rows are
+    distribution_links.distribution_link_id, stringified) used as a
+    near-last-resort determinism tie-break (#395 F6) when two link rows are
     otherwise identical for sorting purposes — same source, same dest, same
     priority (e.g. two genuinely duplicate lanes on the same pair at the same
     priority). Without it, such a tie would be broken by physical scan/list
@@ -60,12 +101,34 @@ class TransferLink:
     row identity, e.g. a hand-built test link) still participates in the sort
     key like any other value; it does not special-case anything.
 
-    Field order/default matter for BOTH new fields: item and link_ref are
-    appended LAST, each with a default, specifically so every pre-existing
-    6-positional-argument construction site (TransferLink(source, dest,
-    lead_buckets, min_qty, max_qty, priority)) keeps working unchanged and
-    resolves to a generic (item=None) lane with no ref — backward compatible
-    by construction, not by convention.
+    link_ref alone is NOT always sufficient (#395 PR2a review, MINOR fix):
+    since the loader populates it from distribution_link_id (a UUID PRIMARY
+    KEY), two REAL rows can never share one, but two HAND-BUILT links (tests,
+    or any future caller) both left at the "" default DO collide on link_ref —
+    at that point the previous sort key (priority, source_location, link_ref)
+    was no longer a TOTAL order, and the outcome silently fell back to input
+    insertion order. _sort_key (below) closes that gap with a further
+    tie-break on the lane's remaining discriminating fields (max_qty, min_qty,
+    transfer_multiple), so the order is a total order UNCONDITIONALLY: two
+    links equal on every field are truly interchangeable (identical output
+    whichever the caller passes first); two links differing in ANY field sort
+    deterministically by that difference, never by call-site accident.
+
+    transfer_multiple is the lane's logistics shipment multiple (case / pallet
+    unit, distribution_links.transfer_multiple, migration 065). The planner
+    rounds each transfer DOWN to a whole multiple of it (see _fair_share_round /
+    the module §SCOPE). DEFAULT 1.0 == no rounding (continuous transfers), so a
+    lane that predates the column, or a hand-built test link, keeps the exact
+    pre-rounding behaviour. Must be > 0 (enforced by the DB CHECK; the core
+    divides by it).
+
+    Field order/default matter for ALL appended fields: item, link_ref and
+    transfer_multiple are appended LAST, each with a default, specifically so
+    every pre-existing 6-positional-argument construction site
+    (TransferLink(source, dest, lead_buckets, min_qty, max_qty, priority)) keeps
+    working unchanged and resolves to a generic (item=None) lane with no ref and
+    a unit (1.0) multiple — backward compatible by construction, not by
+    convention.
     """
 
     source_location: str
@@ -76,6 +139,36 @@ class TransferLink:
     priority: int
     item: str | None = None
     link_ref: str = ""
+    transfer_multiple: float = 1.0
+
+
+def _sort_key(
+    link: TransferLink,
+) -> tuple[int, str, str, float, float, float]:
+    """The lane sort key used EVERYWHERE a set of candidate lanes is ordered
+    (_resolve_candidate_links, the fair-share destination-lane loop, and the
+    final output sort in transfer_signals) — ONE definition so the three sites
+    can never silently drift apart (#395 PR2a review, MINOR fix).
+
+    (priority, source_location, link_ref, max_qty, min_qty, transfer_multiple)
+    — a TOTAL order UNCONDITIONALLY, not just "in practice" (see TransferLink's
+    link_ref docstring for why link_ref alone is not always enough). max_qty is
+    Optional (None == uncapped); mapped to +inf so an uncapped lane sorts AFTER
+    every capped one at the same (priority, source, link_ref) — an arbitrary but
+    fixed choice (the only requirement is a total, deterministic order, not a
+    specific direction). Two links equal on every one of these fields ARE truly
+    interchangeable: this key can never distinguish them, and the caller's own
+    stable sort then preserves whichever input order it saw for that pair —
+    which is fine, because by construction they are identical lanes.
+    """
+    return (
+        link.priority,
+        link.source_location,
+        link.link_ref,
+        link.max_qty if link.max_qty is not None else float("inf"),
+        link.min_qty,
+        link.transfer_multiple,
+    )
 
 
 @dataclass(frozen=True)
@@ -89,6 +182,35 @@ class TransferSignal:
     STILL emitted — that is the honest state of the plan (the transfer is the
     best available action even though it lands late); a consumer reads
     arrival_bucket > deficit_bucket as "covered late". Never silently dropped.
+
+    qty is the FINAL transferred quantity — floored to the lane's
+    transfer_multiple (#395 PR2a). fair_share_qty and rounding_remnant are the
+    fair-share/rounding evidence (explainability, ADR-004), computed IDENTICALLY
+    by _fair_share_round whichever of the two draws below produced the signal
+    (the field's MEANING is the bounded pre-round quantity either way — only
+    the source of `raw_part` differs, not the formula):
+      * fair_share_qty     = the qty BEFORE the logistics down-round, i.e.
+                             min(raw_part, remaining source excess, remaining
+                             max_qty). On a PROPORTIONAL draw (the main pass),
+                             raw_part is this lane's proportional part
+                             (part_dest, capped by the destination's residual).
+                             On a REMNANT-SWEEP draw (#395 PR2a review, MAJOR
+                             fix — see transfer_signals), raw_part is instead
+                             the destination's full remaining residual: the
+                             sweep is not proportional (it targets ONE neediest
+                             destination with whatever the source has left), so
+                             there is no "ideal share" to report — the bounded
+                             need IS the closest analogue, and is what this
+                             field carries for a sweep draw.
+      * rounding_remnant   = fair_share_qty - qty, the sliver the down-round
+                             shaved off (0 whenever transfer_multiple divides
+                             fair_share_qty exactly, always true for the
+                             DEFAULT multiple 1.0). NOT lost: it stays in the
+                             source excess, offered to the next destination /
+                             next priority level / the next sweep iteration.
+    Both are required (TransferSignal is constructed ONLY in this module, so
+    there is no backward-compatibility default to preserve — every construction
+    site sets them).
     """
 
     item: str
@@ -100,6 +222,8 @@ class TransferSignal:
     deficit_bucket: int
     deficit_qty: float
     source_excess_before: float
+    fair_share_qty: float
+    rounding_remnant: float
 
 
 def _projected_deficit_for_coord(
@@ -245,12 +369,12 @@ def _resolve_candidate_links(
         higher-priority one). Lane-duplicate hygiene is a data-quality
         concern, not something this pure function arbitrates.
       * Same-specificity duplicates are therefore ALL kept as candidates and
-        served SEQUENTIALLY by the existing deterministic order (priority ASC,
-        source_location, link_ref — see below): the determinism guarantee
-        (#395 F6) comes from that STABLE ordering, not from evicting one of
-        them. A caller draining a deficit against two same-priority same-pair
-        lanes (one capped, one uncapped) drains the FIRST in that order up to
-        its cap, then falls through to the next.
+        served SEQUENTIALLY by the existing deterministic order (_sort_key —
+        see below): the determinism guarantee (#395 F6) comes from that STABLE
+        ordering, not from evicting one of them. A caller draining a deficit
+        against two same-priority same-pair lanes (one capped, one uncapped)
+        drains the FIRST in that order up to its cap, then falls through to
+        the next.
 
     This refinement-only contract is a business default, documented and
     🎯-adjustable — a future revision could add real dedup of TRUE duplicate
@@ -262,10 +386,12 @@ def _resolve_candidate_links(
     Implementation: partition item-eligible links by (source, dest) pair; a
     pair keeps ONLY its item-specific links if it has at least one, otherwise
     ONLY its generic links — no link-vs-link comparison, no per-pair single
-    winner. Flatten and sort ONCE (priority ASC, source_location, link_ref) —
-    the existing determinism contract, with link_ref (#395 F6) as the final
-    tie-break for two rows that would otherwise compare equal (same source
-    into the same dest at the same priority).
+    winner. Flatten and sort ONCE by _sort_key — the existing determinism
+    contract, TOTAL and unconditional (#395 PR2a review): link_ref (#395 F6) is
+    the first tie-break for two rows that would otherwise compare equal (same
+    source into the same dest at the same priority), and max_qty/min_qty/
+    transfer_multiple close the (rare, hand-built-only) residual tie when
+    link_ref ALSO collides.
     """
     eligible = [lk for lk in dest_links if lk.item is None or lk.item == item]
 
@@ -283,7 +409,67 @@ def _resolve_candidate_links(
     for specifics in specific_by_pair.values():
         resolved.extend(specifics)
 
-    return sorted(resolved, key=lambda lk: (lk.priority, lk.source_location, lk.link_ref))
+    return sorted(resolved, key=_sort_key)
+
+
+# Priority x fair-share interaction switch (#395 PR2a) — 🎯 pilot-adjustable.
+# True (default): serve by ASCENDING priority level, fair-share only among lanes
+# of EQUAL priority, greedy BETWEEN levels (a p1 lane's coverage shrinks the
+# residual deficit before any p2 lane is considered, globally across sources).
+# False: collapse every candidate lane into ONE virtual level — pure fair-share
+# across all lanes regardless of priority. The pilot can flip this trivially to
+# compare "priority-respecting fair-share" against "flat fair-share". See the
+# module §SCOPE.
+_FAIR_SHARE_RESPECTS_PRIORITY: bool = True
+
+
+def _fair_share_round(
+    raw_part: float,
+    mult: float,
+    min_qty: float,
+    max_qty: float | None,
+    avail: float,
+) -> float:
+    """Logistics down-rounding of one fair-share allocation (#395 PR2a, ADR-028).
+
+    PURE, no side effects. Computes the FINAL transferable quantity on one lane
+    from the proportional part it was allocated, the lane's shipment multiple,
+    its min/max shipment bounds, and the source's remaining excess:
+
+      qty_brute = min(raw_part, avail, max_qty if not None)   # bounded need
+      qty       = floor(qty_brute / mult) * mult              # DOWN to a whole
+                                                              # multiple
+
+    raw_part is expected to already be bounded by the destination's residual
+    deficit by the caller, so qty never exceeds what the destination is short.
+
+    Rules (all business defaults, LOCKED but 🎯-adjustable):
+      * DOWN-round, never up (deliberately OPPOSITE to MRP lot_size's CEIL): the
+        DRP MOVES finished stock, so over-transferring would strip the source.
+        The floor is the conservative bound — ship whole cases, never more than
+        needed. The remnant (qty_brute - qty) is the caller's to keep in
+        avail_source (this function does not decrement anything).
+      * Below the lane minimum -> 0. If the rounded qty is < min_qty, emit
+        nothing on this lane (the existing minimum-shipment rule): the lane
+        physically cannot ship below its minimum, and we never inflate the need
+        up to it. The caller falls through to the next lane.
+      * Degenerate residual < one multiple -> 0. When qty_brute < mult the floor
+        is already 0 (no partial-multiple micro-transfer), so a residual smaller
+        than one case size yields no signal — covered by the floor itself, no
+        special case.
+
+    Returns the final qty (>= 0), a whole multiple of mult, or 0.0 when the lane
+    is blocked by the minimum or there is less than one multiple to ship.
+    """
+    qty_brute = min(raw_part, avail)
+    if max_qty is not None:
+        qty_brute = min(qty_brute, max_qty)
+    if qty_brute <= 0:
+        return 0.0
+    qty = math.floor(qty_brute / mult) * mult
+    if qty < min_qty:
+        return 0.0
+    return qty
 
 
 def transfer_signals(
@@ -295,32 +481,78 @@ def transfer_signals(
 ) -> list[TransferSignal]:
     """Canonical DRP transfer signal generation. PURE, DB-free, deterministic.
 
-    For every (item, destination) coordinate in deficit (see projected_deficits),
-    source the deficit from linked locations' distributable excess (see
-    excess_by_location), greedily by link priority:
+    FAIR-SHARE, source-first, priority-stratified, down-rounded, with a
+    remnant-sweep pass (#395 PR2a, ADR-028). Full rationale in the module
+    §SCOPE; the algorithm here:
 
-      * Candidate links for a destination = active links whose dest_location is
-        that coordinate's location, scoped to links generic (item is None) OR
-        specific to that coordinate's item, resolved by specificity-refinement
-        per (source, dest) pair (see _resolve_candidate_links — a specific
-        lane replaces every generic on its OWN pair; same-specificity
-        duplicates are NEVER evicted against each other, both stay candidates)
-        — and whose source_location holds excess of the SAME item — sorted
-        (priority ASC, source_location, link_ref) for determinism.
-      * qty = min(remaining deficit, remaining source excess, link.max_qty if
-        not None).
-      * MINIMUM-SHIPMENT RULE (business default, LOCKED but adjustable): if the
-        computed qty is below link.min_qty, NO signal is emitted on that link.
-        The deficit is neither inflated up to the minimum (we do not ship stock
-        the destination does not need just to clear a lane minimum) nor served
-        below the minimum (the lane physically cannot). The remaining deficit
-        then falls through to the next-priority link. A deficit that no link can
-        satisfy at or above its minimum is left uncovered (no signal) — honest.
-      * GREEDY SHARED EXCESS: each source coordinate's excess is a single running
-        counter decremented as links draw on it, so one unit of excess never
-        funds two destinations (same shared-counter discipline as remaining_fc
-        in mrp/core #349). Sources are drawn in the order destinations are
-        processed (sorted, below), which makes the allocation reproducible.
+      1. Compute per-(item, dest) deficits (projected_deficits) and per-(item,
+         source) distributable excess (excess_by_location).
+      2. Resolve, per (item, dest) in deficit, the candidate lanes via
+         _resolve_candidate_links (item scoping + specificity-refinement dedup,
+         unchanged) — then INVERT that into a source-keyed index: for each
+         (item, source) coordinate, the lanes leaving it toward destinations in
+         deficit. priority_min(source) = the lowest lane priority leaving it.
+      3. Walk PRIORITY LEVELS ascending (one virtual level for all lanes when
+         _FAIR_SHARE_RESPECTS_PRIORITY is False). At each level, walk the
+         SOURCES active at that level in the fixed total order (priority_min,
+         source_location, item). Each source SPLITS its remaining excess across
+         the destinations it serves at that level, PROPORTIONALLY to their
+         RESIDUAL deficits:
+             part_dest = avail_snapshot * (residual_dest / Σ residual_dests)
+         avail_snapshot is the source's excess at the START of this level, so
+         the split is a true proportion; the live excess counter is what is
+         decremented, so rounding/residual slack is never over-drawn.
+      4. Distribute each destination's part across its lanes from this source at
+         this level (sorted by _sort_key for determinism when duplicated),
+         DOWN-rounding each to the lane's transfer_multiple via _fair_share_round
+         (bounded by max_qty and remaining excess). A rounded qty below the
+         lane's min_qty emits nothing and falls through to the next lane / next
+         level (minimum-shipment rule, preserved). The down-round remnant stays
+         in the live excess (returned, never lost).
+      5. REMNANT SWEEP (#395 PR2a review, MAJOR fix). The proportional split in
+         step 4 can leave a source's live excess UNDRAWN even though it could
+         still ship a full multiple: e.g. excess=12, transfer_multiple=12, TWO
+         same-level destinations both short 20 — the proportional ideal splits
+         12 into 6/6, and _fair_share_round floors BOTH to 0 (0.5 of a pallet
+         rounds to nothing), so NEITHER destination is served and the 12 units
+         sit idle — WORSE than the old dest-first greedy, which would have
+         shipped one full pallet to whichever destination it reached first, and
+         a violation of the anti-starvation intent of fair-share (a scarce
+         source should never end up serving NOBODY when at least one whole
+         multiple is shippable to SOMEBODY). After the proportional pass for
+         THIS (source, level), sweep: while the source's live excess can still
+         ship >= 1 whole multiple to some destination with residual > 0 at this
+         level, serve the MOST NEEDY destination (largest remaining residual;
+         ties broken by the same deterministic destination order used above,
+         i.e. dest_location) with the largest whole-multiple quantity that
+         fits: qty = floor(min(residual, avail, remaining max_qty) / mult) *
+         mult, tried lane-by-lane in _sort_key order (falling through past a
+         lane whose remaining max_qty or min_qty blocks it, exactly like the
+         proportional pass). "Most needy first" is a 🎯-adjustable business
+         default (round-robin across tied destinations is an equally
+         defensible alternative that spreads pallets instead of concentrating
+         them — see the inline comment at the sweep loop). A destination that
+         cannot receive a whole multiple from ANY of its lanes (blocked by
+         min_qty, remaining max_qty, or genuinely < 1 multiple of residual) is
+         marked exhausted for this (source, level) and never retried — since
+         the source's live excess only ever DECREASES within the sweep, a
+         destination that cannot be served now can never become servable later
+         in the same sweep, which bounds the loop (each iteration either ships
+         a multiple or permanently exhausts a destination — both are
+         strictly-decreasing, finite quantities). A remaining max_qty is
+         tracked PER LANE OBJECT (by identity, not by value — two lanes equal
+         on every field, e.g. real duplicate rows, still have INDEPENDENT
+         physical capacity and must never share one counter) across BOTH the
+         proportional pass and the sweep, so the sweep never re-offers a cap
+         the proportional pass already spent. mult=1 lanes are UNAFFECTED by
+         this pass in practice: the proportional split already covers every
+         residual down to whole units, so there is never an undrawn whole
+         multiple left over (the sweep loop simply finds nothing to do and
+         exits immediately).
+
+    Determinism BETWEEN levels is greedy: a residual a p1 lane covers shrinks
+    BEFORE any p2 lane is considered, GLOBALLY across sources (that is why the
+    priority level, not the source, is the outer loop).
 
     Timing per signal:
       * ship_bucket   = max(0, deficit_bucket - link.lead_buckets)
@@ -330,12 +562,14 @@ def transfer_signals(
     emitted (covered late is the truth of the plan; see TransferSignal).
 
     Output is sorted (item, dest_location, deficit_bucket, priority,
-    source_location, link_ref) — a total order, so the signal list is
-    byte-stable even across two genuinely duplicate lanes on the same pair at
-    the same priority (#395 F6; link_ref is "" when unset, a no-op tie-break).
+    source_location, link_ref) — a total order (UNCHANGED from before the
+    fair-share rewrite), so the signal list is byte-stable and independent of
+    input dict/list insertion order, even across two genuinely duplicate lanes
+    on the same pair at the same priority (#395 F6; link_ref is "" when unset, a
+    no-op tie-break — see _sort_key for the residual tie-break when link_ref
+    ALSO collides, #395 PR2a review MINOR fix).
 
-    NOTE (deliberately out of scope, V1): multi-hop relay, fair-share splitting
-    of a scarce source across competing destinations, and network cost
+    NOTE (deliberately out of scope, V1): multi-hop relay and network cost
     optimisation. See the module docstring.
     """
     deficits = projected_deficits(demand_by_loc, on_hand_by_loc, safety_by_loc, horizon_buckets)
@@ -343,58 +577,251 @@ def transfer_signals(
 
     # Index active links by destination location ONLY as a first cheap filter
     # (independent of item). The item scoping + specificity-refinement dedup
-    # happens per (item, dest) below via _resolve_candidate_links, since which
-    # links are eligible now depends on the deficit's item, not just its
-    # destination.
+    # happens per (item, dest) via _resolve_candidate_links, since which links
+    # are eligible depends on the deficit's item, not just its destination.
     links_by_dest: dict[str, list[TransferLink]] = {}
     for link in links:
         links_by_dest.setdefault(link.dest_location, []).append(link)
 
-    # Carry the emitting link's priority and link_ref alongside each signal so
-    # the output sort can key on (item, dest, deficit_bucket, priority, source,
-    # link_ref) without a reverse lookup — priority/link_ref are not part of
-    # TransferSignal's public shape (they are link-level evidence, not
-    # signal-level), so they live only in this local sort-key tuple.
-    keyed: list[tuple[str, str, int, int, str, str, TransferSignal]] = []
-    # Process deficits in a deterministic coordinate order so the greedy draw on
-    # shared source excess is reproducible (item, then dest_location).
+    # Resolve the candidate lanes per (item, dest) in deficit, then INVERT into a
+    # source-keyed index — the fair-share loop is source-first, so we need each
+    # source's outgoing lanes, not each destination's incoming ones. Each entry
+    # carries the destination coordinate + its deficit bucket so the inner loop
+    # never re-reads `deficits`.
+    lanes_by_source: dict[tuple[str, str], list[tuple[str, int, TransferLink]]] = {}
     for (item, dest_location) in sorted(deficits):
-        deficit_bucket, deficit_qty = deficits[(item, dest_location)]
-        remaining_deficit = deficit_qty
-        candidates = _resolve_candidate_links(links_by_dest.get(dest_location, []), item)
-        for link in candidates:
-            if remaining_deficit <= 0:
-                break
+        deficit_bucket, _deficit_qty = deficits[(item, dest_location)]
+        for link in _resolve_candidate_links(links_by_dest.get(dest_location, []), item):
             source_coord = (item, link.source_location)
-            avail = excess.get(source_coord, 0.0)
-            if avail <= 0:
-                continue
-            qty = min(remaining_deficit, avail)
-            if link.max_qty is not None:
-                qty = min(qty, link.max_qty)
-            if qty < link.min_qty:
-                # Below the lane minimum: emit nothing on this link, leave the
-                # deficit for the next-priority link (see docstring).
-                continue
-            ship_bucket = max(0, deficit_bucket - link.lead_buckets)
-            arrival_bucket = ship_bucket + link.lead_buckets
-            signal = TransferSignal(
-                item=item,
-                source_location=link.source_location,
-                dest_location=dest_location,
-                qty=qty,
-                ship_bucket=ship_bucket,
-                arrival_bucket=arrival_bucket,
-                deficit_bucket=deficit_bucket,
-                deficit_qty=deficit_qty,
-                source_excess_before=avail,
+            lanes_by_source.setdefault(source_coord, []).append(
+                (dest_location, deficit_bucket, link)
             )
-            keyed.append((
-                item, dest_location, deficit_bucket, link.priority,
-                link.source_location, link.link_ref, signal,
-            ))
-            excess[source_coord] = avail - qty
-            remaining_deficit -= qty
 
-    keyed.sort(key=lambda k: (k[0], k[1], k[2], k[3], k[4], k[5]))
-    return [k[6] for k in keyed]
+    # priority_min per source coordinate — the lowest-priority lane leaving it,
+    # for the source ordering tie-break. When the priority switch is off, every
+    # lane is treated as one virtual level (priority ignored for stratification;
+    # the lane's real priority is still emitted on the signal + used in the
+    # output sort).
+    priority_min: dict[tuple[str, str], int] = {
+        src: min(link.priority for _dest, _b, link in lanes)
+        for src, lanes in lanes_by_source.items()
+    }
+
+    # Residual deficit per (item, dest) — the shared running counter fair-share
+    # splits against; decremented as lanes cover it, globally across sources and
+    # levels (the greedy-between-levels discipline).
+    residual: dict[tuple[str, str], float] = {
+        coord: qty for coord, (_bucket, qty) in deficits.items()
+    }
+
+    # Global priority levels, ascending. With the switch off, a single sentinel
+    # level makes every lane share one fair-share pass (priority ignored).
+    if _FAIR_SHARE_RESPECTS_PRIORITY:
+        levels = sorted({link.priority for lanes in lanes_by_source.values() for _d, _b, link in lanes})
+    else:
+        levels = [0]
+
+    # Carry the emitting lane itself alongside each signal so the output sort
+    # can key on (item, dest, deficit_bucket) + _sort_key(link) — the SAME
+    # total order used to pick candidates in the first place (#395 PR2a review,
+    # MINOR fix) — without a reverse lookup. The lane is link-level evidence,
+    # not part of TransferSignal's public shape, so it lives only in this
+    # local tuple.
+    keyed: list[tuple[str, str, int, TransferLink, TransferSignal]] = []
+
+    for level in levels:
+        # Sources active at this level, in the fixed total order.
+        active_sources = sorted(
+            (src for src in lanes_by_source),
+            key=lambda src: (priority_min[src], src[1], src[0]),
+        )
+        for source_coord in active_sources:
+            item, source_location = source_coord
+            # This source's lanes AT this level (all lanes when the switch is
+            # off). Group by destination so the fair-share split sees each
+            # destination ONCE, whatever its lane count.
+            level_lanes = [
+                (dest_location, deficit_bucket, link)
+                for (dest_location, deficit_bucket, link) in lanes_by_source[source_coord]
+                if (not _FAIR_SHARE_RESPECTS_PRIORITY) or link.priority == level
+            ]
+            if not level_lanes:
+                continue
+            lanes_by_dest_here: dict[str, list[tuple[int, TransferLink]]] = {}
+            for dest_location, deficit_bucket, link in level_lanes:
+                lanes_by_dest_here.setdefault(dest_location, []).append((deficit_bucket, link))
+
+            # Snapshot the excess at the START of the level so the proportion is
+            # stable across this level's destinations; the live counter (excess)
+            # is what actually funds and decrements.
+            avail_snapshot = excess.get(source_coord, 0.0)
+            if avail_snapshot <= 0:
+                continue
+            active_dests = sorted(
+                dest for dest in lanes_by_dest_here if residual.get((item, dest), 0.0) > 0
+            )
+            total_residual = sum(residual[(item, dest)] for dest in active_dests)
+            if total_residual <= 0:
+                continue
+
+            # Remaining max_qty per LANE OBJECT (by identity — id(link) — never
+            # by value: two lanes equal on every field, e.g. genuine duplicate
+            # rows, each have their OWN physical capacity and must never share
+            # a counter). Shared across the proportional pass below AND the
+            # remnant sweep, so the sweep never re-offers a cap the
+            # proportional pass already spent on that exact lane instance.
+            shipped_by_link: dict[int, float] = {}
+
+            def _remaining_max(lk: TransferLink) -> float | None:
+                if lk.max_qty is None:
+                    return None
+                return lk.max_qty - shipped_by_link.get(id(lk), 0.0)
+
+            for dest_location in active_dests:
+                dest_coord = (item, dest_location)
+                # Proportional ideal, capped by the destination's own residual so
+                # a single-destination source (ratio 1.0) never over-serves it.
+                ideal = avail_snapshot * (residual[dest_coord] / total_residual)
+                dest_part = min(ideal, residual[dest_coord])
+                for deficit_bucket, link in sorted(
+                    lanes_by_dest_here[dest_location], key=lambda t: _sort_key(t[1])
+                ):
+                    avail = excess.get(source_coord, 0.0)
+                    if dest_part <= 0 or avail <= 0:
+                        break
+                    raw_part = min(dest_part, residual[dest_coord])
+                    remaining_max = _remaining_max(link)
+                    qty = _fair_share_round(
+                        raw_part, link.transfer_multiple, link.min_qty, remaining_max, avail
+                    )
+                    if qty <= 0:
+                        # Below the lane minimum / less than one multiple: emit
+                        # nothing on this lane, leave the residual for the next
+                        # lane (or the next level / source).
+                        continue
+                    fair_share_qty = min(raw_part, avail)
+                    if remaining_max is not None:
+                        fair_share_qty = min(fair_share_qty, remaining_max)
+                    ship_bucket = max(0, deficit_bucket - link.lead_buckets)
+                    arrival_bucket = ship_bucket + link.lead_buckets
+                    signal = TransferSignal(
+                        item=item,
+                        source_location=source_location,
+                        dest_location=dest_location,
+                        qty=qty,
+                        ship_bucket=ship_bucket,
+                        arrival_bucket=arrival_bucket,
+                        deficit_bucket=deficit_bucket,
+                        deficit_qty=deficits[dest_coord][1],
+                        source_excess_before=avail,
+                        fair_share_qty=fair_share_qty,
+                        rounding_remnant=fair_share_qty - qty,
+                    )
+                    keyed.append((item, dest_location, deficit_bucket, link, signal))
+                    # Decrement the LIVE counters only (the down-round remnant
+                    # stays in excess, available downstream). dest_part shrinks
+                    # by the shipped qty so a duplicate lane picks up the rest.
+                    excess[source_coord] = avail - qty
+                    residual[dest_coord] -= qty
+                    dest_part -= qty
+                    shipped_by_link[id(link)] = shipped_by_link.get(id(link), 0.0) + qty
+
+            # --- REMNANT SWEEP (#395 PR2a review, MAJOR fix) --------------
+            # The proportional pass above can leave the source's live excess
+            # undrawn even though a WHOLE multiple could still ship to SOME
+            # destination (see the function docstring's worked example:
+            # excess=12, mult=12, two destinations both short 20 -> the
+            # proportional ideal splits 6/6, both floor to 0, and 12 units of
+            # real capacity sit idle -> WORSE than the old greedy, and an
+            # anti-starvation violation). Sweep: while this source can still
+            # ship >= 1 whole multiple to a destination with residual > 0 at
+            # this level, serve the MOST NEEDY one.
+            #
+            # "Most needy first" (largest remaining residual, tie-broken by
+            # dest_location) is a 🎯-adjustable business default — the
+            # equally-defensible alternative is round-robin across tied
+            # destinations, which SPREADS whole multiples instead of
+            # concentrating them on the single neediest destination. V1 picks
+            # "most needy" because it is the more conservative starvation
+            # fix (serve whoever is furthest from being covered); a future
+            # revision could make this pluggable the same way the priority
+            # switch above is.
+            #
+            # Bounded: each iteration either ships a multiple (residual and
+            # excess both strictly decrease) or proves NO lane of the chosen
+            # destination can ship one at the CURRENT (monotonically
+            # decreasing) excess and permanently exhausts that destination —
+            # since excess never increases within the sweep, an exhausted
+            # destination can never become servable again in the same sweep,
+            # so the destination set shrinks or excess shrinks every
+            # iteration; both are finite.
+            exhausted_dests: set[str] = set()
+            while True:
+                avail = excess.get(source_coord, 0.0)
+                if avail <= 0:
+                    break
+                candidates = sorted(
+                    (
+                        dest
+                        for dest in lanes_by_dest_here
+                        if dest not in exhausted_dests and residual.get((item, dest), 0.0) > 0
+                    ),
+                    key=lambda dest: (-residual[(item, dest)], dest),
+                )
+                if not candidates:
+                    break
+                dest_location = candidates[0]
+                dest_coord = (item, dest_location)
+                shipped_this_round = False
+                for deficit_bucket, link in sorted(
+                    lanes_by_dest_here[dest_location], key=lambda t: _sort_key(t[1])
+                ):
+                    avail = excess.get(source_coord, 0.0)
+                    if avail <= 0:
+                        break
+                    remaining_max = _remaining_max(link)
+                    raw_part = residual[dest_coord]  # the FULL remaining need, not a share
+                    qty = _fair_share_round(
+                        raw_part, link.transfer_multiple, link.min_qty, remaining_max, avail
+                    )
+                    if qty <= 0:
+                        continue
+                    fair_share_qty = min(raw_part, avail)
+                    if remaining_max is not None:
+                        fair_share_qty = min(fair_share_qty, remaining_max)
+                    ship_bucket = max(0, deficit_bucket - link.lead_buckets)
+                    arrival_bucket = ship_bucket + link.lead_buckets
+                    signal = TransferSignal(
+                        item=item,
+                        source_location=source_location,
+                        dest_location=dest_location,
+                        qty=qty,
+                        ship_bucket=ship_bucket,
+                        arrival_bucket=arrival_bucket,
+                        deficit_bucket=deficit_bucket,
+                        deficit_qty=deficits[dest_coord][1],
+                        source_excess_before=avail,
+                        fair_share_qty=fair_share_qty,
+                        rounding_remnant=fair_share_qty - qty,
+                    )
+                    keyed.append((item, dest_location, deficit_bucket, link, signal))
+                    excess[source_coord] = avail - qty
+                    residual[dest_coord] -= qty
+                    shipped_by_link[id(link)] = shipped_by_link.get(id(link), 0.0) + qty
+                    shipped_this_round = True
+                    break
+                if not shipped_this_round:
+                    # No lane of the neediest destination can ship a whole
+                    # multiple at the CURRENT excess — permanently exhausted
+                    # for this sweep (see the bounding argument above).
+                    exhausted_dests.add(dest_location)
+
+    # Total-order output sort: (item, dest, deficit_bucket) + _sort_key(link) —
+    # the SAME lane key used to pick candidates, so the final tie-break is
+    # never a different rule from the selection rule (#395 PR2a review, MINOR
+    # fix). source_location is _sort_key's 2nd element, matching the documented
+    # (item, dest_location, deficit_bucket, priority, source_location,
+    # link_ref, ...) contract exactly, with max_qty/min_qty/transfer_multiple
+    # closing the residual tie when link_ref ALSO collides.
+    keyed.sort(key=lambda k: (k[0], k[1], k[2]) + _sort_key(k[3]))
+    return [k[4] for k in keyed]

--- a/src/ootils_core/engine/drp/loader.py
+++ b/src/ootils_core/engine/drp/loader.py
@@ -286,12 +286,18 @@ def load_drp_data(conn, horizon_days: int = 180, scenario: str = BASELINE) -> DR
     # core.py's _resolve_candidate_links / transfer_signals) — belt AND
     # braces: the loader emits a stable order, and the core's own sort keys
     # never depend on it holding.
+    # transfer_multiple (migration 065): the lane's logistics shipment multiple,
+    # rounded DOWN by the DRP planner (#395 PR2a). NOT NULL DEFAULT 1 in the
+    # schema, so a value is always present; COALESCE(..., 1) is belt-and-braces
+    # against a hypothetical NULL and keeps a lane loaded on a pre-065 fixture
+    # (where the column is absent from the row) at the no-rounding default.
     links: list[TransferLink] = []
-    for src, dst, lt_days, min_q, max_q, prio, item_key, link_id in cur.execute(
+    for src, dst, lt_days, min_q, max_q, prio, item_key, link_id, mult in cur.execute(
         f"SELECT {_loc_key_sql('su')}, {_loc_key_sql('du')}, "
         "dl.transit_lead_time_days, dl.minimum_shipment_qty, "
         "dl.maximum_shipment_qty, dl.priority, "
-        "COALESCE(ii.external_id, ii.item_id::text), dl.distribution_link_id "
+        "COALESCE(ii.external_id, ii.item_id::text), dl.distribution_link_id, "
+        "COALESCE(dl.transfer_multiple, 1) "
         "FROM distribution_links dl "
         "JOIN locations su ON su.location_id = dl.upstream_location_id "
         "JOIN locations du ON du.location_id = dl.downstream_location_id "
@@ -308,6 +314,7 @@ def load_drp_data(conn, horizon_days: int = 180, scenario: str = BASELINE) -> DR
             priority=int(prio),
             item=item_key,
             link_ref=str(link_id),
+            transfer_multiple=float(mult),
         ))
     d.links = links
 

--- a/tests/integration/test_drp_loader_integration.py
+++ b/tests/integration/test_drp_loader_integration.py
@@ -144,17 +144,46 @@ def _seed_link(
     maximum_shipment_qty=None,
     priority=100,
     active=True,
+    transfer_multiple=None,
 ) -> UUID:
     """A distribution_links row (migration 029). Columns/defaults read straight
     off the real schema: minimum_shipment_qty NOT NULL DEFAULT 1, priority NOT
-    NULL DEFAULT 100 (CHECK >= 1), maximum_shipment_qty NULLABLE."""
+    NULL DEFAULT 100 (CHECK >= 1), maximum_shipment_qty NULLABLE.
+
+    transfer_multiple (#395 PR2a, migration 065): the column is NOT NULL
+    DEFAULT 1. `transfer_multiple=None` (the default here) OMITS the column
+    from the INSERT entirely, so the row exercises the real SQL DEFAULT rather
+    than a Python-side stand-in — the point of
+    test_link_transfer_multiple_defaults_to_one below. Pass an explicit float
+    to seed a lane with a real logistics multiple."""
+    if transfer_multiple is None:
+        return conn.execute(
+            """
+            INSERT INTO distribution_links (
+                distribution_link_id, upstream_location_id, downstream_location_id,
+                transit_lead_time_days, minimum_shipment_qty, maximum_shipment_qty,
+                priority, active
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING distribution_link_id
+            """,
+            (
+                uuid4(),
+                upstream_location_id,
+                downstream_location_id,
+                transit_lead_time_days,
+                minimum_shipment_qty,
+                maximum_shipment_qty,
+                priority,
+                active,
+            ),
+        ).fetchone()["distribution_link_id"]
     return conn.execute(
         """
         INSERT INTO distribution_links (
             distribution_link_id, upstream_location_id, downstream_location_id,
             transit_lead_time_days, minimum_shipment_qty, maximum_shipment_qty,
-            priority, active
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            priority, active, transfer_multiple
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
         RETURNING distribution_link_id
         """,
         (
@@ -166,6 +195,7 @@ def _seed_link(
             maximum_shipment_qty,
             priority,
             active,
+            transfer_multiple,
         ),
     ).fetchone()["distribution_link_id"]
 
@@ -605,3 +635,57 @@ def test_links_order_by_is_stable_across_calls(conn):
 
     assert refs1 == expected_ref_order, "ORDER BY ... distribution_link_id sorts the smaller UUID first"
     assert refs1 == refs2, "the relative order must be stable across two separate calls"
+
+
+# ---------------------------------------------------------------------------
+# #395 PR2a: distribution_links.transfer_multiple (migration 065) surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_link_transfer_multiple_surfaces_onto_transferlink(conn):
+    """#395 PR2a (loader side): a lane seeded with transfer_multiple=25 must
+    surface as TransferLink.transfer_multiple == 25.0 — the loader's
+    COALESCE(dl.transfer_multiple, 1) reads the real column value straight
+    through when it is set."""
+    item_id = _seed_item(conn)
+    dest = _seed_location(conn, "drp-mult-dest")
+    src = _seed_location(conn, "drp-mult-src")
+    _seed_planning_params(conn, item_id, dest)
+
+    link_id = _seed_link(
+        conn, upstream_location_id=src, downstream_location_id=dest,
+        transit_lead_time_days=7, transfer_multiple=25,
+    )
+    conn.commit()
+
+    d = load_drp_data(conn, horizon_days=180, scenario=str(BASELINE))
+    links_by_ref = {lk.link_ref: lk for lk in d.links}
+
+    assert links_by_ref[str(link_id)].transfer_multiple == 25.0
+
+
+def test_link_transfer_multiple_defaults_to_one_when_column_omitted(conn):
+    """#395 PR2a (loader side): a lane inserted WITHOUT transfer_multiple (the
+    column omitted from the INSERT entirely, exercising the real schema
+    DEFAULT — migration 065: NOT NULL DEFAULT 1) surfaces as
+    TransferLink.transfer_multiple == 1.0, the no-rounding default. This is the
+    real DB DEFAULT, not merely the dataclass field default (TransferLink's
+    Python default is exercised separately by the core golden
+    test_transferlink_six_arg_backward_compat_no_rounding, which never touches
+    SQL at all)."""
+    item_id = _seed_item(conn)
+    dest = _seed_location(conn, "drp-mult-default-dest")
+    src = _seed_location(conn, "drp-mult-default-src")
+    _seed_planning_params(conn, item_id, dest)
+
+    link_id = _seed_link(
+        conn, upstream_location_id=src, downstream_location_id=dest,
+        transit_lead_time_days=7,
+        # transfer_multiple intentionally omitted -> real SQL DEFAULT 1.
+    )
+    conn.commit()
+
+    d = load_drp_data(conn, horizon_days=180, scenario=str(BASELINE))
+    links_by_ref = {lk.link_ref: lk for lk in d.links}
+
+    assert links_by_ref[str(link_id)].transfer_multiple == 1.0

--- a/tests/test_drp_core_golden.py
+++ b/tests/test_drp_core_golden.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import pytest
 
 from ootils_core.engine.drp import core
-from ootils_core.engine.drp.core import TransferLink, TransferSignal
+from ootils_core.engine.drp.core import TransferLink, TransferSignal, _fair_share_round, _sort_key
 
 # A generous horizon so no case is truncated by the bucket ceiling; every
 # derivation below reasons about the FIRST safety-breaking bucket, well inside.
@@ -162,6 +162,9 @@ def test_transfer_nominal_single_signal():
         links=[TransferLink("WEST", "EAST", 2, 1.0, None, 1)],
         horizon_buckets=H,
     )
+    # #395 PR2a: a single (source, dest) draw is fair-share degenerate (one
+    # destination -> ratio 1.0), so fair_share_qty == the full residual == qty
+    # (no rounding: transfer_multiple defaults to 1.0) -> rounding_remnant 0.
     assert signals == [
         TransferSignal(
             item="A",
@@ -173,6 +176,8 @@ def test_transfer_nominal_single_signal():
             deficit_bucket=2,
             deficit_qty=3.0,
             source_excess_before=75.0,
+            fair_share_qty=3.0,
+            rounding_remnant=0.0,
         )
     ]
 
@@ -253,6 +258,17 @@ def test_shared_source_excess_decremented_across_destinations():
              (DECREMENTED — the EAST draw already consumed 30).
     Total transferred 30 + 40 = 70 <= initial excess 100 (never over-drawn).
     Links have lead 0, so ship = deficit_bucket = 1, arrival = 1.
+
+    #395 PR2a: EAST and SOUTH are each the ONLY destination WEST serves at
+    priority level 1 in their own draw (they are processed as two SEPARATE
+    (item, dest) coordinates, each pulling on WEST at its own turn — not two
+    destinations split simultaneously at one level, since WEST has no OTHER
+    destination competing for its excess in EITHER draw). Fair-share therefore
+    degenerates to ratio 1.0 each time: fair_share_qty == qty == the full
+    deficit on both signals (no rounding at the default transfer_multiple=1.0)
+    -> rounding_remnant 0.0 on both. Quantities/source_excess_before UNCHANGED
+    from the pre-fair-share greedy (verified by direct execution against this
+    revised core, not merely carried over).
     """
     signals = core.transfer_signals(
         demand_by_loc={("A", "EAST"): {1: 30.0}, ("A", "SOUTH"): {1: 40.0}},
@@ -267,8 +283,12 @@ def test_shared_source_excess_decremented_across_destinations():
     by_dest = {s.dest_location: s for s in signals}
     assert by_dest["EAST"].source_excess_before == pytest.approx(100.0)
     assert by_dest["EAST"].qty == pytest.approx(30.0)
+    assert by_dest["EAST"].fair_share_qty == pytest.approx(30.0)
+    assert by_dest["EAST"].rounding_remnant == pytest.approx(0.0)
     assert by_dest["SOUTH"].source_excess_before == pytest.approx(70.0)
     assert by_dest["SOUTH"].qty == pytest.approx(40.0)
+    assert by_dest["SOUTH"].fair_share_qty == pytest.approx(40.0)
+    assert by_dest["SOUTH"].rounding_remnant == pytest.approx(0.0)
     # Conservation: total drawn from WEST <= its initial excess.
     assert by_dest["EAST"].qty + by_dest["SOUTH"].qty <= 100.0
 
@@ -362,26 +382,43 @@ def test_determinism_insertion_order_independent_and_output_sorted():
         EAST  <- NORTH priority 2   (redundant on EAST — WEST already covers 10)
         SOUTH <- NORTH priority 1
 
-    #395 F7 review fix: the REAL service order is NOT insertion/label order — it
-    is `sorted(deficits)` on the (item, dest) key, i.e. plain alphabetical dest
-    order: DEPOT < EAST < SOUTH. So DEPOT is served FIRST, not EAST — the
-    previous docstring here had this backwards (it asserted "WEST excess after
-    EAST draw = 90" as if EAST went first) and the test PASSED anyway only
-    because it never checked source_excess_before. Corrected order below, with
-    source_excess_before now asserted on all three signals so a future
-    regression to the wrong order fails loudly instead of passing silently.
-
-    Per-destination greedy resolution, in the REAL processed order:
-      DEPOT (deficit 5, processed 1st): WEST(p1) covers all 5 -> signal
-           WEST->DEPOT, source_excess_before=100 (WEST untouched so far).
-           WEST excess drops 100 -> 95.
-      EAST (deficit 10, processed 2nd): WEST(p1) covers all 10 -> signal
-           WEST->EAST, source_excess_before=95 (WEST AFTER the DEPOT draw, NOT
-           100). WEST excess drops 95 -> 85. NORTH(p2) then sees
-           remaining_deficit 0 -> break, NO second EAST signal.
-      SOUTH (deficit 20, processed 3rd): NORTH(p1) covers 20 -> signal
-           NORTH->SOUTH, source_excess_before=100 (NORTH untouched by anything
-           before it — DEPOT/EAST only ever drew on WEST).
+    #395 F7 review fix (kept, re-verified against the #395 PR2a fair-share
+    rewrite): the REAL service order is NOT insertion/label order. Under the
+    CURRENT source-first, priority-stratified engine (module §SCOPE), all four
+    lanes sit at priority levels {1, 2}; only level 1 matters here (WEST->DEPOT
+    p1, WEST->EAST p1, NORTH->SOUTH p1 all fire at level 1; NORTH->EAST p2
+    never fires — see below). Within level 1, sources are ordered
+    (priority_min, source_location): NORTH (priority_min 1) sorts before WEST
+    (priority_min 1) since "NORTH" < "WEST" — but WEST and NORTH share NO
+    destination (WEST only feeds DEPOT/EAST, NORTH only feeds SOUTH), so their
+    relative order has ZERO effect on any number below; the ONLY ordering that
+    actually determines source_excess_before is WEST's OWN destinations, sorted
+    alphabetically (active_dests = sorted(...)): DEPOT < EAST, so DEPOT draws
+    on WEST'S excess BEFORE EAST does.
+      DEPOT (fed by WEST only): fair-share is degenerate for WEST at this level
+           on its first-processed destination (DEPOT is alone in WEST's
+           dest-loop turn since EAST comes after alphabetically) -> WEST's
+           excess snapshot 100 -> signal WEST->DEPOT, qty=5,
+           source_excess_before=100 (WEST untouched so far). WEST's live excess
+           drops 100 -> 95.
+      EAST (fed by WEST at p1, ALSO by NORTH at p2): at level 1, WEST processes
+           EAST next (after DEPOT) -> signal WEST->EAST, qty=10,
+           source_excess_before=95 (WEST AFTER the DEPOT draw, NOT 100). WEST's
+           excess drops 95 -> 85. At level 2, NORTH->EAST would be considered,
+           but EAST's residual deficit is already 0 (WEST fully covered it at
+           level 1) -> NO second EAST signal (greedy-between-levels: a level-1
+           lane's coverage shrinks the residual before level 2 is even reached).
+      SOUTH (fed by NORTH only, p1): NORTH's excess snapshot is its full 100 —
+           untouched by anything before it (DEPOT/EAST only ever drew on WEST,
+           a completely separate source coordinate) -> signal NORTH->SOUTH,
+           qty=20, source_excess_before=100.
+    Each draw above is itself fair-share-degenerate (exactly one destination
+    active per source at that level/turn -> ratio 1.0), so fair_share_qty ==
+    qty == the full deficit on every signal; no rounding at the default
+    transfer_multiple=1.0 -> rounding_remnant 0.0 throughout. Quantities and
+    source_excess_before are UNCHANGED from the pre-fair-share greedy engine —
+    re-verified by direct execution against this revised core, not merely
+    carried over from the old docstring.
 
     Expected emitted signals, already in the documented output sort order
     (item, dest, deficit_bucket, priority, source) since dest is alphabetical:
@@ -451,6 +488,14 @@ def test_determinism_insertion_order_independent_and_output_sorted():
         ("EAST", 2, 10.0, "WEST", 95.0),
         ("SOUTH", 1, 20.0, "NORTH", 100.0),
     ]
+    # #395 PR2a: every draw above is fair-share-degenerate (one active
+    # destination per source at its turn) -> fair_share_qty == qty on all
+    # three, no rounding at the default multiple -> rounding_remnant 0.0.
+    assert [(s.fair_share_qty, s.rounding_remnant) for s in first] == [
+        (5.0, 0.0),
+        (10.0, 0.0),
+        (20.0, 0.0),
+    ]
 
 
 # ─────────────── #395 review fixes: excess window, item scoping, dedup ───────────────
@@ -491,6 +536,9 @@ def test_excess_window_end_to_end_full_transfer():
     on_hand = {("A", "WEST"): 100.0, ("A", "EAST"): 0.0}
     links = [TransferLink("WEST", "EAST", 0, 1.0, None, 1)]
     signals = core.transfer_signals(demand, on_hand, {}, links, horizon_buckets=H)
+    # #395 PR2a: single (source, dest) draw -> fair-share degenerate (ratio
+    # 1.0), fair_share_qty == qty == the full residual; no rounding at the
+    # default transfer_multiple=1.0 -> rounding_remnant 0.
     assert signals == [
         TransferSignal(
             item="A",
@@ -502,6 +550,8 @@ def test_excess_window_end_to_end_full_transfer():
             deficit_bucket=3,
             deficit_qty=80.0,
             source_excess_before=100.0,
+            fair_share_qty=80.0,
+            rounding_remnant=0.0,
         )
     ]
 
@@ -650,6 +700,16 @@ def test_duplicate_generic_lanes_same_pair_deterministic_link_ref_tiebreak():
     ref1 = TransferLink("WEST", "EAST", 0, 1.0, 30.0, 1, item=None, link_ref="1")
     ref2 = TransferLink("WEST", "EAST", 0, 1.0, None, 1, item=None, link_ref="2")
 
+    # #395 PR2a: ONE (item, dest) coordinate served by TWO lanes from the SAME
+    # source at the SAME level -> fair-share degenerate (single destination,
+    # ratio 1.0), so dest_part == the full residual (100) for the whole level;
+    # the two lanes then split it SEQUENTIALLY (sorted by link_ref) exactly as
+    # the old greedy did. Lane "1": raw_part=min(100,100)=100,
+    # fair_share_qty=min(100,100)=100 THEN capped by max_qty=30 -> 30 (the
+    # capping happens on fair_share_qty too, not just qty); qty=floor(30/1)*1=30
+    # (no rounding, mult=1.0) -> rounding_remnant=30-30=0. Lane "2":
+    # dest_part now 100-30=70, raw_part=min(70,70)=70, fair_share_qty=min(70,70)
+    # =70 (uncapped), qty=70 -> rounding_remnant=0.
     expected = [
         TransferSignal(
             item="A",
@@ -661,6 +721,8 @@ def test_duplicate_generic_lanes_same_pair_deterministic_link_ref_tiebreak():
             deficit_bucket=2,
             deficit_qty=100.0,
             source_excess_before=100.0,
+            fair_share_qty=30.0,
+            rounding_remnant=0.0,
         ),
         TransferSignal(
             item="A",
@@ -672,6 +734,8 @@ def test_duplicate_generic_lanes_same_pair_deterministic_link_ref_tiebreak():
             deficit_bucket=2,
             deficit_qty=100.0,
             source_excess_before=70.0,
+            fair_share_qty=70.0,
+            rounding_remnant=0.0,
         ),
     ]
 
@@ -712,13 +776,33 @@ def test_conservation_combined_multi_source_multi_dest():
         EAST  <- NORTH priority 2
         SOUTH <- NORTH priority 1
 
-    Greedy (dest order EAST then SOUTH):
-      EAST (60): WEST(p1) gives min(60, 50)=50 (WEST excess -> 0);
-                 NORTH(p2) gives min(10, 30)=10 (NORTH excess -> 20).
-                 EAST covered 60 total == its deficit (bound (i) tight).
-      SOUTH (10): NORTH(p1) gives min(10, 20)=10 (NORTH excess -> 10).
+    #395 PR2a re-derivation (source-first, priority-stratified — module
+    §SCOPE): level 1 first. Active level-1 sources = WEST (priority_min 1,
+    serves EAST) and NORTH (priority_min 1, via NORTH->SOUTH; NORTH->EAST is
+    priority 2, not active yet), ordered (priority_min, source_location) ->
+    "NORTH" < "WEST" -> NORTH processed first:
+      NORTH @ level 1: only active dest is SOUTH (residual 10) -> fair-share
+          degenerate (ratio 1.0) -> dest_part=min(30, 10)=10 -> qty=10.
+          NORTH excess 30 -> 20; SOUTH residual 10 -> 0.
+      WEST @ level 1: only active dest is EAST (residual 60) -> degenerate ->
+          dest_part=min(50, 60)=50 -> qty=50. WEST excess 50 -> 0; EAST
+          residual 60 -> 10.
+    Level 2: NORTH->EAST becomes active. EAST's residual is now 10 (WEST
+    already covered 50 of the 60 at level 1 — greedy BETWEEN levels).
+      NORTH @ level 2: only active dest is EAST (residual 10) -> degenerate ->
+          dest_part=min(NORTH's remaining excess 20, 10)=10 -> qty=10. NORTH
+          excess 20 -> 10; EAST residual 10 -> 0 (fully covered, == its
+          deficit, bound (i) tight).
+    Every draw above is itself fair-share-degenerate (one active destination
+    per source at its turn), so fair_share_qty == qty and rounding_remnant ==
+    0.0 on all three signals (default transfer_multiple=1.0, no rounding).
     Draws: WEST out = 50 (== initial 50, bound (ii) tight);
            NORTH out = 10 + 10 = 20 (<= initial 30).
+    Quantities/source_excess_before UNCHANGED from the pre-fair-share greedy —
+    re-verified by direct execution against this revised core (the mechanism
+    that produces them changed; the numbers did not, because WEST and NORTH's
+    processing order never actually competes for the SAME destination at the
+    SAME level in this dataset).
     """
     demand = {("A", "EAST"): {2: 60.0}, ("A", "SOUTH"): {3: 10.0}}
     on_hand = {
@@ -760,3 +844,651 @@ def test_conservation_combined_multi_source_multi_dest():
     assert in_by_dest[("A", "EAST")] == pytest.approx(60.0)
     assert out_by_source[("A", "WEST")] == pytest.approx(50.0)
     assert out_by_source[("A", "NORTH")] == pytest.approx(20.0)
+
+    # #395 PR2a: per-signal evidence, indexed by (source, dest) since this is a
+    # 3-signal, 2-source, 2-dest run (unlike the aggregate bounds above, which
+    # do not distinguish the two draws into EAST). Every draw is fair-share-
+    # degenerate here (see docstring), so fair_share_qty == qty and
+    # rounding_remnant == 0.0 throughout, with the announced
+    # source_excess_before values reconfirmed per signal.
+    by_source_dest = {(s.source_location, s.dest_location): s for s in signals}
+    assert len(by_source_dest) == 3, "WEST->EAST, NORTH->EAST, NORTH->SOUTH — three distinct signals"
+    west_east = by_source_dest[("WEST", "EAST")]
+    assert west_east.qty == pytest.approx(50.0)
+    assert west_east.source_excess_before == pytest.approx(50.0)
+    assert west_east.fair_share_qty == pytest.approx(50.0)
+    assert west_east.rounding_remnant == pytest.approx(0.0)
+    north_east = by_source_dest[("NORTH", "EAST")]
+    assert north_east.qty == pytest.approx(10.0)
+    assert north_east.source_excess_before == pytest.approx(20.0)
+    assert north_east.fair_share_qty == pytest.approx(10.0)
+    assert north_east.rounding_remnant == pytest.approx(0.0)
+    north_south = by_source_dest[("NORTH", "SOUTH")]
+    assert north_south.qty == pytest.approx(10.0)
+    assert north_south.source_excess_before == pytest.approx(30.0)
+    assert north_south.fair_share_qty == pytest.approx(10.0)
+    assert north_south.rounding_remnant == pytest.approx(0.0)
+
+
+# ───────────────── #395 PR2a: fair-share, logistics rounding, priority switch ─────────────────
+
+
+def test_fair_share_splits_scarce_source_proportionally_anti_famine():
+    """PR2a-1 — fair-share under scarcity: ONE source, insufficient excess to
+    cover TWO same-level destinations in full, split PROPORTIONALLY to their
+    residual deficits — never first-come-first-served (which would starve the
+    second destination to zero).
+    Source WEST: on_hand=50, safety=0, no own demand -> excess = 50.
+    EAST : demand 30 @bucket 1 -> deficit (bucket 1, 30).
+    SOUTH: demand 70 @bucket 1 -> deficit (bucket 1, 70).
+    Both linked to WEST only, same priority 1 (one level, both destinations
+    active together): total_residual = 30 + 70 = 100.
+      part(EAST)  = avail_snapshot(50) * (30/100) = 15.0
+      part(SOUTH) = avail_snapshot(50) * (70/100) = 35.0
+    Both parts fully fit their own residual (15<=30, 35<=70) and the lane's
+    default transfer_multiple=1.0 makes qty == the ideal part exactly (no
+    rounding) -> qty(EAST)=15.0, qty(SOUTH)=35.0. 15 + 35 = 50 == the full
+    source excess (fully distributed, none wasted). BOTH parts are strictly
+    > 0 — the anti-famine property: neither destination is starved to zero
+    just because the OTHER one asked for more.
+    source_excess_before is the LIVE counter at each individual draw, not the
+    frozen snapshot: EAST draws first (processed order: sorted active_dests ->
+    "EAST" < "SOUTH") against the untouched live counter (50); SOUTH then
+    draws against the live counter AFTER EAST's draw (50 - 15 = 35), even
+    though its IDEAL portion was computed from the ORIGINAL 50 snapshot.
+    fair_share_qty == qty on both signals (no cap, no rounding) ->
+    rounding_remnant 0.0 on both.
+    """
+    demand = {("A", "EAST"): {1: 30.0}, ("A", "SOUTH"): {1: 70.0}}
+    on_hand = {("A", "WEST"): 50.0, ("A", "EAST"): 0.0, ("A", "SOUTH"): 0.0}
+    links = [
+        TransferLink("WEST", "EAST", 0, 1.0, None, 1),
+        TransferLink("WEST", "SOUTH", 0, 1.0, None, 1),
+    ]
+    signals = core.transfer_signals(demand, on_hand, {}, links, horizon_buckets=H)
+    by_dest = {s.dest_location: s for s in signals}
+
+    assert by_dest["EAST"].qty == pytest.approx(15.0)
+    assert by_dest["EAST"].fair_share_qty == pytest.approx(15.0)
+    assert by_dest["EAST"].rounding_remnant == pytest.approx(0.0)
+    assert by_dest["EAST"].source_excess_before == pytest.approx(50.0)
+
+    assert by_dest["SOUTH"].qty == pytest.approx(35.0)
+    assert by_dest["SOUTH"].fair_share_qty == pytest.approx(35.0)
+    assert by_dest["SOUTH"].rounding_remnant == pytest.approx(0.0)
+    assert by_dest["SOUTH"].source_excess_before == pytest.approx(35.0)
+
+    assert by_dest["EAST"].qty > 0 and by_dest["SOUTH"].qty > 0, (
+        "anti-famine: neither destination is starved to zero"
+    )
+    assert by_dest["EAST"].qty + by_dest["SOUTH"].qty == pytest.approx(50.0)
+
+
+def test_logistics_rounding_down_with_remnant_two_destinations():
+    """PR2a-2 — DOWN-rounding to transfer_multiple=10, with the shaved remnant
+    recorded (not lost, but not re-servable here since each residual left over
+    is itself sub-multiple).
+    Source WEST: on_hand=100, safety=0, no own demand -> excess = 100.
+    EAST : demand 33 @bucket 1 -> deficit (bucket 1, 33).
+    SOUTH: demand 67 @bucket 1 -> deficit (bucket 1, 67).
+    Both linked to WEST, same priority 1, BOTH lanes transfer_multiple=10.
+    total_residual = 33 + 67 = 100 (conveniently the full excess, so the IDEAL
+    fair-share parts equal the deficits exactly, isolating the rounding effect
+    from the scarcity effect tested above):
+      ideal(EAST)  = 100 * (33/100) = 33.0 -> fair_share_qty = 33.0 (== raw_part,
+                     uncapped, avail plentiful).
+                     qty = floor(33/10)*10 = 30.0 -> rounding_remnant = 33-30 = 3.0.
+      ideal(SOUTH) = 100 * (67/100) = 67.0 -> fair_share_qty = 67.0.
+                     qty = floor(67/10)*10 = 60.0 -> rounding_remnant = 67-60 = 7.0.
+    Total qty OUT = 30 + 60 = 90.0 <= the initial excess 100 (never over-drawn).
+    The down-round remnant (10 units total: 3 + 7) stays in WEST's live excess
+    counter (100 - 30 - 60 = 10) but is NOT re-offered to either destination in
+    THIS run: EAST's own remaining residual after its draw is 33-30=3 (< the
+    10-unit multiple) and SOUTH's is 67-60=7 (< 10) — both sub-multiple, so
+    _fair_share_round would floor either to 0 on any further pass; there is no
+    third lane/destination in this dataset for the leftover 10 to fund.
+    source_excess_before is the LIVE counter at each draw: EAST draws first
+    (processed order "EAST" < "SOUTH") against the untouched 100; SOUTH draws
+    against the live counter AFTER EAST's draw (100 - 30 = 70).
+    """
+    demand = {("A", "EAST"): {1: 33.0}, ("A", "SOUTH"): {1: 67.0}}
+    on_hand = {("A", "WEST"): 100.0, ("A", "EAST"): 0.0, ("A", "SOUTH"): 0.0}
+    links = [
+        TransferLink("WEST", "EAST", 0, 1.0, None, 1, transfer_multiple=10.0),
+        TransferLink("WEST", "SOUTH", 0, 1.0, None, 1, transfer_multiple=10.0),
+    ]
+    signals = core.transfer_signals(demand, on_hand, {}, links, horizon_buckets=H)
+    by_dest = {s.dest_location: s for s in signals}
+
+    assert by_dest["EAST"].qty == pytest.approx(30.0)
+    assert by_dest["EAST"].fair_share_qty == pytest.approx(33.0)
+    assert by_dest["EAST"].rounding_remnant == pytest.approx(3.0)
+    assert by_dest["EAST"].source_excess_before == pytest.approx(100.0)
+
+    assert by_dest["SOUTH"].qty == pytest.approx(60.0)
+    assert by_dest["SOUTH"].fair_share_qty == pytest.approx(67.0)
+    assert by_dest["SOUTH"].rounding_remnant == pytest.approx(7.0)
+    assert by_dest["SOUTH"].source_excess_before == pytest.approx(70.0)
+
+    total_out = by_dest["EAST"].qty + by_dest["SOUTH"].qty
+    assert total_out == pytest.approx(90.0)
+    assert total_out <= 100.0
+
+
+def test_degenerate_residual_below_multiple_yields_no_micro_transfer():
+    """PR2a-3 — a residual deficit smaller than one transfer_multiple rounds
+    DOWN to exactly 0 -> NO signal at all (no micro-transfer below one case).
+    EAST: demand 7 @bucket 1 -> deficit (bucket 1, 7.0).
+    WEST: on_hand=100, safety=0, no own demand -> excess=100 (plentiful — this
+        case isolates the rounding floor, not a scarcity effect).
+    Link WEST->EAST, transfer_multiple=10.0 (single destination -> fair-share
+    degenerate, dest_part == the full residual == 7.0):
+      raw_part = 7.0; qty_brute = min(7.0, avail=100.0) = 7.0;
+      qty = floor(7.0 / 10.0) * 10.0 = floor(0.7) * 10.0 = 0 * 10.0 = 0.0.
+    0.0 <= 0 in _fair_share_round -> returns 0.0 -> transfer_signals treats it
+    exactly like a below-minimum lane: emit NOTHING, no signal at all (not a
+    zero-qty signal — the deficit is left uncovered, honest, since this is
+    also the ONLY lane for EAST).
+    """
+    demand = {("A", "EAST"): {1: 7.0}}
+    on_hand = {("A", "WEST"): 100.0, ("A", "EAST"): 0.0}
+    links = [TransferLink("WEST", "EAST", 0, 1.0, None, 1, transfer_multiple=10.0)]
+    signals = core.transfer_signals(demand, on_hand, {}, links, horizon_buckets=H)
+    assert signals == []
+
+
+def test_priority_level_fully_covers_before_next_priority_activates():
+    """PR2a-4 — priority x fair-share interaction: a p1 lane's coverage of a
+    destination's residual is applied IN FULL before any p2 lane (a DIFFERENT
+    source) is even considered — the greedy-BETWEEN-levels discipline, on top
+    of fair-share-WITHIN a level.
+    EAST: demand 100 @bucket 1 -> deficit (bucket 1, 100.0).
+    WEST : on_hand=40,  safety=0, no own demand -> excess=40.  Link WEST->EAST
+        priority=1 (level 1).
+    NORTH: on_hand=200, safety=0, no own demand -> excess=200. Link NORTH->EAST
+        priority=2 (level 2) — a DIFFERENT source, so no shared excess counter
+        with WEST.
+    Level 1 (only WEST active — NORTH's lane is priority 2, not yet active):
+        WEST is EAST's ONLY active source at this level -> fair-share
+        degenerate (ratio 1.0) -> dest_part = min(40, 100) = 40 -> qty = 40.0
+        (default transfer_multiple=1.0, no rounding). EAST's residual drops
+        100 -> 60 BEFORE level 2 is even reached.
+    Level 2 (NORTH activates): EAST's residual is now 60 (NOT the original
+        100) -> dest_part = min(200, 60) = 60 -> qty = 60.0.
+    Exactly TWO signals, in that priority order: WEST covers 40 first (full
+    capacity, source_excess_before=40 — WEST is untouched by anything else),
+    THEN NORTH covers the REMAINING 60 (source_excess_before=200 — NORTH is
+    ALSO untouched before its own draw, since WEST and NORTH never share an
+    excess counter). Total 40 + 60 = 100 == the full deficit.
+    """
+    demand = {("A", "EAST"): {1: 100.0}}
+    on_hand = {("A", "WEST"): 40.0, ("A", "NORTH"): 200.0, ("A", "EAST"): 0.0}
+    links = [
+        TransferLink("WEST", "EAST", 0, 1.0, None, 1),
+        TransferLink("NORTH", "EAST", 0, 1.0, None, 2),
+    ]
+    signals = core.transfer_signals(demand, on_hand, {}, links, horizon_buckets=H)
+    assert len(signals) == 2
+    by_source = {s.source_location: s for s in signals}
+
+    assert by_source["WEST"].qty == pytest.approx(40.0)
+    assert by_source["WEST"].fair_share_qty == pytest.approx(40.0)
+    assert by_source["WEST"].rounding_remnant == pytest.approx(0.0)
+    assert by_source["WEST"].source_excess_before == pytest.approx(40.0)
+
+    assert by_source["NORTH"].qty == pytest.approx(60.0)
+    assert by_source["NORTH"].fair_share_qty == pytest.approx(60.0)
+    assert by_source["NORTH"].rounding_remnant == pytest.approx(0.0)
+    assert by_source["NORTH"].source_excess_before == pytest.approx(200.0)
+
+    assert by_source["WEST"].qty + by_source["NORTH"].qty == pytest.approx(100.0)
+
+
+def test_priority_switch_off_flattens_into_one_fair_share_level(monkeypatch):
+    """PR2a-5 — _FAIR_SHARE_RESPECTS_PRIORITY: the SAME dataset with the switch
+    True (default) vs False gives DIFFERENT allocations whenever distinct
+    priority levels exist, because False collapses every lane into ONE virtual
+    fair-share level regardless of priority.
+    Source WEST: on_hand=60, safety=0, no own demand -> excess=60.
+    EAST : demand 100 @bucket 1 -> deficit (bucket 1, 100.0). Link WEST->EAST
+        priority=1.
+    SOUTH: demand 100 @bucket 1 -> deficit (bucket 1, 100.0). Link WEST->SOUTH
+        priority=2 — SAME source WEST, DIFFERENT priority than the EAST lane.
+
+    Switch True (default): level 1 has ONLY the WEST->EAST lane active (WEST->
+    SOUTH is priority 2). WEST's level-1 lanes group -> ONLY EAST is an active
+    destination at level 1 -> fair-share degenerate (ratio 1.0) ->
+    dest_part=min(60,100)=60 -> qty(EAST)=60.0. At level 2, WEST's excess is
+    already 60-60=0 -> avail_snapshot<=0 -> NO signal for SOUTH at all.
+    Result: EAST=60.0, SOUTH gets ZERO.
+
+    Switch False: every lane collapses to ONE level [0] regardless of real
+    priority -> WEST's level_lanes now include BOTH EAST and SOUTH
+    simultaneously -> active_dests=[EAST, SOUTH], total_residual=100+100=200:
+      ideal(EAST)  = 60 * (100/200) = 30.0 -> qty(EAST)=30.0
+      ideal(SOUTH) = 60 * (100/200) = 30.0 -> qty(SOUTH)=30.0
+    Result: EAST=30.0, SOUTH=30.0 — BOTH destinations served, unlike True where
+    SOUTH was shut out entirely by EAST's higher-priority full claim.
+    30+30=60 == the full WEST excess either way (never over- or under-drawn
+    relative to what WEST actually holds); what differs is WHO gets it.
+
+    Constant restored via monkeypatch (auto-teardown) so this test cannot leak
+    into any other test's module state.
+    """
+    demand = {("A", "EAST"): {1: 100.0}, ("A", "SOUTH"): {1: 100.0}}
+    on_hand = {("A", "WEST"): 60.0, ("A", "EAST"): 0.0, ("A", "SOUTH"): 0.0}
+    links = [
+        TransferLink("WEST", "EAST", 0, 1.0, None, 1),
+        TransferLink("WEST", "SOUTH", 0, 1.0, None, 2),
+    ]
+
+    assert core._FAIR_SHARE_RESPECTS_PRIORITY is True, "module default must be True"
+    signals_respecting = core.transfer_signals(demand, on_hand, {}, links, horizon_buckets=H)
+    by_dest_respecting = {s.dest_location: s for s in signals_respecting}
+    assert set(by_dest_respecting) == {"EAST"}, "SOUTH gets shut out entirely when priority is respected"
+    assert by_dest_respecting["EAST"].qty == pytest.approx(60.0)
+
+    monkeypatch.setattr(core, "_FAIR_SHARE_RESPECTS_PRIORITY", False)
+    signals_flat = core.transfer_signals(demand, on_hand, {}, links, horizon_buckets=H)
+    by_dest_flat = {s.dest_location: s for s in signals_flat}
+    assert set(by_dest_flat) == {"EAST", "SOUTH"}, "both destinations served once priority is ignored"
+    assert by_dest_flat["EAST"].qty == pytest.approx(30.0)
+    assert by_dest_flat["SOUTH"].qty == pytest.approx(30.0)
+
+    # Contrast, explicit: the SAME dataset produces DIFFERENT allocations.
+    assert by_dest_respecting["EAST"].qty != by_dest_flat["EAST"].qty
+
+
+def test_fair_share_round_unit_cases():
+    """PR2a-6 — _fair_share_round, the pure helper, exercised directly for
+    every documented rule (identity, floor, avail bound, max_qty bound, both
+    degenerate-to-zero cases).
+    """
+    # Identity at mult=1.0: no rounding at all, qty_brute passes through whole.
+    assert _fair_share_round(47.0, 1.0, 1.0, None, 100.0) == pytest.approx(47.0)
+
+    # Floor to a whole multiple: floor(47/10)*10 = floor(4.7)*10 = 4*10 = 40.
+    assert _fair_share_round(47.0, 10.0, 1.0, None, 100.0) == pytest.approx(40.0)
+
+    # Bounded by avail: qty_brute = min(200, 30) = 30, floor(30/1)*1 = 30 (avail
+    # is the binding constraint, not raw_part).
+    assert _fair_share_round(200.0, 1.0, 1.0, None, 30.0) == pytest.approx(30.0)
+
+    # Bounded by max_qty: qty_brute = min(200, 100, 15) = 15, floor(15/1)*1=15
+    # (max_qty is the binding constraint here, tighter than avail).
+    assert _fair_share_round(200.0, 1.0, 1.0, 15.0, 100.0) == pytest.approx(15.0)
+
+    # Degenerate: residual (7) smaller than one multiple (10) -> floor is 0.
+    assert _fair_share_round(7.0, 10.0, 1.0, None, 100.0) == pytest.approx(0.0)
+
+    # Below the lane minimum: qty_brute=50, floor(50/1)*1=50, but 50 < min_qty
+    # (60) -> the minimum-shipment rule zeroes it out entirely.
+    assert _fair_share_round(50.0, 1.0, 60.0, None, 100.0) == pytest.approx(0.0)
+
+
+def test_transferlink_six_arg_backward_compat_no_rounding():
+    """PR2a-7 — a TransferLink built with the ORIGINAL 6 positional arguments
+    (no transfer_multiple) defaults to 1.0, which is a no-op multiple: a
+    deficit that is NOT itself a multiple of anything (7.0, deliberately
+    arbitrary) transfers EXACTLY, undiminished by any rounding — the
+    pre-PR2a continuous-transfer behaviour is preserved byte-for-byte for
+    every call site that never learned about the new field.
+    EAST: demand 7.0 @bucket 1 -> deficit (bucket 1, 7.0).
+    WEST: on_hand=100, safety=0, no own demand -> excess=100 (plentiful).
+    Single (source, dest) pair -> fair-share degenerate (ratio 1.0) ->
+    raw_part == fair_share_qty == 7.0; qty = floor(7.0/1.0)*1.0 = 7.0 exactly
+    (NOT floored to some smaller value — mult=1.0 is truly a no-op).
+    """
+    link = TransferLink("WEST", "EAST", 0, 1.0, None, 1)
+    assert link.transfer_multiple == pytest.approx(1.0)
+
+    demand = {("A", "EAST"): {1: 7.0}}
+    on_hand = {("A", "WEST"): 100.0, ("A", "EAST"): 0.0}
+    signals = core.transfer_signals(demand, on_hand, {}, [link], horizon_buckets=H)
+    assert len(signals) == 1
+    sig = signals[0]
+    assert sig.qty == pytest.approx(7.0)
+    assert sig.fair_share_qty == pytest.approx(7.0)
+    assert sig.rounding_remnant == pytest.approx(0.0)
+
+
+# ───────────────── #395 PR2a review fix #2: remnant sweep ─────────────────
+# ───────────────── #395 PR2a review fix #1: total-order _sort_key ─────────
+
+
+def test_sweep_proven_case_one_destination_gets_the_pallet_never_zero_zero():
+    """Sweep-1 — THE proven strand case from the module docstring's worked
+    example: excess=12, transfer_multiple=12, TWO same-level destinations both
+    short 20 -> the proportional split floors BOTH to 0 (0.5 pallet each), so
+    the sweep MUST kick in and ship the one full pallet to somebody — never
+    leave it stranded as 0/0.
+    Source WEST: on_hand=12, safety=0, no own demand -> excess=12.
+    D1: demand 20 @bucket 1 -> deficit (bucket 1, 20.0). D2: demand 20 @bucket 1
+        -> deficit (bucket 1, 20.0). Both linked to WEST only, mult=12, same
+        priority 1 (one level, both destinations active together).
+    Proportional pass: total_residual = 20+20 = 40.
+      ideal(D1) = 12 * (20/40) = 6.0 -> dest_part=min(6,20)=6.
+        raw_part=6, qty_brute=min(6,12)=6, floor(6/12)*12=0 -> qty=0 -> no
+        signal, dest_part unchanged (6), residual/excess UNTOUCHED.
+      ideal(D2) = 6.0 likewise -> floors to 0 -> no signal.
+    excess is STILL 12 after the proportional pass (nothing drawn), residual
+    D1=20, D2=20 (both untouched).
+    SWEEP: candidates = destinations with residual>0, sorted by
+    (-residual, dest_location) -> D1 and D2 tie on residual (20==20) ->
+    tie-break alphabetical -> "D1" < "D2" -> D1 chosen FIRST.
+      raw_part = residual(D1) = 20 (the FULL remaining need, not a share).
+      qty_brute = min(20, avail=12) = 12, floor(12/12)*12 = 12 -> qty=12.
+      fair_share_qty = min(raw_part=20, avail=12) = 12 (no max_qty to cap
+      further). Signal D1 qty=12. excess drops 12 -> 0.
+    Sweep loop again: avail=0 -> break immediately. D2 receives NOTHING (not
+    even a zero-qty signal — simply absent). Conservation: total transferred
+    (12) <= the initial excess (12), exactly exhausted, never over-drawn.
+    """
+    demand = {("A", "D1"): {1: 20.0}, ("A", "D2"): {1: 20.0}}
+    on_hand = {("A", "WEST"): 12.0, ("A", "D1"): 0.0, ("A", "D2"): 0.0}
+    links = [
+        TransferLink("WEST", "D1", 0, 1.0, None, 1, transfer_multiple=12.0),
+        TransferLink("WEST", "D2", 0, 1.0, None, 1, transfer_multiple=12.0),
+    ]
+    signals = core.transfer_signals(demand, on_hand, {}, links, horizon_buckets=H)
+
+    assert len(signals) == 1, "exactly ONE destination gets the pallet — never 0/0, never both partially"
+    sig = signals[0]
+    assert sig.dest_location == "D1", "equal residuals -> alphabetical tie-break picks D1 over D2"
+    assert sig.qty == pytest.approx(12.0)
+    assert sig.fair_share_qty == pytest.approx(12.0)
+    assert sig.rounding_remnant == pytest.approx(0.0)
+    assert sig.source_excess_before == pytest.approx(12.0)
+    assert sig.qty <= 12.0, "conservation: never transfer more than the source's initial excess"
+
+
+def test_sweep_asymmetric_serves_most_needy_destination():
+    """Sweep-2 — asymmetric residuals: the sweep picks the MOST NEEDY
+    destination (largest remaining residual), not merely the alphabetically
+    first one — this case has UNEQUAL residuals so the tie-break never enters.
+    Source WEST: on_hand=10, safety=0, no own demand -> excess=10.
+    A: demand 30 @bucket 1 -> deficit (bucket 1, 30.0) (the MORE needy one).
+    B: demand 10 @bucket 1 -> deficit (bucket 1, 10.0).
+    Both linked to WEST, mult=10, same priority 1.
+    Proportional pass: total_residual = 30+10 = 40.
+      ideal(A) = 10 * (30/40) = 7.5 -> qty_brute=min(7.5,10)=7.5,
+        floor(7.5/10)*10=0 -> no signal.
+      ideal(B) = 10 * (10/40) = 2.5 -> floors to 0 likewise -> no signal.
+    excess still 10, residual A=30, residual B=10 (both untouched).
+    SWEEP: residuals are UNEQUAL (30 != 10) -> A (30, most needy) sorts
+    strictly before B (10) by -residual, no tie-break needed.
+      raw_part = residual(A) = 30 (full need). qty_brute=min(30,10)=10,
+      floor(10/10)*10=10 -> qty=10. Signal A qty=10. excess drops 10 -> 0.
+    Sweep loop again: avail=0 -> break. B receives NOTHING even though it was
+    a "smaller", potentially easier-to-satisfy need — "most needy first" means
+    largest residual wins the scarce pallet, not smallest.
+    Total transferred = 10 == the full source excess (exhausted, conserved).
+    """
+    demand = {("A", "A"): {1: 30.0}, ("A", "B"): {1: 10.0}}
+    on_hand = {("A", "WEST"): 10.0, ("A", "A"): 0.0, ("A", "B"): 0.0}
+    links = [
+        TransferLink("WEST", "A", 0, 1.0, None, 1, transfer_multiple=10.0),
+        TransferLink("WEST", "B", 0, 1.0, None, 1, transfer_multiple=10.0),
+    ]
+    signals = core.transfer_signals(demand, on_hand, {}, links, horizon_buckets=H)
+
+    assert len(signals) == 1
+    sig = signals[0]
+    assert sig.dest_location == "A", "most-needy (residual 30) wins the pallet over B (residual 10)"
+    assert sig.qty == pytest.approx(10.0)
+    assert sig.fair_share_qty == pytest.approx(10.0)
+    assert sig.rounding_remnant == pytest.approx(0.0)
+    assert sig.qty == pytest.approx(10.0)  # == the full source excess, exhausted
+
+
+def test_sweep_tie_break_equal_residual_dest_location_alphabetical():
+    """Sweep-3 — isolates the tie-break rule itself: TWO destinations with
+    EXACTLY equal residual and ONLY one pallet available. Destination labels
+    deliberately chosen ("ALPHA"/"BETA") to make the alphabetical rule
+    unambiguous (not merely "the first one written in the test").
+    Source WEST: on_hand=5, safety=0, no own demand -> excess=5.
+    ALPHA: demand 15 @bucket 1 -> deficit (bucket 1, 15.0).
+    BETA : demand 15 @bucket 1 -> deficit (bucket 1, 15.0). EQUAL to ALPHA's.
+    Both linked to WEST, mult=5, same priority 1.
+    Proportional pass: total_residual=30, ideal(ALPHA)=ideal(BETA)=5*(15/30)=2.5
+    each -> qty_brute=min(2.5,5)=2.5, floor(2.5/5)*5=0 -> both floor to 0, no
+    signal from either. excess still 5, both residuals untouched at 15.
+    SWEEP: residuals tie EXACTLY (15==15) -> tie-break is dest_location
+    ascending -> "ALPHA" < "BETA" -> ALPHA is chosen (documented 🎯-adjustable
+    business default: "most needy first, ties broken by dest_location").
+      raw_part=residual(ALPHA)=15, qty_brute=min(15,5)=5, floor(5/5)*5=5 ->
+      qty=5. excess drops 5 -> 0. BETA receives NOTHING (sweep breaks
+      immediately on the next iteration: avail<=0).
+    """
+    demand = {("A", "ALPHA"): {1: 15.0}, ("A", "BETA"): {1: 15.0}}
+    on_hand = {("A", "WEST"): 5.0, ("A", "ALPHA"): 0.0, ("A", "BETA"): 0.0}
+    links = [
+        TransferLink("WEST", "ALPHA", 0, 1.0, None, 1, transfer_multiple=5.0),
+        TransferLink("WEST", "BETA", 0, 1.0, None, 1, transfer_multiple=5.0),
+    ]
+    signals = core.transfer_signals(demand, on_hand, {}, links, horizon_buckets=H)
+
+    assert len(signals) == 1
+    assert signals[0].dest_location == "ALPHA", (
+        "equal residuals (15 == 15) -> dest_location alphabetical tie-break, "
+        "ALPHA sorts before BETA"
+    )
+    assert signals[0].qty == pytest.approx(5.0)
+
+
+def test_sweep_max_qty_tracked_per_lane_instance_not_by_value():
+    """Sweep-4 — max_qty is tracked PER LANE OBJECT (id(link)), not by value:
+    two lane INSTANCES that are equal on every field (same source, dest,
+    priority, max_qty, min_qty, transfer_multiple) are still two INDEPENDENT
+    physical capacities — the sweep (and the proportional pass before it) must
+    never let one instance's consumption count against the other's remaining
+    max_qty. Constructing a case where this actually changes the OUTPUT (not
+    just an internal counter): if the two instances' max_qty were wrongly
+    shared, only 10 units total could ever ship (one pallet); tracked
+    correctly, 20 units ship (two independent 10-unit pallets).
+    Source WEST: on_hand=25, safety=0, no own demand -> excess=25.
+    EAST: demand 100 @bucket 1 -> deficit (bucket 1, 100.0). TWO DISTINCT
+        TransferLink objects (constructed separately, not aliased) into EAST
+        from WEST, both with priority=1, max_qty=10, min_qty=1,
+        transfer_multiple=10 (identical field values, but id(lane1) !=
+        id(lane2) as Python objects).
+    Single destination -> fair-share degenerate (ratio 1.0): dest_part =
+    min(avail_snapshot=25, residual=100) = 25.
+      Lane 1 (processed first — both lanes compare EQUAL under _sort_key
+        since every field matches, so Python's stable sort preserves
+        construction/list order): raw_part=min(25,100)=25. remaining_max
+        (lane1) = 10 - 0 = 10 (nothing shipped on it yet).
+        qty_brute=min(25,25,10)=10, floor(10/10)*10=10 -> qty=10.
+        fair_share_qty=min(25,25)=25 THEN capped by remaining_max(10)->10.
+        excess drops 25->15. dest_part drops 25->15.
+        shipped_by_link[id(lane1)] = 10.
+      Lane 2: avail=15, dest_part=15>0. raw_part=min(15, residual=90)=15.
+        remaining_max(lane2) = 10 - shipped_by_link.get(id(lane2),0)=10-0=10
+        (lane2's OWN counter, untouched by lane1's shipment — the point of
+        this test). qty_brute=min(15,15,10)=10, floor(10/10)*10=10 -> qty=10.
+        excess drops 15->5. dest_part drops 15->5.
+    Both lanes exhaust their OWN 10-unit cap -> the proportional pass alone
+    ships 10+10=20 total (2 independent pallets), confirming per-instance
+    tracking. (The subsequent sweep pass finds excess=5, both lanes'
+    remaining_max now 0 each -> qty_brute capped to 0 on both -> nothing
+    further ships; not asserted in detail here since the proportional pass
+    already demonstrates the property.)
+    """
+    demand = {("A", "EAST"): {1: 100.0}}
+    on_hand = {("A", "WEST"): 25.0, ("A", "EAST"): 0.0}
+    lane1 = TransferLink("WEST", "EAST", 0, 1.0, 10.0, 1, transfer_multiple=10.0, link_ref="lane1")
+    lane2 = TransferLink("WEST", "EAST", 0, 1.0, 10.0, 1, transfer_multiple=10.0, link_ref="lane2")
+    assert lane1 is not lane2, "two DISTINCT instances, not the same object aliased twice"
+
+    signals = core.transfer_signals(demand, on_hand, {}, [lane1, lane2], horizon_buckets=H)
+
+    assert len(signals) == 2, "each lane instance ships its OWN 10-unit cap -> 20 total, not 10"
+    assert sum(s.qty for s in signals) == pytest.approx(20.0)
+    for sig in signals:
+        assert sig.qty == pytest.approx(10.0)
+        assert sig.fair_share_qty == pytest.approx(10.0)
+        assert sig.rounding_remnant == pytest.approx(0.0)
+
+
+def test_sweep_below_min_qty_falls_through_to_next_lane():
+    """Sweep-5 — the sweep respects the minimum-shipment rule exactly like the
+    proportional pass: a lane whose sweep-rounded qty is below its min_qty
+    emits NOTHING and falls through to the next lane at the SAME destination.
+    Source WEST: on_hand=12, safety=0, no own demand -> excess=12.
+    EAST : demand 20 @bucket 1 -> deficit (bucket 1, 20.0). TWO lanes into
+        EAST: lien1 (link_ref="1", min_qty=20 — WILL block), lien2
+        (link_ref="2", min_qty=1 — will serve), both mult=12, priority=1.
+    SOUTH: demand 20 @bucket 1 -> deficit (bucket 1, 20.0). ONE lane
+        (link_ref="3", min_qty=1, mult=12, priority=1) — only present to
+        force the proportional split to scarcity (so BOTH lanes floor to 0
+        and the sweep is what actually resolves EAST, not the proportional
+        pass).
+    Proportional pass: total_residual=20+20=40, ideal(EAST)=12*(20/40)=6 ->
+      dest_part=min(6,20)=6. Lien1: raw_part=6, qty_brute=min(6,12)=6,
+      floor(6/12)*12=0 -> qty=0 (floors to 0 BEFORE min_qty is even checked)
+      -> no signal, dest_part unchanged. Lien2: raw_part=6 still, qty_brute=6,
+      floor=0 -> qty=0 -> no signal either. ideal(SOUTH)=6 likewise floors to
+      0. excess STILL 12, both residuals untouched (EAST=20, SOUTH=20).
+    SWEEP: residuals tie (20==20) -> alphabetical -> "EAST" < "SOUTH" -> EAST
+    chosen. raw_part=residual(EAST)=20 (full need).
+      Lien1 first (link_ref "1" < "2"): qty_brute=min(20,12)=12,
+        floor(12/12)*12=12. 12 < min_qty(20) -> qty=0 -> BLOCKED, fall
+        through (avail still 12, nothing decremented).
+      Lien2: qty_brute=min(20,12)=12, floor=12. 12 >= min_qty(1) -> qty=12 ->
+        EMIT via lien2. excess drops 12 -> 0.
+    Exactly ONE signal: EAST via lien2, qty=12. SOUTH receives NOTHING (excess
+    exhausted before the sweep's next iteration reaches it).
+    """
+    demand = {("A", "EAST"): {1: 20.0}, ("A", "SOUTH"): {1: 20.0}}
+    on_hand = {("A", "WEST"): 12.0, ("A", "EAST"): 0.0, ("A", "SOUTH"): 0.0}
+    lien1 = TransferLink("WEST", "EAST", 0, 20.0, None, 1, transfer_multiple=12.0, link_ref="1")
+    lien2 = TransferLink("WEST", "EAST", 0, 1.0, None, 1, transfer_multiple=12.0, link_ref="2")
+    south_link = TransferLink("WEST", "SOUTH", 0, 1.0, None, 1, transfer_multiple=12.0, link_ref="3")
+    links = [lien1, lien2, south_link]
+
+    signals = core.transfer_signals(demand, on_hand, {}, links, horizon_buckets=H)
+
+    assert len(signals) == 1, "EAST served via the fall-through lane, SOUTH gets nothing"
+    sig = signals[0]
+    assert sig.dest_location == "EAST"
+    assert sig.qty == pytest.approx(12.0)
+    assert sig.fair_share_qty == pytest.approx(12.0)
+    assert sig.rounding_remnant == pytest.approx(0.0)
+
+
+def test_total_order_determinism_capped_lane_before_uncapped():
+    """Determinism-1 (#395 PR2a review fix #1) — two GENERIC lanes on the SAME
+    (source, dest, priority), BOTH with link_ref="" (the default — the
+    collision _sort_key exists to resolve), differing ONLY by max_qty (30 vs
+    None): the OUTPUT must be IDENTICAL regardless of link insertion order, and
+    the CAPPED lane (30) must serve BEFORE the UNCAPPED one (None -> +inf).
+    Before the #1 fix, link_ref alone was not a total order when both lanes
+    left it at the "" default: [a, b] insertion produced 2 signals (30 then
+    70, the intended behaviour) but [b, a] produced only 1 signal of 100 (a's
+    cap silently NEVER APPLIED because it happened to sort second by
+    incidental list order) — the exact bug this test locks shut.
+    Source WEST: on_hand=100, safety=0, no own demand -> excess=100.
+    EAST: demand 100 @bucket 1 -> deficit (bucket 1, 100.0). Lane A: max_qty=
+        30. Lane B: max_qty=None (uncapped). Both priority=1, min_qty=1,
+        transfer_multiple=1.0 (default), link_ref="" (default) — every field
+        equal EXCEPT max_qty.
+    _sort_key(A) = (1, "WEST", "", 30.0, 1.0, 1.0);
+    _sort_key(B) = (1, "WEST", "", inf, 1.0, 1.0) -> A < B (30.0 < inf)
+    REGARDLESS of which was constructed/passed first.
+    Single destination -> fair-share degenerate (ratio 1.0): dest_part=
+    min(100,100)=100.
+      A (sorted first): raw_part=min(100,100)=100, remaining_max=30,
+        qty_brute=min(100,100,30)=30, floor(30/1)*1=30 -> qty=30.
+        fair_share_qty=min(100,100)=100 THEN capped by max_qty(30)->30.
+        excess drops 100->70. dest_part drops 100->70.
+      B: raw_part=min(70,70)=70 (residual EAST now 70), remaining_max=None
+        (uncapped), qty_brute=min(70,70)=70, floor=70 -> qty=70.
+        fair_share_qty=70. excess drops 70->0.
+    TWO signals TOTAL: A=30 THEN B=70 (that exact order, in BOTH insertion
+    permutations) -> 30+70=100 == the full deficit, fully covered.
+    """
+    demand = {("A", "EAST"): {1: 100.0}}
+    on_hand = {("A", "WEST"): 100.0, ("A", "EAST"): 0.0}
+    lane_a = TransferLink("WEST", "EAST", 0, 1.0, 30.0, 1)
+    lane_b = TransferLink("WEST", "EAST", 0, 1.0, None, 1)
+
+    signals_ab = core.transfer_signals(demand, on_hand, {}, [lane_a, lane_b], horizon_buckets=H)
+    signals_ba = core.transfer_signals(demand, on_hand, {}, [lane_b, lane_a], horizon_buckets=H)
+
+    assert signals_ab == signals_ba, "output must be independent of link insertion order"
+    assert [s.qty for s in signals_ab] == [30.0, 70.0], (
+        "the capped lane (30) must be served BEFORE the uncapped one (None -> +inf), "
+        "in BOTH insertion orders — before the fix, [b, a] silently dropped the cap"
+    )
+    assert sum(s.qty for s in signals_ab) == pytest.approx(100.0)
+
+
+def test_sort_key_unit_cases():
+    """Determinism-2 (#395 PR2a review fix #1) — _sort_key, the pure helper,
+    exercised directly:
+      * max_qty=None maps to +inf (an uncapped lane sorts AFTER every capped
+        one at the same priority/source/link_ref).
+      * a TOTAL order across all 6 fields: two lanes differing in ANY field
+        (here: min_qty) produce DIFFERENT keys, ordered by that field.
+      * two lanes equal on EVERY field (even two SEPARATE objects) produce
+        EQUAL keys — they are truly interchangeable by this key's own
+        definition (the caller's own stable sort then decides between them,
+        which is fine since they are identical lanes).
+    """
+    uncapped = TransferLink("WEST", "EAST", 0, 1.0, None, 1)
+    capped = TransferLink("WEST", "EAST", 0, 1.0, 30.0, 1)
+    key_uncapped = _sort_key(uncapped)
+    key_capped = _sort_key(capped)
+    assert key_uncapped == (1, "WEST", "", float("inf"), 1.0, 1.0)
+    assert key_capped == (1, "WEST", "", 30.0, 1.0, 1.0)
+    assert key_capped < key_uncapped, "capped (finite max_qty) sorts BEFORE uncapped (+inf)"
+
+    # Total order across ALL 6 fields: differ only on min_qty -> different key,
+    # ordered by that field (the field the two lanes differ on).
+    low_min = TransferLink("WEST", "EAST", 0, 1.0, None, 1)
+    high_min = TransferLink("WEST", "EAST", 0, 5.0, None, 1)
+    assert _sort_key(low_min) != _sort_key(high_min)
+    assert _sort_key(low_min) < _sort_key(high_min)
+
+    # Two DISTINCT objects, every field equal -> EQUAL keys (interchangeable).
+    twin_a = TransferLink("WEST", "EAST", 0, 1.0, 30.0, 1, item="X", link_ref="r", transfer_multiple=2.0)
+    twin_b = TransferLink("WEST", "EAST", 0, 1.0, 30.0, 1, item="X", link_ref="r", transfer_multiple=2.0)
+    assert twin_a is not twin_b
+    assert _sort_key(twin_a) == _sort_key(twin_b)
+
+
+def test_mult_one_multi_dest_scarcity_unaffected_by_sweep():
+    """Non-regression — the exact 15/35 fair-share-under-scarcity golden from
+    the previous PR2a round (test_fair_share_splits_scarce_source_
+    proportionally_anti_famine), re-asserted standalone to prove the sweep
+    review fixes NEVER perturb the mult=1.0 (no-rounding) case: the
+    proportional pass already covers every residual down to whole units when
+    transfer_multiple=1.0, so there is never an undrawn whole multiple left
+    for the sweep to find — the sweep loop must run and exit immediately,
+    finding nothing to do, on every mult=1 dataset.
+    Source WEST: on_hand=50, safety=0, no own demand -> excess=50.
+    EAST : demand 30 @bucket 1 -> deficit (bucket 1, 30.0).
+    SOUTH: demand 70 @bucket 1 -> deficit (bucket 1, 70.0).
+    Both linked to WEST, DEFAULT transfer_multiple=1.0, same priority 1.
+    total_residual=100: ideal(EAST)=50*(30/100)=15.0 (raw_part==fair_share_qty,
+    no cap, mult=1.0 -> qty=floor(15/1)*1=15 exactly, no rounding at all) ->
+    qty(EAST)=15.0, remnant 0.0. ideal(SOUTH)=50*(70/100)=35.0 -> qty(SOUTH)=
+    35.0 exactly, remnant 0.0. 15+35=50 == the full excess (fully distributed
+    by the proportional pass alone; the sweep finds excess already at 0 and
+    exits on its first iteration without shipping anything).
+    """
+    demand = {("A", "EAST"): {1: 30.0}, ("A", "SOUTH"): {1: 70.0}}
+    on_hand = {("A", "WEST"): 50.0, ("A", "EAST"): 0.0, ("A", "SOUTH"): 0.0}
+    links = [
+        TransferLink("WEST", "EAST", 0, 1.0, None, 1),
+        TransferLink("WEST", "SOUTH", 0, 1.0, None, 1),
+    ]
+    signals = core.transfer_signals(demand, on_hand, {}, links, horizon_buckets=H)
+    by_dest = {s.dest_location: s for s in signals}
+
+    assert len(signals) == 2, "the sweep never adds a THIRD signal on a mult=1.0 dataset"
+    assert by_dest["EAST"].qty == pytest.approx(15.0)
+    assert by_dest["EAST"].rounding_remnant == pytest.approx(0.0)
+    assert by_dest["SOUTH"].qty == pytest.approx(35.0)
+    assert by_dest["SOUTH"].rounding_remnant == pytest.approx(0.0)
+    assert by_dest["EAST"].qty + by_dest["SOUTH"].qty == pytest.approx(50.0)


### PR DESCRIPTION
Réf #395 (PR2a) — **révision du core DRP selon 2 décisions métier du pilote (expert mondial).**

## Décisions métier
1. **Fair-share proportionnel** remplace le greedy priorisé — pour tuer la « famine des dealers B » : quand une source ne couvre pas tous ses sites en déficit, son excédent est réparti **au prorata des déficits résiduels**.
2. **Arrondi logistique** : `transfer_multiple` par lane (migration 065) → transferts physiquement expédiables.

## Algo (déterministe)
Source-first, ordre total figé ; fair-share à priorité égale, greedy entre paliers, derrière l'interrupteur `_FAIR_SHARE_RESPECTS_PRIORITY` (🎯). Arrondi **inférieur** (le DRP *déplace* du stock fini → sur-transférer prive la source ; divergence assumée du `ceil` MRP), reliquat reversé au pool.

## Revue adversariale (6 agents) : 2 défauts, corrigés
- **MAJEUR** : fair-share + floor pouvait tout bloquer à **0/0** alors qu'une palette entière tenait (excès=12, mult=12, 2 dests court de 20) — **strictement pire que le greedy** et ré-ouvrant la famine. Fix : **passe de balayage** du reliquat (attribue les palettes entières au plus nécessiteux d'abord — 🎯 alternative round-robin). Invariant ADR reformulé en « anti-blocage palette » (la forme « tout dest > 0 » est mathématiquement inatteignable sous palette grossière).
- **mineur** : déterminisme conditionné au `link_ref` unique → clé de tri **totale** `_sort_key` → déterminisme inconditionnel.

## Invariants (goldens)
Σ sortie ≤ excédent source (jamais de sur-transfert) · Σ reçue ≤ déficit · déterminisme byte-stable (permutation d'ordre) · anti-blocage palette · min_qty préservé.

## Tests
**37 goldens dérivés à la main** (dont les 2 cas exacts de la revue : balayage palette 12→un dealer pas 0/0, max_qty par instance 2×10, déterminisme [a,b]==[b,a]) + 14 intégration. Suite : 2337 passed, mypy 0/169.

## 🎯 Deux sous-choix ouverts pour le pilote
- Interaction priorité × fair-share (défaut : greedy entre paliers) vs fair-share pur.
- Balayage : plus nécessiteux d'abord (défaut) vs round-robin.
Les deux sont gravés dans l'ADR-028 et pilotables par flag.

**PR2b** : recos TRANSFER gouvernées L1 + watcher scenario-backed + `POST /v1/drp/run` + seed démo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)