### PR TITLE
fix(dq): le dq_agent ne committe jamais — la boucle DQ tourne enfin sur les ingests

### DIFF
--- a/src/ootils_core/engine/dq/agent/agent.py
+++ b/src/ootils_core/engine/dq/agent/agent.py
@@ -196,13 +196,25 @@ def run_dq_agent(
       4. Impact score all issues
       5. LLM report
       6. Persist everything
+
+    Transaction ownership: this function NEVER commits — persistence belongs
+    to the caller's context (the ingest path wraps the whole DQ run in
+    ``with db.transaction():``, where an explicit commit() is FORBIDDEN by
+    psycopg and used to make this agent fail silently on every ingest; the
+    direct router path relies on get_db's autocommit-on-success). Trade-off
+    accepted: the 'running' row is no longer visible from other connections
+    mid-run (runs are seconds-long), and on the ROUTER path an agent failure
+    that propagates rolls back its own 'failed' bookkeeping row — the 500 +
+    api_request_log remain the loud failure signal there; on the ingest path
+    the failure is caught upstream (non-fatal) so the 'failed' row commits
+    with the batch.
     """
     run_id = uuid4()
     started_at = datetime.now(timezone.utc)
 
     logger.info("dq_agent.run start batch_id=%s run_id=%s", batch_id, run_id)
 
-    # Mark run as running
+    # Mark run as running (persisted by the caller's transaction/commit)
     db.execute(
         """
         INSERT INTO dq_agent_runs
@@ -211,7 +223,6 @@ def run_dq_agent(
         """,
         (run_id, batch_id, started_at),
     )
-    db.commit()
 
     try:
         entity_type, total_rows = _get_entity_type(db, batch_id)
@@ -279,8 +290,6 @@ def run_dq_agent(
         # Enrich existing L1/L2 issues
         _enrich_existing_issues(db, run_id, existing_issues)
 
-        db.commit()
-
         logger.info(
             "dq_agent.run complete batch_id=%s run_id=%s issues=%d stat=%d temporal=%d",
             batch_id, run_id, len(all_issues), len(stat_issues), len(temporal_issues),
@@ -302,6 +311,9 @@ def run_dq_agent(
     except Exception as exc:
         logger.exception("dq_agent.run failed batch_id=%s run_id=%s: %s", batch_id, run_id, exc)
         completed_at = datetime.now(timezone.utc)
+        # Persisted by the caller's context when the failure is swallowed
+        # upstream (the ingest path); lost with the request rollback when the
+        # raise propagates (router path) — see the docstring trade-off.
         db.execute(
             """
             UPDATE dq_agent_runs
@@ -310,5 +322,4 @@ def run_dq_agent(
             """,
             (completed_at, run_id),
         )
-        db.commit()
         raise

--- a/src/ootils_core/engine/dq/engine.py
+++ b/src/ootils_core/engine/dq/engine.py
@@ -714,10 +714,20 @@ def run_dq(db: DictRowConnection, batch_id: UUID) -> DQResult:
         batch_id, entity_type, len(ingest_rows), passed_rows, failed_rows, warning_rows, len(all_issues),
     )
 
-    # Auto-trigger DQ Agent (stat + temporal + impact + LLM) after L1+L2
+    # Auto-trigger DQ Agent (stat + temporal + impact + LLM) after L1+L2.
+    # SAVEPOINT isolation: the nested transaction() opens a savepoint when the
+    # caller already holds one (the ingest path) or a plain transaction
+    # otherwise (the direct dq router path). On success the agent's writes
+    # commit with the caller; on ANY failure — Python OR SQL — the savepoint
+    # rolls back the agent's writes ALONE and the caller's transaction stays
+    # healthy (a raw SQL error would otherwise abort the shared transaction
+    # and 500 every subsequent statement of the batch — measured in CI the
+    # day the agent first ran to completion). Clean-slate on failure: no
+    # phantom 'running'/'failed' rows survive; the warning log is the signal.
     try:
         from ootils_core.engine.dq.agent import run_dq_agent
-        run_dq_agent(db, batch_id)
+        with db.transaction():
+            run_dq_agent(db, batch_id)
     except Exception as agent_exc:
         # Agent failure must never break the core DQ result
         logger.warning("dq_agent failed for batch %s (non-fatal): %s", batch_id, agent_exc)

--- a/tests/test_dq_agent.py
+++ b/tests/test_dq_agent.py
@@ -279,7 +279,10 @@ class TestRunDqAgent:
         assert result.priority_actions == ["Fix nulls"]
         assert result.model_used == "gpt-4.1-mini"
         assert len(result.issues) == 3  # 1 existing + 1 stat + 1 temporal
-        db.commit.assert_called()
+        # Transaction ownership belongs to the CALLER (the ingest path wraps
+        # the DQ run in conn.transaction(), where an explicit commit() is
+        # forbidden by psycopg and silently killed the agent on every ingest).
+        db.commit.assert_not_called()
 
     @patch("ootils_core.engine.dq.agent.agent.generate_llm_report")
     @patch("ootils_core.engine.dq.agent.agent.score_issues")
@@ -308,8 +311,15 @@ class TestRunDqAgent:
         with pytest.raises(RuntimeError, match="stat boom"):
             run_dq_agent(db, batch_id)
 
-        # Should have committed for the failed status update
-        assert db.commit.call_count >= 2
+        # The failed-status UPDATE is issued but NEVER committed here —
+        # persistence belongs to the caller's context (see run_dq_agent
+        # docstring trade-off).
+        db.commit.assert_not_called()
+        update_calls = [
+            c for c in db.execute.call_args_list
+            if "update dq_agent_runs" in c.args[0].strip().lower()
+        ]
+        assert len(update_calls) == 1, "failed-status UPDATE must still be issued"
 
     @patch("ootils_core.engine.dq.agent.agent.generate_llm_report")
     @patch("ootils_core.engine.dq.agent.agent.score_issues")


### PR DESCRIPTION
Bug réel mesuré sur base pilote : le dq_agent faisait db.commit() dans le transaction() de l'ingest → ProgrammingError catché non-fatal → **la boucle DQ n'a jamais tourné sur aucun ingest**. Fix minimal : suppression des 3 commits explicites, persistance = contexte appelant, trade-offs documentés (running invisible mid-run ; ligne failed perdue sur rollback routeur — le 500 reste le signal). 288 tests dq verts, revue éclair GO (3 appelants tracés). Branche rebasée sur main courant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)