### PR TITLE
feat(pyramide): exposer les CI conformal + la réconciliation hiérarchique via REST (#394, B1)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4534,6 +4534,526 @@
         }
       }
     },
+    "/v1/drp/run": {
+      "post": {
+        "tags": [
+          "drp"
+        ],
+        "summary": "Run DRP (inter-site transfer planning)",
+        "description": "Deterministic DRP fair-share transfer planner. Computes projected per-site deficits vs linked-source excess and emits inter-site TRANSFER moves as governed L1 DRAFT recommendations (idempotent: an unchanged plan re-run emits zero new rows). Read-only on the graph; writes only into `recommendations`, never `shortages` (ADR-021). Scenario-scoped (forkable).",
+        "operationId": "run_drp_v1_drp_run_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "scenario_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scenario UUID or 'baseline'",
+              "title": "Scenario Id"
+            },
+            "description": "Scenario UUID or 'baseline'"
+          },
+          {
+            "name": "X-Scenario-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Scenario-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DrpRunRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DrpRunResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/snapshots": {
+      "post": {
+        "tags": [
+          "snapshots"
+        ],
+        "summary": "Capture inventory snapshots",
+        "description": "Scan on-hand per (item, location) for a scenario and upsert one `inventory_snapshots` row per coordinate for `as_of` (default CURRENT_DATE), source='api'. Idempotent: a re-capture of the same scenario/day overwrites, never duplicates. Per-site, never pooled. Requires the `ingest` scope (a write of persistent operational rows).",
+        "operationId": "capture_snapshots_v1_snapshots_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "scenario_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scenario UUID or 'baseline'",
+              "title": "Scenario Id"
+            },
+            "description": "Scenario UUID or 'baseline'"
+          },
+          {
+            "name": "X-Scenario-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Scenario-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SnapshotCaptureRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnapshotCaptureResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "snapshots"
+        ],
+        "summary": "Query inventory snapshots",
+        "description": "Read captured snapshots filtered by scenario (required, forkable), optional as_of day and item_id. Fully parameterized SQL.",
+        "operationId": "list_snapshots_v1_snapshots_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "as_of",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to a single capture day (YYYY-MM-DD).",
+              "title": "As Of"
+            },
+            "description": "Filter to a single capture day (YYYY-MM-DD)."
+          },
+          {
+            "name": "item_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to a single item.",
+              "title": "Item Id"
+            },
+            "description": "Filter to a single item."
+          },
+          {
+            "name": "scenario_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scenario UUID or 'baseline'",
+              "title": "Scenario Id"
+            },
+            "description": "Scenario UUID or 'baseline'"
+          },
+          {
+            "name": "X-Scenario-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Scenario-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnapshotListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/recommendations/{recommendation_id}/outcome": {
+      "get": {
+        "tags": [
+          "outcomes"
+        ],
+        "summary": "Get a recommendation's observed outcome",
+        "description": "The latest observed outcome of one recommendation: its deterministic verdict (AVOIDED / MATERIALIZED / PARTIAL / NOT_APPLICABLE / INDETERMINATE) plus the NULL-honest predicted/observed/avoided $ figures. 404 if the reco has no outcome yet.",
+        "operationId": "get_recommendation_outcome_v1_recommendations__recommendation_id__outcome_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "recommendation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The recommendation UUID.",
+              "title": "Recommendation Id"
+            },
+            "description": "The recommendation UUID."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutcomeOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/outcomes/summary": {
+      "get": {
+        "tags": [
+          "outcomes"
+        ],
+        "summary": "Proof-of-value KPI summary",
+        "description": "The five proof KPIs for a scenario: pct_shortages_avoided, avoided_severity_usd_total, avg_fva_wape (see FVA caveat), reco_approval_rate, cost_of_inaction_usd. Every KPI is NULL/0-honest (NULL = no data, 0 = genuine zero). Fully parameterized SQL, scenario-scoped. `from`/`to` window recommendation_outcomes.evaluated_as_of and therefore filter ONLY KPIs 1/2/5 (avoided rate, avoided $, cost of inaction); KPI 3 (Pyramide run accuracy) and KPI 4 (reco approval rate) have no evaluated_as_of of their own and are ALWAYS scenario-scope-lifetime, window or not.",
+        "operationId": "outcomes_summary_v1_outcomes_summary_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "from",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Window start (inclusive) on the OUTCOME observation date (recommendation_outcomes.evaluated_as_of). Filters KPIs 1/2/5 only — KPI 3/4 have no evaluated_as_of and ignore this filter (always scenario-scope-lifetime).",
+              "title": "From"
+            },
+            "description": "Window start (inclusive) on the OUTCOME observation date (recommendation_outcomes.evaluated_as_of). Filters KPIs 1/2/5 only — KPI 3/4 have no evaluated_as_of and ignore this filter (always scenario-scope-lifetime)."
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Window end (inclusive) on the OUTCOME observation date (recommendation_outcomes.evaluated_as_of). Filters KPIs 1/2/5 only — KPI 3/4 have no evaluated_as_of and ignore this filter (always scenario-scope-lifetime).",
+              "title": "To"
+            },
+            "description": "Window end (inclusive) on the OUTCOME observation date (recommendation_outcomes.evaluated_as_of). Filters KPIs 1/2/5 only — KPI 3/4 have no evaluated_as_of and ignore this filter (always scenario-scope-lifetime)."
+          },
+          {
+            "name": "scenario_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scenario UUID or 'baseline'",
+              "title": "Scenario Id"
+            },
+            "description": "Scenario UUID or 'baseline'"
+          },
+          {
+            "name": "X-Scenario-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Scenario-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutcomeSummaryOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/outcomes/evaluate": {
+      "post": {
+        "tags": [
+          "outcomes"
+        ],
+        "summary": "Evaluate recommendation outcomes",
+        "description": "Classify every eligible recommendation's observed outcome for `as_of` (default CURRENT_DATE) and upsert the verdicts (idempotent: a re-run for the same day overwrites, never duplicates). Read-only on recommendations/shortages/inventory_snapshots (ADR-021); writes only recommendation_outcomes. Requires the `ingest` scope.",
+        "operationId": "evaluate_outcomes_v1_outcomes_evaluate_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "scenario_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scenario UUID or 'baseline'",
+              "title": "Scenario Id"
+            },
+            "description": "Scenario UUID or 'baseline'"
+          },
+          {
+            "name": "X-Scenario-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Scenario-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OutcomeEvaluateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutcomeEvaluateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/demand/forecast/generate": {
       "post": {
         "tags": [
@@ -4913,6 +5433,53 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PyramideRunOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/v1/forecast/hierarchical-runs": {
+      "post": {
+        "tags": [
+          "pyramide"
+        ],
+        "summary": "Create a hierarchical (multi-level, reconciled) Pyramide forecast run",
+        "description": "Forecast and reconcile ONE summing block of the hierarchy registry\n(HierarchicalRunner, #348). Every level is persisted as its own\npyramide_runs row (aggregates carry hierarchy_id/level/node_code, leaves\ncarry item/location); the response lists each run_id so the existing\nGET /runs/{run_id}/result endpoint reads any of them — leaf results carry\nconformal bounds, aggregate results carry NULL bounds (hierarchical\ninterval reconciliation is a documented V1 non-goal).\n\n``recon_method`` reflects the method EFFECTIVELY applied: a\n'mintrace_wls_shrink' request that fell back reports 'middleout' with the\nreason in ``warnings`` — provenance never lies.",
+        "operationId": "create_hierarchical_run_v1_forecast_hierarchical_runs_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HierarchicalRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HierarchicalRunResultOut"
                 }
               }
             }
@@ -7312,7 +7879,7 @@
         "properties": {
           "file": {
             "type": "string",
-            "contentMediaType": "application/octet-stream",
+            "format": "binary",
             "title": "File",
             "description": "Source file (TSV/CSV/XLSX/JSON)"
           },
@@ -7701,7 +8268,7 @@
           },
           "violations": {
             "items": {
-              "$ref": "#/components/schemas/ootils_core__atp__routers__CapacityViolationOut"
+              "$ref": "#/components/schemas/CapacityViolationOut"
             },
             "type": "array",
             "title": "Violations",
@@ -8128,6 +8695,46 @@
         ],
         "title": "CapacityCheckResponse",
         "description": "Response from capacity check endpoint."
+      },
+      "CapacityViolationOut": {
+        "properties": {
+          "resource_id": {
+            "type": "string",
+            "title": "Resource Id"
+          },
+          "resource_name": {
+            "type": "string",
+            "title": "Resource Name"
+          },
+          "violation_date": {
+            "type": "string",
+            "format": "date",
+            "title": "Violation Date"
+          },
+          "required_capacity": {
+            "type": "number",
+            "title": "Required Capacity"
+          },
+          "available_capacity": {
+            "type": "number",
+            "title": "Available Capacity"
+          },
+          "overload_pct": {
+            "type": "number",
+            "title": "Overload Pct"
+          }
+        },
+        "type": "object",
+        "required": [
+          "resource_id",
+          "resource_name",
+          "violation_date",
+          "required_capacity",
+          "available_capacity",
+          "overload_pct"
+        ],
+        "title": "CapacityViolationOut",
+        "description": "Capacity violation details for API response."
       },
       "CausalStepOut": {
         "properties": {
@@ -8947,6 +9554,81 @@
           "created_at"
         ],
         "title": "DemoRunSummary"
+      },
+      "DrpRunRequest": {
+        "properties": {
+          "horizon_days": {
+            "type": "integer",
+            "maximum": 1095.0,
+            "minimum": 1.0,
+            "title": "Horizon Days",
+            "default": 180
+          }
+        },
+        "type": "object",
+        "title": "DrpRunRequest",
+        "description": "Body of POST /v1/drp/run. scenario_id is resolved from the query param /\nX-Scenario-ID header (Depends(resolve_scenario_id)), NOT the body, matching\nthe forkable read-path convention of the other scenario-scoped routers."
+      },
+      "DrpRunResponse": {
+        "properties": {
+          "scenario_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Scenario Id"
+          },
+          "agent_run_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Agent Run Id"
+          },
+          "decision_level": {
+            "type": "string",
+            "title": "Decision Level"
+          },
+          "horizon_days": {
+            "type": "integer",
+            "title": "Horizon Days"
+          },
+          "signals": {
+            "type": "integer",
+            "title": "Signals"
+          },
+          "recommendations_emitted": {
+            "type": "integer",
+            "title": "Recommendations Emitted"
+          },
+          "recommendations_idempotent_noop": {
+            "type": "integer",
+            "title": "Recommendations Idempotent Noop"
+          },
+          "expired_stale_drafts": {
+            "type": "integer",
+            "title": "Expired Stale Drafts"
+          },
+          "unresolved_coords": {
+            "type": "integer",
+            "title": "Unresolved Coords"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "scenario_id",
+          "agent_run_id",
+          "decision_level",
+          "horizon_days",
+          "signals",
+          "recommendations_emitted",
+          "recommendations_idempotent_noop",
+          "expired_stale_drafts",
+          "unresolved_coords",
+          "message"
+        ],
+        "title": "DrpRunResponse",
+        "description": "Response from a DRP transfer run."
       },
       "EdgeOut": {
         "properties": {
@@ -10242,6 +10924,247 @@
         },
         "type": "object",
         "title": "HTTPValidationError"
+      },
+      "HierarchicalRunRequest": {
+        "properties": {
+          "hierarchy_id": {
+            "type": "string",
+            "title": "Hierarchy Id"
+          },
+          "block_code": {
+            "type": "string",
+            "title": "Block Code"
+          },
+          "leaf_location_id": {
+            "type": "string",
+            "title": "Leaf Location Id"
+          },
+          "horizon_days": {
+            "type": "integer",
+            "maximum": 365.0,
+            "minimum": 1.0,
+            "title": "Horizon Days",
+            "default": 90
+          },
+          "granularity": {
+            "type": "string",
+            "pattern": "^(daily|weekly|monthly)$",
+            "title": "Granularity",
+            "default": "daily"
+          },
+          "method": {
+            "type": "string",
+            "title": "Method",
+            "default": "AUTO_SELECT"
+          },
+          "method_params": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Method Params"
+          },
+          "scenario_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scenario Id"
+          },
+          "model_strategy": {
+            "type": "string",
+            "pattern": "^(auto|stat|ml|fm|hybrid)$",
+            "title": "Model Strategy",
+            "default": "stat"
+          },
+          "recon_method": {
+            "type": "string",
+            "pattern": "^(middleout|mintrace_wls_shrink)$",
+            "title": "Recon Method",
+            "default": "middleout"
+          },
+          "block_level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Block Level"
+          },
+          "recon_level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recon Level"
+          },
+          "lookback_days": {
+            "type": "integer",
+            "maximum": 3650.0,
+            "minimum": 1.0,
+            "title": "Lookback Days",
+            "default": 365
+          },
+          "random_seed": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Random Seed",
+            "default": 0
+          },
+          "code_version": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Code Version",
+            "default": "local"
+          }
+        },
+        "type": "object",
+        "required": [
+          "hierarchy_id",
+          "block_code",
+          "leaf_location_id"
+        ],
+        "title": "HierarchicalRunRequest"
+      },
+      "HierarchicalRunResultOut": {
+        "properties": {
+          "hierarchy_id": {
+            "type": "string",
+            "title": "Hierarchy Id"
+          },
+          "block_code": {
+            "type": "string",
+            "title": "Block Code"
+          },
+          "block_level": {
+            "type": "string",
+            "title": "Block Level"
+          },
+          "recon_level": {
+            "type": "string",
+            "title": "Recon Level"
+          },
+          "recon_method": {
+            "type": "string",
+            "title": "Recon Method"
+          },
+          "scenario_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Scenario Id"
+          },
+          "horizon_start": {
+            "type": "string",
+            "format": "date",
+            "title": "Horizon Start"
+          },
+          "horizon_end": {
+            "type": "string",
+            "format": "date",
+            "title": "Horizon End"
+          },
+          "granularity": {
+            "type": "string",
+            "title": "Granularity"
+          },
+          "method": {
+            "type": "string",
+            "title": "Method"
+          },
+          "series": {
+            "items": {
+              "$ref": "#/components/schemas/HierarchicalSeriesOut"
+            },
+            "type": "array",
+            "title": "Series"
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Warnings"
+          }
+        },
+        "type": "object",
+        "required": [
+          "hierarchy_id",
+          "block_code",
+          "block_level",
+          "recon_level",
+          "recon_method",
+          "scenario_id",
+          "horizon_start",
+          "horizon_end",
+          "granularity",
+          "method",
+          "series",
+          "warnings"
+        ],
+        "title": "HierarchicalRunResultOut"
+      },
+      "HierarchicalSeriesOut": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "key": {
+            "type": "string",
+            "title": "Key"
+          },
+          "level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Level"
+          },
+          "run_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Run Id"
+          },
+          "forecast_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Forecast Id"
+          },
+          "snapshot_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Snapshot Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "kind",
+          "key",
+          "run_id",
+          "forecast_id"
+        ],
+        "title": "HierarchicalSeriesOut"
       },
       "IngestBOMRequest": {
         "properties": {
@@ -12012,6 +12935,277 @@
         ],
         "title": "OnHandRow"
       },
