### PR TITLE
feat(proof): snapshots de stock quotidiens — inventory_snapshots + capture + CLI + endpoints (#393 A3-PR1)

### DIFF
--- a/scripts/snapshot_inventory.py
+++ b/scripts/snapshot_inventory.py
@@ -1,0 +1,95 @@
+"""
+snapshot_inventory.py — inventory snapshot capture CLI (chantier #393 A3-PR1).
+
+Cron-friendly capturer: scans on-hand per (item, location) for a scenario and
+upserts one ``inventory_snapshots`` row per coordinate for the capture day
+(source='cli'). This is the proof-machine historisation entry point — run it
+daily (cron) to build the stock history a later pass reads to compare "what we
+projected" against "what actually happened".
+
+Thin over the engine: all logic lives in engine/snapshot/capture.py
+(``capture_snapshot`` SELECT-only + ``persist_snapshot`` idempotent upsert). The
+CLI only parses args, opens the connection, and reports.
+
+Idempotent: a re-run for the same scenario/day OVERWRITES each coordinate's row
+(ON CONFLICT on the UNIQUE key) — running twice a day is safe, never
+duplicates. Per-site, never pooled (the DRP lesson): the snapshot is a
+site-level fact.
+
+V1 baseline-only (migration 067): defaults to the baseline scenario. The
+--scenario flag exists for schema/forkability parity but the V1 capture target
+is baseline.
+
+Usage:
+    DATABASE_URL=postgresql://... python scripts/snapshot_inventory.py \
+        [--scenario <uuid>] [--as-of YYYY-MM-DD] [--allow-dev]
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import logging
+import os
+import sys
+import time
+
+import psycopg
+
+import mrp_core as core
+
+from ootils_core.engine.snapshot import capture_snapshot, persist_snapshot
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+logger = logging.getLogger("snapshot_inventory")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Inventory snapshot capture (#393) — per-(item, location) "
+        "on-hand history for the proof machine."
+    )
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    p.add_argument("--scenario", default=core.BASELINE,
+                   help="scenario_id to capture (default: baseline)")
+    p.add_argument("--as-of", default=None,
+                   help="capture day YYYY-MM-DD (default: DB CURRENT_DATE)")
+    p.add_argument("--allow-dev", action="store_true")
+    args = p.parse_args(argv)
+    if not args.dsn:
+        logger.error("DATABASE_URL not set")
+        return 2
+
+    as_of: _dt.date | None = None
+    if args.as_of is not None:
+        try:
+            as_of = _dt.date.fromisoformat(args.as_of)
+        except ValueError:
+            logger.error("invalid --as-of %r — expected YYYY-MM-DD", args.as_of)
+            return 2
+
+    db = core.guard_db(args.dsn, args.allow_dev)
+    scenario = args.scenario
+    logger.info(
+        "Inventory Snapshot (#393) running on DB=%s scenario=%s as_of=%s",
+        db, scenario, as_of if as_of is not None else "CURRENT_DATE",
+    )
+    t0 = time.perf_counter()
+
+    with psycopg.connect(args.dsn) as conn:
+        rows = capture_snapshot(conn, scenario, as_of, source="cli")
+        written = persist_snapshot(conn, rows, source="cli")
+        conn.commit()
+
+    resolved_as_of = rows[0].as_of_date if rows else as_of
+    elapsed = round(time.perf_counter() - t0, 2)
+    logger.info("=" * 92)
+    logger.info("INVENTORY SNAPSHOT — COMPLETED in %.2fs", elapsed)
+    logger.info("  Scenario                     : %s", scenario)
+    logger.info("  As-of date                   : %s", resolved_as_of)
+    logger.info("  Coordinates captured (upsert): %d", written)
+    logger.info("=" * 92)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ootils_core/api/app.py
+++ b/src/ootils_core/api/app.py
@@ -34,7 +34,7 @@ except ImportError:
 
 from ootils_core.api.auth import _expected_token
 from ootils_core.api.dependencies import _get_ootils_db, get_db
-from ootils_core.api.routers import bom, calc, calendars, demo, dq, drp, events, explain, forecasting, ghosts, graph, ingest, issues, mrp, mrp_apics, param_overrides, planning_params, projection, pyramide, rccp, recommendations, scenarios, simulate, staging, stream
+from ootils_core.api.routers import bom, calc, calendars, demo, dq, drp, events, explain, forecasting, ghosts, graph, ingest, issues, mrp, mrp_apics, param_overrides, planning_params, projection, pyramide, rccp, recommendations, scenarios, simulate, snapshots, staging, stream
 from ootils_core.api.routers.graph import nodes_router
 from ootils_core.mps import router as mps_router
 from ootils_core.atp import atp_router
@@ -403,6 +403,7 @@ def create_app() -> FastAPI:
     application.include_router(mrp.router)
     application.include_router(mrp_apics.router)
     application.include_router(drp.router)
+    application.include_router(snapshots.router)
     application.include_router(forecasting.router)
     application.include_router(pyramide.router)
     application.include_router(mps_router)

--- a/src/ootils_core/api/routers/snapshots.py
+++ b/src/ootils_core/api/routers/snapshots.py
@@ -1,0 +1,243 @@
+"""
+/v1/snapshots — inventory snapshot capture + query (chantier #393 A3-PR1, ADR-030).
+
+The HTTP surface over the proof-machine historisation backbone
+(``engine/snapshot/capture.py`` + ``inventory_snapshots``, migration 067):
+
+  * ``POST /v1/snapshots`` captures on-hand per (item, location) for a scenario
+    and idempotently upserts one row per coordinate for ``as_of`` (default
+    CURRENT_DATE), source='api'. A re-POST for the same scenario/day overwrites,
+    never duplicates (ON CONFLICT on the UNIQUE key).
+  * ``GET /v1/snapshots`` reads captured rows back, filtered by scenario/as_of/
+    item — fully parameterized SQL (no f-string WHERE).
+
+SCOPES (chantier #392):
+  * POST requires ``ingest`` — capturing a snapshot WRITES persistent operational
+    rows into the system of record, the same class of action as ``/v1/ingest/*``
+    (which holds ``ingest``). It is deliberately NOT ``read`` (a write must not
+    ride a read scope) and NOT ``recommend:draft`` (a snapshot is a stock FACT,
+    not a governed recommendation). Reusing the established write scope avoids
+    minting a new ``snapshots:*`` vocabulary the token registry (migration 064)
+    would have to learn in PR1; the legacy ``admin`` token satisfies ``ingest``,
+    so no pre-#392 caller regresses.
+  * GET requires ``read`` — a plain query path.
+
+SCENARIO_ID ON EVERY PATH (North Star doctrine): both verbs resolve scenario_id
+(``Depends(resolve_scenario_id)`` on POST; a required query filter on GET) so
+the read path is forkable — an agent queries snapshots FROM a fork, not just
+baseline. V1 captures baseline only (migration 067) but the surface is
+scenario-scoped by construction.
+
+Kill switch: ``OOTILS_SNAPSHOTS_ENABLED`` (default enabled). Falsy → 503 on the
+capture verb, checked AFTER auth/scope but BEFORE the DB pool (an operational
+escape hatch must not depend on the DB being healthy). Mirrors
+``api/routers/drp.py``'s ``OOTILS_DRP_ENABLED`` / ``param_overrides.py``'s
+overlay switch.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import os
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+
+from ootils_core.api.auth import Principal, require_scope
+from ootils_core.api.dependencies import get_db, resolve_scenario_id
+from ootils_core.db.types import DictRowConnection
+from ootils_core.engine.snapshot import capture_snapshot, persist_snapshot
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/snapshots", tags=["snapshots"])
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _snapshots_enabled() -> bool:
+    """Kill switch, default ON. Falsy OOTILS_SNAPSHOTS_ENABLED -> 503."""
+    return os.environ.get("OOTILS_SNAPSHOTS_ENABLED", "1").strip().lower() in _TRUTHY
+
+
+def require_snapshots_enabled() -> None:
+    """FastAPI dependency — checked AFTER auth/scope but BEFORE ``Depends(get_db)``
+    in the capture endpoint (FastAPI resolves synchronous dependencies in
+    signature order and short-circuits on the first HTTPException). Auth-first so
+    an unauthenticated caller always gets 401 and cannot probe the switch state;
+    kill-switch-before-DB so a disabled capturer answers 503 without touching the
+    DB pool."""
+    if not _snapshots_enabled():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Snapshot capture is disabled (OOTILS_SNAPSHOTS_ENABLED).",
+        )
+
+
+class SnapshotCaptureRequest(BaseModel):
+    """Body of POST /v1/snapshots. scenario_id is resolved from the query param /
+    X-Scenario-ID header (Depends(resolve_scenario_id)), NOT the body — matching
+    the forkable read-path convention of the other scenario-scoped routers."""
+
+    as_of: Optional[_dt.date] = Field(
+        default=None,
+        description="Capture day (YYYY-MM-DD). Defaults to the DB CURRENT_DATE.",
+    )
+
+
+class SnapshotCaptureResponse(BaseModel):
+    """Response from a snapshot capture."""
+
+    scenario_id: UUID
+    as_of_date: _dt.date
+    snapshots_captured: int
+
+
+class SnapshotOut(BaseModel):
+    """One captured coordinate row.
+
+    ``first_shortage_date`` / ``shortage_severity_usd`` are NULL-honest: None
+    means no projected shortage at this coordinate on as_of_date (enrichment is
+    deferred to a later PR — captured None in PR1; the two are None together)."""
+
+    snapshot_id: UUID
+    scenario_id: UUID
+    item_id: UUID
+    location_id: UUID
+    as_of_date: _dt.date
+    on_hand_qty: float
+    first_shortage_date: Optional[_dt.date] = None
+    shortage_severity_usd: Optional[float] = None
+    source: str
+    captured_at: _dt.datetime
+
+
+class SnapshotListResponse(BaseModel):
+    scenario_id: UUID
+    snapshots: list[SnapshotOut]
+    total: int
+
+
+def _row_to_out(row: dict) -> SnapshotOut:
+    severity = row["shortage_severity_usd"]
+    return SnapshotOut(
+        snapshot_id=UUID(str(row["snapshot_id"])),
+        scenario_id=UUID(str(row["scenario_id"])),
+        item_id=UUID(str(row["item_id"])),
+        location_id=UUID(str(row["location_id"])),
+        as_of_date=row["as_of_date"],
+        on_hand_qty=float(row["on_hand_qty"]),
+        first_shortage_date=row["first_shortage_date"],
+        shortage_severity_usd=float(severity) if severity is not None else None,
+        source=row["source"],
+        captured_at=row["captured_at"],
+    )
+
+
+@router.post(
+    "",
+    response_model=SnapshotCaptureResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Capture inventory snapshots",
+    description=(
+        "Scan on-hand per (item, location) for a scenario and upsert one "
+        "`inventory_snapshots` row per coordinate for `as_of` (default "
+        "CURRENT_DATE), source='api'. Idempotent: a re-capture of the same "
+        "scenario/day overwrites, never duplicates. Per-site, never pooled. "
+        "Requires the `ingest` scope (a write of persistent operational rows)."
+    ),
+)
+def capture_snapshots(
+    body: SnapshotCaptureRequest,
+    _principal: Principal = Depends(require_scope("ingest")),
+    _enabled: None = Depends(require_snapshots_enabled),
+    scenario_id: UUID = Depends(resolve_scenario_id),
+    db: DictRowConnection = Depends(get_db),
+) -> SnapshotCaptureResponse:
+    """Capture + persist inventory snapshots for a scenario.
+
+    get_db owns commit/rollback. The engine's ``capture_snapshot`` is SELECT-only
+    and ``persist_snapshot`` is the single idempotent upsert writer; this handler
+    adds no SQL of its own on the write path."""
+    scenario_str = str(scenario_id)
+
+    rows = capture_snapshot(db, scenario_str, body.as_of, source="api")
+    written = persist_snapshot(db, rows, source="api")
+
+    # Resolve the effective as_of: the rows carry the DB CURRENT_DATE the scan
+    # resolved when body.as_of was None. With zero on-hand coordinates there are
+    # no rows to read it from, so fall back to the request value (which is the
+    # only as_of the caller asked for) or the DB CURRENT_DATE.
+    if rows:
+        as_of_date = rows[0].as_of_date
+    elif body.as_of is not None:
+        as_of_date = body.as_of
+    else:
+        current = db.execute("SELECT CURRENT_DATE AS d").fetchone()
+        if current is None:
+            raise RuntimeError("snapshots.capture: SELECT CURRENT_DATE yielded no row")
+        as_of_date = current["d"]
+
+    logger.info(
+        "snapshots.capture scenario_id=%s as_of=%s captured=%d",
+        scenario_str, as_of_date, written,
+    )
+
+    return SnapshotCaptureResponse(
+        scenario_id=scenario_id,
+        as_of_date=as_of_date,
+        snapshots_captured=written,
+    )
+
+
+@router.get(
+    "",
+    response_model=SnapshotListResponse,
+    summary="Query inventory snapshots",
+    description=(
+        "Read captured snapshots filtered by scenario (required, forkable), "
+        "optional as_of day and item_id. Fully parameterized SQL."
+    ),
+)
+def list_snapshots(
+    _principal: Principal = Depends(require_scope("read")),
+    scenario_id: UUID = Depends(resolve_scenario_id),
+    as_of: Optional[_dt.date] = Query(
+        default=None, description="Filter to a single capture day (YYYY-MM-DD)."
+    ),
+    item_id: Optional[UUID] = Query(
+        default=None, description="Filter to a single item."
+    ),
+    db: DictRowConnection = Depends(get_db),
+) -> SnapshotListResponse:
+    """Query snapshots for a scenario. scenario_id is always constrained (North
+    Star: every read path is scenario-scoped). Optional as_of / item_id narrow
+    the result. SQL is fully parameterized — every filter is a static ``col =
+    %s`` predicate with its value bound positionally; the assembled WHERE string
+    contains only hardcoded column names, never caller data (the house idiom,
+    cf. recommendations.py / graph.py)."""
+    conditions = ["scenario_id = %s"]
+    params: list = [scenario_id]
+    if as_of is not None:
+        conditions.append("as_of_date = %s")
+        params.append(as_of)
+    if item_id is not None:
+        conditions.append("item_id = %s")
+        params.append(item_id)
+    where_clause = "WHERE " + " AND ".join(conditions)
+
+    rows = db.execute(
+        f"""
+        SELECT snapshot_id, scenario_id, item_id, location_id, as_of_date,
+               on_hand_qty, first_shortage_date, shortage_severity_usd, source, captured_at
+        FROM inventory_snapshots
+        {where_clause}
+        ORDER BY as_of_date DESC, item_id, location_id
+        """,  # noqa: S608 — static columns, parameterized values
+        params,
+    ).fetchall()
+
+    out = [_row_to_out(r) for r in rows]
+    return SnapshotListResponse(scenario_id=scenario_id, snapshots=out, total=len(out))

--- a/src/ootils_core/db/migrations/067_inventory_snapshots.sql
+++ b/src/ootils_core/db/migrations/067_inventory_snapshots.sql
@@ -1,0 +1,131 @@
+-- ============================================================
+-- Migration 067 — Inventory snapshots (proof machine foundation)
+-- ============================================================
+-- Chantier #393 A3-PR1. ADR-030 (à venir): "Inventory historisation +
+-- outcome/proof machine".
+--
+-- WHAT: a per-day, per-(item, location) point-in-time record of on-hand
+-- stock and the projected-shortage picture at that coordinate. This is the
+-- historisation backbone the proof machine reads to compare "what we said
+-- would happen" against "what actually happened" over time. One snapshot per
+-- coordinate per day (the natural capture grain).
+--
+-- SCENARIO_ID (schema-consistent, V1 baseline-only): every stateful table in
+-- the graph carries scenario_id (nodes/edges/shortages, migrations 002/005)
+-- so forks are first-class. inventory_snapshots follows the house rule for
+-- schema consistency and future extension, but V1 CAPTURES BASELINE ONLY —
+-- the capturers (CLI/cron/API) always write the baseline scenario. A hard FK
+-- to scenarios(scenario_id) with the default RESTRICT is correct here (unlike
+-- the audit-record SET NULL of migration 066): a snapshot is meaningless
+-- without its scenario coordinate, and baseline is never hard-deleted.
+--
+-- SEVERITY $-VALUED, NULL-HONEST (ADR-021 alignment): shortage_severity_usd
+-- mirrors the canonical $-valued severity owned by ShortageDetector (the
+-- shortages table is the canonical persistence/query system per ADR-021).
+-- This column is a DENORMALISED capture of the severity AS OF the snapshot
+-- day, NOT a second source of shortage truth — the snapshot never writes into
+-- shortages and ShortageDetector never reads this. NULL is the honest value
+-- when the coordinate had NO projected shortage on as_of_date (no shortage =>
+-- no $-severity), exactly as first_shortage_date is NULL then. A row with
+-- first_shortage_date IS NULL MUST have shortage_severity_usd IS NULL, and
+-- vice-versa; the two are captured together from the same MRP projection.
+--
+-- FK POLICY: item_id / location_id are hard FKs to items/locations with the
+-- default RESTRICT — the house pattern (item_planning_params, nodes,
+-- shortages … migrations 002/005). A snapshot is master-data-anchored; master
+-- data referenced by a stock history must not be silently orphaned.
+--
+-- PRECISION: on_hand_qty and shortage_severity_usd are NUMERIC(18,6) — the
+-- canonical scaled precision for quantities across the engine (MRP buckets
+-- migration 021, forecast 026, MPS 027, DRP 029) and a safe superset for a $
+-- value (money columns migration 029). Never FLOAT/REAL on a quantity or a
+-- cost.
+--
+-- IDEMPOTENCE (repo migration policy — the runner in db/connection.py wraps
+-- each file in its own transaction and, on ANY error, ROLLS BACK and ABORTS;
+-- it does NOT swallow "already exists"): every statement re-runs as a clean
+-- no-op — CREATE TABLE/INDEX IF NOT EXISTS. The UNIQUE (scenario_id, item_id,
+-- location_id, as_of_date) additionally lets the capturer upsert the same day
+-- with ON CONFLICT ... DO UPDATE, so a re-capture of the same coordinate/day
+-- is idempotent at the application level too (re-running today's capture
+-- overwrites, never duplicates).
+--
+-- No JSONB. Typed columns only.
+--
+-- Rolling-safe: brand-new, additive table — no reader depends on it yet, no
+-- existing object is altered.
+--
+-- ref: ADR-030 (proof machine), #393 A3-PR1.
+-- ============================================================
+
+BEGIN;
+
+-- ------------------------------------------------------------
+-- inventory_snapshots: per-day per-coordinate stock history
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS inventory_snapshots (
+    snapshot_id            UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+    scenario_id            UUID          NOT NULL REFERENCES scenarios(scenario_id),
+    item_id                UUID          NOT NULL REFERENCES items(item_id),
+    location_id            UUID          NOT NULL REFERENCES locations(location_id),
+    as_of_date             DATE          NOT NULL,
+    on_hand_qty            NUMERIC(18,6) NOT NULL,
+    first_shortage_date    DATE,
+    shortage_severity_usd  NUMERIC(18,6),
+    source                 TEXT          NOT NULL
+                                         CHECK (source IN ('cli', 'api', 'cron')),
+    captured_at            TIMESTAMPTZ   NOT NULL DEFAULT now(),
+
+    -- One snapshot per coordinate per day. Enables ON CONFLICT DO UPDATE
+    -- (idempotent re-capture of the same day).
+    UNIQUE (scenario_id, item_id, location_id, as_of_date)
+);
+
+COMMENT ON TABLE inventory_snapshots IS
+    'Per-day, per-(item, location) point-in-time stock history — the proof '
+    'machine foundation (#393 A3-PR1, ADR-030). V1 captures BASELINE ONLY '
+    '(scenario_id present for schema consistency + future forkability). One '
+    'row per (scenario, item, location, as_of_date); the UNIQUE key backs an '
+    'idempotent ON CONFLICT DO UPDATE re-capture.';
+
+COMMENT ON COLUMN inventory_snapshots.scenario_id IS
+    'Scenario coordinate. V1 baseline-only (capturers always write baseline); '
+    'column exists for schema consistency and future fork historisation.';
+
+COMMENT ON COLUMN inventory_snapshots.as_of_date IS
+    'The captured day — the point in time this stock/shortage picture '
+    'represents.';
+
+COMMENT ON COLUMN inventory_snapshots.on_hand_qty IS
+    'On-hand stock at the coordinate on as_of_date. NUMERIC(18,6) — canonical '
+    'scaled quantity precision.';
+
+COMMENT ON COLUMN inventory_snapshots.first_shortage_date IS
+    'First projected shortage date at this coordinate as of as_of_date; NULL '
+    'if no shortage was projected. Captured together with '
+    'shortage_severity_usd (both NULL or both set).';
+
+COMMENT ON COLUMN inventory_snapshots.shortage_severity_usd IS
+    'Denormalised $-valued shortage severity (ADR-021 semantics) AS OF '
+    'as_of_date — NOT a second source of shortage truth (ShortageDetector '
+    'stays canonical; this row never writes into shortages). NULL-honest: '
+    'NULL when the coordinate had no projected shortage on as_of_date '
+    '(mirrors first_shortage_date IS NULL).';
+
+COMMENT ON COLUMN inventory_snapshots.source IS
+    'Capture channel: cli (manual/script), api (endpoint), cron (scheduled).';
+
+-- ------------------------------------------------------------
+-- Indexes
+-- ------------------------------------------------------------
+-- Query-by-date within a scenario ("all snapshots for day D"): the proof
+-- machine's daily scan.
+CREATE INDEX IF NOT EXISTS idx_inventory_snapshots_scenario_date
+    ON inventory_snapshots (scenario_id, as_of_date);
+
+-- Latest snapshot for a coordinate ("what did we last know about this item @
+-- location?"): DESC on as_of_date makes the newest row the leading match.
+CREATE INDEX IF NOT EXISTS idx_inventory_snapshots_coord_latest
+    ON inventory_snapshots (item_id, location_id, as_of_date DESC);
+
+COMMIT;

--- a/src/ootils_core/db/migrations/067_inventory_snapshots.sql
+++ b/src/ootils_core/db/migrations/067_inventory_snapshots.sql
@@ -65,9 +65,14 @@ BEGIN;
 -- ------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS inventory_snapshots (
     snapshot_id            UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
-    scenario_id            UUID          NOT NULL REFERENCES scenarios(scenario_id),
-    item_id                UUID          NOT NULL REFERENCES items(item_id),
-    location_id            UUID          NOT NULL REFERENCES locations(location_id),
+    -- ON DELETE RESTRICT is EXPLICIT, not inherited: Postgres' default FK action
+    -- is NO ACTION, and the repo-wide guard test_scenario_fk_retention enforces
+    -- that every FK referencing scenarios uses ON DELETE RESTRICT (a scenario
+    -- must never be deleted out from under its data). item/location follow the
+    -- same discipline — a snapshot without its coordinate is meaningless.
+    scenario_id            UUID          NOT NULL REFERENCES scenarios(scenario_id) ON DELETE RESTRICT,
+    item_id                UUID          NOT NULL REFERENCES items(item_id) ON DELETE RESTRICT,
+    location_id            UUID          NOT NULL REFERENCES locations(location_id) ON DELETE RESTRICT,
     as_of_date             DATE          NOT NULL,
     on_hand_qty            NUMERIC(18,6) NOT NULL,
     first_shortage_date    DATE,

--- a/src/ootils_core/engine/snapshot/__init__.py
+++ b/src/ootils_core/engine/snapshot/__init__.py
@@ -1,0 +1,22 @@
+"""
+Inventory snapshot engine — the proof-machine historisation backbone
+(chantier #393 A3-PR1, ADR-030).
+
+capture: SELECT-only per-(item, location) on-hand capture (``capture_snapshot``,
+    pure/DB-read) + the single idempotent upsert writer (``persist_snapshot``)
+    into ``inventory_snapshots`` (migration 067). Per-site, never pooled (the
+    DRP lesson) — the snapshot is a site-level stock fact.
+"""
+from ootils_core.engine.snapshot.capture import (
+    VALID_SOURCES,
+    SnapshotRow,
+    capture_snapshot,
+    persist_snapshot,
+)
+
+__all__ = [
+    "VALID_SOURCES",
+    "SnapshotRow",
+    "capture_snapshot",
+    "persist_snapshot",
+]

--- a/src/ootils_core/engine/snapshot/capture.py
+++ b/src/ootils_core/engine/snapshot/capture.py
@@ -1,0 +1,222 @@
+"""
+capture.py — inventory snapshot capture (chantier #393 A3-PR1, ADR-030).
+
+The proof-machine foundation: a per-day, per-(item, location) point-in-time
+record of on-hand stock, persisted in ``inventory_snapshots`` (migration 067)
+so a later pass can compare "what we said would happen" against "what actually
+happened".
+
+Split, mirroring the engine's DB-boundary convention (mrp/core is pure,
+mrp/loader owns SQL):
+
+  * ``capture_snapshot`` is a SELECT-only read that scans on-hand per
+    (item, location) coordinate from the scenario's ``OnHandSupply`` nodes and
+    returns a deterministic, stably-sorted list of in-memory ``SnapshotRow``.
+    It writes NOTHING — testable against a golden without any persistence.
+  * ``persist_snapshot`` is the only writer: an idempotent upsert into
+    ``inventory_snapshots`` keyed on the UNIQUE (scenario_id, item_id,
+    location_id, as_of_date), so a re-capture of the same coordinate/day
+    overwrites rather than duplicates.
+
+PER-SITE, NEVER POOLED (the DRP lesson, ADR-028): on-hand is scanned per
+(item, location) — the snapshot is a site-level fact. This is deliberately NOT
+the item-pooled scan of ``mrp/loader.load_planning_data`` (which SUMs on-hand
+across locations for the make/buy echelon). A node with a NULL location_id is
+skipped: an un-located on-hand has no place in a per-site history (the FK on
+``inventory_snapshots.location_id`` is NOT NULL anyway).
+
+RAW UUID COORDINATES: the snapshot stores the raw ``nodes.item_id`` /
+``nodes.location_id`` UUIDs (matching the migration 067 FK columns), NOT the
+external_id business keys the DRP resolves — a snapshot is an internal stock
+fact anchored to master data, and the UNIQUE key is UUID-shaped.
+
+SHORTAGE ENRICHMENT (first_shortage_date / shortage_severity_usd) IS DEFERRED
+to a later PR — captured NULL here, honestly. The canonical shortage math
+(``mrp/core.first_shortage``) is ITEM-POOLED (pooled on-hand + pooled demand),
+so stamping its date/severity onto each per-location row would attribute a
+pooled shortage to individual sites and double-count the same item deficit
+across N locations — the exact per-site collapse this module (and ADR-028)
+exists to prevent. The DRP's per-location ``projected_deficits`` is closer in
+grain but (a) keys by external_id, not the UUIDs this table stores, (b) nets NO
+firm receipts (its projection is deliberately receipt-free), so its shortage
+picture diverges from the canonical ``shortages`` truth, and (c) yields a
+unit deficit, not the $-valued ShortageDetector severity. An honest per-(item,
+location) severity therefore needs a per-location projection that nets firm
+receipts AND applies the $ formula — future work. Until then both columns stay
+NULL, which the migration's contract reads as "no projected shortage / not
+calculable at this grain" (first_shortage_date and shortage_severity_usd are
+NULL together by design).
+
+Scenario-scoped (schema-consistent, V1 baseline-only per migration 067): the
+scan reads the scenario's own nodes, so a fork would snapshot fork state — but
+the V1 capturers (CLI/cron/API) always pass baseline.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+from dataclasses import dataclass
+from decimal import Decimal
+from uuid import UUID
+
+from psycopg.rows import tuple_row
+
+from ootils_core.db.types import DictRowConnection
+from ootils_core.engine.mrp.core import BASELINE
+
+# Capture channels — kept in sync with the inventory_snapshots.source CHECK
+# constraint (migration 067). Validated here so a bad source fails loudly at the
+# persistence boundary rather than as an opaque DB CHECK violation.
+VALID_SOURCES: frozenset[str] = frozenset({"cli", "api", "cron"})
+
+
+@dataclass(frozen=True)
+class SnapshotRow:
+    """One captured coordinate — an in-memory row destined for
+    ``inventory_snapshots``.
+
+    Coordinates are the raw graph UUIDs (``nodes.item_id`` / ``location_id``),
+    matching the migration 067 FK columns. ``on_hand_qty`` is a Decimal so it
+    round-trips into NUMERIC(18,6) without float drift.
+
+    ``first_shortage_date`` and ``shortage_severity_usd`` are the NULL-honest
+    shortage picture: both are None in PR1 (enrichment deferred — see the module
+    docstring). The contract is that they are None together or set together.
+    """
+
+    scenario_id: UUID
+    item_id: UUID
+    location_id: UUID
+    as_of_date: _dt.date
+    on_hand_qty: Decimal
+    first_shortage_date: _dt.date | None
+    shortage_severity_usd: Decimal | None
+    source: str
+
+
+def capture_snapshot(
+    conn: DictRowConnection,
+    scenario: str = BASELINE,
+    as_of_date: _dt.date | None = None,
+    *,
+    source: str = "cli",
+) -> list[SnapshotRow]:
+    """Scan on-hand per (item, location) for ``scenario`` and build snapshot rows.
+
+    SELECT-only — writes nothing (persistence is ``persist_snapshot``'s job).
+    Deterministic: rows are sorted by (item_id, location_id) so the output is
+    stable regardless of scan order, and on-hand is summed per coordinate with
+    Decimal arithmetic (no float pooling error).
+
+    ``as_of_date`` defaults to the DB's CURRENT_DATE — resolved from the same
+    connection so the capture day matches the scenario's own clock (the MRP /
+    DRP loaders anchor their horizon to CURRENT_DATE identically).
+
+    ``source`` is carried onto every row (validated at persist time) so the
+    caller declares its channel once; it does not affect the scan.
+    """
+    # tuple_row for positional access regardless of the connection's configured
+    # row_factory — a scenario-aware caller (API path) hands us the app's
+    # dict_row connection, under which positional access would raise; the CLI
+    # hands us a tuple_row connection. Same defensive pin as mrp/drp loaders.
+    cur = conn.cursor(row_factory=tuple_row)
+
+    if as_of_date is None:
+        today_row = cur.execute("SELECT CURRENT_DATE").fetchone()
+        if today_row is None:
+            raise RuntimeError("capture_snapshot: SELECT CURRENT_DATE yielded no row")
+        as_of_date = today_row[0]
+
+    # On-hand per (item, location), summed. Scenario-scoped like the MRP/DRP
+    # nodes scans. A NULL location_id (or item_id) is excluded: a snapshot row
+    # must carry both coordinates (NOT NULL FKs on inventory_snapshots), and an
+    # un-located on-hand has no per-site home. Raw UUIDs — no external_id
+    # resolution (the snapshot stores UUID coordinates, unlike the DRP).
+    on_hand: dict[tuple[UUID, UUID], Decimal] = {}
+    for item_id, location_id, qty in cur.execute(
+        "SELECT item_id, location_id, quantity FROM nodes "
+        "WHERE scenario_id = %(b)s AND active "
+        "AND node_type = 'OnHandSupply' "
+        "AND item_id IS NOT NULL AND location_id IS NOT NULL "
+        "AND quantity IS NOT NULL",
+        {"b": scenario},
+    ).fetchall():
+        coord = (item_id, location_id)
+        # quantity is NUMERIC -> psycopg yields Decimal; keep it exact.
+        on_hand[coord] = on_hand.get(coord, Decimal(0)) + qty
+
+    scenario_uuid = UUID(scenario)
+    rows: list[SnapshotRow] = []
+    for (item_id, location_id), qty in sorted(
+        on_hand.items(), key=lambda kv: (str(kv[0][0]), str(kv[0][1]))
+    ):
+        rows.append(
+            SnapshotRow(
+                scenario_id=scenario_uuid,
+                item_id=item_id,
+                location_id=location_id,
+                as_of_date=as_of_date,
+                on_hand_qty=qty,
+                # Enrichment deferred (see module docstring). NULL-honest: both
+                # shortage columns stay None together in PR1.
+                first_shortage_date=None,
+                shortage_severity_usd=None,
+                source=source,
+            )
+        )
+    return rows
+
+
+def persist_snapshot(
+    conn: DictRowConnection,
+    rows: list[SnapshotRow],
+    source: str,
+) -> int:
+    """Idempotently upsert snapshot rows into ``inventory_snapshots``.
+
+    The ONLY writer of the table. ON CONFLICT on the UNIQUE (scenario_id,
+    item_id, location_id, as_of_date) DO UPDATE — a re-capture of the same
+    coordinate/day overwrites the stock/shortage picture and re-stamps
+    ``captured_at``, never duplicates. Returns the number of rows written
+    (inserted or updated).
+
+    ``source`` overrides the per-row source so the channel is declared once by
+    the caller (CLI='cli', API='api', cron='cron'). Validated here — an invalid
+    channel fails loudly rather than as an opaque DB CHECK violation. Does NOT
+    commit: the caller owns the transaction (``get_db`` for the API, the CLI's
+    own ``with psycopg.connect`` context).
+    """
+    if source not in VALID_SOURCES:
+        raise ValueError(
+            f"invalid snapshot source {source!r} — must be one of {sorted(VALID_SOURCES)}"
+        )
+    if not rows:
+        return 0
+
+    written = 0
+    for row in rows:
+        conn.execute(
+            """
+            INSERT INTO inventory_snapshots
+                (scenario_id, item_id, location_id, as_of_date, on_hand_qty,
+                 first_shortage_date, shortage_severity_usd, source)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (scenario_id, item_id, location_id, as_of_date) DO UPDATE SET
+                on_hand_qty           = EXCLUDED.on_hand_qty,
+                first_shortage_date   = EXCLUDED.first_shortage_date,
+                shortage_severity_usd = EXCLUDED.shortage_severity_usd,
+                source                = EXCLUDED.source,
+                captured_at           = now()
+            """,
+            (
+                row.scenario_id,
+                row.item_id,
+                row.location_id,
+                row.as_of_date,
+                row.on_hand_qty,
+                row.first_shortage_date,
+                row.shortage_severity_usd,
+                source,
+            ),
+        )
+        written += 1
+    return written

--- a/tests/integration/test_snapshot_integration.py
+++ b/tests/integration/test_snapshot_integration.py
@@ -1,0 +1,749 @@
+"""
+tests/integration/test_snapshot_integration.py — DB-backed tests for the
+inventory-snapshot backbone (chantier #393 A3-PR1, ADR-030) against a real
+Postgres. Migration 067 (inventory_snapshots) is applied by the ``migrated_db``
+fixture exactly as production applies it (OotilsDB startup). No mocks — CLAUDE.md.
+
+Two surfaces are under test:
+
+  * The engine (``engine/snapshot/capture.py``): ``capture_snapshot`` (SELECT-only
+    per-(item, location) on-hand scan) + ``persist_snapshot`` (the single
+    idempotent upsert). These use the function-scoped ``conn`` fixture directly.
+  * The HTTP surface (``api/routers/snapshots.py``): POST captures (scope
+    ``ingest`` + kill switch), GET queries (scope ``read``). These use a
+    TestClient with ``get_db`` overridden onto the test DB and minted tokens
+    (the #392 pattern of test_agent_floor_integration.py).
+
+Locked contracts:
+  1. Per-SITE, never pooled (the DRP lesson / ADR-028): two OnHand nodes on the
+     SAME (item, location) SUM to one row; the SAME item across TWO locations
+     yields TWO distinct rows; a NULL item/location coordinate is excluded.
+  2. Idempotent upsert on the UNIQUE (scenario, item, location, as_of): a
+     re-capture of the same day overwrites (one row/coord), never duplicates,
+     and re-stamps captured_at; an empty batch writes nothing.
+  3. NULL-honest shortage pair: first_shortage_date and shortage_severity_usd
+     are BOTH NULL on every PR1 row (never 0).
+  4. POST /v1/snapshots: 201 with {scenario_id, as_of_date, snapshots_captured};
+     401 unauthenticated; 403 with a read-only token (write needs ingest);
+     503 when OOTILS_SNAPSHOTS_ENABLED is falsy (no row written); source='api'.
+  5. GET /v1/snapshots: requires read; filters by scenario/as_of/item_id;
+     deterministic ORDER BY; parameterized SQL (an item_id filter is a bound
+     value, never string-interpolated).
+  6. Forkable: a capture on baseline and on a fork land on distinct,
+     scenario-scoped rows.
+  7. CLI (scripts/snapshot_inventory.py): main(["--dsn", ..., "--allow-dev"])
+     exits 0 and persists rows with source='cli'.
+
+Every test seeds its own uuid4-suffixed master data and cleans the coordinates
+it created (or relies on the module teardown that DROPs every public table).
+Dates are anchored on the DB-side CURRENT_DATE. No wall-clock timing assertions.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import psycopg
+import pytest
+from psycopg.rows import dict_row
+
+from ootils_core.engine.snapshot import capture_snapshot, persist_snapshot
+
+from .conftest import requires_db
+
+# Import seam for the CLI (scripts/ is outside the package; it does a bare
+# "import mrp_core", so scripts/ must be on sys.path).
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+pytestmark = requires_db
+
+# Seeded by migration 002 (is_baseline=TRUE) — the only baseline scenario.
+BASELINE = UUID("00000000-0000-0000-0000-000000000001")
+LEGACY_TOKEN = "integration-test-token"
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers (calqued on test_drp_loader_integration.py). The snapshot stores
+# RAW UUID coordinates, so external_id is not strictly needed — a uuid4 suffix is
+# carried only to keep each seed's master data collision-free.
+# ---------------------------------------------------------------------------
+
+
+def _seed_item(conn, name: str = "snap-item") -> UUID:
+    return conn.execute(
+        "INSERT INTO items (item_id, external_id, name) VALUES (%s, %s, %s) RETURNING item_id",
+        (uuid4(), f"{name}-{uuid4()}", name),
+    ).fetchone()["item_id"]
+
+
+def _seed_location(conn, name: str = "snap-loc") -> UUID:
+    return conn.execute(
+        "INSERT INTO locations (location_id, external_id, name) "
+        "VALUES (%s, %s, %s) RETURNING location_id",
+        (uuid4(), f"{name}-{uuid4()}", name),
+    ).fetchone()["location_id"]
+
+
+def _seed_scenario(conn, name: str = "snap-fork") -> UUID:
+    """A non-baseline scenario (a fork). The capture scan is scenario-scoped by
+    node.scenario_id; a plain fork row (no ScenarioManager deep-copy) is all we
+    need to prove scoping."""
+    return conn.execute(
+        "INSERT INTO scenarios (scenario_id, name, is_baseline, status) "
+        "VALUES (%s, %s, FALSE, 'active') RETURNING scenario_id",
+        (uuid4(), f"{name}-{uuid4()}"),
+    ).fetchone()["scenario_id"]
+
+
+def _seed_on_hand(conn, *, scenario_id, item_id, location_id, qty, active=True) -> UUID:
+    """An OnHandSupply node explicitly scoped to ``scenario_id`` (the capture
+    scan is strictly scenario-scoped and filters node_type='OnHandSupply' AND
+    active). item_id / location_id may be None to exercise the NULL exclusion."""
+    node_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO nodes (
+            node_id, node_type, scenario_id, item_id, location_id,
+            quantity, time_grain, time_ref, active
+        ) VALUES (%s, 'OnHandSupply', %s, %s, %s, %s, 'exact_date', CURRENT_DATE, %s)
+        """,
+        (node_id, scenario_id, item_id, location_id, qty, active),
+    )
+    return node_id
+
+
+def _snapshots_for(conn, scenario_id, item_id) -> list[dict]:
+    return conn.execute(
+        "SELECT * FROM inventory_snapshots "
+        "WHERE scenario_id = %s AND item_id = %s "
+        "ORDER BY location_id, as_of_date",
+        (scenario_id, item_id),
+    ).fetchall()
+
+
+# ===========================================================================
+# 1. Capture per-site, NOT pooled — THE central case
+# ===========================================================================
+
+
+def test_capture_sums_two_nodes_on_same_coordinate(conn):
+    """Two OnHandSupply nodes on the SAME (item, location) collapse to ONE
+    SnapshotRow whose on_hand_qty is the Decimal SUM — the per-coordinate
+    aggregation."""
+    item_id = _seed_item(conn)
+    loc = _seed_location(conn)
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_id, location_id=loc, qty=10)
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_id, location_id=loc, qty=32)
+    conn.commit()
+
+    rows = capture_snapshot(conn, str(BASELINE), source="cli")
+    mine = [r for r in rows if r.item_id == item_id and r.location_id == loc]
+
+    assert len(mine) == 1, "two nodes on one coordinate must collapse to one row"
+    assert mine[0].on_hand_qty == 42
+    assert mine[0].scenario_id == BASELINE
+
+
+def test_capture_same_item_two_locations_stays_distinct_not_pooled(conn):
+    """THE anti-pooling proof: ONE item at TWO locations yields TWO distinct
+    rows (one per location), never a single item-pooled row. This is the whole
+    reason the snapshot exists per-site (ADR-028)."""
+    item_id = _seed_item(conn)
+    east = _seed_location(conn, "snap-east")
+    west = _seed_location(conn, "snap-west")
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_id, location_id=east, qty=8)
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_id, location_id=west, qty=20)
+    conn.commit()
+
+    rows = capture_snapshot(conn, str(BASELINE), source="cli")
+    mine = {r.location_id: r for r in rows if r.item_id == item_id}
+
+    assert set(mine) == {east, west}, "one item / two locations -> two rows"
+    assert mine[east].on_hand_qty == 8
+    assert mine[west].on_hand_qty == 20
+    # Never summed together onto a single item-level coordinate.
+    assert mine[east].on_hand_qty + mine[west].on_hand_qty == 28
+
+
+def test_capture_excludes_null_item_or_location(conn):
+    """A node with a NULL item_id OR a NULL location_id is excluded (both
+    coordinates are required; the migration-067 FKs are NOT NULL). Only the
+    fully-coordinated node survives the scan."""
+    item_id = _seed_item(conn)
+    loc = _seed_location(conn)
+    # Fully-coordinated -> kept.
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_id, location_id=loc, qty=5)
+    # NULL location -> excluded.
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_id, location_id=None, qty=99)
+    # NULL item -> excluded.
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=None, location_id=loc, qty=77)
+    conn.commit()
+
+    rows = capture_snapshot(conn, str(BASELINE), source="cli")
+    mine = [r for r in rows if r.item_id == item_id and r.location_id == loc]
+
+    assert len(mine) == 1
+    assert mine[0].on_hand_qty == 5
+    # The un-located node's quantity is NOT folded into the kept row.
+    assert all(r.on_hand_qty != 99 for r in rows)
+
+
+def test_capture_excludes_inactive_nodes(conn):
+    """The scan filters ``active`` — an inactive OnHandSupply never contributes
+    (belt on the WHERE clause)."""
+    item_id = _seed_item(conn)
+    loc = _seed_location(conn)
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_id, location_id=loc, qty=15)
+    _seed_on_hand(
+        conn, scenario_id=BASELINE, item_id=item_id, location_id=loc, qty=500, active=False
+    )
+    conn.commit()
+
+    rows = capture_snapshot(conn, str(BASELINE), source="cli")
+    mine = [r for r in rows if r.item_id == item_id and r.location_id == loc]
+
+    assert len(mine) == 1
+    assert mine[0].on_hand_qty == 15, "inactive node's 500 must not be summed in"
+
+
+def test_capture_rows_sorted_by_coordinate(conn):
+    """Output is deterministically sorted by (item_id, location_id) so a golden
+    caller sees a stable order regardless of physical scan order."""
+    item_id = _seed_item(conn)
+    loc_a = _seed_location(conn, "snap-a")
+    loc_b = _seed_location(conn, "snap-b")
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_id, location_id=loc_a, qty=1)
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_id, location_id=loc_b, qty=2)
+    conn.commit()
+
+    rows = capture_snapshot(conn, str(BASELINE), source="cli")
+    keyed = [(str(r.item_id), str(r.location_id)) for r in rows]
+    assert keyed == sorted(keyed), "rows must be sorted by (item_id, location_id)"
+
+
+# ===========================================================================
+# 2. Idempotent upsert
+# ===========================================================================
+
+
+def test_persist_is_idempotent_on_same_day(conn):
+    """capture+persist twice for the same scenario/day writes ONE row per
+    coordinate, not two — the ON CONFLICT DO UPDATE on the UNIQUE key."""
+    item_id = _seed_item(conn)
+    loc = _seed_location(conn)
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_id, location_id=loc, qty=12)
+    conn.commit()
+
+    rows = capture_snapshot(conn, str(BASELINE), source="cli")
+    n1 = persist_snapshot(conn, rows, source="cli")
+    n2 = persist_snapshot(conn, rows, source="cli")
+    conn.commit()
+
+    assert n1 >= 1 and n2 >= 1  # both report the coordinate as written
+    stored = _snapshots_for(conn, BASELINE, item_id)
+    assert len(stored) == 1, "same scenario/day -> one row per coordinate, never two"
+    assert stored[0]["on_hand_qty"] == 12
+    assert stored[0]["source"] == "cli"
+
+
+def test_recapture_updates_on_hand_and_restamps_captured_at(conn):
+    """A second capture after on-hand changed OVERWRITES on_hand_qty in place
+    and re-stamps captured_at (EXCLUDED ... captured_at = now())."""
+    item_id = _seed_item(conn)
+    loc = _seed_location(conn)
+    node = _seed_on_hand(
+        conn, scenario_id=BASELINE, item_id=item_id, location_id=loc, qty=100
+    )
+    conn.commit()
+
+    first = capture_snapshot(conn, str(BASELINE), source="cli")
+    persist_snapshot(conn, first, source="cli")
+    conn.commit()
+    captured_at_1 = _snapshots_for(conn, BASELINE, item_id)[0]["captured_at"]
+
+    # On-hand drops to 60 for the same coordinate/day.
+    conn.execute("UPDATE nodes SET quantity = 60 WHERE node_id = %s", (node,))
+    conn.commit()
+
+    second = capture_snapshot(conn, str(BASELINE), source="cli")
+    persist_snapshot(conn, second, source="cli")
+    conn.commit()
+
+    stored = _snapshots_for(conn, BASELINE, item_id)
+    assert len(stored) == 1, "still one row for the coordinate/day"
+    assert stored[0]["on_hand_qty"] == 60, "on_hand overwritten in place"
+    assert stored[0]["captured_at"] >= captured_at_1, "captured_at re-stamped"
+
+
+def test_persist_empty_batch_writes_nothing(conn):
+    """persist_snapshot([]) is a no-op returning 0 — no row appears."""
+    item_id = _seed_item(conn)
+    conn.commit()
+
+    assert persist_snapshot(conn, [], source="cli") == 0
+    conn.commit()
+    assert _snapshots_for(conn, BASELINE, item_id) == []
+
+
+# ===========================================================================
+# 3. NULL-honest shortage pair
+# ===========================================================================
+
+
+def test_persisted_rows_have_both_shortage_columns_null(conn):
+    """PR1 contract: every persisted row carries first_shortage_date AND
+    shortage_severity_usd as NULL together — never 0, never one-set-one-null."""
+    item_a = _seed_item(conn, "snap-null-a")
+    item_b = _seed_item(conn, "snap-null-b")
+    loc = _seed_location(conn)
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_a, location_id=loc, qty=3)
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_b, location_id=loc, qty=0)
+    conn.commit()
+
+    rows = capture_snapshot(conn, str(BASELINE), source="cli")
+    persist_snapshot(conn, rows, source="cli")
+    conn.commit()
+
+    for item_id in (item_a, item_b):
+        stored = _snapshots_for(conn, BASELINE, item_id)
+        assert len(stored) == 1
+        assert stored[0]["first_shortage_date"] is None
+        assert stored[0]["shortage_severity_usd"] is None
+
+
+# ===========================================================================
+# 4/6. Forkability — baseline vs a fork land on distinct scoped rows
+# ===========================================================================
+
+
+def test_capture_is_scenario_scoped_baseline_vs_fork(conn):
+    """Same (item, location) with DIFFERENT on-hand on baseline vs a fork:
+    capturing each scenario reads only that scenario's node, and persisting both
+    yields two rows distinguished by scenario_id (forkable historisation)."""
+    item_id = _seed_item(conn)
+    loc = _seed_location(conn)
+    fork = _seed_scenario(conn)
+    _seed_on_hand(conn, scenario_id=BASELINE, item_id=item_id, location_id=loc, qty=10)
+    _seed_on_hand(conn, scenario_id=fork, item_id=item_id, location_id=loc, qty=999)
+    conn.commit()
+
+    base_rows = capture_snapshot(conn, str(BASELINE), source="cli")
+    fork_rows = capture_snapshot(conn, str(fork), source="cli")
+
+    base_mine = [r for r in base_rows if r.item_id == item_id]
+    fork_mine = [r for r in fork_rows if r.item_id == item_id]
+    assert len(base_mine) == 1 and base_mine[0].on_hand_qty == 10
+    assert len(fork_mine) == 1 and fork_mine[0].on_hand_qty == 999
+    assert base_mine[0].scenario_id == BASELINE
+    assert fork_mine[0].scenario_id == fork
+
+    persist_snapshot(conn, base_rows, source="cli")
+    persist_snapshot(conn, fork_rows, source="cli")
+    conn.commit()
+
+    base_stored = _snapshots_for(conn, BASELINE, item_id)
+    fork_stored = _snapshots_for(conn, fork, item_id)
+    assert len(base_stored) == 1 and base_stored[0]["on_hand_qty"] == 10
+    assert len(fork_stored) == 1 and fork_stored[0]["on_hand_qty"] == 999
+
+
+# ===========================================================================
+# HTTP surface — app fixtures (the #392 test_agent_floor_integration pattern)
+# ===========================================================================
+
+
+@pytest.fixture(scope="module")
+def api_client(migrated_db):
+    """TestClient with get_db overridden onto the test DB (mirrors
+    test_agent_floor_integration.py). The override means each request runs on a
+    fresh OotilsDB connection bound to the test DSN."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = LEGACY_TOKEN
+
+    from fastapi.testclient import TestClient
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_token_cache():
+    """Clear the in-process minted-token cache around every test so a seed in
+    one test never leaks a cached auth decision into another."""
+    import ootils_core.api.auth as auth
+
+    auth._token_cache.clear()
+    yield
+    auth._token_cache.clear()
+
+
+def _db_conn(dsn):
+    return psycopg.connect(dsn, row_factory=dict_row, autocommit=True)
+
+
+def _mint_token(dsn, *, actor_kind: str, scopes: list[str]) -> str:
+    """Insert one api_tokens row; return the cleartext. The DB stores its
+    SHA-256 via the same hash_token the auth layer uses on lookup."""
+    from ootils_core.api.auth import hash_token, token_prefix
+
+    clear = f"ootk_{actor_kind}_{uuid4().hex}"
+    token_id = uuid4()
+    with _db_conn(dsn) as c:
+        c.execute(
+            """
+            INSERT INTO api_tokens (
+                token_id, name, actor_kind, token_hash, token_prefix, scopes
+            ) VALUES (%s, %s, %s, %s, %s, %s)
+            """,
+            (
+                token_id,
+                f"snap-{actor_kind}-{token_id}",
+                actor_kind,
+                hash_token(clear),
+                token_prefix(clear),
+                scopes,
+            ),
+        )
+    return clear
+
+
+def _bearer(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def seed_api(migrated_db):
+    """Seed one (item, location) with on-hand in BASELINE for the HTTP tests;
+    return (item_id, location_id). Cleans its own coordinate afterwards."""
+    with _db_conn(migrated_db) as c:
+        item_id = c.execute(
+            "INSERT INTO items (item_id, external_id, name) VALUES (%s, %s, %s) RETURNING item_id",
+            (uuid4(), f"snap-api-{uuid4()}", "snap-api-item"),
+        ).fetchone()["item_id"]
+        loc = c.execute(
+            "INSERT INTO locations (location_id, external_id, name) VALUES (%s, %s, %s) "
+            "RETURNING location_id",
+            (uuid4(), f"snap-api-loc-{uuid4()}", "snap-api-loc"),
+        ).fetchone()["location_id"]
+        c.execute(
+            """
+            INSERT INTO nodes (
+                node_id, node_type, scenario_id, item_id, location_id,
+                quantity, time_grain, time_ref, active
+            ) VALUES (%s, 'OnHandSupply', %s, %s, %s, %s, 'exact_date', CURRENT_DATE, TRUE)
+            """,
+            (uuid4(), str(BASELINE), item_id, loc, 25),
+        )
+    yield item_id, loc
+    with _db_conn(migrated_db) as c:
+        c.execute("DELETE FROM inventory_snapshots WHERE item_id = %s", (item_id,))
+        c.execute("DELETE FROM nodes WHERE item_id = %s", (item_id,))
+
+
+# ===========================================================================
+# 4. POST /v1/snapshots
+# ===========================================================================
+
+
+class TestCapturePost:
+    def test_capture_201_and_persists_source_api(self, api_client, seed_api, migrated_db):
+        item_id, loc = seed_api
+        clear = _mint_token(migrated_db, actor_kind="service", scopes=["ingest"])
+
+        resp = api_client.post("/v1/snapshots", json={}, headers=_bearer(clear))
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["scenario_id"] == str(BASELINE)
+        assert body["as_of_date"] is not None
+        assert body["snapshots_captured"] >= 1
+
+        with _db_conn(migrated_db) as c:
+            row = c.execute(
+                "SELECT on_hand_qty, source FROM inventory_snapshots "
+                "WHERE scenario_id = %s AND item_id = %s AND location_id = %s",
+                (str(BASELINE), item_id, loc),
+            ).fetchone()
+        assert row is not None
+        assert row["on_hand_qty"] == 25
+        assert row["source"] == "api", "the endpoint stamps source='api'"
+
+    def test_capture_401_without_token(self, api_client, seed_api):
+        resp = api_client.post("/v1/snapshots", json={})
+        assert resp.status_code == 401, resp.text
+
+    def test_capture_403_with_read_only_token(self, api_client, seed_api, migrated_db):
+        """A write of persistent rows requires ``ingest`` — a read-only token is
+        blocked on the scope floor (a write must not ride a read scope)."""
+        clear = _mint_token(migrated_db, actor_kind="agent", scopes=["read"])
+        resp = api_client.post("/v1/snapshots", json={}, headers=_bearer(clear))
+        assert resp.status_code == 403, resp.text
+        assert "ingest" in resp.json()["detail"].lower()
+
+    def test_capture_503_when_kill_switch_off_writes_nothing(
+        self, api_client, seed_api, migrated_db
+    ):
+        """OOTILS_SNAPSHOTS_ENABLED falsy -> 503 on the capture verb (checked
+        after auth/scope but before the DB), and NO row is written — the escape
+        hatch fully short-circuits the handler."""
+        item_id, _loc = seed_api
+        clear = _mint_token(migrated_db, actor_kind="service", scopes=["ingest"])
+        prev = os.environ.get("OOTILS_SNAPSHOTS_ENABLED")
+        os.environ["OOTILS_SNAPSHOTS_ENABLED"] = "0"
+        try:
+            resp = api_client.post("/v1/snapshots", json={}, headers=_bearer(clear))
+        finally:
+            if prev is None:
+                del os.environ["OOTILS_SNAPSHOTS_ENABLED"]
+            else:
+                os.environ["OOTILS_SNAPSHOTS_ENABLED"] = prev
+        assert resp.status_code == 503, resp.text
+
+        with _db_conn(migrated_db) as c:
+            n = c.execute(
+                "SELECT COUNT(*) AS n FROM inventory_snapshots WHERE item_id = %s",
+                (item_id,),
+            ).fetchone()["n"]
+        assert n == 0, "a disabled capturer must not have written any row"
+
+    def test_capture_respects_explicit_as_of(self, api_client, seed_api, migrated_db):
+        """A body-supplied as_of is honoured on the persisted row and echoed in
+        the response."""
+        item_id, loc = seed_api
+        clear = _mint_token(migrated_db, actor_kind="service", scopes=["ingest"])
+        resp = api_client.post(
+            "/v1/snapshots", json={"as_of": "2026-03-15"}, headers=_bearer(clear)
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["as_of_date"] == "2026-03-15"
+
+        with _db_conn(migrated_db) as c:
+            row = c.execute(
+                "SELECT as_of_date FROM inventory_snapshots "
+                "WHERE item_id = %s AND location_id = %s",
+                (item_id, loc),
+            ).fetchone()
+        assert str(row["as_of_date"]) == "2026-03-15"
+
+
+# ===========================================================================
+# 5. GET /v1/snapshots
+# ===========================================================================
+
+
+class TestQueryGet:
+    def _capture(self, api_client, migrated_db, as_of: str | None = None):
+        clear = _mint_token(migrated_db, actor_kind="service", scopes=["ingest"])
+        body = {} if as_of is None else {"as_of": as_of}
+        resp = api_client.post("/v1/snapshots", json=body, headers=_bearer(clear))
+        assert resp.status_code == 201, resp.text
+        return resp.json()["as_of_date"]
+
+    def test_get_403_without_read_scope(self, api_client, seed_api, migrated_db):
+        clear = _mint_token(migrated_db, actor_kind="agent", scopes=["recommend:draft"])
+        resp = api_client.get("/v1/snapshots", headers=_bearer(clear))
+        assert resp.status_code == 403, resp.text
+        assert "read" in resp.json()["detail"].lower()
+
+    def test_get_returns_captured_rows_for_scenario(self, api_client, seed_api, migrated_db):
+        item_id, loc = seed_api
+        self._capture(api_client, migrated_db)
+        clear = _mint_token(migrated_db, actor_kind="service", scopes=["read"])
+
+        resp = api_client.get("/v1/snapshots", headers=_bearer(clear))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["scenario_id"] == str(BASELINE)
+        mine = [
+            s
+            for s in body["snapshots"]
+            if s["item_id"] == str(item_id) and s["location_id"] == str(loc)
+        ]
+        assert len(mine) == 1
+        assert mine[0]["on_hand_qty"] == 25.0
+        assert mine[0]["source"] == "api"
+        assert mine[0]["first_shortage_date"] is None
+        assert mine[0]["shortage_severity_usd"] is None
+
+    def test_get_filters_by_item_id(self, api_client, seed_api, migrated_db):
+        item_id, _loc = seed_api
+        self._capture(api_client, migrated_db)
+        clear = _mint_token(migrated_db, actor_kind="service", scopes=["read"])
+
+        # A DIFFERENT item filter returns none of our coordinate.
+        other = uuid4()
+        resp = api_client.get(
+            "/v1/snapshots", params={"item_id": str(other)}, headers=_bearer(clear)
+        )
+        assert resp.status_code == 200, resp.text
+        assert all(s["item_id"] != str(item_id) for s in resp.json()["snapshots"])
+
+        # Filtering to OUR item returns exactly our row(s).
+        resp = api_client.get(
+            "/v1/snapshots", params={"item_id": str(item_id)}, headers=_bearer(clear)
+        )
+        assert resp.status_code == 200, resp.text
+        got = resp.json()["snapshots"]
+        assert got and all(s["item_id"] == str(item_id) for s in got)
+
+    def test_get_filters_by_as_of(self, api_client, seed_api, migrated_db):
+        item_id, _loc = seed_api
+        self._capture(api_client, migrated_db, as_of="2026-02-10")
+        clear = _mint_token(migrated_db, actor_kind="service", scopes=["read"])
+
+        resp = api_client.get(
+            "/v1/snapshots", params={"as_of": "2026-02-10"}, headers=_bearer(clear)
+        )
+        assert resp.status_code == 200, resp.text
+        mine = [s for s in resp.json()["snapshots"] if s["item_id"] == str(item_id)]
+        assert mine and all(s["as_of_date"] == "2026-02-10" for s in mine)
+
+        # A different day excludes our row.
+        resp = api_client.get(
+            "/v1/snapshots", params={"as_of": "2020-01-01"}, headers=_bearer(clear)
+        )
+        assert resp.status_code == 200, resp.text
+        assert all(s["item_id"] != str(item_id) for s in resp.json()["snapshots"])
+
+    def test_get_item_id_filter_is_parameterized_not_injected(
+        self, api_client, seed_api, migrated_db
+    ):
+        """SQL-injection guard: item_id is typed as UUID by FastAPI, so a value
+        carrying SQL metacharacters is rejected at the boundary (422) rather
+        than reaching the query — the filter value is never string-interpolated
+        into the WHERE. A malformed UUID cannot break or subvert the SQL."""
+        clear = _mint_token(migrated_db, actor_kind="service", scopes=["read"])
+        resp = api_client.get(
+            "/v1/snapshots",
+            params={"item_id": "'; DROP TABLE inventory_snapshots; --"},
+            headers=_bearer(clear),
+        )
+        assert resp.status_code == 422, resp.text
+
+        # The table is unharmed: a normal query still works.
+        ok = api_client.get("/v1/snapshots", headers=_bearer(clear))
+        assert ok.status_code == 200, ok.text
+
+    def test_get_order_is_deterministic(self, api_client, migrated_db):
+        """ORDER BY as_of_date DESC, item_id, location_id — the same query
+        returns the same order across calls, and item_id is a non-decreasing
+        secondary key within a single as_of day."""
+        # Seed two items on two locations, captured for one explicit day.
+        with _db_conn(migrated_db) as c:
+            items = []
+            for _ in range(2):
+                iid = c.execute(
+                    "INSERT INTO items (item_id, external_id, name) VALUES (%s, %s, %s) "
+                    "RETURNING item_id",
+                    (uuid4(), f"snap-ord-{uuid4()}", "snap-ord"),
+                ).fetchone()["item_id"]
+                items.append(iid)
+                for _l in range(2):
+                    lid = c.execute(
+                        "INSERT INTO locations (location_id, external_id, name) "
+                        "VALUES (%s, %s, %s) RETURNING location_id",
+                        (uuid4(), f"snap-ord-loc-{uuid4()}", "snap-ord-loc"),
+                    ).fetchone()["location_id"]
+                    c.execute(
+                        """
+                        INSERT INTO nodes (node_id, node_type, scenario_id, item_id,
+                            location_id, quantity, time_grain, time_ref, active)
+                        VALUES (%s, 'OnHandSupply', %s, %s, %s, %s, 'exact_date',
+                            CURRENT_DATE, TRUE)
+                        """,
+                        (uuid4(), str(BASELINE), iid, lid, 1),
+                    )
+        try:
+            ing = _mint_token(migrated_db, actor_kind="service", scopes=["ingest"])
+            api_client.post(
+                "/v1/snapshots", json={"as_of": "2026-05-20"}, headers=_bearer(ing)
+            )
+            clear = _mint_token(migrated_db, actor_kind="service", scopes=["read"])
+            r1 = api_client.get(
+                "/v1/snapshots", params={"as_of": "2026-05-20"}, headers=_bearer(clear)
+            )
+            r2 = api_client.get(
+                "/v1/snapshots", params={"as_of": "2026-05-20"}, headers=_bearer(clear)
+            )
+            assert r1.status_code == 200 and r2.status_code == 200
+            keys1 = [(s["item_id"], s["location_id"]) for s in r1.json()["snapshots"]]
+            keys2 = [(s["item_id"], s["location_id"]) for s in r2.json()["snapshots"]]
+            assert keys1 == keys2, "same query -> same order across calls"
+            # Within a single as_of day, item_id is non-decreasing (the DESC is on
+            # as_of_date only; item_id/location_id ascend as the tiebreak).
+            item_seq = [s["item_id"] for s in r1.json()["snapshots"]]
+            assert item_seq == sorted(item_seq)
+        finally:
+            with _db_conn(migrated_db) as c:
+                for iid in items:
+                    c.execute(
+                        "DELETE FROM inventory_snapshots WHERE item_id = %s", (iid,)
+                    )
+                    c.execute("DELETE FROM nodes WHERE item_id = %s", (iid,))
+
+
+# ===========================================================================
+# 7. CLI — scripts/snapshot_inventory.py
+# ===========================================================================
+
+
+def test_cli_main_exits_zero_and_persists_source_cli(migrated_db):
+    """snapshot_inventory.main(["--dsn", dsn, "--allow-dev"]) exits 0 and writes
+    rows with source='cli'. --allow-dev clears the mrp_core.guard_db semi-prod
+    refusal for an ``ootils_*`` test DB, exactly as the watcher CLIs are driven
+    in test_agent_fleet_smoke.py."""
+    import snapshot_inventory  # noqa: PLC0415 - scripts/ import seam
+
+    with _db_conn(migrated_db) as c:
+        item_id = c.execute(
+            "INSERT INTO items (item_id, external_id, name) VALUES (%s, %s, %s) RETURNING item_id",
+            (uuid4(), f"snap-cli-{uuid4()}", "snap-cli-item"),
+        ).fetchone()["item_id"]
+        loc = c.execute(
+            "INSERT INTO locations (location_id, external_id, name) VALUES (%s, %s, %s) "
+            "RETURNING location_id",
+            (uuid4(), f"snap-cli-loc-{uuid4()}", "snap-cli-loc"),
+        ).fetchone()["location_id"]
+        c.execute(
+            """
+            INSERT INTO nodes (node_id, node_type, scenario_id, item_id, location_id,
+                quantity, time_grain, time_ref, active)
+            VALUES (%s, 'OnHandSupply', %s, %s, %s, %s, 'exact_date', CURRENT_DATE, TRUE)
+            """,
+            (uuid4(), str(BASELINE), item_id, loc, 33),
+        )
+    try:
+        rc = snapshot_inventory.main(["--dsn", migrated_db, "--allow-dev"])
+        assert rc == 0
+
+        with _db_conn(migrated_db) as c:
+            row = c.execute(
+                "SELECT on_hand_qty, source FROM inventory_snapshots "
+                "WHERE scenario_id = %s AND item_id = %s AND location_id = %s",
+                (str(BASELINE), item_id, loc),
+            ).fetchone()
+        assert row is not None
+        assert row["on_hand_qty"] == 33
+        assert row["source"] == "cli"
+    finally:
+        with _db_conn(migrated_db) as c:
+            c.execute("DELETE FROM inventory_snapshots WHERE item_id = %s", (item_id,))
+            c.execute("DELETE FROM nodes WHERE item_id = %s", (item_id,))

--- a/tests/test_snapshot_capture.py
+++ b/tests/test_snapshot_capture.py
@@ -1,0 +1,176 @@
+"""
+Pure (DB-free) unit tests for ootils_core.engine.snapshot.capture (chantier
+#393 A3-PR1, ADR-030).
+
+Scope: everything in the capture module that is testable WITHOUT a live
+connection. ``capture_snapshot`` and the write path of ``persist_snapshot``
+need a real Postgres and live in tests/integration/test_snapshot_integration.py
+instead — here we lock only the pure surface:
+
+  * ``VALID_SOURCES`` is the frozen {cli, api, cron} set kept in sync with the
+    migration-067 source CHECK.
+  * ``persist_snapshot`` validates ``source`` BEFORE it touches the connection
+    (an invalid channel fails loudly as a ValueError, not an opaque DB CHECK
+    violation) and short-circuits an empty batch to 0 WITHOUT any SQL — both
+    proven with a connection stand-in that raises on any attribute access, so
+    the test genuinely asserts "no DB work happened".
+  * ``SnapshotRow`` is a frozen dataclass carrying the raw-UUID coordinates and
+    the NULL-honest shortage pair.
+
+No mocks of the engine and no DB — CLAUDE.md: pure helpers live in tests/test_*.
+"""
+from __future__ import annotations
+
+import dataclasses
+import datetime as _dt
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from ootils_core.engine.snapshot import (
+    VALID_SOURCES,
+    SnapshotRow,
+    persist_snapshot,
+)
+
+
+# ---------------------------------------------------------------------------
+# A connection stand-in that fails on ANY use.
+#
+# persist_snapshot's two pure paths (invalid source, empty batch) must both
+# return/raise WITHOUT touching the connection. Passing this object as `conn`
+# turns "the code touched the DB" into an AttributeError the test would catch,
+# so a passing test is positive evidence that no SQL was attempted.
+# ---------------------------------------------------------------------------
+class _ExplodingConn:
+    def __getattr__(self, name: str):  # noqa: ANN401 - test stand-in
+        raise AssertionError(
+            f"persist_snapshot touched the connection ({name!r}) on a path that "
+            "must be DB-free"
+        )
+
+
+# ---------------------------------------------------------------------------
+# VALID_SOURCES
+# ---------------------------------------------------------------------------
+
+
+class TestValidSources:
+    def test_exact_membership_matches_migration_067_check(self):
+        # The migration 067 CHECK is source IN ('cli', 'api', 'cron').
+        assert VALID_SOURCES == frozenset({"cli", "api", "cron"})
+
+    def test_is_a_frozenset_immutable(self):
+        assert isinstance(VALID_SOURCES, frozenset)
+        with pytest.raises(AttributeError):
+            VALID_SOURCES.add("rogue")  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# persist_snapshot — pure paths (source validation + empty short-circuit)
+# ---------------------------------------------------------------------------
+
+
+class TestPersistSnapshotPurePaths:
+    def test_invalid_source_raises_valueerror_before_touching_conn(self):
+        """A bad channel fails loudly as ValueError — and BEFORE any SQL. The
+        exploding conn proves the validation short-circuits ahead of the DB."""
+        with pytest.raises(ValueError, match="invalid snapshot source"):
+            persist_snapshot(_ExplodingConn(), [], "rogue")
+
+    def test_invalid_source_message_lists_allowed_sorted(self):
+        with pytest.raises(ValueError) as exc:
+            persist_snapshot(_ExplodingConn(), [], "SQL")
+        msg = str(exc.value)
+        # The message names the offending value and the sorted allowed set.
+        assert "'SQL'" in msg
+        assert "['api', 'cli', 'cron']" in msg
+
+    def test_empty_rows_returns_zero_without_touching_conn(self):
+        """No rows => 0 written and NO SQL — even with a valid source. The
+        exploding conn proves the empty-batch fast path never hits the DB."""
+        assert persist_snapshot(_ExplodingConn(), [], "cli") == 0
+
+    @pytest.mark.parametrize("source", ["cli", "api", "cron"])
+    def test_each_valid_source_accepted_on_empty_batch(self, source):
+        """Every whitelisted channel passes validation; with an empty batch the
+        call returns 0 without touching the connection (so no DB needed to prove
+        the source is accepted)."""
+        assert persist_snapshot(_ExplodingConn(), [], source) == 0
+
+    def test_source_validation_precedes_empty_check(self):
+        """Ordering guarantee: an invalid source with an empty batch still
+        raises (validation is first), rather than silently returning 0."""
+        with pytest.raises(ValueError):
+            persist_snapshot(_ExplodingConn(), [], "")
+
+
+# ---------------------------------------------------------------------------
+# SnapshotRow — frozen dataclass, raw-UUID coordinates, NULL-honest shortage
+# ---------------------------------------------------------------------------
+
+
+def _row(**overrides) -> SnapshotRow:
+    base = dict(
+        scenario_id=uuid4(),
+        item_id=uuid4(),
+        location_id=uuid4(),
+        as_of_date=_dt.date(2026, 7, 6),
+        on_hand_qty=Decimal("12.5"),
+        first_shortage_date=None,
+        shortage_severity_usd=None,
+        source="cli",
+    )
+    base.update(overrides)
+    return SnapshotRow(**base)
+
+
+class TestSnapshotRow:
+    def test_is_frozen(self):
+        row = _row()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            row.on_hand_qty = Decimal("99")  # type: ignore[misc]
+
+    def test_fields_round_trip(self):
+        sid, iid, lid = uuid4(), uuid4(), uuid4()
+        as_of = _dt.date(2026, 1, 2)
+        row = _row(
+            scenario_id=sid,
+            item_id=iid,
+            location_id=lid,
+            as_of_date=as_of,
+            on_hand_qty=Decimal("7.000000"),
+        )
+        assert row.scenario_id == sid
+        assert row.item_id == iid
+        assert row.location_id == lid
+        assert row.as_of_date == as_of
+        assert row.on_hand_qty == Decimal("7.000000")
+        assert row.source == "cli"
+
+    def test_on_hand_qty_is_decimal_no_float_drift(self):
+        # Decimal preserves scale where a float would drift — the whole point of
+        # NUMERIC(18,6) round-tripping.
+        row = _row(on_hand_qty=Decimal("0.1") + Decimal("0.2"))
+        assert row.on_hand_qty == Decimal("0.3")
+
+    def test_shortage_pair_null_honest_both_none_in_pr1(self):
+        """The PR1 contract: the two shortage columns are None together (no
+        projected shortage / not calculable at this grain)."""
+        row = _row()
+        assert row.first_shortage_date is None
+        assert row.shortage_severity_usd is None
+
+    def test_shortage_pair_can_be_set_together(self):
+        """The dataclass itself does not forbid a both-set pair (a later PR fills
+        both from the same projection); it only holds the two fields."""
+        d = _dt.date(2026, 9, 1)
+        row = _row(first_shortage_date=d, shortage_severity_usd=Decimal("4800"))
+        assert row.first_shortage_date == d
+        assert row.shortage_severity_usd == Decimal("4800")
+
+    def test_equality_by_value(self):
+        sid, iid, lid = uuid4(), uuid4(), uuid4()
+        kw = dict(scenario_id=sid, item_id=iid, location_id=lid)
+        assert _row(**kw) == _row(**kw)


### PR DESCRIPTION
Réf #393 (A3-PR1) — **1re brique de la machine à preuve (fossé n°4 de la revue AI-native).** Historiser le stock réel pour permettre le « avant/après » et le chaînage reco→résultat (PR2).

## Livré
- **Migration 067** `inventory_snapshots` : (scenario, item, location, as_of_date) → on_hand + severity$ (NULL-différé), UNIQUE + 2 index, FK RESTRICT, rolling-safe.
- **`engine/snapshot/capture.py`** : `capture_snapshot` SELECT-only, on-hand **per-(item,location) NON poolée** (leçon DRP), somme Decimal, tri stable ; `persist_snapshot` ON CONFLICT DO UPDATE (re-capture idempotente). **Écrit uniquement `inventory_snapshots`** — jamais `shortages` (ADR-021).
- **first_shortage/severity NULL-différé** (both-NULL, contrat honnête) : `mrp_core.first_shortage` est item-poolé → le stamper par site double-compterait ; un severity per-site honnête exige une projection per-location nettant les FPO (PR ultérieure). Jamais un 0 masqué.
- **CLI** `snapshot_inventory.py` (cron) + **`POST /v1/snapshots`** (scope `ingest`, kill-switch, forkable) + **`GET /v1/snapshots`** (scope `read`, SQL paramétrée, scenario_id sur le read path).

## Tests
15 purs + 22 intégration (capture per-site non poolée, idempotence, kill-switch, forkabilité, POST/GET scopes, CLI). Suite : 2371 passed, mypy 0/174. Invariants vérifiés à la main (SELECT-only, per-site, zéro write shortages).

PR2 (outcome chaining, 🎯 KPI) + PR3 (FVA) suivent ; ADR-030 avec PR2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)