### PR TITLE
feat(proof): FVA v1 — forecast value added vs seasonal-naive (#393 A3-PR3)

### DIFF
--- a/src/ootils_core/api/routers/pyramide.py
+++ b/src/ootils_core/api/routers/pyramide.py
@@ -80,6 +80,17 @@ class PyramideAccuracyMetricOut(BaseModel):
     coverage: Decimal | None = None
     n_cutoffs: int
     n_observations: int
+    # Forecast Value Added over the seasonal-naive baseline (migration 068,
+    # #393 A3-PR3), on the aggregate row (horizon None) only. naive_* = the
+    # trivial baseline error scored on the SAME backtest; fva_* = naive_* -
+    # stat (POSITIVE = the stat model beats the naive — a negative FVA is a
+    # legitimate honest result, never clamped). None = not computable / not
+    # comparable (baseline needs >= 1 season of history, or the stat metric
+    # is itself None), never a masked 0.
+    naive_wape: Decimal | None = None
+    naive_mase: Decimal | None = None
+    fva_wape: Decimal | None = None
+    fva_mase: Decimal | None = None
 
 
 class PyramideRunOut(BaseModel):
@@ -266,7 +277,10 @@ def create_pyramide_run(
         and freshness.ingest_age_days > body.freshness_sla_days
     )
 
-    persisted = persist_run(db, result, stale_demand=stale)
+    # history feeds the FVA seasonal-naive baseline (migration 068): it is
+    # the SAME series the run was computed on, so the naive is backtested on
+    # identical cutoffs (methodological consistency — see fva.compute_fva).
+    persisted = persist_run(db, result, stale_demand=stale, history=history)
     if stale:
         # Exactly once per run (this endpoint is the only writer and the
         # run is created exactly once) — no spam, evidence carries run_id.
@@ -465,6 +479,10 @@ def _accuracy_metric_out(metric) -> PyramideAccuracyMetricOut:
         coverage=metric.coverage,
         n_cutoffs=metric.n_cutoffs,
         n_observations=metric.n_observations,
+        naive_wape=metric.naive_wape,
+        naive_mase=metric.naive_mase,
+        fva_wape=metric.fva_wape,
+        fva_mase=metric.fva_mase,
     )
 
 

--- a/src/ootils_core/db/migrations/068_fva.sql
+++ b/src/ootils_core/db/migrations/068_fva.sql
@@ -1,0 +1,102 @@
+-- ============================================================
+-- Migration 068 — Forecast Value Added (FVA) on the backtest report (#393 A3-PR3)
+-- ============================================================
+-- Chantier #393 axis A3. ADR-030 (à venir): "Forecast Value Added — is the
+-- stat model worth its complexity vs a trivial seasonal-naive baseline?".
+--
+-- WHAT: four additive, typed, nullable columns on pyramide_accuracy_metrics
+-- (migration 055) — the naive-baseline error (naive_wape/naive_mase) and the
+-- value the stat model ADDS over it (fva_wape/fva_mase). FVA is NOT a sibling
+-- table: it is an ATTRIBUTE of the very same rolling-origin backtest — same
+-- run_id, same per-horizon granularity, same None-honest contract — computed on
+-- the exact same cutoffs/observations as the stat metrics it sits next to. A
+-- new table would duplicate (run_id, horizon) and force a join to compare a
+-- model against its own baseline; four columns keep the comparison on one row.
+--
+-- BASELINE = seasonal-naive (deliberately trivial). FVA is only credible if the
+-- benchmark is a benchmark nobody would defend deploying: the seasonal-naive
+-- forecast (repeat the value one season ago). If the stat pipeline cannot beat
+-- "same week last year", its complexity is not paying for itself. The baseline
+-- is scored on the SAME backtest so naive_wape/wape (and naive_mase/mase) are
+-- apples-to-apples.
+--
+-- FVA DEFINITION (the load-bearing sign convention): fva = naive - stat.
+--   * fva_wape = naive_wape - wape ; POSITIVE = the stat model beats the naive
+--     baseline (lower WAPE is better, so the model REMOVED error → value added).
+--   * fva_mase = naive_mase - mase ; POSITIVE = the stat model beats the naive.
+--   A NEGATIVE FVA is a legitimate, honest result — the stat model LOST to the
+--   trivial baseline on this data — so there is intentionally NO sign CHECK on
+--   the fva_* columns (unlike a quantity). Consumers (Decision Ladder) decide
+--   what a non-positive FVA means; the module never clamps it to 0.
+--
+-- NULL-honest contract (INHERITED verbatim from migration 055): a NULL here
+-- means "not computable on this data" — NEVER a masked 0.
+--   * naive_wape/naive_mase are NULL when the seasonal-naive baseline itself is
+--     undefined: it needs >= 1 full season of history to have a value one season
+--     ago (and, for MASE, a usable naive-scaling denominator). Short history →
+--     NULL baseline, never a fabricated 0.
+--   * fva_wape/fva_mase are NULL whenever EITHER operand is NULL (naive missing,
+--     or the stat wape/mase already NULL per 055 — e.g. per-horizon rows carry
+--     no actuals, so wape/mase and therefore fva stay NULL there). A NULL FVA is
+--     "not comparable", NOT "no value added".
+--
+-- TYPING: NUMERIC (bare, NULL, no DEFAULT) — byte-for-byte the type of the
+-- existing wape/mase columns in migration 055 (which are bare NUMERIC, not
+-- NUMERIC(p,s)). fva_* is a difference of two NUMERICs, so it shares the type.
+-- No FLOAT/REAL on a metric.
+--
+-- Rolling-deploy safe: purely additive nullable columns with NO default. Old
+-- writers (pre-FVA repository.persist_accuracy_metrics) simply leave them NULL,
+-- which reads exactly as the honest "baseline not computed" — no backfill, no
+-- rewrite of existing rows, no behavioural change to the 055 metrics.
+--
+-- Idempotence (repo migration policy — the runner in db/connection.py wraps
+-- each file in its own transaction and, on ANY error, ROLLS BACK and ABORTS; it
+-- does NOT swallow "already exists"): ADD COLUMN IF NOT EXISTS re-runs as a
+-- clean no-op.
+-- No index: the FVA columns are read alongside their run's metric rows (already
+-- covered by idx_pyramide_accuracy_metrics_run from migration 055), never as a
+-- filter/join predicate.
+-- No JSONB. Typed columns only.
+--
+-- ref: ADR-030 (FVA), #393 A3-PR3. Baseline table: migration 055.
+-- ============================================================
+
+BEGIN;
+
+-- ------------------------------------------------------------
+-- FVA columns on the existing per-run / per-horizon backtest report
+-- ------------------------------------------------------------
+-- Seasonal-naive baseline error (naive_*) + value the stat model adds over it
+-- (fva_* = naive - stat). All bare NUMERIC NULL, matching wape/mase in 055.
+ALTER TABLE pyramide_accuracy_metrics
+    ADD COLUMN IF NOT EXISTS naive_wape NUMERIC NULL,
+    ADD COLUMN IF NOT EXISTS naive_mase NUMERIC NULL,
+    ADD COLUMN IF NOT EXISTS fva_wape   NUMERIC NULL,
+    ADD COLUMN IF NOT EXISTS fva_mase   NUMERIC NULL;
+
+COMMENT ON COLUMN pyramide_accuracy_metrics.naive_wape IS
+    'WAPE of the seasonal-naive baseline (repeat value one season ago), scored '
+    'on the SAME rolling-origin backtest as wape (#393 A3-PR3, ADR-030). NULL = '
+    'not computable — the seasonal-naive needs >= 1 full season of history to '
+    'have a value one season ago (None-honest contract, migration 055); NEVER a '
+    'masked 0.';
+COMMENT ON COLUMN pyramide_accuracy_metrics.naive_mase IS
+    'MASE of the seasonal-naive baseline, scored on the SAME backtest as mase '
+    '(#393 A3-PR3, ADR-030). NULL = not computable (needs >= 1 season of '
+    'history and a usable naive-scaling denominator); NEVER a masked 0.';
+COMMENT ON COLUMN pyramide_accuracy_metrics.fva_wape IS
+    'Forecast Value Added on WAPE = naive_wape - wape (#393 A3-PR3, ADR-030). '
+    'POSITIVE = the stat model beats the trivial seasonal-naive baseline (it '
+    'removed error). NEGATIVE is a legitimate honest result (model lost to the '
+    'baseline) — deliberately NOT clamped. NULL when EITHER operand is NULL '
+    '(baseline undefined, or wape NULL per migration 055, e.g. per-horizon '
+    'rows) = not comparable; NEVER a masked 0.';
+COMMENT ON COLUMN pyramide_accuracy_metrics.fva_mase IS
+    'Forecast Value Added on MASE = naive_mase - mase (#393 A3-PR3, ADR-030). '
+    'POSITIVE = the stat model beats the seasonal-naive baseline. NEGATIVE is '
+    'legitimate (model lost) — NOT clamped. NULL when EITHER operand is NULL '
+    '(baseline undefined, or mase NULL per migration 055) = not comparable; '
+    'NEVER a masked 0.';
+
+COMMIT;