+      "OutcomeEvaluateRequest": {
+        "properties": {
+          "as_of": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "As Of",
+            "description": "Observation day (YYYY-MM-DD). Defaults to the DB CURRENT_DATE."
+          }
+        },
+        "type": "object",
+        "title": "OutcomeEvaluateRequest",
+        "description": "Body of POST /v1/outcomes/evaluate. scenario_id is resolved from the query\nparam / X-Scenario-ID header (Depends(resolve_scenario_id)), NOT the body."
+      },
+      "OutcomeEvaluateResponse": {
+        "properties": {
+          "scenario_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Scenario Id"
+          },
+          "evaluated_as_of": {
+            "type": "string",
+            "format": "date",
+            "title": "Evaluated As Of"
+          },
+          "evaluated": {
+            "type": "integer",
+            "title": "Evaluated"
+          },
+          "upserted": {
+            "type": "integer",
+            "title": "Upserted"
+          },
+          "with_avoided_usd": {
+            "type": "integer",
+            "title": "With Avoided Usd"
+          },
+          "by_status": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "By Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "scenario_id",
+          "evaluated_as_of",
+          "evaluated",
+          "upserted",
+          "with_avoided_usd",
+          "by_status"
+        ],
+        "title": "OutcomeEvaluateResponse",
+        "description": "Response from an evaluation pass."
+      },
+      "OutcomeOut": {
+        "properties": {
+          "outcome_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Outcome Id"
+          },
+          "recommendation_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Recommendation Id"
+          },
+          "evaluated_as_of": {
+            "type": "string",
+            "format": "date",
+            "title": "Evaluated As Of"
+          },
+          "evaluation_status": {
+            "type": "string",
+            "title": "Evaluation Status"
+          },
+          "predicted_shortage_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Predicted Shortage Date"
+          },
+          "predicted_deficit_qty": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Predicted Deficit Qty"
+          },
+          "observed_deficit_qty": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Observed Deficit Qty"
+          },
+          "avoided_severity_usd": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avoided Severity Usd"
+          },
+          "snapshot_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Snapshot Id"
+          },
+          "evaluated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Evaluated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "outcome_id",
+          "recommendation_id",
+          "evaluated_as_of",
+          "evaluation_status",
+          "evaluated_at"
+        ],
+        "title": "OutcomeOut",
+        "description": "One recommendation-outcome verdict.\n\nNULL-honest: ``avoided_severity_usd`` is None when NOT computable (no cost\nbasis / INDETERMINATE / a reco that never acted), never a masked 0. The\n``predicted_*`` are None when the reco carried no such figure."
+      },
+      "OutcomeSummaryOut": {
+        "properties": {
+          "scenario_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Scenario Id"
+          },
+          "from_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "From Date"
+          },
+          "to_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "To Date"
+          },
+          "pct_shortages_avoided": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pct Shortages Avoided"
+          },
+          "avoided_basis_count": {
+            "type": "integer",
+            "title": "Avoided Basis Count",
+            "description": "AVOIDED+MATERIALIZED+PARTIAL on acted recos (KPI 1 denominator)."
+          },
+          "avoided_severity_usd_total": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avoided Severity Usd Total"
+          },
+          "avg_fva_wape": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg Fva Wape"
+          },
+          "fva_basis_count": {
+            "type": "integer",
+            "title": "Fva Basis Count",
+            "description": "Non-NULL aggregate WAPE rows averaged (KPI 3 denominator)."
+          },
+          "reco_approval_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reco Approval Rate"
+          },
+          "reco_total_count": {
+            "type": "integer",
+            "title": "Reco Total Count",
+            "description": "Total recos emitted in scope (KPI 4 denominator)."
+          },
+          "cost_of_inaction_usd": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost Of Inaction Usd"
+          }
+        },
+        "type": "object",
+        "required": [
+          "scenario_id",
+          "avoided_basis_count",
+          "fva_basis_count",
+          "reco_total_count"
+        ],
+        "title": "OutcomeSummaryOut",
+        "description": "The five proof KPIs over a scenario. ``from_date``/``to_date`` echo the\nOUTCOME observation window applied to KPI 1/2/5 only — KPI 3/4 are always\nscenario-scope-lifetime regardless of the window (see the router docstring).\n\nEvery field is NULL/0-honest: None means \"no data to compute this KPI\"\n(e.g. zero acted recos for the rate, no WAPE rows for the accuracy), a real\nnumber (including 0) means the KPI computed to that value. The ``*_basis``\ncounters make the denominators explicit so a consumer can tell a genuine 0\nfrom an empty set."
+      },
       "OverloadOut": {
         "properties": {
           "work_center_id": {
@@ -13368,6 +14562,54 @@
           "n_observations": {
             "type": "integer",
             "title": "N Observations"
+          },
+          "naive_wape": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Naive Wape"
+          },
+          "naive_mase": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Naive Mase"
+          },
+          "fva_wape": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fva Wape"
+          },
+          "fva_mase": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fva Mase"
           }
         },
         "type": "object",
@@ -13903,6 +15145,30 @@
           "method": {
             "type": "string",
             "title": "Method"
+          },
+          "confidence_lower": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence Lower"
+          },
+          "confidence_upper": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence Upper"
           }
         },
         "type": "object",
@@ -15122,6 +16388,157 @@
         ],
         "title": "SimulateResponse"
       },
+      "SnapshotCaptureRequest": {
+        "properties": {
+          "as_of": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "As Of",
+            "description": "Capture day (YYYY-MM-DD). Defaults to the DB CURRENT_DATE."
+          }
+        },
+        "type": "object",
+        "title": "SnapshotCaptureRequest",
+        "description": "Body of POST /v1/snapshots. scenario_id is resolved from the query param /\nX-Scenario-ID header (Depends(resolve_scenario_id)), NOT the body — matching\nthe forkable read-path convention of the other scenario-scoped routers."
+      },
+      "SnapshotCaptureResponse": {
+        "properties": {
+          "scenario_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Scenario Id"
+          },
+          "as_of_date": {
+            "type": "string",
+            "format": "date",
+            "title": "As Of Date"
+          },
+          "snapshots_captured": {
+            "type": "integer",
+            "title": "Snapshots Captured"
+          }
+        },
+        "type": "object",
+        "required": [
+          "scenario_id",
+          "as_of_date",
+          "snapshots_captured"
+        ],
+        "title": "SnapshotCaptureResponse",
+        "description": "Response from a snapshot capture."
+      },
+      "SnapshotListResponse": {
+        "properties": {
+          "scenario_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Scenario Id"
+          },
+          "snapshots": {
+            "items": {
+              "$ref": "#/components/schemas/SnapshotOut"
+            },
+            "type": "array",
+            "title": "Snapshots"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "scenario_id",
+          "snapshots",
+          "total"
+        ],
+        "title": "SnapshotListResponse"
+      },
+      "SnapshotOut": {
+        "properties": {
+          "snapshot_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Snapshot Id"
+          },
+          "scenario_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Scenario Id"
+          },
+          "item_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Item Id"
+          },
+          "location_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Location Id"
+          },
+          "as_of_date": {
+            "type": "string",
+            "format": "date",
+            "title": "As Of Date"
+          },
+          "on_hand_qty": {
+            "type": "number",
+            "title": "On Hand Qty"
+          },
+          "first_shortage_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Shortage Date"
+          },
+          "shortage_severity_usd": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shortage Severity Usd"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source"
+          },
+          "captured_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Captured At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "snapshot_id",
+          "scenario_id",
+          "item_id",
+          "location_id",
+          "as_of_date",
+          "on_hand_qty",
+          "source",
+          "captured_at"
+        ],
+        "title": "SnapshotOut",
+        "description": "One captured coordinate row.\n\n``first_shortage_date`` / ``shortage_severity_usd`` are NULL-honest: None\nmeans no projected shortage at this coordinate on as_of_date (enrichment is\ndeferred to a later PR — captured None in PR1; the two are None together)."
+      },
       "SupplierItemRow": {
         "properties": {
           "supplier_external_id": {
@@ -15516,13 +16933,6 @@
           "type": {
             "type": "string",
             "title": "Error Type"
-          },
-          "input": {
-            "title": "Input"
-          },
-          "ctx": {
-            "type": "object",
-            "title": "Context"
           }
         },
         "type": "object",
@@ -15646,46 +17056,6 @@
           "non_working_days_skipped"
         ],
         "title": "WorkingDaysResponse"
-      },
-      "ootils_core__atp__routers__CapacityViolationOut": {
-        "properties": {
-          "resource_id": {
-            "type": "string",
-            "title": "Resource Id"
-          },
-          "resource_name": {
-            "type": "string",
-            "title": "Resource Name"
-          },
-          "violation_date": {
-            "type": "string",
-            "format": "date",
-            "title": "Violation Date"
-          },
-          "required_capacity": {
-            "type": "number",
-            "title": "Required Capacity"
-          },
-          "available_capacity": {
-            "type": "number",
-            "title": "Available Capacity"
-          },
-          "overload_pct": {
-            "type": "number",
-            "title": "Overload Pct"
-          }
-        },
-        "type": "object",
-        "required": [
-          "resource_id",
-          "resource_name",
-          "violation_date",
-          "required_capacity",
-          "available_capacity",
-          "overload_pct"
-        ],
-        "title": "CapacityViolationOut",
-        "description": "Capacity violation details for API response."
       },
       "ootils_core__mps__api__CapacityViolationOut": {
         "properties": {

--- a/src/ootils_core/api/routers/pyramide.py
+++ b/src/ootils_core/api/routers/pyramide.py
@@ -14,6 +14,12 @@ from ootils_core.api.dependencies import get_db
 from ootils_core.db.types import DictRowConnection
 from ootils_core.pyramide import PyramideError, PyramideRunConfig, PyramideRunner, SUPPORTED_METHODS
 from ootils_core.pyramide.confidence import DEFAULT_SLA_DAYS
+from ootils_core.pyramide.hierarchy import (
+    RECON_MIDDLEOUT,
+    SUPPORTED_RECON_METHODS,
+    HierarchicalRunConfig,
+    HierarchicalRunner,
+)
 from ootils_core.pyramide.repository import (
     PyramideAggregateCommitError,
     commit_run,
@@ -142,11 +148,99 @@ class PyramideValueOut(BaseModel):
     forecast_date: date
     quantity: Decimal
     method: str
+    # Bornes conformal du bucket (confidence_interval_lower/upper, migration
+    # 026 — écrites par persist_run/persist_series_run, exposées ici depuis
+    # #394 B1). None = NULL en base = pas de calibration honnête (pas de
+    # backtest déterministe, ou trop peu de résidus pour la garantie
+    # finite-sample) — jamais 0. Additif, rétro-compatible.
+    confidence_lower: Decimal | None = None
+    confidence_upper: Decimal | None = None
 
 
 class PyramideRunResultOut(BaseModel):
     run: PyramideRunOut
     values: list[PyramideValueOut]
+
+
+class HierarchicalRunRequest(BaseModel):
+    # A hierarchical run forecasts ONE summing block of the migration-047
+    # hierarchy registry (hierarchy / hierarchy_node / item_hierarchy) and
+    # reconciles every level (middle-out deterministic core, MinT-shrink
+    # optional edge — HierarchicalRunner, #348). It is NOT a single
+    # (item, location) leaf run: it produces N coherent series (aggregate
+    # nodes + leaves), each persisted as its own pyramide_runs row. The GET
+    # /runs/{run_id}/result endpoint reads any of those run_ids.
+    hierarchy_id: str
+    block_code: str
+    # Leaf series are addressed to this location (locations.external_id) —
+    # the network/central site whose graph consumes the demand plan; the
+    # per-site split is the DRP layer's job (ADR-020). Generic: the caller
+    # chooses, nothing is hardcoded.
+    leaf_location_id: str
+    horizon_days: int = Field(default=90, ge=1, le=365)
+    granularity: str = Field(default="daily", pattern="^(daily|weekly|monthly)$")
+    method: str = Field(default="AUTO_SELECT")
+    method_params: dict[str, Any] = Field(default_factory=dict)
+    scenario_id: str | None = None
+    model_strategy: str = Field(default="stat", pattern="^(auto|stat|ml|fm|hybrid)$")
+    # recon_method opened to the methods HierarchicalRunner actually
+    # supports and tests (#348): 'middleout' (guaranteed deterministic
+    # core) and 'mintrace_wls_shrink' (optional Nixtla edge, falls back to
+    # middleout when the backend or its aligned inputs are unavailable —
+    # the runner reports the EFFECTIVE method, provenance never lies). No
+    # 'none': this endpoint always reconciles (a leaf-only run with no
+    # reconciliation is POST /runs).
+    recon_method: str = Field(
+        default=RECON_MIDDLEOUT, pattern="^(middleout|mintrace_wls_shrink)$"
+    )
+    # Level of the hierarchy to cut blocks at (default: the root/block
+    # level). None = the registry default resolved by load_summing_blocks.
+    block_level: str | None = None
+    # Level at which the base forecast is produced before disaggregating to
+    # the leaves. None = the block level itself (one base forecast at the
+    # block root). Pass a deeper level for a classic middle-out.
+    recon_level: str | None = None
+    lookback_days: int = Field(default=365, ge=1, le=3650)
+    random_seed: int = Field(default=0, ge=0)
+    code_version: str = Field(default="local", min_length=1, max_length=64)
+
+    @staticmethod
+    def _method_error() -> str:
+        return f"method must be one of: {sorted(SUPPORTED_METHODS)}"
+
+
+class HierarchicalSeriesOut(BaseModel):
+    # One persisted series of the block. kind = 'aggregate' (carries level +
+    # node_code, addresses a hierarchy node) or 'leaf' (carries item_id +
+    # location_id). snapshot_id is None for aggregates (leaf-only snapshot
+    # contract — aggregates never enter the graph). run_id is the handle for
+    # GET /runs/{run_id} and /runs/{run_id}/result.
+    kind: str
+    key: str
+    level: str | None = None
+    run_id: UUID
+    forecast_id: UUID
+    snapshot_id: UUID | None = None
+
+
+class HierarchicalRunResultOut(BaseModel):
+    hierarchy_id: str
+    block_code: str
+    block_level: str
+    recon_level: str
+    # The reconciliation method EFFECTIVELY applied (never the rejected
+    # request): a 'mintrace_wls_shrink' request that fell back reports
+    # 'middleout' here, and warnings carries the reason.
+    recon_method: str
+    scenario_id: UUID
+    horizon_start: date
+    horizon_end: date
+    granularity: str
+    method: str
+    series: list[HierarchicalSeriesOut]
+    # Explainability trail: reconciliation fallbacks, cold-start twin rules,
+    # NULL-bound leaves, routing provenance notes. Empty = nothing to flag.
+    warnings: list[str]
 
 
 class PyramideCommitOut(BaseModel):
@@ -306,6 +400,109 @@ def create_pyramide_run(
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Pyramide run persistence failed")
 
     return _run_out(summary)
+
+
+@router.post(
+    "/hierarchical-runs",
+    response_model=HierarchicalRunResultOut,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a hierarchical (multi-level, reconciled) Pyramide forecast run",
+)
+def create_hierarchical_run(
+    body: HierarchicalRunRequest,
+    db: DictRowConnection = Depends(get_db),
+    _token: str = Depends(require_auth),
+) -> HierarchicalRunResultOut:
+    """Forecast and reconcile ONE summing block of the hierarchy registry
+    (HierarchicalRunner, #348). Every level is persisted as its own
+    pyramide_runs row (aggregates carry hierarchy_id/level/node_code, leaves
+    carry item/location); the response lists each run_id so the existing
+    GET /runs/{run_id}/result endpoint reads any of them — leaf results carry
+    conformal bounds, aggregate results carry NULL bounds (hierarchical
+    interval reconciliation is a documented V1 non-goal).
+
+    ``recon_method`` reflects the method EFFECTIVELY applied: a
+    'mintrace_wls_shrink' request that fell back reports 'middleout' with the
+    reason in ``warnings`` — provenance never lies.
+    """
+    body.method = body.method.upper()
+    if body.method not in SUPPORTED_METHODS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=HierarchicalRunRequest._method_error(),
+        )
+    if body.recon_method not in SUPPORTED_RECON_METHODS:
+        # Defensive: the pattern already constrains recon_method, but keep the
+        # runner's catalogue as the single source of truth for the message.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"recon_method must be one of: {sorted(SUPPORTED_RECON_METHODS)}",
+        )
+
+    location_uuid = resolve_location_uuid(db, body.leaf_location_id)
+    if location_uuid is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Location '{body.leaf_location_id}' not found",
+        )
+
+    try:
+        scenario_uuid = resolve_scenario_uuid(body.scenario_id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Invalid scenario_id '{body.scenario_id}'",
+        ) from exc
+
+    config = HierarchicalRunConfig(
+        hierarchy_id=body.hierarchy_id,
+        block_code=body.block_code,
+        leaf_location_id=location_uuid,
+        scenario_id=scenario_uuid,
+        horizon_start=date.today() + timedelta(days=1),
+        horizon_days=body.horizon_days,
+        block_level=body.block_level,
+        recon_level=body.recon_level,
+        granularity=body.granularity,
+        method=body.method,
+        method_params=body.method_params,
+        model_strategy=body.model_strategy,
+        recon_method=body.recon_method,
+        lookback_days=body.lookback_days,
+        random_seed=body.random_seed,
+        code_version=body.code_version,
+    )
+
+    try:
+        result = HierarchicalRunner().run(db, config)
+    except PyramideError as exc:
+        # Typed domain-exception carve-out (cf. CLAUDE.md): hand-authored
+        # message from config validation (unknown block/level/method,
+        # empty node history) — DB-free, no SQL/DSN can reach this string.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
+        ) from exc
+
+    logger.info(
+        "pyramide.hierarchical_run hierarchy=%s block=%s scenario_id=%s "
+        "recon_method=%s series=%d warnings=%d",
+        result.hierarchy_id, result.block_code, scenario_uuid,
+        result.recon_method, len(result.persisted), len(result.warnings),
+    )
+    return HierarchicalRunResultOut(
+        hierarchy_id=result.hierarchy_id,
+        block_code=result.block_code,
+        block_level=result.block_level,
+        recon_level=result.recon_level,
+        recon_method=result.recon_method,
+        scenario_id=scenario_uuid,
+        horizon_start=result.horizon_start,
+        horizon_end=result.horizon_end,
+        granularity=result.granularity,
+        method=result.method,
+        series=[_hierarchical_series_out(series) for series in result.persisted],
+        warnings=list(result.warnings),
+    )
 
 
 @router.get(
@@ -492,6 +689,19 @@ def _value_out(value) -> PyramideValueOut:
         forecast_date=value.forecast_date,
         quantity=value.quantity,
         method=value.method,
+        confidence_lower=value.confidence_lower,
+        confidence_upper=value.confidence_upper,
+    )
+
+
+def _hierarchical_series_out(series) -> HierarchicalSeriesOut:
+    return HierarchicalSeriesOut(
+        kind=series.kind,
+        key=series.key,
+        level=series.level,
+        run_id=series.run_id,
+        forecast_id=series.forecast_id,
+        snapshot_id=series.snapshot_id,
     )
 
 