--- a/src/ootils_core/pyramide/fva.py
+++ b/src/ootils_core/pyramide/fva.py
@@ -1,0 +1,282 @@
+"""
+Pyramide axis A3 — Forecast Value Added (FVA) over a trivial seasonal-naive.
+
+FVA answers the governance question "is the stat forecast worth its complexity
+versus a benchmark nobody would defend deploying?" (#393, ADR-030). The
+benchmark is the **seasonal-naive** forecast — repeat the value one season ago,
+``y_hat[t] = y[t - season_length]`` — deliberately the most trivial model that
+still respects seasonality. If the stat pipeline cannot beat "same period last
+season", its complexity is not paying for itself.
+
+    FVA = naive - stat  (POSITIVE = the stat model beats the naive baseline)
+
+Lower WAPE/MASE is better, so removing error yields a positive FVA. A NEGATIVE
+FVA is a legitimate, honest result (the stat model lost to the trivial
+baseline) and is NEVER clamped — consumers (Decision Ladder) decide what a
+non-positive FVA means.
+
+This module follows the same discipline as ``pyramide/accuracy.py`` and
+``engine/mrp/core.py``:
+
+- **DB-free, model-free, deterministic.** In-memory Decimal sequences in,
+  ``FvaResult`` out. No randomness, no wall-clock, no I/O — golden-testable in
+  isolation.
+- **None-honest (STRICT).** ``None`` means "not computable on this data",
+  NEVER a masked 0. A FVA of ``0.0`` means "stat == naive" (a real, comparable
+  result); ``None`` means "not comparable" — the two must never be conflated.
+
+Methodological consistency — the load-bearing invariant
+-------------------------------------------------------
+FVA is only honest if the naive baseline is scored on the EXACT SAME
+rolling-origin backtest as the stat model: same series, same cutoffs, same
+horizon, same error normalisation. Comparing a naive backtested on different
+windows against the stat metrics would compare apples and oranges.
+
+We guarantee this by REUSING ``accuracy.evaluate_rolling_origin`` — the very
+function that produced the stat report — over the SAME series with the SAME
+``step=1``/``m=1``, and by RECOVERING the stat's exact origin set from the
+report instead of guessing it: with ``step=1`` the stat cutoffs are
+``range(min_train_stat, len(series))``, so
+``min_train_stat = len(series) - stat_report.n_cutoffs`` (the migration-055
+52-origin tail is already folded into that count). Backtesting the naive from
+that same origin makes the two span identical cutoffs by construction; a final
+``n_cutoffs`` equality check is the safety net, and ``compute_fva`` returns
+``None`` (never a mismatched comparison) whenever the seasonal-naive cannot be
+aligned there — e.g. the first shared origin holds less than one full season
+of training, so there is no value one season ago.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Mapping, Sequence
+
+from .accuracy import AccuracyReport, evaluate_rolling_origin
+
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "FvaResult",
+    "compute_fva",
+    "resolve_season_length",
+    "seasonal_naive_forecast",
+]
+
+
+# Default seasonal cycle per granularity — the SAME table as
+# engines._default_season_length (7 daily / 52 weekly / 12 monthly). Kept in
+# sync here (rather than importing a private) so fva.py stays the single FVA
+# surface; the run's season is method_params["season_length"] when set, else
+# this default — exactly the resolution engines.forecast() applies.
+_DEFAULT_SEASON_LENGTH: Mapping[str, int] = {"daily": 7, "weekly": 52, "monthly": 12}
+
+
+def resolve_season_length(granularity: str, method_params: Mapping[str, Any]) -> int:
+    """Seasonal cycle length a Pyramide run actually used: the caller-supplied
+    ``method_params["season_length"]`` when present and readable, else the
+    granularity default (7/52/12) — the identical resolution
+    ``engines.forecast()`` performs via ``params.setdefault(...)``.
+
+    Tolerant on the override (like ``engines._candidate_specs``): an illegible
+    value falls back to the granularity default with a debug trace, never an
+    exception — the FVA baseline must not crash a run over a bad param.
+    """
+    raw = method_params.get("season_length")
+    if raw is not None:
+        try:
+            season = int(raw)
+        except (TypeError, ValueError):
+            logger.debug(
+                "season_length illisible (%r); défaut par granularité", raw
+            )
+        else:
+            if season >= 1:
+                return season
+            logger.debug("season_length < 1 (%r); défaut par granularité", raw)
+    return _DEFAULT_SEASON_LENGTH[granularity]
+
+
+@dataclass(frozen=True)
+class FvaResult:
+    """Forecast Value Added of the stat model over the seasonal-naive baseline.
+
+    Every field is ``Optional`` and None-honest (migration 068, inherited from
+    055): ``None`` = "not computable on this data", never a masked 0.
+
+    - ``naive_wape`` / ``naive_mase``: the seasonal-naive baseline error,
+      scored on the SAME rolling-origin backtest as the stat metrics. ``None``
+      when the baseline is undefined (history < 1 full season, so no value one
+      season ago) OR when the naive backtest could not be aligned to the stat's
+      cutoffs (see ``compute_fva``).
+    - ``fva_wape`` = ``naive_wape - wape``; ``fva_mase`` = ``naive_mase - mase``
+      (POSITIVE = stat beats naive). ``None`` whenever EITHER operand is None
+      (naive missing, or the stat wape/mase is itself None per migration 055).
+    """
+
+    naive_wape: Decimal | None
+    naive_mase: Decimal | None
+    fva_wape: Decimal | None
+    fva_mase: Decimal | None
+
+
+def seasonal_naive_forecast(
+    history: Sequence[Decimal],
+    season_length: int,
+    horizon: int,
+) -> list[Decimal]:
+    """Seasonal-naive forecast: ``y_hat[t] = y[t - season_length]``.
+
+    Repeats the last observed season forward: horizon step ``i`` (0-based)
+    takes the value ``season_length`` positions before the corresponding
+    future index, i.e. ``history[len(history) - season_length + (i mod
+    season_length)]``. This is the textbook seasonal-naive (S-naive), the
+    deliberately trivial FVA benchmark — NOT the full SeasonalForecaster
+    (level x seasonal indices), which would inflate the "value added".
+
+    Deterministic and clamped to 0 (a negative demand forecast does not
+    exist), consistent with every served curve in the Pyramide layer.
+
+    Raises:
+        ValueError: ``season_length < 1`` or ``horizon < 1`` (structural
+            misuse — fail loudly, like the accuracy module).
+
+    Returns an empty list when the baseline is NOT computable — history
+    shorter than one full season, so there is no value "one season ago". The
+    caller treats an empty curve as "baseline undefined" (None-honest),
+    never as a zero forecast.
+    """
+    if season_length < 1:
+        raise ValueError(f"season_length must be >= 1 (got {season_length})")
+    if horizon < 1:
+        raise ValueError(f"horizon must be >= 1 (got {horizon})")
+    if len(history) < season_length:
+        return []
+
+    last_season_start = len(history) - season_length
+    return [
+        max(history[last_season_start + (step % season_length)], Decimal("0"))
+        for step in range(horizon)
+    ]
+
+
+def compute_fva(
+    history: Sequence[Decimal],
+    season_length: int,
+    *,
+    stat_report: AccuracyReport,
+) -> FvaResult:
+    """Forecast Value Added of the stat model over the seasonal-naive baseline.
+
+    ``stat_report`` is the rolling-origin backtest report of the model that
+    PRODUCED the run's values (``PyramideRunResult.accuracy_report``). Its
+    ``wape`` / ``mase`` are the stat operands (already computed by the run —
+    never recomputed here), and its ``n_cutoffs`` is the alignment witness.
+
+    Methodological consistency (the critical point) — the naive is backtested
+    by the SAME ``accuracy.evaluate_rolling_origin`` used for the stat report,
+    with the SAME ``series`` (``history``), ``horizon`` (derived from the
+    report's per-horizon residuals), ``step=1`` and ``m=1``. The stat's exact
+    origin set is RECOVERED from the report rather than guessed: with
+    ``step=1`` the stat cutoffs are ``range(min_train_stat, len(series))``, so
+    ``min_train_stat = len(series) - stat_report.n_cutoffs``. Backtesting the
+    naive from that same origin makes the two span identical cutoffs by
+    construction. A final ``n_cutoffs`` equality check is kept as a safety net
+    (a naive that cannot run on the first shared origin — history shorter than
+    one season there — collapses to ``None`` rather than a mismatched
+    comparison). The naive metrics (and thus the FVA) are ``None`` whenever
+    that alignment does not hold.
+
+    None-honest, all fields:
+    - naive metrics ``None`` when the baseline is undefined (history < 1 full
+      season, or the report carries no horizon to size the window) or the
+      cutoffs cannot be aligned to the stat report;
+    - ``fva_*`` ``None`` whenever either operand is ``None`` (naive missing, or
+      the stat ``wape``/``mase`` already ``None`` per migration 055 — a FVA is
+      "not comparable", never "no value added").
+
+    Determinism: no randomness, no wall-clock; same inputs -> same output.
+    """
+    if season_length < 1:
+        raise ValueError(f"season_length must be >= 1 (got {season_length})")
+
+    naive_wape, naive_mase = _backtest_seasonal_naive(
+        history, season_length, stat_report
+    )
+    return FvaResult(
+        naive_wape=naive_wape,
+        naive_mase=naive_mase,
+        fva_wape=_fva(naive_wape, stat_report.wape),
+        fva_mase=_fva(naive_mase, stat_report.mase),
+    )
+
+
+def _backtest_seasonal_naive(
+    history: Sequence[Decimal],
+    season_length: int,
+    stat_report: AccuracyReport,
+) -> tuple[Decimal | None, Decimal | None]:
+    """Score the seasonal-naive on the stat report's own cutoffs.
+
+    Returns ``(naive_wape, naive_mase)``, either ``None`` when the baseline is
+    not computable or its backtest cannot be aligned to the stat cutoffs. MASE
+    uses ``m=1`` uniformly, exactly like ``engines._backtest_report`` — the
+    scaling naive stays identical across the compared models, so ``naive_mase``
+    and ``mase`` are directly subtractable.
+    """
+    # Horizon of the stat backtest = deepest per-horizon residual bucket. No
+    # residuals (or no cutoffs) means the stat report has no rolling-origin
+    # structure to mirror (external backend, blend, too-short history) —
+    # nothing to align.
+    if not stat_report.per_horizon_residuals or stat_report.n_cutoffs < 1:
+        return None, None
+    horizon = max(stat_report.per_horizon_residuals)
+
+    # Recover the stat's EXACT first origin: with step=1 the stat cutoffs are
+    # range(min_train_stat, len), i.e. len - min_train_stat = n_cutoffs. The
+    # 52-origin tail of the stat harness (migration 055) is already baked into
+    # that count, so the naive inherits the same window without re-deriving it.
+    min_train = len(history) - stat_report.n_cutoffs
+    if min_train < season_length or min_train >= len(history):
+        # The first shared origin has less than one full season of training,
+        # so the seasonal-naive has no value one season ago there: the
+        # baseline is not computable on the stat's cutoffs.
+        return None, None
+
+    def forecast_fn(train: Sequence[Decimal], periods: int) -> Sequence[Decimal]:
+        return seasonal_naive_forecast(train, season_length, periods)
+
+    try:
+        naive_report = evaluate_rolling_origin(
+            series=list(history),
+            forecast_fn=forecast_fn,
+            horizon=horizon,
+            min_train=min_train,
+            step=1,
+            m=1,
+        )
+    except ValueError:
+        # A structural mismatch (e.g. a train slice shorter than one season
+        # yielding an empty curve) means the naive cannot be scored on these
+        # cutoffs — refuse rather than emit an unaligned baseline.
+        return None, None
+
+    # Apples-to-apples witness: with step=1 on a fixed series the origin set
+    # is range(min_train, len). Identical n_cutoffs <=> identical cutoffs.
+    # Any divergence would compare the naive on different windows than the
+    # stat — None, never a mismatched FVA.
+    if naive_report.n_cutoffs != stat_report.n_cutoffs:
+        return None, None
+    return naive_report.wape, naive_report.mase
+
+
+def _fva(naive: Decimal | None, stat: Decimal | None) -> Decimal | None:
+    """``naive - stat`` (positive = stat beats naive). ``None`` if EITHER
+    operand is ``None`` — a FVA is "not comparable", never "no value added".
+    The negative result is legitimate and returned as-is (never clamped)."""
+    if naive is None or stat is None:
+        return None
+    return naive - stat

--- a/src/ootils_core/pyramide/repository.py
+++ b/src/ootils_core/pyramide/repository.py
@@ -14,6 +14,7 @@ from ootils_core.api.dependencies import BASELINE_SCENARIO_ID
 from ootils_core.db.types import DictRowConnection
 
 from .accuracy import AccuracyReport
+from .fva import FvaResult, compute_fva, resolve_season_length
 from .models import PyramideRunResult
 from .routing import RoutingDecision
 
@@ -135,6 +136,15 @@ class PyramideAccuracyMetric:
     n_cutoffs: int
     n_observations: int
     created_at: datetime
+    # FVA over the seasonal-naive baseline (migration 068, #393 A3-PR3),
+    # populated on the aggregate row (horizon NULL) only. None-honest: None
+    # = baseline not computable / not comparable, never a masked 0. fva_* =
+    # naive_* - stat (POSITIVE = the stat model beats the naive; a negative
+    # FVA is legitimate and never clamped).
+    naive_wape: Decimal | None = None
+    naive_mase: Decimal | None = None
+    fva_wape: Decimal | None = None
+    fva_mase: Decimal | None = None
 
 
 @dataclass(frozen=True)
@@ -656,12 +666,23 @@ def persist_accuracy_metrics(
     run_id: UUID,
     report: AccuracyReport,
     bias_scale: Decimal = _ONE,
+    fva: FvaResult | None = None,
 ) -> int:
     """
     Persist a run's backtest report into pyramide_accuracy_metrics
     (migration 055): the aggregate row + one row per horizon (see
     ``accuracy_metric_rows`` for the exact mapping and the ``bias_scale``
     transport semantics).
+
+    ``fva`` (migration 068, #393 A3-PR3): the Forecast Value Added of the
+    stat model over the seasonal-naive baseline (``fva.compute_fva``),
+    computed on the SAME backtest as ``report``. Its four values
+    (naive_wape/naive_mase/fva_wape/fva_mase) are written ON THE AGGREGATE
+    ROW ONLY (horizon NULL) — per-horizon rows carry no actuals (like the
+    other non-residual metrics of migration 055), so FVA stays NULL there.
+    ``None`` (the default, and the hierarchical/aggregate path in V1) leaves
+    all four columns NULL — the None-honest "baseline not computed", never a
+    masked 0.
 
     Idempotence: DELETE + INSERT of the run's full row set. The report is
     an atomic artifact of ONE backtest — replacing the whole set keeps
@@ -675,16 +696,26 @@ def persist_accuracy_metrics(
     )
     rows = accuracy_metric_rows(report, bias_scale=bias_scale)
     for horizon, mase, wape, smape, bias_value, coverage, n_cutoffs, n_observations in rows:
+        # FVA columns belong to the all-horizons aggregate row only
+        # (horizon IS NULL); per-horizon rows keep them NULL, exactly like
+        # mase/wape/smape/coverage above (no per-horizon actuals).
+        is_aggregate = horizon is None
+        naive_wape = fva.naive_wape if (fva is not None and is_aggregate) else None
+        naive_mase = fva.naive_mase if (fva is not None and is_aggregate) else None
+        fva_wape = fva.fva_wape if (fva is not None and is_aggregate) else None
+        fva_mase = fva.fva_mase if (fva is not None and is_aggregate) else None
         db.execute(
             """
             INSERT INTO pyramide_accuracy_metrics (
                 run_id, horizon, mase, wape, smape, bias, coverage,
-                n_cutoffs, n_observations
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                n_cutoffs, n_observations,
+                naive_wape, naive_mase, fva_wape, fva_mase
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 run_id, horizon, mase, wape, smape, bias_value, coverage,
                 n_cutoffs, n_observations,
+                naive_wape, naive_mase, fva_wape, fva_mase,
             ),
         )
     return len(rows)
@@ -702,7 +733,8 @@ def fetch_accuracy_metrics(
     rows = db.execute(
         """
         SELECT metric_id, run_id, horizon, mase, wape, smape, bias,
-               coverage, n_cutoffs, n_observations, created_at
+               coverage, n_cutoffs, n_observations, created_at,
+               naive_wape, naive_mase, fva_wape, fva_mase
         FROM pyramide_accuracy_metrics
         WHERE run_id = %s
         ORDER BY horizon ASC NULLS FIRST
@@ -722,6 +754,10 @@ def fetch_accuracy_metrics(
             n_cutoffs=row["n_cutoffs"],
             n_observations=row["n_observations"],
             created_at=row["created_at"],
+            naive_wape=_optional_decimal(row["naive_wape"]),
+            naive_mase=_optional_decimal(row["naive_mase"]),
+            fva_wape=_optional_decimal(row["fva_wape"]),
+            fva_mase=_optional_decimal(row["fva_mase"]),
         )
         for row in rows
     ]
@@ -775,6 +811,7 @@ def persist_run(
     *,
     stale_demand: bool = False,
     routing: RoutingDecision | None = None,
+    history: Sequence[Decimal] | None = None,
 ) -> PyramidePersistedRun:
     """``stale_demand`` (ADR-023, migration 056): the caller measured the
     demand_history freshness at run time and it PROVABLY exceeded the SLA.
@@ -785,7 +822,15 @@ def persist_run(
     decision for this series when the caller routed it — persisted as the
     routed_method/routed_level/routing_reason provenance columns. None
     (the default and the historical behaviour) = the method was requested
-    explicitly, columns stay NULL."""
+    explicitly, columns stay NULL.
+
+    ``history`` (migration 068, #393 A3-PR3): the demand series the run was
+    computed on — the raw material of the Forecast Value Added baseline. When
+    supplied together with a backtest report, ``compute_fva`` scores the
+    seasonal-naive on the SAME cutoffs and persists naive/fva on the
+    aggregate metric row. None (default) leaves the FVA columns NULL
+    (None-honest "baseline not computed") — the accuracy metrics themselves
+    are unchanged."""
     run_id = uuid4()
     snapshot_id = uuid4()
     forecast_id = uuid4()
@@ -893,7 +938,21 @@ def persist_run(
     # honnête existe — run sans rapport (ENSEMBLE_STAT, backend externe,
     # historique trop court) = zéro ligne, documenté.
     if result.accuracy_report is not None:
-        persist_accuracy_metrics(db, run_id, result.accuracy_report)
+        # FVA (migration 068) : la naïve seasonal-naive backtestée sur les
+        # MÊMES cutoffs que le rapport stat. season_length = celui que le run
+        # a réellement utilisé (override method_params, sinon défaut de
+        # granularité — même résolution qu'engines.forecast). history absent
+        # ⇒ fva=None ⇒ colonnes NULL (None-honnête), métriques inchangées.
+        fva = (
+            compute_fva(
+                history,
+                resolve_season_length(config.granularity, config.method_params),
+                stat_report=result.accuracy_report,
+            )
+            if history is not None
+            else None
+        )
+        persist_accuracy_metrics(db, run_id, result.accuracy_report, fva=fva)
     return PyramidePersistedRun(run_id=run_id, snapshot_id=snapshot_id, forecast_id=forecast_id)
 
 

--- a/tests/integration/test_fva_integration.py
+++ b/tests/integration/test_fva_integration.py
@@ -1,0 +1,345 @@
+"""
+Integration tests for Pyramide axis A3 — Forecast Value Added persistence
+(migration 068, #393 A3-PR3) against a real PostgreSQL database (no mocks).
+
+Mirrors test_pyramide_accuracy_metrics_integration.py: a real leaf
+PyramideRunner run seeds forecasts + pyramide_runs + pyramide_accuracy_metrics
+via persist_run, and we assert the FVA columns behave to contract:
+
+  - a LONG history persists naive_wape/naive_mase/fva_wape/fva_mase on the
+    AGGREGATE row (horizon NULL) only; per-horizon rows keep them NULL (they
+    carry no actuals, like every other non-residual metric of migration 055);
+  - a run persisted WITHOUT history (history=None, the pre-FVA default) leaves
+    all four columns NULL — non-regressive, the accuracy metrics unchanged;
+  - re-persisting the SAME run (persist_accuracy_metrics is DELETE + INSERT)
+    keeps the four values stable (idempotent);
+  - GET /v1/forecast/runs/{run_id} round-trips the four fields None-honestly;
+  - a SHORT history (< 1 season available at the stat's first cutoff) persists
+    NULL FVA even though the run's own accuracy metrics are present — the
+    honest "baseline not computable on insufficient history".
+
+Anti-flake rule (inherited): the FVA path reads NO clock and NO demand_history
+row (the series is passed to persist_run directly), so nothing here depends on
+booked_date/ingested_at timing.
+"""
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+BASELINE_SCENARIO_ID = UUID("00000000-0000-0000-0000-000000000001")
+TODAY = date.today()
+
+# Deterministic weekly pattern (ADR-003 discipline applies to fixtures too):
+# a seasonal daily series so the seasonal-naive baseline is well-defined.
+WEEK_PATTERN = (20, 22, 25, 30, 28, 15, 12)
+
+
+def _db_conn(dsn):
+    import psycopg
+    from psycopg.rows import dict_row
+    return psycopg.connect(dsn, row_factory=dict_row, autocommit=True)
+
+
+def _create_item(conn, ext_id: str) -> UUID:
+    item_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO items (item_id, name, item_type, uom, status, external_id)
+        VALUES (%s, %s, 'finished_good', 'EA', 'active', %s)
+        """,
+        (item_id, f"{ext_id} fva test item", ext_id),
+    )
+    return item_id
+
+
+def _create_location(conn, ext_id: str) -> UUID:
+    loc_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO locations (location_id, name, location_type, country, external_id)
+        VALUES (%s, %s, 'dc', 'US', %s)
+        """,
+        (loc_id, f"{ext_id} fva test DC", ext_id),
+    )
+    return loc_id
+
+
+def _seasonal_series(days: int) -> list[Decimal]:
+    # Weekly seasonal shape plus a slow trend so neither the naive nor the
+    # stat is trivially perfect — the FVA is a real, non-degenerate number.
+    return [
+        Decimal(WEEK_PATTERN[i % 7] + i // 14)
+        for i in range(days)
+    ]
+
+
+def _cleanup(conn, item_id: UUID, location_id: UUID) -> None:
+    conn.execute(
+        """
+        DELETE FROM pyramide_snapshots WHERE forecast_id IN (
+            SELECT forecast_id FROM forecasts WHERE item_id = %s
+        )
+        """,
+        (item_id,),
+    )
+    conn.execute(
+        """
+        DELETE FROM pyramide_runs WHERE forecast_id IN (
+            SELECT forecast_id FROM forecasts WHERE item_id = %s
+        )
+        """,
+        (item_id,),
+    )
+    conn.execute("DELETE FROM forecasts WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM items WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM locations WHERE location_id = %s", (location_id,))
+
+
+def _run(conn, item_id: UUID, location_id: UUID, history: list[Decimal],
+         horizon_days: int):
+    from ootils_core.pyramide import PyramideRunConfig, PyramideRunner
+
+    config = PyramideRunConfig(
+        item_id=item_id,
+        location_id=location_id,
+        scenario_id=BASELINE_SCENARIO_ID,
+        horizon_start=TODAY + timedelta(days=2),
+        horizon_days=horizon_days,
+        granularity="daily",  # season_length default = 7
+        method="MA",
+        method_params={"window": 4},
+    )
+    return PyramideRunner().run(config, history)
+
+
+def _aggregate_row(conn, run_id: UUID) -> dict:
+    return conn.execute(
+        """
+        SELECT horizon, wape, mase, naive_wape, naive_mase, fva_wape, fva_mase
+        FROM pyramide_accuracy_metrics
+        WHERE run_id = %s AND horizon IS NULL
+        """,
+        (run_id,),
+    ).fetchone()
+
+
+def _per_horizon_rows(conn, run_id: UUID) -> list[dict]:
+    return conn.execute(
+        """
+        SELECT horizon, naive_wape, naive_mase, fva_wape, fva_mase
+        FROM pyramide_accuracy_metrics
+        WHERE run_id = %s AND horizon IS NOT NULL
+        ORDER BY horizon
+        """,
+        (run_id,),
+    ).fetchall()
+
+
+def test_long_history_persists_fva_on_aggregate_row_only(migrated_db):
+    """persist_run(..., history=<long series>) computes the seasonal-naive on
+    the stat's own cutoffs and writes naive/fva on the aggregate row; the
+    per-horizon rows keep the four columns NULL."""
+    from ootils_core.pyramide.repository import fetch_accuracy_metrics, persist_run
+
+    with _db_conn(migrated_db) as conn:
+        code = f"FVA-{uuid4().hex[:8].upper()}"
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            history = _seasonal_series(60)
+            result = _run(conn, item_id, location_id, history, horizon_days=7)
+            assert result.accuracy_report is not None
+
+            persisted = persist_run(conn, result, history=history)
+
+            aggregate = _aggregate_row(conn, persisted.run_id)
+            # season=7 default, min_train = 60 - 52 = 8 >= 7 => naive aligned.
+            assert aggregate["naive_wape"] is not None
+            assert aggregate["naive_mase"] is not None
+            assert aggregate["fva_wape"] is not None
+            assert aggregate["fva_mase"] is not None
+            # FVA = naive - stat, read back exactly against the stat columns.
+            assert aggregate["fva_wape"] == aggregate["naive_wape"] - aggregate["wape"]
+            assert aggregate["fva_mase"] == aggregate["naive_mase"] - aggregate["mase"]
+
+            for row in _per_horizon_rows(conn, persisted.run_id):
+                assert row["naive_wape"] is None
+                assert row["naive_mase"] is None
+                assert row["fva_wape"] is None
+                assert row["fva_mase"] is None
+
+            # The typed reader surfaces the same values on the aggregate row.
+            metrics = fetch_accuracy_metrics(conn, persisted.run_id)
+            assert metrics[0].horizon is None
+            assert metrics[0].fva_wape == aggregate["fva_wape"]
+            assert metrics[0].naive_mase == aggregate["naive_mase"]
+            assert all(m.fva_wape is None for m in metrics[1:])
+        finally:
+            _cleanup(conn, item_id, location_id)
+
+
+def test_run_without_history_leaves_fva_null(migrated_db):
+    """persist_run WITHOUT history (the pre-FVA default) is non-regressive:
+    the accuracy metrics persist as before and all four FVA columns stay
+    NULL — the honest 'baseline not computed', never a masked 0."""
+    from ootils_core.pyramide.repository import persist_run
+
+    with _db_conn(migrated_db) as conn:
+        code = f"FVA-{uuid4().hex[:8].upper()}"
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            history = _seasonal_series(60)
+            result = _run(conn, item_id, location_id, history, horizon_days=5)
+            assert result.accuracy_report is not None
+
+            persisted = persist_run(conn, result)  # history omitted
+
+            aggregate = _aggregate_row(conn, persisted.run_id)
+            # Accuracy metrics themselves are unchanged (stat wape present)...
+            assert aggregate["wape"] is not None
+            # ...but FVA is fully NULL (no baseline requested).
+            assert aggregate["naive_wape"] is None
+            assert aggregate["naive_mase"] is None
+            assert aggregate["fva_wape"] is None
+            assert aggregate["fva_mase"] is None
+        finally:
+            _cleanup(conn, item_id, location_id)
+
+
+def test_short_history_persists_null_fva_but_keeps_accuracy(migrated_db):
+    """A history shorter than one season at the stat's first cutoff: the run
+    still backtests (accuracy metrics present) but the seasonal-naive has no
+    value one season ago there, so FVA is NULL — insufficient-history honesty,
+    distinct from a fabricated 0."""
+    from ootils_core.pyramide.repository import persist_run
+
+    with _db_conn(migrated_db) as conn:
+        code = f"FVA-{uuid4().hex[:8].upper()}"
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            # 9 daily points, season 7 => min_train = 9 - n_cutoffs < 7.
+            history = _seasonal_series(9)
+            result = _run(conn, item_id, location_id, history, horizon_days=3)
+            assert result.accuracy_report is not None  # MA still backtests
+
+            persisted = persist_run(conn, result, history=history)
+
+            aggregate = _aggregate_row(conn, persisted.run_id)
+            assert aggregate["wape"] is not None  # run's own metrics intact
+            assert aggregate["naive_wape"] is None
+            assert aggregate["fva_wape"] is None
+            assert aggregate["naive_mase"] is None
+            assert aggregate["fva_mase"] is None
+        finally:
+            _cleanup(conn, item_id, location_id)
+
+
+def test_re_persisting_run_keeps_fva_stable(migrated_db):
+    """persist_accuracy_metrics is DELETE + INSERT: re-persisting the same run
+    with the same fva rewrites identical FVA values (idempotent), never
+    duplicating the aggregate row nor drifting the numbers."""
+    from ootils_core.pyramide.fva import compute_fva, resolve_season_length
+    from ootils_core.pyramide.repository import persist_accuracy_metrics, persist_run
+
+    with _db_conn(migrated_db) as conn:
+        code = f"FVA-{uuid4().hex[:8].upper()}"
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            history = _seasonal_series(60)
+            result = _run(conn, item_id, location_id, history, horizon_days=5)
+            persisted = persist_run(conn, result, history=history)
+
+            first = _aggregate_row(conn, persisted.run_id)
+            assert first["fva_wape"] is not None
+
+            # Re-persist with an independently recomputed FvaResult on the same
+            # run_id (same DELETE + INSERT path persist_run took).
+            fva = compute_fva(
+                history,
+                resolve_season_length("daily", {"window": 4}),
+                stat_report=result.accuracy_report,
+            )
+            persist_accuracy_metrics(
+                conn, persisted.run_id, result.accuracy_report, fva=fva,
+            )
+
+            # Exactly one aggregate row survives, with identical values.
+            count = conn.execute(
+                "SELECT COUNT(*) AS n FROM pyramide_accuracy_metrics "
+                "WHERE run_id = %s AND horizon IS NULL",
+                (persisted.run_id,),
+            ).fetchone()["n"]
+            assert count == 1
+
+            second = _aggregate_row(conn, persisted.run_id)
+            assert second["naive_wape"] == first["naive_wape"]
+            assert second["naive_mase"] == first["naive_mase"]
+            assert second["fva_wape"] == first["fva_wape"]
+            assert second["fva_mase"] == first["fva_mase"]
+        finally:
+            _cleanup(conn, item_id, location_id)
+
+
+def test_get_run_endpoint_exposes_fva_fields(migrated_db):
+    """GET /v1/forecast/runs/{run_id}: the aggregate accuracy_metrics entry
+    carries the four FVA fields (None-honest), a purely additive contract
+    change."""
+    os.environ["OOTILS_API_TOKEN"] = "integration-test-token"
+
+    from fastapi.testclient import TestClient
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+    from ootils_core.pyramide.repository import persist_run
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+    auth = {"Authorization": "Bearer integration-test-token"}
+
+    with _db_conn(migrated_db) as conn:
+        code = f"FVA-{uuid4().hex[:8].upper()}"
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            history = _seasonal_series(60)
+            result = _run(conn, item_id, location_id, history, horizon_days=4)
+            persisted = persist_run(conn, result, history=history)
+
+            with TestClient(app) as client:
+                response = client.get(
+                    f"/v1/forecast/runs/{persisted.run_id}", headers=auth
+                )
+            assert response.status_code == 200
+            metrics = response.json()["accuracy_metrics"]
+
+            aggregate = metrics[0]
+            assert aggregate["horizon"] is None
+            assert aggregate["naive_wape"] is not None
+            assert aggregate["naive_mase"] is not None
+            assert aggregate["fva_wape"] is not None
+            assert aggregate["fva_mase"] is not None
+
+            # Per-horizon rows expose the four fields as null (None-honest).
+            for row in metrics[1:]:
+                assert row["naive_wape"] is None
+                assert row["fva_wape"] is None
+        finally:
+            app.dependency_overrides.clear()
+            _cleanup(conn, item_id, location_id)

--- a/tests/test_fva.py
+++ b/tests/test_fva.py
@@ -1,0 +1,354 @@
+"""
+Golden unit tests for the PURE Forecast Value Added core (pyramide/fva.py,
+#393 A3-PR3, ADR-030). DB-free: in-memory Decimal series in, ``FvaResult``
+out. The real persistence / round-trip / migration-068 wiring lives in
+tests/integration/test_fva_integration.py.
+
+The load-bearing invariants under test:
+
+- ``seasonal_naive_forecast`` = the deliberately trivial baseline
+  ``y_hat[t] = y[t - season]`` (wrap by season, clamp <0, ``[]`` below one
+  season, ValueError on structural misuse).
+- FVA = naive - stat, POSITIVE = the stat model beats the trivial baseline.
+  A NEGATIVE FVA is legitimate and NEVER clamped (proven with a strict
+  ``< 0`` assertion).
+- **None-honest, STRICT.** ``None`` = "not computable on this data"; ``0.0``
+  = "stat == naive" (a real, comparable result). The two are asserted
+  distinct — the single most important property of this module.
+- Methodological consistency: the naive is backtested on the SAME
+  rolling-origin cutoffs as the stat report (``naive.n_cutoffs ==
+  stat.n_cutoffs`` witness).
+
+Every expected number below is hand-derived; ``test_naive_backtest_exact_by_hand``
+pins a fully hand-worked case to literals so the naive math is proven
+independently of the implementation.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from ootils_core.pyramide.accuracy import (
+    AccuracyReport,
+    evaluate_rolling_origin,
+)
+from ootils_core.pyramide.fva import (
+    FvaResult,
+    compute_fva,
+    resolve_season_length,
+    seasonal_naive_forecast,
+)
+
+D = Decimal
+
+
+def _stat_report(
+    *,
+    wape: Decimal | None,
+    mase: Decimal | None,
+    n_cutoffs: int,
+    horizon: int,
+) -> AccuracyReport:
+    """A stat AccuracyReport shaped like a real rolling-origin backtest:
+    ``n_cutoffs`` origins, per-horizon residual buckets 1..horizon (their
+    VALUES are irrelevant to compute_fva — only the KEYS size the naive
+    window and n_cutoffs is the alignment witness). wape/mase are the stat
+    operands compute_fva subtracts from the naive."""
+    return AccuracyReport(
+        mase=mase,
+        wape=wape,
+        smape=D("0.1"),
+        bias=D("0"),
+        coverage=None,
+        per_horizon_residuals={
+            h: tuple(D("0") for _ in range(n_cutoffs)) for h in range(1, horizon + 1)
+        },
+        n_cutoffs=n_cutoffs,
+        n_observations=n_cutoffs * horizon,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. seasonal_naive_forecast — the trivial baseline curve
+# ---------------------------------------------------------------------------
+
+
+def test_seasonal_naive_repeats_last_season_exactly():
+    # Two full seasons; the forecast for one horizon-season is the last
+    # observed season verbatim: y_hat[i] = history[len - season + i].
+    history = [D(1), D(2), D(3), D(4), D(5), D(6)]
+    assert seasonal_naive_forecast(history, 3, 3) == [D(4), D(5), D(6)]
+
+
+def test_seasonal_naive_wraps_modulo_season_beyond_one_cycle():
+    # Horizon longer than a season wraps: [4,5,6, 4,5,6, 4] for horizon 7.
+    history = [D(1), D(2), D(3), D(4), D(5), D(6)]
+    assert seasonal_naive_forecast(history, 3, 7) == [
+        D(4), D(5), D(6), D(4), D(5), D(6), D(4),
+    ]
+
+
+def test_seasonal_naive_clamps_negative_to_zero():
+    # A negative demand forecast does not exist: last season [-5, 2, -1]
+    # clamps to [0, 2, 0]. The clamp is per-step, not the whole curve.
+    history = [D(-5), D(2), D(-1)]
+    assert seasonal_naive_forecast(history, 3, 3) == [D(0), D(2), D(0)]
+
+
+def test_seasonal_naive_below_one_season_returns_empty():
+    # < one full season of history => no value "one season ago" => []
+    # (the caller reads this as "baseline undefined", None-honest — never a
+    # zero forecast).
+    assert seasonal_naive_forecast([D(1), D(2)], 3, 4) == []
+
+
+def test_seasonal_naive_rejects_structural_misuse():
+    history = [D(1), D(2), D(3)]
+    with pytest.raises(ValueError):
+        seasonal_naive_forecast(history, 0, 3)  # season < 1
+    with pytest.raises(ValueError):
+        seasonal_naive_forecast(history, 2, 0)  # horizon < 1
+
+
+# ---------------------------------------------------------------------------
+# 2. compute_fva — the sign of the value added (positive/negative, no clamp)
+# ---------------------------------------------------------------------------
+
+
+def test_fva_positive_when_stat_beats_naive_on_a_trend():
+    # Linear-trend series: the seasonal-naive carries a big error (it repeats
+    # a stale season), so a stat model with a much lower WAPE ADDS value:
+    # fva_wape = naive_wape - stat_wape > 0.
+    series = [D(x) for x in (10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32)]
+    stat = _stat_report(wape=D("0.01"), mase=D("0.1"), n_cutoffs=4, horizon=2)
+
+    result = compute_fva(series, 3, stat_report=stat)
+
+    assert result.naive_wape is not None
+    assert result.fva_wape is not None
+    assert result.fva_wape > 0  # stat removed error => value added
+    assert result.fva_wape == result.naive_wape - D("0.01")
+    assert result.fva_mase == result.naive_mase - D("0.1")
+
+
+def test_fva_strictly_negative_when_naive_wins_never_clamped():
+    # Same series, but a DELIBERATELY worse stat: wape/mase above the naive.
+    # The FVA must be STRICTLY < 0 — proving the module never clamps a
+    # negative value added to 0 (the load-bearing "honest negative" rule).
+    series = [D(x) for x in (10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32)]
+    baseline = compute_fva(
+        series, 3, stat_report=_stat_report(
+            wape=D("0"), mase=D("0"), n_cutoffs=4, horizon=2,
+        ),
+    )
+    assert baseline.naive_wape is not None and baseline.naive_mase is not None
+
+    worse = _stat_report(
+        wape=baseline.naive_wape + D("0.5"),
+        mase=baseline.naive_mase + D("1"),
+        n_cutoffs=4,
+        horizon=2,
+    )
+    result = compute_fva(series, 3, stat_report=worse)
+
+    assert result.fva_wape == D("-0.5")
+    assert result.fva_mase == D("-1")
+    assert result.fva_wape < 0  # not clamped to 0
+    assert result.fva_mase < 0
+
+
+# ---------------------------------------------------------------------------
+# 3. compute_fva — None-honest, STRICT (None vs 0.0). The core contract.
+# ---------------------------------------------------------------------------
+
+
+def test_fva_none_when_history_shorter_than_one_season_at_first_origin():
+    # season=5 but the stat's first shared origin (min_train = L - n_cutoffs
+    # = 8 - 5 = 3) holds < 1 full season: no value one season ago there, so
+    # the naive is undefined => naive AND fva None (not a fabricated 0).
+    series = [D(x) for x in (3, 1, 4, 1, 5, 9, 2, 6)]
+    stat = _stat_report(wape=D("0.2"), mase=D("1.0"), n_cutoffs=5, horizon=2)
+
+    result = compute_fva(series, 5, stat_report=stat)
+
+    assert result.naive_wape is None
+    assert result.naive_mase is None
+    assert result.fva_wape is None
+    assert result.fva_mase is None
+
+
+def test_fva_none_when_stat_operand_none_but_naive_stays_computable():
+    # The distinctive None-honest case: the stat WAPE is None (migration 055
+    # — e.g. an all-zero pooled window), yet the naive baseline IS computable.
+    # fva_wape must be None (one operand missing) WITHOUT poisoning the naive
+    # side: naive_wape is a real number, and the MASE axis (stat mase given)
+    # still yields a real fva_mase. None and "missing operand" stay local.
+    series = [D(x) for x in range(10, 34, 2)]  # 12 points, 10..32
+    stat = _stat_report(wape=None, mase=D("0.5"), n_cutoffs=4, horizon=2)
+
+    result = compute_fva(series, 3, stat_report=stat)
+
+    assert result.naive_wape is not None  # baseline computed regardless
+    assert result.fva_wape is None  # but no comparison without a stat wape
+    assert result.naive_mase is not None
+    assert result.fva_mase is not None  # the mase axis is unaffected
+    assert result.fva_mase == result.naive_mase - D("0.5")
+
+
+def test_fva_zero_is_distinct_from_none_when_stat_equals_naive():
+    # stat == naive exactly => fva == 0.0 (a real, comparable "no value
+    # added"), which must be DISTINCT from None ("not comparable"). This is
+    # the pair the whole module refuses to conflate.
+    series = [D(x) for x in range(10, 34, 2)]
+
+    def naive_fn(train, periods):
+        return seasonal_naive_forecast(train, 3, periods)
+
+    # Recover the exact naive metrics on the stat's cutoffs (min_train =
+    # 12 - 4 = 8) and hand them back AS the stat metrics.
+    naive_ref = evaluate_rolling_origin(
+        series=series, forecast_fn=naive_fn, horizon=2, min_train=8, step=1, m=1,
+    )
+    stat = _stat_report(
+        wape=naive_ref.wape, mase=naive_ref.mase, n_cutoffs=4, horizon=2,
+    )
+
+    result = compute_fva(series, 3, stat_report=stat)
+
+    assert result.fva_wape == 0  # stat == naive, a real 0
+    assert result.fva_wape is not None  # explicitly NOT None
+    assert result.fva_mase == 0
+    assert result.fva_mase is not None
+
+
+def test_fva_none_when_report_carries_no_rolling_origin_structure():
+    # A report with no per-horizon residuals / no cutoffs (external backend,
+    # blend, too-short history) has nothing for the naive to mirror: naive
+    # and fva collapse to None rather than guessing a window.
+    series = [D(x) for x in range(20)]
+    empty = AccuracyReport(
+        mase=D("1"), wape=D("0.2"), smape=D("0.1"), bias=D("0"), coverage=None,
+        per_horizon_residuals={}, n_cutoffs=0, n_observations=0,
+    )
+
+    result = compute_fva(series, 3, stat_report=empty)
+
+    assert result == FvaResult(
+        naive_wape=None, naive_mase=None, fva_wape=None, fva_mase=None,
+    )
+
+
+def test_compute_fva_rejects_bad_season_length():
+    stat = _stat_report(wape=D("0.1"), mase=D("0.1"), n_cutoffs=1, horizon=1)
+    with pytest.raises(ValueError):
+        compute_fva([D(1), D(2)], 0, stat_report=stat)
+
+
+# ---------------------------------------------------------------------------
+# 3b. A fully hand-worked golden: the naive backtest math pinned to literals
+# ---------------------------------------------------------------------------
+
+
+def test_naive_backtest_exact_by_hand():
+    # season=2, series=[10,20,12,24,14,28], stat n_cutoffs=2 => min_train=4,
+    # horizon=1. Naive backtest, step=1:
+    #   origin 4: train=[10,20,12,24] -> snf=train[2]=12 ; actual=14 ; |14-12|=2
+    #   origin 5: train=[10,20,12,24,14] -> snf=train[3]=24 ; actual=28 ; |28-24|=4
+    # naive_wape = (2+4) / (14+28) = 6/42 = 1/7.
+    # MASE (m=1, per-cutoff 1-step naive MAE):
+    #   origin 4 |20-10|,|12-20|,|24-12| = 10,8,12 -> mean 10 -> scaled 2/10=0.2
+    #   origin 5 add |14-24|=10 -> mean 40/4=10 -> scaled 4/10=0.4
+    #   naive_mase = (0.2+0.4)/2 = 0.3
+    series = [D(10), D(20), D(12), D(24), D(14), D(28)]
+    stat = _stat_report(wape=D("0.05"), mase=D("0.1"), n_cutoffs=2, horizon=1)
+
+    result = compute_fva(series, 2, stat_report=stat)
+
+    assert result.naive_wape == D(6) / D(42)
+    assert result.naive_mase == D("0.3")
+    assert result.fva_wape == D(6) / D(42) - D("0.05")
+    assert result.fva_mase == D("0.3") - D("0.1")
+
+
+# ---------------------------------------------------------------------------
+# 4. Methodological alignment — naive on the SAME cutoffs as the stat
+# ---------------------------------------------------------------------------
+
+
+def test_naive_aligned_to_stat_cutoffs_on_long_series():
+    # A long series (>= 52 + season) with a real stat backtest: compute_fva
+    # recovers the stat's exact origin (min_train = L - n_cutoffs) and scores
+    # the naive there. The apples-to-apples witness — identical n_cutoffs —
+    # is verified against an independent naive backtest at the same origin,
+    # and fva_wape reduces exactly to naive_wape - stat_wape.
+    season = 7
+    length = 52 + season + 10
+    pattern = (20, 22, 25, 30, 28, 15, 12)
+    series = [D(pattern[i % 7] + i // 7) for i in range(length)]
+
+    def stat_fn(train, periods):
+        return [train[-1]] * periods  # plain last-value naive as the "stat"
+
+    stat_report = evaluate_rolling_origin(
+        series=series, forecast_fn=stat_fn, horizon=3, min_train=30, step=1, m=1,
+    )
+
+    result = compute_fva(series, season, stat_report=stat_report)
+
+    assert result.naive_wape is not None
+    assert result.naive_mase is not None
+    assert result.fva_wape is not None
+    assert result.fva_mase is not None
+
+    # Independent witness: re-backtest the naive at the same recovered origin.
+    def naive_fn(train, periods):
+        return seasonal_naive_forecast(train, season, periods)
+
+    naive_ref = evaluate_rolling_origin(
+        series=series, forecast_fn=naive_fn, horizon=3,
+        min_train=length - stat_report.n_cutoffs, step=1, m=1,
+    )
+    assert naive_ref.n_cutoffs == stat_report.n_cutoffs  # aligned by construction
+    assert result.naive_wape == naive_ref.wape
+    assert result.fva_wape == naive_ref.wape - stat_report.wape
+    assert result.fva_mase == naive_ref.mase - stat_report.mase
+
+
+# ---------------------------------------------------------------------------
+# 5. resolve_season_length — granularity defaults + tolerant override
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_season_length_defaults_per_granularity():
+    assert resolve_season_length("daily", {}) == 7
+    assert resolve_season_length("weekly", {}) == 52
+    assert resolve_season_length("monthly", {}) == 12
+
+
+def test_resolve_season_length_honours_valid_override():
+    assert resolve_season_length("daily", {"season_length": 4}) == 4
+    assert resolve_season_length("weekly", {"season_length": "9"}) == 9  # int-coercible
+
+
+def test_resolve_season_length_tolerant_on_illegible_override():
+    # Illegible / out-of-range overrides fall back to the granularity
+    # default WITHOUT raising — a bad param must never crash a run.
+    assert resolve_season_length("monthly", {"season_length": "oops"}) == 12
+    assert resolve_season_length("daily", {"season_length": None}) == 7
+    assert resolve_season_length("weekly", {"season_length": 0}) == 52
+    assert resolve_season_length("daily", {"season_length": -3}) == 7
+
+
+# ---------------------------------------------------------------------------
+# 6. FvaResult is a frozen value object
+# ---------------------------------------------------------------------------
+
+
+def test_fva_result_is_frozen():
+    result = FvaResult(
+        naive_wape=D("0.2"), naive_mase=D("1"),
+        fva_wape=D("0.05"), fva_mase=D("0.1"),
+    )
+    with pytest.raises(Exception):
+        result.fva_wape = D("0")  # type: ignore[misc]


### PR DESCRIPTION
Réf #393 (A3-PR3) — **la preuve côté demande.** Chaque run Pyramide comparé à une naïve seasonal-naive triviale : FVA = naive − stat (positif = le modèle bat la naïve).

## Livré
- **`pyramide/fva.py`** (pur) : `seasonal_naive_forecast` + `compute_fva` qui backteste la naïve sur les **MÊMES cutoffs rolling-origin** que le stat (garde-fou `naive.n_cutoffs == stat.n_cutoffs` sinon None — jamais choux-vs-carottes), réutilise le wape/mase stat déjà calculés.
- **None-honnête STRICT** : None = non calculable ; 0.0 = stat==naïve ; jamais confondus. FVA négatif **légitime et non clampé** (sur une vraie série saisonnière, la naïve est un benchmark fort).
- **Migration 068** : 4 colonnes NUMERIC NULL sur `pyramide_accuracy_metrics` (agrégat), pas de CHECK de signe.
- Branché : `persist_run(history=)` → 4 colonnes ; `history=None` → NULL (non-régressif) ; exposé sur `GET /v1/forecast/runs/{id}`.

## Qualité
Revue adversariale ciblée (alignement méthodologique / None-honnêteté / wiring) : **0 défaut**. 18 goldens purs (dont un dérivé à la main) + 5 intégration. Suite : 2374 passed, mypy 0/172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)