--- a/src/ootils_core/api/routers/pyramide.py
+++ b/src/ootils_core/api/routers/pyramide.py
@@ -475,10 +475,16 @@ def create_hierarchical_run(
 
     try:
         result = HierarchicalRunner().run(db, config)
-    except PyramideError as exc:
+    except (PyramideError, ValueError) as exc:
         # Typed domain-exception carve-out (cf. CLAUDE.md): hand-authored
         # message from config validation (unknown block/level/method,
         # empty node history) — DB-free, no SQL/DSN can reach this string.
+        # ValueError is included for the hierarchy registry validation layer
+        # (pyramide/hierarchy/summing.py: unknown hierarchy_id, no levels,
+        # duplicate codes...) which predates PyramideError and is asserted as
+        # ValueError by its own unit tests — its messages are equally
+        # hand-authored (they interpolate only caller-supplied identifiers).
+        # Without this, an unknown hierarchy_id surfaced as a generic 500.
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)
         ) from exc

--- a/src/ootils_core/pyramide/repository.py
+++ b/src/ootils_core/pyramide/repository.py
@@ -88,6 +88,12 @@ class PyramideForecastValue:
     forecast_date: date
     quantity: Decimal
     method: str
+    # Bornes conformal du bucket (confidence_interval_lower/upper, migration
+    # 026). None = NULL en base = pas de calibration honnête (pas de backtest
+    # déterministe, ou trop peu de résidus pour la garantie finite-sample) —
+    # jamais 0, jamais des bornes inventées. Voir engines.conformal_bounds.
+    confidence_lower: Decimal | None = None
+    confidence_upper: Decimal | None = None
 
 
 @dataclass(frozen=True)
@@ -1179,7 +1185,8 @@ def fetch_run_values(db: DictRowConnection, run_id: UUID) -> list[PyramideForeca
 
     rows = db.execute(
         """
-        SELECT value_id, forecast_date, quantity, method
+        SELECT value_id, forecast_date, quantity, method,
+               confidence_interval_lower, confidence_interval_upper
         FROM forecast_values
         WHERE forecast_id = %s
         ORDER BY forecast_date ASC, value_id ASC
@@ -1192,6 +1199,8 @@ def fetch_run_values(db: DictRowConnection, run_id: UUID) -> list[PyramideForeca
             forecast_date=row["forecast_date"],
             quantity=Decimal(str(row["quantity"])),
             method=row["method"],
+            confidence_lower=_optional_decimal(row["confidence_interval_lower"]),
+            confidence_upper=_optional_decimal(row["confidence_interval_upper"]),
         )
         for row in rows
     ]

--- a/tests/integration/test_pyramide_b1_integration.py
+++ b/tests/integration/test_pyramide_b1_integration.py
@@ -1,0 +1,658 @@
+"""
+Integration tests for #394 B1 against a real PostgreSQL database (no mocks):
+
+  1. conformal bounds exposed on GET /v1/forecast/runs/{run_id}/result — a
+     calibrable leaf seed yields >= 1 bucket with non-None lower/upper and the
+     sanity ordering lower <= value <= upper; a too-short seed yields None
+     bounds on EVERY bucket (never 0);
+  2. the new POST /v1/forecast/hierarchical-runs — a seeded block produces a
+     201 with aggregate + leaf series (each carrying a run_id), recon_method
+     == 'middleout', and GET /runs/{run_id}/result works for BOTH a leaf (CI
+     exposed) and an aggregate (CI None, value_count > 0);
+  3. backward-compat — POST /runs without recon_method still 201; the old
+     endpoint rejects recon_method='middleout' (its ^none$ pattern holds);
+  4. errors — unknown leaf_location_id -> 404; unknown block_code (VALID
+     hierarchy) -> 422; recon_method='banana' -> 422 before the DB; malformed
+     scenario_id -> 422;
+  5. auth — POST /hierarchical-runs without a Bearer token -> 401;
+  6. MinT provenance — recon_method='mintrace_wls_shrink' -> 201 with an
+     EFFECTIVE recon_method in {mintrace_wls_shrink, middleout} (asserts
+     membership, since the Nixtla backend may be absent in CI — provenance,
+     not a fixed value, is the point).
+
+Seeds mirror tests/integration/test_forecast_conformal_integration.py (the
+calibrable noisy leaf series) and tests/integration/test_pyramide_reconcile_
+integration.py (the _seed_block family/product generator), adapted to an
+AUTOCOMMIT connection with an explicit teardown so the FastAPI TestClient —
+which opens its OWN connection through the get_db override — sees the rows.
+
+Anti-flake rule (inherited from those files): every seeded demand fact sits at
+TODAY-2 or earlier (booked_date < server CURRENT_DATE), the forecast horizon
+starts at TODAY+2. No timing assertions anywhere.
+"""
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+BASELINE_SCENARIO_ID = UUID("00000000-0000-0000-0000-000000000001")
+TODAY = date.today()
+
+# Deterministic "noise" (mirrors test_forecast_conformal_integration.py):
+# amplitude around a base level of 100, zero randomness (ADR-003 discipline
+# applies to fixtures too). Period 8 vs MA window 4 exposes the full residual
+# spread over the rolling backtest.
+NOISE_PATTERN = (-8, 5, -3, 9, -6, 2, -7, 8)
+BASE_LEVEL = 100
+
+# _seed_block generator (mirrors test_pyramide_reconcile_integration.py):
+# a KNOWN 7-day weekly pattern scaled per leaf; 8 full weeks so every weekday
+# appears 8 times.
+WEEK_PATTERN = (2, 1, 1, 1, 3, 4, 2)  # sum = 14
+AMPLITUDES = {"A1": 10, "A2": 6, "A3": 4}
+HISTORY_DAYS = range(4, 60)  # 56 consecutive days = 8 full weeks
+
+
+# ---------------------------------------------------------------------------
+# DB access + seeding helpers
+# ---------------------------------------------------------------------------
+
+
+def _db_conn(dsn):
+    import psycopg
+    from psycopg.rows import dict_row
+
+    return psycopg.connect(dsn, row_factory=dict_row, autocommit=True)
+
+
+def _create_item(conn, ext_id: str) -> UUID:
+    item_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO items (item_id, name, item_type, uom, status, external_id)
+        VALUES (%s, %s, 'finished_good', 'EA', 'active', %s)
+        """,
+        (item_id, f"{ext_id} b1 test item", ext_id),
+    )
+    return item_id
+
+
+def _create_location(conn, ext_id: str) -> UUID:
+    loc_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO locations (location_id, name, location_type, country, external_id)
+        VALUES (%s, %s, 'dc', 'US', %s)
+        """,
+        (loc_id, f"{ext_id} b1 test DC", ext_id),
+    )
+    return loc_id
+
+
+def _seed_demand(conn, item_id: UUID, item_code: str, warehouse_id: str,
+                 booked_date: date, qty) -> None:
+    conn.execute(
+        """
+        INSERT INTO demand_history (
+            item_id, item_code, stream, booked_date, ordered_quantity,
+            value_ext, counts_for_asp, org_id, fulfillment, order_number,
+            warehouse_id
+        ) VALUES (%s, %s, 'regular', %s, %s, 0, FALSE, 'PPS', 'standard',
+                  'TEST-B1', %s)
+        """,
+        (item_id, item_code, booked_date, qty, warehouse_id),
+    )
+
+
+def _seed_noisy_series(conn, item_id: UUID, item_code: str, warehouse_id: str,
+                       days: int) -> list[Decimal]:
+    """``days`` consecutive daily facts ending at TODAY - 2, quantity =
+    BASE_LEVEL + NOISE_PATTERN cycling. Returns quantities in date order."""
+    quantities: list[Decimal] = []
+    start = TODAY - timedelta(days=2 + days - 1)
+    for i in range(days):
+        qty = Decimal(BASE_LEVEL + NOISE_PATTERN[i % len(NOISE_PATTERN)])
+        _seed_demand(conn, item_id, item_code, warehouse_id,
+                     start + timedelta(days=i), qty)
+        quantities.append(qty)
+    return quantities
+
+
+def _run_and_persist(conn, item_id: UUID, location_id: UUID,
+                     history: list[Decimal], horizon_days: int):
+    """Run the leaf runner on an in-memory series and persist it (mirrors the
+    conformal-seed helper). Returns (result, persisted)."""
+    from ootils_core.pyramide import PyramideRunConfig, PyramideRunner
+    from ootils_core.pyramide.repository import persist_run
+
+    config = PyramideRunConfig(
+        item_id=item_id,
+        location_id=location_id,
+        scenario_id=BASELINE_SCENARIO_ID,
+        horizon_start=TODAY + timedelta(days=2),
+        horizon_days=horizon_days,
+        granularity="daily",
+        method="MA",
+        method_params={"window": 4},
+    )
+    result = PyramideRunner().run(config, history)
+    persisted = persist_run(conn, result)
+    return result, persisted
+
+
+def _cleanup_item(conn, item_id: UUID, location_id: UUID | None) -> None:
+    conn.execute(
+        "DELETE FROM pyramide_snapshots WHERE forecast_id IN "
+        "(SELECT forecast_id FROM forecasts WHERE item_id = %s)",
+        (item_id,),
+    )
+    conn.execute(
+        "DELETE FROM pyramide_runs WHERE forecast_id IN "
+        "(SELECT forecast_id FROM forecasts WHERE item_id = %s)",
+        (item_id,),
+    )
+    conn.execute("DELETE FROM forecasts WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM demand_history WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM items WHERE item_id = %s", (item_id,))
+    if location_id is not None:
+        conn.execute("DELETE FROM locations WHERE location_id = %s", (location_id,))
+
+
+def _seed_block(conn, h: str, tag: str):
+    """FAM-<tag> (family) -> PRD-<tag>1 (2 items) + PRD-<tag>2 (1 item),
+    with 8 weeks of KNOWN weekly-seasonal demand per leaf (mirrors
+    test_pyramide_reconcile_integration.py:_seed_block). AUTOCOMMIT variant so
+    the API TestClient sees the rows."""
+    conn.execute(
+        """
+        INSERT INTO hierarchy (hierarchy_id, domain, scope, levels, is_default)
+        VALUES (%s, 'product', 'local', %s, FALSE)
+        """,
+        (h, ["family", "product"]),
+    )
+    fam, prd1, prd2 = f"FAM-{tag}", f"PRD-{tag}1", f"PRD-{tag}2"
+    for code, level, parent in [
+        (fam, "family", None),
+        (prd1, "product", fam),
+        (prd2, "product", fam),
+    ]:
+        conn.execute(
+            "INSERT INTO hierarchy_node (hierarchy_id, code, level, parent_code) "
+            "VALUES (%s, %s, %s, %s)",
+            (h, code, level, parent),
+        )
+
+    items: dict[str, UUID] = {}
+    for suffix, leaf_code in [("A1", prd1), ("A2", prd1), ("A3", prd2)]:
+        item_id = uuid4()
+        ext = f"B1-{tag}-{suffix}"
+        conn.execute(
+            "INSERT INTO items (item_id, name, item_type, uom, status, external_id) "
+            "VALUES (%s, %s, 'finished_good', 'EA', 'active', %s)",
+            (item_id, f"{ext} item", ext),
+        )
+        conn.execute(
+            "INSERT INTO item_hierarchy (item_id, hierarchy_id, leaf_code) "
+            "VALUES (%s, %s, %s)",
+            (item_id, h, leaf_code),
+        )
+        items[suffix] = item_id
+        for back in HISTORY_DAYS:
+            day = TODAY - timedelta(days=back)
+            qty = AMPLITUDES[suffix] * WEEK_PATTERN[day.weekday()]
+            conn.execute(
+                """
+                INSERT INTO demand_history (
+                    item_id, item_code, stream, booked_date,
+                    ordered_quantity, value_ext, counts_for_asp,
+                    fulfillment, order_number
+                ) VALUES (%s, %s, 'regular', %s, %s, 0, FALSE, 'standard', 'B1')
+                """,
+                (item_id, ext, day, qty),
+            )
+
+    loc_id = uuid4()
+    conn.execute(
+        "INSERT INTO locations (location_id, name, location_type, country, external_id) "
+        "VALUES (%s, %s, 'dc', 'US', %s)",
+        (loc_id, f"B1-{tag} DC", f"B1-{tag}-DC"),
+    )
+    return fam, prd1, prd2, items, loc_id
+
+
+def _cleanup_block(conn, h: str, items: dict[str, UUID], loc_id: UUID) -> None:
+    """FK-safe teardown of a seeded block (forecasts cascade their values)."""
+    item_ids = list(items.values())
+    conn.execute(
+        "DELETE FROM pyramide_snapshots WHERE forecast_id IN "
+        "(SELECT forecast_id FROM forecasts WHERE hierarchy_id = %s "
+        " OR item_id = ANY(%s))",
+        (h, item_ids),
+    )
+    conn.execute(
+        "DELETE FROM pyramide_runs WHERE forecast_id IN "
+        "(SELECT forecast_id FROM forecasts WHERE hierarchy_id = %s "
+        " OR item_id = ANY(%s))",
+        (h, item_ids),
+    )
+    conn.execute(
+        "DELETE FROM forecasts WHERE hierarchy_id = %s OR item_id = ANY(%s)",
+        (h, item_ids),
+    )
+    conn.execute(
+        "DELETE FROM nodes WHERE node_type = 'ForecastDemand' AND location_id = %s",
+        (loc_id,),
+    )
+    conn.execute("DELETE FROM demand_history WHERE item_id = ANY(%s)", (item_ids,))
+    conn.execute("DELETE FROM item_hierarchy WHERE hierarchy_id = %s", (h,))
+    conn.execute("DELETE FROM items WHERE item_id = ANY(%s)", (item_ids,))
+    conn.execute("DELETE FROM locations WHERE location_id = %s", (loc_id,))
+    conn.execute("DELETE FROM hierarchy_node WHERE hierarchy_id = %s", (h,))
+    conn.execute("DELETE FROM hierarchy WHERE hierarchy_id = %s", (h,))
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app / client wiring (mirrors the seeded-DB pattern)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app(migrated_db):
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = "integration-test-token"
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+
+    application = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    application.dependency_overrides[get_db] = override_db
+    yield application
+    application.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client(app):
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def auth():
+    return {"Authorization": "Bearer integration-test-token"}
+
+
+# ---------------------------------------------------------------------------
+# 1. Conformal bounds on GET /runs/{run_id}/result
+# ---------------------------------------------------------------------------
+
+
+def test_result_exposes_conformal_bounds_when_calibrated(migrated_db, client, auth):
+    """A long calibrable seed: GET /runs/{run_id}/result returns >= 1 bucket
+    with non-None bounds and lower <= value <= upper (sanity)."""
+    with _db_conn(migrated_db) as conn:
+        code = f"B1CONF-{uuid4().hex[:8].upper()}"
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            seeded = _seed_noisy_series(conn, item_id, code, f"DC-{code}", days=124)
+            _, persisted = _run_and_persist(
+                conn, item_id, location_id, seeded, horizon_days=14
+            )
+
+            resp = client.get(
+                f"/v1/forecast/runs/{persisted.run_id}/result", headers=auth
+            )
+            assert resp.status_code == 200, resp.text
+            values = resp.json()["values"]
+            assert len(values) == 14
+            with_bounds = [
+                v for v in values
+                if v["confidence_lower"] is not None
+                and v["confidence_upper"] is not None
+            ]
+            assert with_bounds, "expected at least one calibrated bucket"
+            for v in with_bounds:
+                lower = Decimal(v["confidence_lower"])
+                upper = Decimal(v["confidence_upper"])
+                point = Decimal(v["quantity"])
+                assert lower >= Decimal("0")
+                assert lower <= point <= upper
+        finally:
+            _cleanup_item(conn, item_id, location_id)
+
+
+def test_result_bounds_are_none_without_calibration(migrated_db, client, auth):
+    """A too-short seed (not enough backtest residuals for the finite-sample
+    guarantee): EVERY bucket's bounds are None — honest, never 0."""
+    with _db_conn(migrated_db) as conn:
+        code = f"B1SHORT-{uuid4().hex[:8].upper()}"
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            seeded = _seed_noisy_series(conn, item_id, code, f"DC-{code}", days=5)
+            _, persisted = _run_and_persist(
+                conn, item_id, location_id, seeded, horizon_days=3
+            )
+
+            resp = client.get(
+                f"/v1/forecast/runs/{persisted.run_id}/result", headers=auth
+            )
+            assert resp.status_code == 200, resp.text
+            values = resp.json()["values"]
+            assert len(values) == 3
+            for v in values:
+                assert v["confidence_lower"] is None
+                assert v["confidence_upper"] is None
+        finally:
+            _cleanup_item(conn, item_id, location_id)
+
+
+# ---------------------------------------------------------------------------
+# 2. POST /hierarchical-runs — nominal
+# ---------------------------------------------------------------------------
+
+
+def test_hierarchical_run_nominal(migrated_db, client, auth):
+    """A seeded block -> 201 with aggregate + leaf series (each with a run_id),
+    recon_method == 'middleout'; GET result works for a LEAF (CI exposed) and
+    an AGGREGATE (CI None, value_count > 0)."""
+    h = "b1-h-nominal"
+    with _db_conn(migrated_db) as conn:
+        fam, prd1, prd2, items, loc_id = _seed_block(conn, h, "NOM")
+        try:
+            resp = client.post(
+                "/v1/forecast/hierarchical-runs",
+                json={
+                    "hierarchy_id": h,
+                    "block_code": fam,
+                    "leaf_location_id": f"B1-{'NOM'}-DC",
+                    "horizon_days": 14,
+                    "method": "SEASONAL",
+                    "method_params": {"season_length": 7},
+                    "lookback_days": 90,
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["hierarchy_id"] == h
+            assert body["block_code"] == fam
+            assert body["recon_method"] == "middleout"
+            assert body["block_level"] == "family"
+
+            series = body["series"]
+            # 3 aggregates (fam + prd1 + prd2) + 3 leaves.
+            kinds = [s["kind"] for s in series]
+            assert kinds.count("aggregate") == 3
+            assert kinds.count("leaf") == 3
+            for s in series:
+                assert UUID(s["run_id"])  # every series is queryable
+
+            leaf_item_ids = {str(i) for i in items.values()}
+            leaf_series = next(s for s in series if s["key"] in leaf_item_ids)
+            agg_series = next(s for s in series if s["key"] == fam)
+
+            # A leaf result: bounds exposed (>= 1 calibrated bucket expected on
+            # 8 seasonal cycles of node residuals).
+            leaf_res = client.get(
+                f"/v1/forecast/runs/{leaf_series['run_id']}/result", headers=auth
+            )
+            assert leaf_res.status_code == 200, leaf_res.text
+            leaf_body = leaf_res.json()
+            assert leaf_body["run"]["value_count"] == 14
+            assert leaf_body["run"]["item_id"] is not None
+            leaf_bounded = [
+                v for v in leaf_body["values"]
+                if v["confidence_lower"] is not None
+            ]
+            assert leaf_bounded, "leaf run should carry conformal bounds"
+            for v in leaf_bounded:
+                lower = Decimal(v["confidence_lower"])
+                upper = Decimal(v["confidence_upper"])
+                assert lower <= Decimal(v["quantity"]) <= upper
+
+            # An aggregate result: CI None everywhere, but value_count > 0.
+            agg_res = client.get(
+                f"/v1/forecast/runs/{agg_series['run_id']}/result", headers=auth
+            )
+            assert agg_res.status_code == 200, agg_res.text
+            agg_body = agg_res.json()
+            assert agg_body["run"]["value_count"] == 14
+            assert agg_body["run"]["item_id"] is None
+            assert agg_body["run"]["node_code"] == fam
+            assert agg_body["run"]["level"] == "family"
+            assert len(agg_body["values"]) == 14
+            for v in agg_body["values"]:
+                assert v["confidence_lower"] is None
+                assert v["confidence_upper"] is None
+        finally:
+            _cleanup_block(conn, h, items, loc_id)
+
+
+# ---------------------------------------------------------------------------
+# 3. Backward compatibility of the leaf POST /runs endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_post_runs_without_recon_method_still_created(migrated_db, client, auth):
+    """The leaf endpoint keeps working unchanged when recon_method is omitted
+    (it defaults to 'none') — 201."""
+    with _db_conn(migrated_db) as conn:
+        code = f"B1BC-{uuid4().hex[:8].upper()}"
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        forecast_id = None
+        try:
+            _seed_noisy_series(conn, item_id, code, f"DC-{code}", days=60)
+            resp = client.post(
+                "/v1/forecast/runs",
+                json={
+                    "item_id": code,
+                    "location_id": f"DC-{code}",
+                    "horizon_days": 7,
+                    "method": "MA",
+                    "method_params": {"window": 4},
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            forecast_id = body["forecast_id"]
+            assert body["recon_method"] == "none"
+        finally:
+            _cleanup_item(conn, item_id, location_id)
+            assert forecast_id is None or UUID(forecast_id)
+
+
+def test_post_runs_rejects_reconciliation_method(migrated_db, client, auth):
+    """The OLD endpoint's ^none$ pattern holds: recon_method='middleout' on
+    POST /runs is a 422 (before any DB work)."""
+    resp = client.post(
+        "/v1/forecast/runs",
+        json={
+            "item_id": "ANY-ITEM",
+            "location_id": "ANY-LOC",
+            "recon_method": "middleout",
+        },
+        headers=auth,
+    )
+    assert resp.status_code == 422, resp.text
+    locs = {
+        tuple(err["loc"]) for err in resp.json()["detail"]
+        if isinstance(err, dict) and "loc" in err
+    }
+    assert any("recon_method" in loc for loc in locs)
+
+
+# ---------------------------------------------------------------------------
+# 4. Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_hierarchical_run_unknown_location_404(migrated_db, client, auth):
+    """Unknown leaf_location_id -> 404 (resolve_location_uuid returns None)."""
+    h = "b1-h-badloc"
+    with _db_conn(migrated_db) as conn:
+        fam, _, _, items, loc_id = _seed_block(conn, h, "BADLOC")
+        try:
+            resp = client.post(
+                "/v1/forecast/hierarchical-runs",
+                json={
+                    "hierarchy_id": h,
+                    "block_code": fam,
+                    "leaf_location_id": "NO-SUCH-LOCATION-XYZ",
+                    "method": "SEASONAL",
+                    "method_params": {"season_length": 7},
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 404, resp.text
+            assert "not found" in resp.json()["detail"].lower()
+        finally:
+            _cleanup_block(conn, h, items, loc_id)
+
+
+def test_hierarchical_run_unknown_block_422(migrated_db, client, auth):
+    """A VALID hierarchy but an unknown block_code -> 422 (PyramideError from
+    _load_block; the handler maps PyramideError to 422)."""
+    h = "b1-h-badblock"
+    with _db_conn(migrated_db) as conn:
+        _, _, _, items, loc_id = _seed_block(conn, h, "BADBLK")
+        try:
+            resp = client.post(
+                "/v1/forecast/hierarchical-runs",
+                json={
+                    "hierarchy_id": h,
+                    "block_code": "FAM-DOES-NOT-EXIST",
+                    "leaf_location_id": f"B1-{'BADBLK'}-DC",
+                    "method": "SEASONAL",
+                    "method_params": {"season_length": 7},
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 422, resp.text
+        finally:
+            _cleanup_block(conn, h, items, loc_id)
+
+
+def test_hierarchical_run_bad_recon_method_422_before_db(migrated_db, client, auth):
+    """recon_method='banana' is rejected by the Pydantic pattern -> 422, before
+    any resolution/DB work (no seed needed)."""
+    resp = client.post(
+        "/v1/forecast/hierarchical-runs",
+        json={
+            "hierarchy_id": "whatever",
+            "block_code": "whatever",
+            "leaf_location_id": "whatever",
+            "recon_method": "banana",
+        },
+        headers=auth,
+    )
+    assert resp.status_code == 422, resp.text
+    locs = {
+        tuple(err["loc"]) for err in resp.json()["detail"]
+        if isinstance(err, dict) and "loc" in err
+    }
+    assert any("recon_method" in loc for loc in locs)
+
+
+def test_hierarchical_run_malformed_scenario_id_422(migrated_db, client, auth):
+    """A syntactically invalid scenario_id -> 422 (resolve_scenario_uuid raises
+    ValueError, the handler maps it to 422)."""
+    h = "b1-h-badscenario"
+    with _db_conn(migrated_db) as conn:
+        fam, _, _, items, loc_id = _seed_block(conn, h, "BADSC")
+        try:
+            resp = client.post(
+                "/v1/forecast/hierarchical-runs",
+                json={
+                    "hierarchy_id": h,
+                    "block_code": fam,
+                    "leaf_location_id": f"B1-{'BADSC'}-DC",
+                    "scenario_id": "not-a-uuid",
+                    "method": "SEASONAL",
+                    "method_params": {"season_length": 7},
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 422, resp.text
+            assert "scenario_id" in resp.json()["detail"].lower()
+        finally:
+            _cleanup_block(conn, h, items, loc_id)
+
+
+# ---------------------------------------------------------------------------
+# 5. Auth
+# ---------------------------------------------------------------------------
+
+
+def test_hierarchical_run_without_bearer_401(migrated_db, client):
+    """The router uses require_auth: no Bearer token -> 401."""
+    resp = client.post(
+        "/v1/forecast/hierarchical-runs",
+        json={
+            "hierarchy_id": "whatever",
+            "block_code": "whatever",
+            "leaf_location_id": "whatever",
+        },
+    )
+    assert resp.status_code == 401, resp.text
+
+
+# ---------------------------------------------------------------------------
+# 6. MinT provenance never lies
+# ---------------------------------------------------------------------------
+
+
+def test_hierarchical_run_mint_reports_effective_method(migrated_db, client, auth):
+    """recon_method='mintrace_wls_shrink' -> 201 with an EFFECTIVE recon_method
+    in {mintrace_wls_shrink, middleout}: the runner reports the method it
+    actually applied (fallback to middleout when the Nixtla backend or its
+    aligned inputs are unavailable). Membership, not a fixed value — provenance
+    is the object of the test."""
+    h = "b1-h-mint"
+    with _db_conn(migrated_db) as conn:
+        fam, _, _, items, loc_id = _seed_block(conn, h, "MINT")
+        try:
+            resp = client.post(
+                "/v1/forecast/hierarchical-runs",
+                json={
+                    "hierarchy_id": h,
+                    "block_code": fam,
+                    "leaf_location_id": f"B1-{'MINT'}-DC",
+                    "horizon_days": 14,
+                    "method": "SEASONAL",
+                    "method_params": {"season_length": 7},
+                    "lookback_days": 90,
+                    "recon_method": "mintrace_wls_shrink",
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["recon_method"] in {"mintrace_wls_shrink", "middleout"}
+            # If it fell back, the runner must say so in warnings (provenance).
+            if body["recon_method"] == "middleout":
+                assert any(
+                    "fell back" in w or "skipped" in w or "falling back" in w
+                    for w in body["warnings"]
+                ), body["warnings"]
+        finally:
+            _cleanup_block(conn, h, items, loc_id)

--- a/tests/integration/test_pyramide_b1_integration.py
+++ b/tests/integration/test_pyramide_b1_integration.py
@@ -552,6 +552,36 @@ def test_hierarchical_run_unknown_block_422(migrated_db, client, auth):
             _cleanup_block(conn, h, items, loc_id)
 
 
+def test_hierarchical_run_unknown_hierarchy_422_not_500(migrated_db, client, auth):
+    """An UNKNOWN hierarchy_id (valid location, valid payload otherwise) -> 422,
+    never a generic 500. load_summing_blocks raises a bare ValueError
+    ("hierarchy '...' not found", pyramide/hierarchy/summing.py) which the
+    handler now maps to 422 alongside PyramideError (both are hand-authored
+    registry-validation messages). Pre-fix this surfaced as an uncaught
+    ValueError -> generic 500."""
+    h = "b1-h-ghost"
+    with _db_conn(migrated_db) as conn:
+        # Seed a real block only to obtain a VALID leaf location (the handler
+        # resolves the location before touching the hierarchy registry).
+        _, _, _, items, loc_id = _seed_block(conn, h, "GHOSTL")
+        try:
+            resp = client.post(
+                "/v1/forecast/hierarchical-runs",
+                json={
+                    "hierarchy_id": "hierarchy-does-not-exist",
+                    "block_code": "FAM-IRRELEVANT",
+                    "leaf_location_id": f"B1-{'GHOSTL'}-DC",
+                    "method": "SEASONAL",
+                    "method_params": {"season_length": 7},
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 422, resp.text
+            assert "hierarchy-does-not-exist" in resp.json()["detail"]
+        finally:
+            _cleanup_block(conn, h, items, loc_id)
+
+
 def test_hierarchical_run_bad_recon_method_422_before_db(migrated_db, client, auth):
     """recon_method='banana' is rejected by the Pydantic pattern -> 422, before
     any resolution/DB work (no seed needed)."""

--- a/tests/test_pyramide_b1_models.py
+++ b/tests/test_pyramide_b1_models.py
@@ -1,0 +1,254 @@
+"""
+Pure (DB-free) tests for the #394 B1 request/response contract additions on
+the Pyramide router:
+
+  * ``PyramideValueOut`` — the conformal bounds ``confidence_lower`` /
+    ``confidence_upper`` are exposed additively: present when known, honestly
+    None when not (NEVER 0 by default), and NOT part of the required set (an
+    old serialized payload without them still validates);
+  * ``HierarchicalRunRequest`` — ``recon_method`` defaults to 'middleout',
+    only accepts the two methods HierarchicalRunner supports
+    ('middleout' / 'mintrace_wls_shrink'), and rejects anything else at the
+    Pydantic layer (before any DB work);
+  * ``_hierarchical_series_out`` — the pure aggregate|leaf mapping is
+    faithful without a database (fed a tiny stand-in series object).
+
+These mirror the boundary-validation style of tests/test_pyramide_api.py
+(422 before the DB) but target the schema objects directly, so no FastAPI app
+or connection is constructed.
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from ootils_core.api.routers.pyramide import (
+    HierarchicalRunRequest,
+    HierarchicalSeriesOut,
+    PyramideValueOut,
+    _hierarchical_series_out,
+)
+
+
+# ---------------------------------------------------------------------------
+# PyramideValueOut — the conformal-bounds carve-out (additive, None-honest)
+# ---------------------------------------------------------------------------
+
+
+class TestPyramideValueOutBounds:
+    def test_bounds_present_are_preserved(self):
+        value = PyramideValueOut(
+            value_id=uuid4(),
+            forecast_date=date(2026, 7, 10),
+            quantity=Decimal("100"),
+            method="MA",
+            confidence_lower=Decimal("92.5"),
+            confidence_upper=Decimal("108.5"),
+        )
+        assert value.confidence_lower == Decimal("92.5")
+        assert value.confidence_upper == Decimal("108.5")
+
+    def test_bounds_default_to_none_never_zero(self):
+        """A value built without bounds carries None on BOTH sides — the
+        honest 'no calibration' signal — never a masked 0."""
+        value = PyramideValueOut(
+            value_id=uuid4(),
+            forecast_date=date(2026, 7, 10),
+            quantity=Decimal("100"),
+            method="MA",
+        )
+        assert value.confidence_lower is None
+        assert value.confidence_upper is None
+        # Guard against a "0 default" regression that would look like a
+        # collapsed interval instead of an absent one.
+        assert value.confidence_lower != Decimal("0")
+        assert value.confidence_upper != Decimal("0")
+
+    def test_explicit_none_bounds_round_trip(self):
+        value = PyramideValueOut(
+            value_id=uuid4(),
+            forecast_date=date(2026, 7, 10),
+            quantity=Decimal("100"),
+            method="MA",
+            confidence_lower=None,
+            confidence_upper=None,
+        )
+        assert value.confidence_lower is None
+        assert value.confidence_upper is None
+
+    def test_bounds_are_not_required_fields(self):
+        """Additive contract: the two bound fields must NOT be required, so a
+        payload minted before #394 (no bounds keys) still validates."""
+        required = {
+            name
+            for name, field in PyramideValueOut.model_fields.items()
+            if field.is_required()
+        }
+        assert "confidence_lower" not in required
+        assert "confidence_upper" not in required
+        # The pre-#394 field set is still sufficient on its own.
+        legacy_payload = {
+            "value_id": str(uuid4()),
+            "forecast_date": "2026-07-10",
+            "quantity": "100",
+            "method": "MA",
+        }
+        value = PyramideValueOut.model_validate(legacy_payload)
+        assert value.confidence_lower is None
+        assert value.confidence_upper is None
+
+    def test_serialization_emits_bound_keys(self):
+        """Both keys must appear in the serialized payload (as null when
+        absent) so a client can always read them — the whole point of B1."""
+        value = PyramideValueOut(
+            value_id=uuid4(),
+            forecast_date=date(2026, 7, 10),
+            quantity=Decimal("100"),
+            method="MA",
+        )
+        dumped = value.model_dump()
+        assert "confidence_lower" in dumped
+        assert "confidence_upper" in dumped
+        assert dumped["confidence_lower"] is None
+        assert dumped["confidence_upper"] is None
+
+    def test_serialization_preserves_present_bounds(self):
+        value = PyramideValueOut(
+            value_id=uuid4(),
+            forecast_date=date(2026, 7, 10),
+            quantity=Decimal("100"),
+            method="MA",
+            confidence_lower=Decimal("92.5"),
+            confidence_upper=Decimal("108.5"),
+        )
+        dumped = value.model_dump(mode="json")
+        assert Decimal(dumped["confidence_lower"]) == Decimal("92.5")
+        assert Decimal(dumped["confidence_upper"]) == Decimal("108.5")
+
+
+# ---------------------------------------------------------------------------
+# HierarchicalRunRequest — recon_method contract
+# ---------------------------------------------------------------------------
+
+
+class TestHierarchicalRunRequestReconMethod:
+    def _base_payload(self) -> dict:
+        return {
+            "hierarchy_id": "prod-default",
+            "block_code": "FAM-1",
+            "leaf_location_id": "DC-CENTRAL",
+        }
+
+    def test_recon_method_defaults_to_middleout(self):
+        body = HierarchicalRunRequest(**self._base_payload())
+        assert body.recon_method == "middleout"
+
+    def test_recon_method_accepts_middleout(self):
+        body = HierarchicalRunRequest(
+            **self._base_payload(), recon_method="middleout"
+        )
+        assert body.recon_method == "middleout"
+
+    def test_recon_method_accepts_mintrace_wls_shrink(self):
+        body = HierarchicalRunRequest(
+            **self._base_payload(), recon_method="mintrace_wls_shrink"
+        )
+        assert body.recon_method == "mintrace_wls_shrink"
+
+    def test_recon_method_rejects_none_value(self):
+        """'none' is valid ONLY on the leaf POST /runs endpoint; the
+        hierarchical endpoint always reconciles, so 'none' is out of pattern."""
+        with pytest.raises(ValidationError):
+            HierarchicalRunRequest(**self._base_payload(), recon_method="none")
+
+    def test_recon_method_rejects_unknown_value(self):
+        with pytest.raises(ValidationError):
+            HierarchicalRunRequest(**self._base_payload(), recon_method="banana")
+
+    def test_recon_method_error_targets_the_field(self):
+        with pytest.raises(ValidationError) as excinfo:
+            HierarchicalRunRequest(**self._base_payload(), recon_method="banana")
+        locs = {tuple(err["loc"]) for err in excinfo.value.errors()}
+        assert ("recon_method",) in locs
+
+    def test_method_error_helper_lists_supported_methods(self):
+        """The _method_error helper (used by the handler for a 422 detail) is
+        about the forecast method catalogue, not recon_method."""
+        message = HierarchicalRunRequest._method_error()
+        assert "method must be one of" in message
+        assert "SEASONAL" in message
+
+    def test_defaults_match_the_documented_contract(self):
+        body = HierarchicalRunRequest(**self._base_payload())
+        assert body.horizon_days == 90
+        assert body.granularity == "daily"
+        assert body.method == "AUTO_SELECT"
+        assert body.model_strategy == "stat"
+        assert body.block_level is None
+        assert body.recon_level is None
+        assert body.lookback_days == 365
+
+
+# ---------------------------------------------------------------------------
+# _hierarchical_series_out — pure aggregate|leaf mapping
+# ---------------------------------------------------------------------------
+
+
+class _StubSeries:
+    """Minimal stand-in for HierarchicalPersistedSeries — the mapping only
+    reads these six attributes, so no DB / dataclass import is needed."""
+
+    def __init__(self, kind, key, level, run_id, forecast_id, snapshot_id):
+        self.kind = kind
+        self.key = key
+        self.level = level
+        self.run_id = run_id
+        self.forecast_id = forecast_id
+        self.snapshot_id = snapshot_id
+
+
+class TestHierarchicalSeriesOutMapping:
+    def test_leaf_series_maps_faithfully(self):
+        run_id, forecast_id, snapshot_id = uuid4(), uuid4(), uuid4()
+        item_key = str(uuid4())
+        out = _hierarchical_series_out(
+            _StubSeries(
+                kind="leaf",
+                key=item_key,
+                level=None,
+                run_id=run_id,
+                forecast_id=forecast_id,
+                snapshot_id=snapshot_id,
+            )
+        )
+        assert isinstance(out, HierarchicalSeriesOut)
+        assert out.kind == "leaf"
+        assert out.key == item_key
+        assert out.level is None
+        assert out.run_id == run_id
+        assert out.forecast_id == forecast_id
+        assert out.snapshot_id == snapshot_id
+
+    def test_aggregate_series_maps_faithfully(self):
+        run_id, forecast_id = uuid4(), uuid4()
+        out = _hierarchical_series_out(
+            _StubSeries(
+                kind="aggregate",
+                key="FAM-1",
+                level="family",
+                run_id=run_id,
+                forecast_id=forecast_id,
+                snapshot_id=None,
+            )
+        )
+        assert out.kind == "aggregate"
+        assert out.key == "FAM-1"
+        assert out.level == "family"
+        assert out.run_id == run_id
+        assert out.forecast_id == forecast_id
+        # Aggregates carry no snapshot (leaf-only snapshot contract).
+        assert out.snapshot_id is None


### PR DESCRIPTION
**Closes #394** (B1 du plan AI-native) — deux capacités **déjà calculées, testées-DB et persistées** mais invisibles, désormais exposées. Aucun changement de calcul.

## Livré
- **Bornes conformal** sur `GET /v1/forecast/runs/{id}/result` (`confidence_lower/upper`, additif, None-honnête — NULL = pas de calibration, jamais 0). Sert aussi les runs hiérarchiques (agrégats CI NULL, non-objectif V1 documenté).
- **`POST /v1/forecast/hierarchical-runs`** — expose `HierarchicalRunner` (#348) honnêtement : bloc → N séries cohérentes (agrégats + feuilles). `recon_method` ∈ {middleout, mintrace_wls_shrink} avec **provenance effective** (fallback rapporté + warnings, jamais masqué). `POST /runs` byte-identique.
- **Fix** : `hierarchy_id` inconnu → **422** (ValueError registre attrapée, carve-out étendu et documenté) — c'était un 500 générique. Verrouillé par test.
- openapi.json régénéré (+1 path, +3 schemas ; ramasse aussi 5 paths dérivés des PR précédentes).

## Tests
16 purs + 12 intégration (CI bout-en-bout avec sanity lower≤value≤upper, hiérarchique nominal, rétro-compat `^none$`, 404/422/401, provenance mintrace). Suite : 2450 passed, mypy 0/178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
