### PR TITLE
feat(events): AN-1 #401 — émission typée run-level de la flotte + --subscribe (migration 071)

### DIFF
--- a/scripts/agent_governance.py
+++ b/scripts/agent_governance.py
@@ -38,6 +38,7 @@ import psycopg
 from psycopg import sql
 from psycopg.types.json import Jsonb
 
+from ootils_core.engine.events import emit_recommendation_created_for_run
 from ootils_core.engine.recommendation.transfer import TRANSFER_DECISION_LEVEL
 
 logger = logging.getLogger(__name__)
@@ -197,6 +198,27 @@ class _Run:
             "WHERE agent_run_id=%s",
             (status, Jsonb(metrics), self._run_id),
         )
+        # Fleet emission (#401 AN-1): one recommendation_created per COMPLETED run
+        # that actually created >=1 recommendation row. Count is read back from
+        # the recommendations table by agent_run_id (robust across every watcher's
+        # metric-key convention AND insertion path — run.insert here, the
+        # deterministic-uuid _upsert in the transfer/reschedule watchers, which
+        # ALSO run inside governed_run). Same connection/transaction (atomic with
+        # the reco writes + this UPDATE); the caller's commit follows in __exit__.
+        # DELIBERATE: only COMPLETED emits. A FAILED run's writes are COMMITTED
+        # by the exception path of governed_run (so the FAILED status row
+        # survives) — recos inserted before the failure can therefore exist
+        # WITHOUT a stream event. Accepted: announcing a half-finished run
+        # would invite consumers to act on it; the next successful run of the
+        # same watcher supersedes and announces. Strictly better than pre-#401
+        # (nothing ever emitted).
+        if status == "COMPLETED":
+            emit_recommendation_created_for_run(
+                self._conn,
+                self._run_id,
+                self._scenario_id,
+                self._agent_name,
+            )
 
 
 @contextmanager

--- a/scripts/agent_governance.py
+++ b/scripts/agent_governance.py
@@ -36,6 +36,7 @@ from typing import Any, Generator, Sequence
 
 import psycopg
 from psycopg import sql
+from psycopg.rows import dict_row
 from psycopg.types.json import Jsonb
 
 from ootils_core.engine.events import emit_recommendation_created_for_run
@@ -252,12 +253,15 @@ def governed_run(
                      the caller's t0 to include the full elapsed time.
     """
     _t0 = t0 if t0 is not None else time.perf_counter()
-    cur = conn.cursor()
+    # Row-factory agnostic: watchers pass tuple_row connections, the
+    # integration harness passes the dict_row fixture — an explicit dict_row
+    # cursor + access by name works under both (repo rule, cf. bootstrap_pi).
+    cur = conn.cursor(row_factory=dict_row)
     run_id = cur.execute(
         "INSERT INTO agent_runs (agent_name, scenario_id, status) "
         "VALUES (%s, %s, 'RUNNING') RETURNING agent_run_id",
         (agent_name, scenario_id),
-    ).fetchone()[0]
+    ).fetchone()["agent_run_id"]
     logger.debug("agent=%s scenario=%s run_id=%s status=RUNNING", agent_name, scenario_id, run_id)
 
     run = _Run(conn, run_id, _t0)

--- a/scripts/agent_material_watcher.py
+++ b/scripts/agent_material_watcher.py
@@ -35,6 +35,7 @@ import psycopg
 from psycopg.types.json import Jsonb
 import mrp_core as core
 import agent_simulation
+import agent_subscribe
 from agent_governance import decision_level, governed_run
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
@@ -58,6 +59,13 @@ def main(argv=None) -> int:
     p.add_argument("--horizon-days", type=int, default=540)
     p.add_argument("--top", type=int, default=15)
     p.add_argument("--allow-dev", action="store_true")
+    p.add_argument(
+        "--subscribe", action="store_true",
+        help="Event-driven mode (#401): drain the events stream from this "
+             "agent's last cursor and run ONLY if a relevant event "
+             "(calc_run_finished / shortage_detected) fired since. Without this "
+             "flag: full scan every run (byte-identical to the legacy behaviour).",
+    )
     args = p.parse_args(argv)
     if not args.dsn:
         logger.error("DATABASE_URL not set")
@@ -65,6 +73,29 @@ def main(argv=None) -> int:
     db = core.guard_db(args.dsn, args.allow_dev)
     logger.info("Material Watcher running on DB=%s", db)
     t0 = time.perf_counter()
+
+    # Event-driven gate (#401 AN-1). Resolve the cursor + drain BEFORE opening a
+    # governed_run so a skipped tick leaves NO agent_runs row. seed_cursor is what
+    # this run persists (the drained high-water mark, or the from-now seed on the
+    # first subscribed run), stamped into the run metrics below.
+    seed_cursor: int | None = None
+    if args.subscribe:
+        with psycopg.connect(args.dsn) as gate_conn:
+            prior = agent_subscribe.fetch_stream_cursor(gate_conn, AGENT_NAME, core.BASELINE)
+            base_cursor = prior if prior is not None else agent_subscribe.current_max_seq(
+                gate_conn, core.BASELINE)
+            seed_cursor, relevant = agent_subscribe.drain_stream(
+                gate_conn, core.BASELINE, base_cursor)
+        if prior is not None and relevant == 0:
+            logger.info(
+                "Material Watcher --subscribe: no relevant event since cursor=%s "
+                "(drained to %s) — skipping run.", base_cursor, seed_cursor)
+            return 0
+        logger.info(
+            "Material Watcher --subscribe: cursor %s -> %s, relevant=%d (%s) — running.",
+            base_cursor, seed_cursor, relevant,
+            "first subscribed run, seeded from now" if prior is None else "relevant events",
+        )
 
     with psycopg.connect(args.dsn) as conn:
         d = core.load_planning_data(conn, args.horizon_days)
@@ -158,13 +189,19 @@ def main(argv=None) -> int:
                  "action", "decision_level", "status", "confidence", "evidence"],
                 recs,
             )
-            run.set_metrics({
+            run_metrics = {
                 "component_recommendations": len(recs), "po": n_po, "wo": n_wo,
                 "superseded": superseded,
                 "estimated_spend": {k: round(v, 2) for k, v in spend.items()},
                 "max_llc": d.max_llc,
                 "simulation": sim_summary,
-            })
+            }
+            # Persist the drained cursor (#401 --subscribe) so the next tick
+            # resumes from it. Only in subscribe mode — a plain run stores no
+            # cursor, keeping its metrics byte-identical to the legacy shape.
+            if seed_cursor is not None:
+                run_metrics[agent_subscribe.STREAM_CURSOR_KEY] = seed_cursor
+            run.set_metrics(run_metrics)
             metrics = run.metrics
 
     elapsed = round(time.perf_counter() - t0, 2)

--- a/scripts/agent_shortage_watcher.py
+++ b/scripts/agent_shortage_watcher.py
@@ -45,6 +45,7 @@ import psycopg
 from psycopg.types.json import Jsonb
 import mrp_core as core
 import agent_simulation
+import agent_subscribe
 from agent_governance import decision_level, governed_run
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
@@ -70,6 +71,13 @@ def main(argv=None) -> int:
     p.add_argument("--horizon-days", type=int, default=540)
     p.add_argument("--top", type=int, default=15)
     p.add_argument("--allow-dev", action="store_true")
+    p.add_argument(
+        "--subscribe", action="store_true",
+        help="Event-driven mode (#401): drain the events stream from this "
+             "agent's last cursor and run ONLY if a relevant event "
+             "(calc_run_finished / shortage_detected) fired since. Without this "
+             "flag: full scan every run (byte-identical to the legacy behaviour).",
+    )
     args = p.parse_args(argv)
     if not args.dsn:
         logger.error("DATABASE_URL not set")
@@ -77,6 +85,30 @@ def main(argv=None) -> int:
     db = core.guard_db(args.dsn, args.allow_dev)
     logger.info("Shortage Watcher (W01) running on DB=%s", db)
     t0 = time.perf_counter()
+
+    # Event-driven gate (#401 AN-1). Resolve the cursor + drain BEFORE opening a
+    # governed_run so a skipped tick leaves NO agent_runs row. seed_cursor is what
+    # this run persists (the drained high-water mark, or the from-now seed on the
+    # first subscribed run); it is stamped into the run metrics below so the next
+    # tick resumes from it.
+    seed_cursor: int | None = None
+    if args.subscribe:
+        with psycopg.connect(args.dsn) as gate_conn:
+            prior = agent_subscribe.fetch_stream_cursor(gate_conn, AGENT_NAME, core.BASELINE)
+            base_cursor = prior if prior is not None else agent_subscribe.current_max_seq(
+                gate_conn, core.BASELINE)
+            seed_cursor, relevant = agent_subscribe.drain_stream(
+                gate_conn, core.BASELINE, base_cursor)
+        if prior is not None and relevant == 0:
+            logger.info(
+                "Shortage Watcher --subscribe: no relevant event since cursor=%s "
+                "(drained to %s) — skipping run.", base_cursor, seed_cursor)
+            return 0
+        logger.info(
+            "Shortage Watcher --subscribe: cursor %s -> %s, relevant=%d (%s) — running.",
+            base_cursor, seed_cursor, relevant,
+            "first subscribed run, seeded from now" if prior is None else "relevant events",
+        )
 
     with psycopg.connect(args.dsn) as conn:
         d = core.load_planning_data(conn, args.horizon_days)
@@ -187,6 +219,11 @@ def main(argv=None) -> int:
                        "fg_items_to_order": len(fg_first), "demand_nodes": dn, "past_due_demand_nodes": pdn,
                        "past_due_ratio": round(past_due_ratio, 4),
                        "simulation": sim_summary}
+            # Persist the drained cursor (#401 --subscribe) so the next tick
+            # resumes from it. Only in subscribe mode — a plain run stores no
+            # cursor, keeping its metrics byte-identical to the legacy shape.
+            if seed_cursor is not None:
+                metrics[agent_subscribe.STREAM_CURSOR_KEY] = seed_cursor
             run.set_metrics(metrics)
 
     m = metrics

--- a/scripts/agent_subscribe.py
+++ b/scripts/agent_subscribe.py
@@ -1,0 +1,179 @@
+"""
+agent_subscribe.py — the shared `--subscribe` (cron) drain for the watcher fleet
+(chantier AN-1, #401).
+
+North Star "Streamable": agents subscribe to deltas, they do not poll. In
+``--subscribe`` mode a watcher does NOT re-scan the whole plan on every cron
+tick; it first drains the ``events`` stream from its last cursor and only runs
+its expensive pass when the drain reports >=1 RELEVANT event (a calc run
+finished / shortages were detected) since it last looked. Nothing changed since
+last time ⇒ no work, no recomputation.
+
+DRAIN PATH = DIRECT DB READ, not the HTTP SSE endpoint. The watcher fleet already
+talks to Postgres directly (psycopg.connect(DATABASE_URL)); it has NO API base
+URL and NO bearer token in its config — a cron watcher is a DB client, not an API
+client. Migration 063 documents the keyset SELECT on ``events.stream_seq`` as
+"the replayable truth"; ``GET /v1/stream`` is merely a transport over that same
+query. So a watcher reading ``events`` directly with the SAME keyset contract
+(WHERE scenario_id = %s AND stream_seq > %s ORDER BY stream_seq) IS the stream —
+no self-referential HTTP hop back into the API the DB already backs, no new
+token/URL config surface, everything in the connection the watcher already holds.
+
+CURSOR PERSISTENCE = agent_runs.metrics JSONB (migration 039). Each subscribed
+run stores its final ``stream_cursor`` (the highest stream_seq it drained) in its
+own agent_runs metrics; the next run reads the LAST COMPLETED run's cursor to
+resume. First-ever subscribed run (no prior cursor) seeds from the current
+MAX(stream_seq) — "start from now", never a full replay of history (migration 063
+resume semantics).
+
+Opt-in: only the two first watchers (agent_shortage_watcher,
+agent_material_watcher) wire ``--subscribe``. Without the flag their behaviour is
+byte-identical to before (full scan every run).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, Sequence
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+# Metrics key under which a subscribed run persists its drained high-water mark.
+STREAM_CURSOR_KEY = "stream_cursor"
+
+# The fleet-emission event types a demand/material watcher acts on: a completed
+# calc run (the plan was recomputed) or a shortage-detection pass (new shortages
+# persisted). Both are migration-071 types. A recommendation_created /
+# snapshot_captured / outcome_evaluated event is NOT a trigger to re-plan, so it
+# is drained (advancing the cursor) but does NOT count as "relevant".
+RELEVANT_EVENT_TYPES: tuple[str, ...] = ("calc_run_finished", "shortage_detected")
+
+
+def fetch_stream_cursor(
+    conn: psycopg.Connection[Any],
+    agent_name: str,
+    scenario_id: Any,
+) -> Optional[int]:
+    """Return the stream cursor persisted by this agent's LAST COMPLETED run.
+
+    Reads ``agent_runs.metrics->>'stream_cursor'`` for the most recent COMPLETED
+    run of the same (agent_name, scenario_id), migration 039. Returns the int
+    high-water mark to resume AFTER (drain uses stream_seq > cursor), or None when
+    there is no prior completed run OR it stored no cursor (a pre-subscribe run) —
+    the caller then seeds "from now" (current MAX(stream_seq)) rather than
+    replaying history.
+
+    Robust to a malformed/absent stored value: a non-integer stream_cursor is
+    treated as "no cursor" (None) rather than crashing the watcher — the run
+    degrades to a from-now seed, never a stack trace on a cron tick.
+    """
+    row = conn.execute(
+        """
+        SELECT metrics
+        FROM agent_runs
+        WHERE agent_name = %s AND scenario_id = %s AND status = 'COMPLETED'
+        ORDER BY finished_at DESC NULLS LAST, started_at DESC
+        LIMIT 1
+        """,
+        (agent_name, scenario_id),
+    ).fetchone()
+    if row is None:
+        return None
+    metrics = _metrics_from_row(row)
+    if not isinstance(metrics, dict):
+        return None
+    return _coerce_cursor(metrics.get(STREAM_CURSOR_KEY))
+
+
+def current_max_seq(conn: psycopg.Connection[Any], scenario_id: Any) -> int:
+    """Current MAX(stream_seq) for a scenario (the "from now" seed).
+
+    Used when there is no prior cursor: the first subscribed run starts from the
+    live high-water mark so it never replays the scenario's whole event history
+    (migration 063 resume semantics). Returns 0 on an empty stream."""
+    row = conn.execute(
+        "SELECT COALESCE(MAX(stream_seq), 0) AS seq FROM events WHERE scenario_id = %s",
+        (scenario_id,),
+    ).fetchone()
+    if row is None:
+        return 0
+    return _scalar_int(row, "seq")
+
+
+def drain_stream(
+    conn: psycopg.Connection[Any],
+    scenario_id: Any,
+    cursor: int,
+    *,
+    relevant_types: Sequence[str] = RELEVANT_EVENT_TYPES,
+) -> tuple[int, int]:
+    """Drain the events stream past ``cursor`` for a scenario (direct DB keyset).
+
+    Returns ``(new_cursor, relevant_count)`` where new_cursor is the highest
+    stream_seq seen (or the input cursor when the stream is empty past it), and
+    relevant_count is how many drained events are of ``relevant_types`` (the
+    watcher runs its pass iff relevant_count > 0).
+
+    Same keyset contract as GET /v1/stream (migration 063): WHERE scenario_id = %s
+    AND stream_seq > %s ORDER BY stream_seq. The cursor advances over EVERY drained
+    row (relevant or not) so an irrelevant event is not re-seen next tick; only the
+    relevant subset is COUNTED. stream_seq is an opaque high-water mark compared
+    with `>` only (never gap-checked, never last+1) — a rolled-back INSERT may have
+    burned values, which is fine.
+    """
+    rows = conn.execute(
+        """
+        SELECT stream_seq, event_type
+        FROM events
+        WHERE scenario_id = %s AND stream_seq > %s
+        ORDER BY stream_seq
+        """,
+        (scenario_id, cursor),
+    ).fetchall()
+
+    new_cursor = cursor
+    relevant = 0
+    wanted = set(relevant_types)
+    for row in rows:
+        seq = _scalar_int(row, "stream_seq")
+        if seq > new_cursor:
+            new_cursor = seq
+        if _row_event_type(row) in wanted:
+            relevant += 1
+    return new_cursor, relevant
+
+
+# ---------------------------------------------------------------------------
+# Row-factory-agnostic accessors — the fleet mixes dict_row (app pool) and
+# tuple_row (a watcher's psycopg.connect() default), so every read below works
+# for both.
+# ---------------------------------------------------------------------------
+
+
+def _metrics_from_row(row: Any) -> Any:
+    if isinstance(row, dict):
+        return row.get("metrics")
+    return row[0]
+
+
+def _scalar_int(row: Any, key: str) -> int:
+    if isinstance(row, dict):
+        return int(row[key] or 0)
+    return int(row[0] or 0)
+
+
+def _row_event_type(row: Any) -> Optional[str]:
+    if isinstance(row, dict):
+        return row.get("event_type")
+    return row[1]
+
+
+def _coerce_cursor(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logger.warning("agent_subscribe: ignoring non-integer stored cursor %r", value)
+        return None

--- a/scripts/evaluate_outcomes.py
+++ b/scripts/evaluate_outcomes.py
@@ -38,6 +38,7 @@ import psycopg
 
 import mrp_core as core
 
+from ootils_core.engine.events import emit_stream_event
 from ootils_core.engine.outcome import evaluate_and_persist
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
@@ -78,6 +79,21 @@ def main(argv: list[str] | None = None) -> int:
 
     with psycopg.connect(args.dsn) as conn:
         summary = evaluate_and_persist(conn, scenario, as_of)
+        # Fleet emission (#401 AN-1): ONE outcome_evaluated per evaluation batch,
+        # on this connection BEFORE commit — atomic with the upserted verdicts.
+        # new_quantity carries the count of recos classified in the run; the
+        # observation day travels in new_date (context, not identity). Skipped
+        # when the batch classified nothing (empty pass, nothing to announce).
+        evaluated = int(summary["evaluated"])
+        if evaluated > 0:
+            emit_stream_event(
+                conn,
+                "outcome_evaluated",
+                scenario,
+                field_changed="outcome_evaluated",
+                new_date=_dt.date.fromisoformat(summary["evaluated_as_of"]),
+                new_quantity=evaluated,
+            )
         conn.commit()
 
     elapsed = round(time.perf_counter() - t0, 2)

--- a/scripts/snapshot_inventory.py
+++ b/scripts/snapshot_inventory.py
@@ -37,6 +37,7 @@ import psycopg
 
 import mrp_core as core
 
+from ootils_core.engine.events import emit_stream_event
 from ootils_core.engine.snapshot import capture_snapshot, persist_snapshot
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
@@ -78,6 +79,19 @@ def main(argv: list[str] | None = None) -> int:
     with psycopg.connect(args.dsn) as conn:
         rows = capture_snapshot(conn, scenario, as_of, source="cli")
         written = persist_snapshot(conn, rows, source="cli")
+        # Fleet emission (#401 AN-1): ONE snapshot_captured per capture batch, on
+        # this connection BEFORE commit — atomic with the persisted rows. new_date
+        # carries the resolved as_of; new_quantity the coordinate count. Skipped
+        # when nothing was captured (no as_of to stamp, nothing to announce).
+        if written > 0 and rows:
+            emit_stream_event(
+                conn,
+                "snapshot_captured",
+                scenario,
+                field_changed="snapshot_captured",
+                new_date=rows[0].as_of_date,
+                new_quantity=written,
+            )
         conn.commit()
 
     resolved_as_of = rows[0].as_of_date if rows else as_of

--- a/src/ootils_core/api/routers/drp.py
+++ b/src/ootils_core/api/routers/drp.py
@@ -43,6 +43,7 @@ from pydantic import BaseModel, Field
 from ootils_core.api.auth import require_scope
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
 from ootils_core.db.types import DictRowConnection
+from ootils_core.engine.events import emit_recommendation_created_for_run
 from ootils_core.engine.recommendation.transfer import (
     TRANSFER_DECISION_LEVEL,
     emit_transfer_recommendations,
@@ -161,6 +162,17 @@ def run_drp(
         "UPDATE agent_runs SET status='COMPLETED', finished_at=now(), metrics=%s "
         "WHERE agent_run_id=%s",
         (Jsonb(metrics), agent_run_id),
+    )
+
+    # Fleet emission (#401 AN-1): the DRP endpoint does NOT go through
+    # governed_run (it drives its own agent_runs lifecycle above), so it emits
+    # its own recommendation_created — same RUN-level contract, same shared
+    # helper the watchers use through governed_run. One event iff this run
+    # inserted >=1 new recommendation (an idempotent no-op re-run emits nothing).
+    # source='api': this is the API request path. Same transaction as the reco
+    # writes (get_db owns commit/rollback).
+    emit_recommendation_created_for_run(
+        db, agent_run_id, scenario_str, _AGENT_NAME, source="api"
     )
 
     logger.info(

--- a/src/ootils_core/api/routers/events.py
+++ b/src/ootils_core/api/routers/events.py
@@ -94,7 +94,8 @@ def _build_propagation_engine(db):
     )
 
 
-# Must stay in sync with events.event_type CHECK constraint in migrations 002 + 006 + 051 + 062.
+# Must stay in sync with events.event_type CHECK constraint in migrations
+# 002 + 006 + 051 + 062 + 071.
 # Any new event type requires both a DB migration (ALTER TABLE ... ADD CONSTRAINT)
 # and an addition here.
 VALID_EVENT_TYPES = {
@@ -116,6 +117,12 @@ VALID_EVENT_TYPES = {
     "recommendation_transition",
     # From migration 062 CHECK constraint extension (FPO firm/unfirm, #346)
     "node_firm_changed",
+    # From migration 071 CHECK constraint extension (#401 AN-1, fleet emission)
+    "recommendation_created",
+    "shortage_detected",
+    "calc_run_finished",
+    "snapshot_captured",
+    "outcome_evaluated",
 }
 
 

--- a/src/ootils_core/api/routers/outcomes.py
+++ b/src/ootils_core/api/routers/outcomes.py
@@ -72,6 +72,7 @@ from pydantic import BaseModel, Field
 from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
 from ootils_core.db.types import DictRowConnection
+from ootils_core.engine.events import emit_stream_event
 from ootils_core.engine.outcome import evaluate_and_persist
 
 logger = logging.getLogger(__name__)
@@ -334,6 +335,21 @@ def evaluate_outcomes(
     idempotent writer of ``recommendation_outcomes``."""
     summary = evaluate_and_persist(db, str(scenario_id), body.as_of)
     evaluated_as_of = _dt.date.fromisoformat(summary["evaluated_as_of"])
+
+    # Fleet emission (#401 AN-1): ONE outcome_evaluated per evaluation batch on
+    # the request connection — atomic with the upserted verdicts (get_db owns
+    # commit/rollback). source='api'. Skipped when the batch classified nothing.
+    evaluated = int(summary["evaluated"])
+    if evaluated > 0:
+        emit_stream_event(
+            db,
+            "outcome_evaluated",
+            str(scenario_id),
+            field_changed="outcome_evaluated",
+            new_date=evaluated_as_of,
+            new_quantity=evaluated,
+            source="api",
+        )
 
     logger.info(
         "outcomes.evaluate scenario_id=%s as_of=%s evaluated=%d upserted=%d",

--- a/src/ootils_core/api/routers/snapshots.py
+++ b/src/ootils_core/api/routers/snapshots.py
@@ -48,6 +48,7 @@ from pydantic import BaseModel, Field
 from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
 from ootils_core.db.types import DictRowConnection
+from ootils_core.engine.events import emit_stream_event
 from ootils_core.engine.snapshot import capture_snapshot, persist_snapshot
 
 logger = logging.getLogger(__name__)
@@ -179,6 +180,21 @@ def capture_snapshots(
         if current is None:
             raise RuntimeError("snapshots.capture: SELECT CURRENT_DATE yielded no row")
         as_of_date = current["d"]
+
+    # Fleet emission (#401 AN-1): ONE snapshot_captured per capture batch on the
+    # request connection — atomic with the upserted rows (get_db owns
+    # commit/rollback). source='api' (the API request path). Skipped on an
+    # empty capture (nothing persisted, nothing to announce).
+    if written > 0:
+        emit_stream_event(
+            db,
+            "snapshot_captured",
+            scenario_str,
+            field_changed="snapshot_captured",
+            new_date=as_of_date,
+            new_quantity=written,
+            source="api",
+        )
 
     logger.info(
         "snapshots.capture scenario_id=%s as_of=%s captured=%d",

--- a/src/ootils_core/db/migrations/071_events_fleet_types.sql
+++ b/src/ootils_core/db/migrations/071_events_fleet_types.sql
@@ -1,0 +1,99 @@
+-- ============================================================
+-- Migration 071 — events.event_type += 5 fleet-emission types
+-- ============================================================
+-- Chantier AN-1 (#401, "events emission"). North Star "Streamable":
+-- every state-changing capability MUST write a typed `events` row so the
+-- fleet subscribes to deltas via GET /v1/stream (keyset cursor on
+-- events.stream_seq, migration 063) instead of polling. Until now four
+-- fleet-relevant capabilities emitted nothing and were invisible to the
+-- stream. This migration widens the events.event_type CHECK with the 5
+-- new types they emit — NO new column (the payload reuses the existing
+-- typed columns of `events`, migration 002) and NO new index (all 5 share
+-- idx_events_stream_seq, the (scenario_id, stream_seq) keyset index).
+--
+-- The 5 new types:
+--   recommendation_created  — a governed DRAFT recommendation was written
+--                             (ShortageDetector / watchers / reschedule).
+--   shortage_detected       — a ShortageDetector run persisted shortages.
+--   calc_run_finished       — a propagation / calc run reached a terminal
+--                             state (completed | completed_stale | failed).
+--   snapshot_captured       — an inventory-snapshot capture run persisted
+--                             on-hand rows (ADR-030, migration 067).
+--   outcome_evaluated       — a reco→outcome evaluation run classified
+--                             recommendations (ADR-030, migration 069).
+--
+-- GRANULARITY = RUN, NEVER PER-ITEM (ADR-027). One event per governed
+-- run / calc run / capture batch / evaluation batch — NOT one per
+-- recommendation, shortage, snapshot row or outcome. A calc run touching
+-- 200 items emits ONE calc_run_finished; a ShortageDetector pass over 50
+-- items emits ONE shortage_detected. This keeps the stream a feed of
+-- decisions/runs the fleet acts on, not a firehose of row-level noise, and
+-- keeps stream_seq cursors cheap. The per-run count lives in new_quantity
+-- (see mapping below) so a subscriber sees "how many" without a join.
+--
+-- TYPED-COLUMN CONTRACT per new type (no JSONB — migration 002 columns):
+--   recommendation_created:
+--       trigger_node_id = target node of the reco (nullable if none)
+--       field_changed   = the reco action (e.g. 'EXPEDITE','ORDER_NOW',
+--                         'RESCHEDULE_IN','TRANSFER') — the discriminant
+--       new_text        = recommendation_id (UUID as text)
+--       old_text        = source/agent ref (e.g. 'shortage_watcher')
+--       new_quantity    = count of recos created in the run
+--   shortage_detected:
+--       field_changed   = 'shortage_detected' (discriminant)
+--       new_quantity    = count of shortages persisted in the run
+--       new_text        = calc_run_id / detector run ref (UUID as text)
+--   calc_run_finished:
+--       field_changed   = terminal status ('completed'|'completed_stale'
+--                         |'failed') — the discriminant
+--       new_text        = calc_run_id (UUID as text)
+--       new_quantity    = count of nodes (re)computed in the run
+--   snapshot_captured:
+--       field_changed   = 'snapshot_captured' (discriminant)
+--       new_date        = as_of_date of the capture
+--       new_quantity    = count of snapshot rows persisted
+--       new_text        = capture run ref (UUID as text)
+--   outcome_evaluated:
+--       field_changed   = 'outcome_evaluated' (discriminant)
+--       new_quantity    = count of recommendations classified in the run
+--       new_text        = evaluation run ref (UUID as text)
+-- In all cases scenario_id (NOT NULL, migration 002) scopes the event to
+-- the fork/baseline; snapshot_captured/outcome_evaluated are baseline-only
+-- by nature (ADR-030) but the column contract is identical.
+--
+-- Idempotence (runner wraps each file in ONE transaction and ABORTS on any
+-- error — it does NOT swallow "already exists"; see migration 063 header).
+-- DROP CONSTRAINT IF EXISTS *before* ADD CONSTRAINT is the replay-safe
+-- idiom used by every prior widening (006, 051, 062): on a re-run the DROP
+-- removes the constraint this migration just added, then ADD re-creates the
+-- identical one — a clean no-op. (A bare ADD would fail on re-run because
+-- events_event_type_check already exists; the DROP-first pattern is what
+-- makes DROP+ADD re-executable.) No payload rewrite, no UPDATE — events
+-- stays immutable on its payload (ADR-005 D2).
+--
+-- Keep this list in sync with VALID_EVENT_TYPES in
+-- src/ootils_core/api/routers/events.py
+-- (migrations 002 + 006 + 051 + 062 + 071).
+-- ============================================================
+
+BEGIN;
+
+ALTER TABLE events DROP CONSTRAINT IF EXISTS events_event_type_check;
+ALTER TABLE events ADD CONSTRAINT events_event_type_check
+    CHECK (event_type IN (
+        -- migrations 002 + 006 + 051 + 062 (existing, unchanged)
+        'supply_date_changed', 'supply_qty_changed',
+        'demand_qty_changed', 'onhand_updated',
+        'policy_changed', 'structure_changed',
+        'scenario_created', 'calc_triggered',
+        'ingestion_complete', 'po_date_changed',
+        'test_event', 'scenario_merge',
+        'recommendation_transition',
+        'node_firm_changed',
+        -- migration 071 (#401 AN-1, fleet emission)
+        'recommendation_created', 'shortage_detected',
+        'calc_run_finished', 'snapshot_captured',
+        'outcome_evaluated'
+    ));
+
+COMMIT;

--- a/src/ootils_core/engine/events/__init__.py
+++ b/src/ootils_core/engine/events/__init__.py
@@ -1,0 +1,20 @@
+"""
+Fleet-event emission (chantier AN-1, #401).
+
+emit: the single ``emit_stream_event`` helper — ONE typed ``events`` INSERT on
+    the caller's connection, in the caller's transaction, for the five
+    fleet-emission types (migration 071). North Star "Streamable": a
+    state-changing capability that writes no ``events`` row is invisible to
+    ``GET /v1/stream``. Granularity is RUN, never per-item (ADR-027).
+"""
+from ootils_core.engine.events.emit import (
+    FLEET_EVENT_TYPES,
+    emit_recommendation_created_for_run,
+    emit_stream_event,
+)
+
+__all__ = [
+    "FLEET_EVENT_TYPES",
+    "emit_recommendation_created_for_run",
+    "emit_stream_event",
+]

--- a/src/ootils_core/engine/events/emit.py
+++ b/src/ootils_core/engine/events/emit.py
@@ -1,0 +1,228 @@
+"""
+emit.py — the single fleet-emission helper (chantier AN-1, #401).
+
+North Star "Streamable": every state-changing capability MUST write a typed
+``events`` row so the fleet subscribes to deltas via ``GET /v1/stream`` (keyset
+cursor on ``events.stream_seq``, migration 063) instead of polling. Until AN-1
+five fleet-relevant capabilities emitted nothing and were invisible to the
+stream; ``emit_stream_event`` is the one place they now write their run-level
+event.
+
+ONE INSERT, ONE TRANSACTION, ONE CONTRACT. The helper takes the caller's own
+connection and inserts on it — so the event is part of the SAME transaction as
+the business write it announces. Atomicity is the contract: if the business
+write rolls back, its event rolls back with it (no phantom stream row for a
+change that did not happen); if it commits, the event is durably visible to the
+stream. The helper NEVER commits, NEVER rolls back, NEVER opens its own
+connection — the caller owns the transaction (get_db in a router, governed_run
+in a watcher, the CLI's own connection in a batch).
+
+GRANULARITY = RUN, NEVER PER-ITEM (ADR-027, migration 071 header). One event per
+governed run / calc run / capture batch / evaluation batch — the per-run count
+travels in ``new_quantity`` so a subscriber sees "how many" without a join.
+
+TYPED-COLUMN CONTRACT per event_type (no JSONB — migration 002 columns, kept in
+sync with the migration 071 header block):
+
+  recommendation_created:
+      trigger_node_id = target node of the reco (nullable if none)
+      field_changed   = the reco action (e.g. 'EXPEDITE','ORDER_NOW',
+                        'RESCHEDULE_IN','TRANSFER') — the discriminant
+      new_text        = recommendation_id (UUID as text) OR the agent_run_id
+                        when a run emits an aggregate for several recos
+      old_text        = source/agent ref (e.g. 'shortage_watcher')
+      new_quantity    = count of recos created in the run
+  shortage_detected:
+      field_changed   = 'shortage_detected' (discriminant)
+      new_quantity    = count of shortages persisted in the run
+      new_text        = calc_run_id / detector run ref (UUID as text)
+  calc_run_finished:
+      field_changed   = terminal status ('completed'|'completed_stale'|'failed')
+      new_text        = calc_run_id (UUID as text)
+      new_quantity    = count of nodes (re)computed in the run
+  snapshot_captured:
+      field_changed   = 'snapshot_captured' (discriminant)
+      new_date        = as_of_date of the capture
+      new_quantity    = count of snapshot rows persisted
+      new_text        = capture run ref (UUID as text)
+  outcome_evaluated:
+      field_changed   = 'outcome_evaluated' (discriminant)
+      new_quantity    = count of recommendations classified in the run
+      new_text        = evaluation run ref (UUID as text)
+
+``scenario_id`` (NOT NULL, migration 002) scopes the event to the fork/baseline.
+snapshot_captured / outcome_evaluated are baseline-only by nature (ADR-030) but
+the column contract is identical.
+
+Keep FLEET_EVENT_TYPES in sync with the events.event_type CHECK constraint
+(migration 071) and with VALID_EVENT_TYPES in api/routers/events.py.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Any, Optional, Union
+from uuid import UUID, uuid4
+
+import psycopg
+
+# The five fleet-emission types added by migration 071 (#401 AN-1). Validated
+# locally so a typo fails loudly in Python (ValueError) rather than as an opaque
+# psycopg CHECK violation at INSERT time. This set is the subset emit_stream_event
+# is meant to write; the DB CHECK (migration 071) is the full authoritative list.
+FLEET_EVENT_TYPES: frozenset[str] = frozenset(
+    {
+        "recommendation_created",
+        "shortage_detected",
+        "calc_run_finished",
+        "snapshot_captured",
+        "outcome_evaluated",
+    }
+)
+
+# events.source CHECK (migration 002): 'api' | 'ingestion' | 'engine' | 'user'
+# | 'test'. Fleet emissions default to 'engine' (a deterministic-core write);
+# a router on the API request path passes source='api'.
+_VALID_SOURCES: frozenset[str] = frozenset(
+    {"api", "ingestion", "engine", "user", "test"}
+)
+
+
+def emit_stream_event(
+    conn: psycopg.Connection[Any],
+    event_type: str,
+    scenario_id: Union[UUID, str],
+    *,
+    trigger_node_id: Optional[Union[UUID, str]] = None,
+    field_changed: Optional[str] = None,
+    new_quantity: Optional[Union[int, Decimal]] = None,
+    old_text: Optional[str] = None,
+    new_text: Optional[str] = None,
+    new_date: Optional[date] = None,
+    source: str = "engine",
+) -> UUID:
+    """Insert ONE typed fleet event on the caller's connection (same transaction).
+
+    Returns the generated event_id. Does NOT commit — the caller owns the
+    transaction so the event is atomic with the business write it announces.
+
+    Raises ValueError on an unknown ``event_type`` (not in FLEET_EVENT_TYPES) or
+    an invalid ``source`` — fail-loudly, so a typo never becomes a silent
+    CHECK-violation at INSERT time or a mis-sourced row.
+
+    The parameter set maps 1:1 to the typed-column contract documented at the top
+    of this module; a caller passes only the columns its event_type populates and
+    leaves the rest at their None default.
+    """
+    if event_type not in FLEET_EVENT_TYPES:
+        raise ValueError(
+            f"emit_stream_event: unknown fleet event_type {event_type!r} — "
+            f"valid: {sorted(FLEET_EVENT_TYPES)}"
+        )
+    if source not in _VALID_SOURCES:
+        raise ValueError(
+            f"emit_stream_event: invalid source {source!r} — "
+            f"valid: {sorted(_VALID_SOURCES)}"
+        )
+
+    event_id = uuid4()
+    now = datetime.now(timezone.utc)
+
+    conn.execute(
+        """
+        INSERT INTO events (
+            event_id, event_type, scenario_id, trigger_node_id,
+            field_changed, new_date, new_quantity, old_text, new_text,
+            processed, source, created_at
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, TRUE, %s, %s)
+        """,
+        (
+            event_id,
+            event_type,
+            scenario_id,
+            trigger_node_id,
+            field_changed,
+            new_date,
+            new_quantity,
+            old_text,
+            new_text,
+            source,
+            now,
+        ),
+    )
+    return event_id
+
+
+# The governed-RECOMMENDATION artifact tables — the ones whose rows are
+# "recommendation_created" in the migration-071 sense (a governed DRAFT action a
+# planner reviews): the procurement/reschedule/transfer queue (`recommendations`)
+# and the planning-parameter proposals (`parameter_recommendations`, the
+# scenario-backed lot_policy_watcher, ADR-025). Both carry agent_run_id (migrations
+# 039/041). DELIBERATELY EXCLUDES dq_findings and eando_recommendations: those are
+# data-quality findings / disposition changes, not governed action recommendations
+# (baseline-only by nature, out of the #340/#347 scenario-backed scope per
+# CLAUDE.md) — counting them here would mislabel a DQ scan as a recommendation run.
+_RECO_TABLES: tuple[str, ...] = ("recommendations", "parameter_recommendations")
+
+
+def emit_recommendation_created_for_run(
+    conn: psycopg.Connection[Any],
+    agent_run_id: Union[UUID, str],
+    scenario_id: Union[UUID, str],
+    agent_name: str,
+    *,
+    source: str = "engine",
+) -> Optional[UUID]:
+    """Emit ONE ``recommendation_created`` event for a governed run, iff the run
+    created >=1 governed recommendation row (#401 AN-1).
+
+    The count is read from the authoritative governed-recommendation tables
+    (_RECO_TABLES) by agent_run_id — the ONE run-level source of truth that is
+    robust across the fleet's divergent metric-key conventions (the shortage
+    watcher stores ``recommendations``, the transfer/reschedule watchers
+    ``recommendations_inserted``, the lot-policy watcher ``proposals``; a COUNT by
+    agent_run_id needs no such convention) AND across insertion paths (run.insert
+    for the supersede-reinsert watchers, the deterministic-uuid ON CONFLICT DO
+    NOTHING _upsert for transfer/reschedule). Idempotent no-op re-emissions keep
+    the ORIGINAL run's agent_run_id, so a re-run that inserts nothing new counts 0
+    and emits nothing — exactly the "unchanged plan re-run emits zero new rows"
+    contract (#346/#395).
+
+    Same connection/transaction as the reco writes (atomic). Returns the event_id
+    when an event was emitted, or None when the run created no recommendation
+    (nothing to announce). ``agent_name`` is carried in old_text; the run id in
+    new_text; the total count in new_quantity (RUN granularity, ADR-027).
+    """
+    count = 0
+    for table in _RECO_TABLES:
+        # Table name is a hardcoded literal from the module-level whitelist, never
+        # caller data — safe to interpolate. Values are bound positionally.
+        row = conn.execute(
+            f"SELECT COUNT(*) AS n FROM {table} WHERE agent_run_id = %s",  # noqa: S608
+            (agent_run_id,),
+        ).fetchone()
+        count += _count_from_row(row)
+    if count <= 0:
+        return None
+    return emit_stream_event(
+        conn,
+        "recommendation_created",
+        scenario_id,
+        old_text=agent_name,
+        new_text=str(agent_run_id),
+        new_quantity=count,
+        source=source,
+    )
+
+
+def _count_from_row(row: Any) -> int:
+    """Extract a COUNT(*) result from either a dict_row or a tuple_row.
+
+    The fleet mixes row factories: the app pool is dict_row (get_db), a watcher's
+    psycopg.connect() default is tuple_row. Reading the count works for both so
+    emit_recommendation_created_for_run is callable from every path."""
+    if row is None:
+        return 0
+    if isinstance(row, dict):
+        return int(row.get("n", 0) or 0)
+    return int(row[0] or 0)

--- a/src/ootils_core/engine/orchestration/calc_run.py
+++ b/src/ootils_core/engine/orchestration/calc_run.py
@@ -14,6 +14,7 @@ from typing import Optional
 from uuid import UUID, uuid4
 
 from ootils_core.db.types import DictRowConnection
+from ootils_core.engine.events import emit_stream_event
 from ootils_core.models import CalcRun, Scenario
 
 
@@ -154,11 +155,63 @@ class CalcRunManager:
                 (now, run.triggered_by_event_ids),
             )
 
+        # Fleet emission (#401 AN-1). GRANULARITY = RUN: exactly one
+        # calc_run_finished per terminal run, and one shortage_detected iff this
+        # run PERSISTED shortages. Both go on the SAME connection/transaction as
+        # the UPDATE above — atomic with the run's completion (a rolled-back
+        # completion emits nothing). The shortage count comes from the
+        # authoritative persistence system (the `shortages` table, ADR-021,
+        # ShortageDetector-owned) via COUNT WHERE calc_run_id: the propagator
+        # persists shortages one PI at a time and never aggregates a per-run
+        # count, so reading the table back here is the ONE place the run-level
+        # count exists without threading a counter through the (SQL AND Python)
+        # propagator public signatures. Works identically for both engines.
+        self._emit_run_events(run, final_status, db)
+
         # Release advisory lock (must use same hash as acquire)
         db.execute(
             "SELECT pg_advisory_unlock(hashtext(%s)::bigint)",
             (str(run.scenario_id),),
         )
+
+    def _emit_run_events(
+        self,
+        run: CalcRun,
+        final_status: str,
+        db: DictRowConnection,
+    ) -> None:
+        """Emit the RUN-level fleet events for a terminal calc run (#401 AN-1).
+
+        Always one ``calc_run_finished``; additionally one ``shortage_detected``
+        when this run persisted >=1 shortage row. The shortage count is read from
+        the ``shortages`` table (the canonical persistence system, ADR-021) by
+        this run's calc_run_id — the only place a per-run aggregate exists. Same
+        transaction as the completion write (atomic); never a swallowed except —
+        an emission failure must surface so the run is not silently unstreamed.
+        """
+        emit_stream_event(
+            db,
+            "calc_run_finished",
+            run.scenario_id,
+            field_changed=final_status,
+            new_text=str(run.calc_run_id),
+            new_quantity=run.nodes_recalculated,
+        )
+
+        shortage_row = db.execute(
+            "SELECT COUNT(*) AS n FROM shortages WHERE calc_run_id = %s",
+            (run.calc_run_id,),
+        ).fetchone()
+        shortage_count = int(shortage_row["n"]) if shortage_row else 0
+        if shortage_count > 0:
+            emit_stream_event(
+                db,
+                "shortage_detected",
+                run.scenario_id,
+                field_changed="shortage_detected",
+                new_quantity=shortage_count,
+                new_text=str(run.calc_run_id),
+            )
 
     def fail_calc_run(
         self,
@@ -170,6 +223,16 @@ class CalcRunManager:
 
         Uses autocommit on the failure UPDATE so the audit record is persisted
         even if the caller's transaction rolls back (HIGH-4).
+
+        No ``calc_run_finished`` fleet event is emitted here (#401 AN-1): this is
+        the EXCEPTION path — the propagator has already done ROLLBACK TO SAVEPOINT
+        and the caller re-raises, so the transaction is being torn down. An
+        ``events`` INSERT on a rolling-back transaction leaves no row (it only
+        burns a stream_seq, migration 063), so a failed-run event would be a
+        phantom the stream never sees. calc_run_finished is emitted only from
+        complete_calc_run, on the COMMITTED terminal path (completed |
+        completed_stale). Surfacing a run failure to the fleet is the caller's
+        job (the 503 the events router raises), not a best-effort stream write.
         """
         now = datetime.now(timezone.utc)
         run.status = "failed"

--- a/tests/integration/test_fleet_events_integration.py
+++ b/tests/integration/test_fleet_events_integration.py
@@ -1,0 +1,925 @@
+"""
+tests/integration/test_fleet_events_integration.py — THE North Star guard-rail
+for chantier AN-1 (#401, "events emission"), against a real Postgres. No mocks.
+
+WHY THIS FILE IS THE GUARD-RAIL. The North Star "Streamable" rule (CLAUDE.md,
+ADR-027) is absolute: *every state-changing capability MUST write a typed
+``events`` row*, so the agent fleet subscribes to deltas via ``GET /v1/stream``
+(keyset cursor on ``events.stream_seq``, migration 063) instead of polling. A
+governed write that emits no event is invisible to the fleet — it silently
+breaks the substrate. This suite encodes the inverse as a red line:
+
+    A GOVERNED WRITE WITHOUT ITS STREAM EVENT = RED.
+
+The 26 pure unit tests (test_emit_stream_event.py, test_agent_subscribe.py)
+prove the helper's column MAPPING and the drain's cursor LOGIC in isolation
+against fake connections. They CANNOT prove the thing that actually matters end
+to end: that each of the five real emission SITES, wired into five real
+capabilities, lands exactly one correctly-typed row on the SAME transaction as
+the business write it announces, that the migration-071 CHECK accepts every
+type the emitter writes, and that the keyset SELECT the stream is built on
+surfaces it. That is this file's job.
+
+The seven cases (one per backend contract, per the AN-1 hand-off):
+  1. THE GUARD-RAIL — table-driven capability -> event_type over ALL FIVE
+     fleet emissions: run each once on a seeded fork, assert EXACTLY one row of
+     the right type, RUN-level ``new_quantity`` (one event per run, the count
+     travels in the column — never one event per item), and that the /v1/stream
+     keyset SELECT (WHERE scenario_id=%s AND stream_seq>%s ORDER BY stream_seq)
+     surfaces it. Every capability is driven through its REAL emission site
+     (complete_calc_run / governed_run._close / the snapshot & outcome routers),
+     NEVER a raw ``INSERT INTO events`` that would bypass the site under test.
+  2. RUN granularity — a calc run with 0 shortages emits calc_run_finished
+     ALONE; a run persisting N shortages adds ONE shortage_detected with
+     new_quantity=N (proof it is run-level, not one-per-shortage).
+  3. Atomicity — emitting on a transaction that then ROLLS BACK leaves NO event
+     (a burned stream_seq is tolerated — the keyset only ever compares `>`).
+  4. Idempotence of recommendation_created — the count is read back by the
+     CURRENT run's agent_run_id, so an idempotent re-run that inserts 0 new
+     recommendations (the transfer/reschedule ON CONFLICT DO NOTHING mechanic)
+     emits NOTHING; the first run of N recos emits one event new_quantity=N.
+  5. API request-transaction — the drp/snapshots/outcomes routers emit on the
+     REQUEST's get_db transaction: after the POST the event is visible from a
+     SEPARATE connection (proof it committed) and carries source='api'.
+  6. --subscribe end to end — the shortage watcher's event-driven gate: the
+     first subscribed run seeds "from now" and runs; a tick with no relevant
+     event skips (no agent_runs row); a tick after a calc_run_finished runs and
+     advances the persisted cursor; and WITHOUT the flag the metrics stay
+     byte-identical to legacy (no cursor key).
+  7. Migration-071 CHECK — emit_stream_event succeeds for each of the five
+     FLEET_EVENT_TYPES against the real constraint, catching any drift between
+     FLEET_EVENT_TYPES (emitter) <-> VALID_EVENT_TYPES (events router) <-> the
+     events.event_type CHECK (migration 071).
+
+Coverage note (justified level-below, case 5): the POST /v1/drp/run endpoint's
+recommendation_created emission uses the IDENTICAL, already-proven shared helper
+``emit_recommendation_created_for_run`` — exercised end to end here through
+governed_run (cases 1 & 4). Driving the DRP planner itself to the point of
+emitting requires a full inter-site distribution plan whose test harness
+TRUNCATEs the whole graph (see test_transfer_watcher_integration.py), which
+would be destructive to this module's shared DB and disproportionate for CI. The
+DRP route's emission is therefore covered at the shared-helper level (its only
+new-vs-governed_run code is the ``source='api'`` argument, whose behaviour is
+proven by the snapshots/outcomes request-transaction tests below), not re-driven.
+
+Conventions cloned from the passing suites: the ``migrated_db`` / ``conn``
+fixtures + the app ``get_db``-override / minted-token pattern
+(test_snapshot_integration.py, test_outcome_integration.py); the direct-engine
+propagation driver (test_param_overlay_propagation_integration.py); the
+in-process watcher driving on a DB-anchored baseline seed
+(test_agent_fleet_smoke.py, test_scenario_backed_watchers_integration.py). Every
+capability runs on its OWN fresh uuid4-suffixed scenario so the keyset
+assertions never bleed across cases; case 6 is the ONLY user of BASELINE (the
+watcher is baseline-only). Dates are anchored on the DB-side CURRENT_DATE.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import sys
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import psycopg
+import pytest
+from psycopg.rows import dict_row
+
+from ootils_core.engine.events.emit import FLEET_EVENT_TYPES, emit_stream_event
+from ootils_core.engine.kernel.calc.projection import ProjectionKernel
+from ootils_core.engine.kernel.graph.dirty import DirtyFlagManager
+from ootils_core.engine.kernel.graph.store import GraphStore
+from ootils_core.engine.kernel.graph.traversal import GraphTraversal
+from ootils_core.engine.kernel.shortage.detector import ShortageDetector
+from ootils_core.engine.orchestration.calc_run import CalcRunManager
+from ootils_core.engine.orchestration.propagator_sql import SqlPropagationEngine
+from ootils_core.models import Scenario
+
+from .conftest import requires_db
+
+# Import seam: mrp_core + the watchers + agent_subscribe/agent_governance live
+# under scripts/ (outside the package); the watchers do a bare "import
+# mrp_core", so scripts/ must be on sys.path — same seam as the fleet tests.
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import agent_shortage_watcher  # noqa: E402
+import agent_subscribe  # noqa: E402
+from agent_governance import governed_run  # noqa: E402
+
+pytestmark = requires_db
+
+# Seeded by migration 002 (is_baseline=TRUE) — the only baseline scenario, and
+# the only scenario the shortage watcher reads (case 6).
+BASELINE = UUID("00000000-0000-0000-0000-000000000001")
+LEGACY_TOKEN = "integration-test-token"
+
+
+# ===========================================================================
+# The /v1/stream keyset contract + typed-column readback helpers
+# ===========================================================================
+
+# The EXACT keyset SELECT GET /v1/stream is built on (migration 063 header:
+# "the replayable truth"). Every event assertion below goes through it so the
+# test proves the fleet-visible contract, not just that a row exists.
+_KEYSET_SQL = (
+    "SELECT stream_seq, event_id, event_type, scenario_id, new_quantity, "
+    "       field_changed, new_text, old_text, new_date, source "
+    "FROM events "
+    "WHERE scenario_id = %s AND stream_seq > %s "
+    "ORDER BY stream_seq"
+)
+
+
+def _keyset(conn, scenario_id, cursor: int = 0) -> list[dict]:
+    """Drain the events stream for a scenario past ``cursor`` via the exact
+    /v1/stream keyset SELECT. dict_row rows."""
+    return conn.execute(_KEYSET_SQL, (scenario_id, cursor)).fetchall()
+
+
+def _events_of_type(conn, scenario_id, event_type: str) -> list[dict]:
+    """Every event of ``event_type`` for a scenario, read THROUGH the keyset
+    SELECT (so a passing assertion also proves the stream surfaces it)."""
+    return [r for r in _keyset(conn, scenario_id, 0) if r["event_type"] == event_type]
+
+
+def _db_conn(dsn):
+    """Autocommit dict_row connection for out-of-band seed / readback — a
+    SEPARATE session from any request/engine transaction, so anything it can
+    read is provably COMMITTED."""
+    return psycopg.connect(dsn, row_factory=dict_row, autocommit=True)
+
+
+# ===========================================================================
+# Master-data + graph seed helpers (calqued on
+# test_param_overlay_propagation_integration.py / test_snapshot_integration.py)
+# ===========================================================================
+
+
+def _seed_fork(conn, name: str = "fe-fork") -> UUID:
+    """A fresh non-baseline scenario. Every capability runs on its own fork so
+    its event stream is isolated (a clean exactly-one-of-type assertion)."""
+    return conn.execute(
+        "INSERT INTO scenarios (scenario_id, name, is_baseline, status) "
+        "VALUES (%s, %s, FALSE, 'active') RETURNING scenario_id",
+        (uuid4(), f"{name}-{uuid4()}"),
+    ).fetchone()["scenario_id"]
+
+
+def _seed_item(conn, name: str = "fe-item") -> UUID:
+    return conn.execute(
+        "INSERT INTO items (item_id, name) VALUES (%s, %s) RETURNING item_id",
+        (uuid4(), f"{name}-{uuid4()}"),
+    ).fetchone()["item_id"]
+
+
+def _seed_location(conn, name: str = "fe-loc") -> UUID:
+    return conn.execute(
+        "INSERT INTO locations (location_id, name) VALUES (%s, %s) RETURNING location_id",
+        (uuid4(), f"{name}-{uuid4()}"),
+    ).fetchone()["location_id"]
+
+
+def _seed_planning_params(conn, item_id, location_id, *, safety_stock) -> None:
+    """One CURRENT (effective_to NULL) item_planning_params row — the base row
+    both propagation engines read for safety stock. safety_stock=0 gives a clean
+    (no-shortage) bucket-0 PI; safety_stock>0 makes the bucket a
+    below_safety_stock shortage of qty=safety_stock (the param-overlay
+    propagation test's proven signal)."""
+    conn.execute(
+        """
+        INSERT INTO item_planning_params (
+            item_id, location_id, effective_from, effective_to,
+            lead_time_sourcing_days, lead_time_manufacturing_days, lead_time_transit_days,
+            safety_stock_qty, min_order_qty, lot_size_rule
+        ) VALUES (
+            %s, %s, %s, NULL,
+            30, NULL, NULL,
+            %s, NULL, 'LOTFORLOT'
+        )
+        """,
+        (item_id, location_id, _dt.date.today(), safety_stock),
+    )
+
+
+def _seed_pi_bucket(conn, *, scenario_id, item_id, location_id) -> UUID:
+    """A bucket-0 ProjectedInventory node in its own projection_series, no
+    replenish/consume edges — it projects to closing_stock=0, which is a
+    below_safety_stock shortage for any safety_stock_qty > 0 and NO shortage for
+    safety_stock_qty = 0. Verbatim shape from the param-overlay propagation
+    test."""
+    series_id = conn.execute(
+        """
+        INSERT INTO projection_series
+            (series_id, item_id, location_id, scenario_id, horizon_start, horizon_end)
+        VALUES (%s, %s, %s, %s, %s, %s)
+        RETURNING series_id
+        """,
+        (uuid4(), item_id, location_id, scenario_id, _dt.date.today(), _dt.date.today()),
+    ).fetchone()["series_id"]
+    node_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO nodes (
+            node_id, node_type, scenario_id, item_id, location_id,
+            time_grain, time_span_start, time_span_end,
+            projection_series_id, bucket_sequence,
+            opening_stock, inflows, outflows, closing_stock,
+            has_shortage, shortage_qty, active
+        ) VALUES (
+            %s, 'ProjectedInventory', %s, %s, %s,
+            'day', %s, %s,
+            %s, 0,
+            0, 0, 0, 0,
+            FALSE, 0, TRUE
+        )
+        """,
+        (
+            node_id, scenario_id, item_id, location_id,
+            _dt.date.today(), _dt.date.today() + _dt.timedelta(days=7), series_id,
+        ),
+    )
+    return node_id
+
+
+def _seed_agent_run(conn, scenario_id, agent_name: str = "shortage_watcher") -> UUID:
+    return conn.execute(
+        "INSERT INTO agent_runs (agent_run_id, agent_name, scenario_id, status) "
+        "VALUES (%s, %s, %s, 'COMPLETED') RETURNING agent_run_id",
+        (uuid4(), agent_name, scenario_id),
+    ).fetchone()["agent_run_id"]
+
+
+def _seed_reco_row(conn, *, scenario_id, item_id, shortage_date, status: str = "APPROVED") -> UUID:
+    """One `recommendations` row via direct SQL (NO governed_run, so NO
+    recommendation_created event) — used only to give the outcome evaluator
+    something to classify. Column set cloned from test_outcome_integration."""
+    run_id = _seed_agent_run(conn, scenario_id)
+    return conn.execute(
+        """
+        INSERT INTO recommendations (
+            recommendation_id, agent_name, agent_run_id, scenario_id,
+            item_id, item_external_id, shortage_date,
+            deficit_qty, recommended_qty, estimated_cost, currency,
+            action, status, confidence, evidence
+        ) VALUES (
+            %s, 'shortage_watcher', %s, %s,
+            %s, %s, %s,
+            100, 120, 4800, 'EUR',
+            'EXPEDITE', %s, 'HIGH', %s
+        )
+        RETURNING recommendation_id
+        """,
+        (
+            uuid4(), run_id, scenario_id,
+            item_id, f"EXT-{uuid4().hex[:8]}", shortage_date,
+            status, json.dumps({"unit_cost": 3.0}),
+        ),
+    ).fetchone()["recommendation_id"]
+
+
+def _seed_snapshot_row(conn, *, scenario_id, item_id, location_id, as_of_date) -> None:
+    conn.execute(
+        """
+        INSERT INTO inventory_snapshots (snapshot_id, scenario_id, item_id,
+            location_id, as_of_date, on_hand_qty, source)
+        VALUES (%s, %s, %s, %s, %s, 10, 'cli')
+        """,
+        (uuid4(), scenario_id, item_id, location_id, as_of_date),
+    )
+
+
+# ===========================================================================
+# Calc-run engine driver — start -> mark dirty -> _propagate -> complete.
+# complete_calc_run IS the emission site (it calls _emit_run_events), so this
+# reaches the fleet emission through the REAL propagation path, exactly as
+# test_param_overlay_propagation_integration.py drives the engine — only with the
+# real complete_calc_run instead of a manual UPDATE.
+# ===========================================================================
+
+
+def _build_sql_engine(conn) -> SqlPropagationEngine:
+    store = GraphStore(conn)
+    return SqlPropagationEngine(
+        store=store,
+        traversal=GraphTraversal(store),
+        dirty=DirtyFlagManager(),
+        calc_run_mgr=CalcRunManager(),
+        kernel=ProjectionKernel(),
+        shortage_detector=ShortageDetector(),
+    )
+
+
+def _run_calc(conn, scenario_id, node_ids):
+    """Run ONE real calc run over the given dirty PI buckets and CLOSE it through
+    CalcRunManager.complete_calc_run — the fleet emission site. Returns the
+    CalcRun (with nodes_recalculated set by _propagate). Commits."""
+    engine = _build_sql_engine(conn)
+    calc_mgr = CalcRunManager()
+    calc_run = calc_mgr.start_calc_run(scenario_id=scenario_id, event_ids=[], db=conn)
+    assert calc_run is not None, "could not acquire advisory lock for the fork"
+
+    dirty = DirtyFlagManager()
+    nodes = set(node_ids)
+    dirty.mark_dirty(nodes, scenario_id, calc_run.calc_run_id, conn)
+    dirty.flush_to_postgres(calc_run.calc_run_id, scenario_id, conn)
+
+    engine._propagate(calc_run, nodes, conn)
+
+    scenario_obj = Scenario(
+        scenario_id=scenario_id, name="fe-calc", is_baseline=False,
+        baseline_snapshot_id=None,
+    )
+    calc_mgr.complete_calc_run(calc_run, scenario_obj, conn)
+    conn.commit()
+    return calc_run
+
+
+# ===========================================================================
+# HTTP surface — app fixtures (the #392 test_snapshot / test_outcome pattern)
+# ===========================================================================
+
+
+@pytest.fixture(scope="module")
+def api_client(migrated_db):
+    """TestClient with get_db overridden onto the test DB. Each request runs on a
+    fresh OotilsDB connection bound to the test DSN (get_db owns commit/rollback),
+    so an event emitted by a router lands on the request's OWN transaction —
+    exactly what case 5 asserts."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = LEGACY_TOKEN
+
+    from fastapi.testclient import TestClient
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_token_cache():
+    """Clear the minted-token cache around every test so a seed in one test never
+    leaks a cached auth decision into another."""
+    import ootils_core.api.auth as auth
+
+    auth._token_cache.clear()
+    yield
+    auth._token_cache.clear()
+
+
+def _mint_token(dsn, *, actor_kind: str, scopes: list[str]) -> str:
+    from ootils_core.api.auth import hash_token, token_prefix
+
+    clear = f"ootk_{actor_kind}_{uuid4().hex}"
+    token_id = uuid4()
+    with _db_conn(dsn) as c:
+        c.execute(
+            """
+            INSERT INTO api_tokens (
+                token_id, name, actor_kind, token_hash, token_prefix, scopes
+            ) VALUES (%s, %s, %s, %s, %s, %s)
+            """,
+            (
+                token_id,
+                f"fe-{actor_kind}-{token_id}",
+                actor_kind,
+                hash_token(clear),
+                token_prefix(clear),
+                scopes,
+            ),
+        )
+    return clear
+
+
+def _bearer(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ===========================================================================
+# Capability triggers — each drives ONE real emission site on its OWN fork and
+# returns (scenario_id, event_type, expected_run_level_new_quantity).
+# ===========================================================================
+
+
+def _cap_calc_run_finished(api_client, dsn):
+    """A calc run with 0 shortages (safety_stock=0) -> calc_run_finished ALONE,
+    new_quantity = run-level nodes_recalculated."""
+    with psycopg.connect(dsn, row_factory=dict_row) as conn:
+        fork = _seed_fork(conn, "fe-calc")
+        item = _seed_item(conn)
+        loc = _seed_location(conn)
+        _seed_planning_params(conn, item, loc, safety_stock=0)
+        node = _seed_pi_bucket(conn, scenario_id=fork, item_id=item, location_id=loc)
+        conn.commit()
+        run = _run_calc(conn, fork, [node])
+    return fork, "calc_run_finished", run.nodes_recalculated
+
+
+def _cap_shortage_detected(api_client, dsn):
+    """A calc run that persists ONE shortage (safety_stock>0) -> shortage_detected
+    with new_quantity = 1 (one shortage persisted this run)."""
+    with psycopg.connect(dsn, row_factory=dict_row) as conn:
+        fork = _seed_fork(conn, "fe-short")
+        item = _seed_item(conn)
+        loc = _seed_location(conn)
+        _seed_planning_params(conn, item, loc, safety_stock=10)
+        node = _seed_pi_bucket(conn, scenario_id=fork, item_id=item, location_id=loc)
+        conn.commit()
+        _run_calc(conn, fork, [node])
+    return fork, "shortage_detected", 1
+
+
+def _cap_recommendation_created(api_client, dsn):
+    """governed_run inserts ONE recommendation; _close(COMPLETED) emits ONE
+    recommendation_created, new_quantity = 1 (the run's reco count)."""
+    with psycopg.connect(dsn, row_factory=dict_row) as conn:
+        fork = _seed_fork(conn, "fe-reco")
+        item = _seed_item(conn)
+        conn.commit()
+        today = conn.execute("SELECT CURRENT_DATE AS d").fetchone()["d"]
+        with governed_run(conn, "shortage_watcher", str(fork)) as run:
+            run.insert(
+                "recommendations",
+                ["agent_name", "agent_run_id", "scenario_id", "item_id",
+                 "item_external_id", "shortage_date", "deficit_qty",
+                 "recommended_qty", "action"],
+                [("shortage_watcher", run.run_id, str(fork), item,
+                  f"EXT-{uuid4().hex[:6]}", today, 10, 12, "ORDER_NOW")],
+            )
+            run.set_metrics({"recommendations": 1})
+        # governed_run committed on exit; _close emitted recommendation_created.
+    return fork, "recommendation_created", 1
+
+
+def _cap_snapshot_captured(api_client, dsn):
+    """POST /v1/snapshots on a fork with one on-hand coordinate -> ONE
+    snapshot_captured, new_quantity = rows persisted."""
+    with _db_conn(dsn) as c:
+        fork = _seed_fork(c, "fe-snap")
+        item = _seed_item(c)
+        loc = _seed_location(c)
+        c.execute(
+            """
+            INSERT INTO nodes (node_id, node_type, scenario_id, item_id, location_id,
+                quantity, time_grain, time_ref, active)
+            VALUES (%s, 'OnHandSupply', %s, %s, %s, 25, 'exact_date', CURRENT_DATE, TRUE)
+            """,
+            (uuid4(), fork, item, loc),
+        )
+    clear = _mint_token(dsn, actor_kind="service", scopes=["ingest"])
+    resp = api_client.post(
+        "/v1/snapshots", params={"scenario_id": str(fork)}, json={}, headers=_bearer(clear)
+    )
+    assert resp.status_code == 201, resp.text
+    written = resp.json()["snapshots_captured"]
+    assert written >= 1
+    return fork, "snapshot_captured", written
+
+
+def _cap_outcome_evaluated(api_client, dsn):
+    """POST /v1/outcomes/evaluate on a fork with one classifiable reco -> ONE
+    outcome_evaluated, new_quantity = recos classified."""
+    with _db_conn(dsn) as c:
+        fork = _seed_fork(c, "fe-outcome")
+        item = _seed_item(c)
+        loc = _seed_location(c)
+        today = c.execute("SELECT CURRENT_DATE AS d").fetchone()["d"]
+        _seed_reco_row(
+            c, scenario_id=fork, item_id=item,
+            shortage_date=today + _dt.timedelta(days=20), status="APPROVED",
+        )
+        # Snapshot present + NO shortage -> AVOIDED -> classified (evaluated>=1).
+        _seed_snapshot_row(c, scenario_id=fork, item_id=item, location_id=loc, as_of_date=today)
+    clear = _mint_token(dsn, actor_kind="service", scopes=["ingest"])
+    resp = api_client.post(
+        "/v1/outcomes/evaluate", params={"scenario_id": str(fork)}, json={}, headers=_bearer(clear)
+    )
+    assert resp.status_code == 201, resp.text
+    evaluated = resp.json()["evaluated"]
+    assert evaluated >= 1
+    return fork, "outcome_evaluated", evaluated
+
+
+_CAPABILITIES = [
+    ("calc_run_finished", _cap_calc_run_finished),
+    ("shortage_detected", _cap_shortage_detected),
+    ("recommendation_created", _cap_recommendation_created),
+    ("snapshot_captured", _cap_snapshot_captured),
+    ("outcome_evaluated", _cap_outcome_evaluated),
+]
+
+
+# ===========================================================================
+# Case 1 — THE GUARD-RAIL. Every fleet capability emits EXACTLY one run-level
+# event, surfaced by the /v1/stream keyset SELECT.
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "event_type,trigger", _CAPABILITIES, ids=[c[0] for c in _CAPABILITIES]
+)
+def test_every_governed_write_emits_exactly_one_run_level_stream_event(
+    event_type, trigger, api_client, migrated_db
+):
+    scenario_id, emitted_type, expected_nq = trigger(api_client, migrated_db)
+    assert emitted_type == event_type
+
+    with _db_conn(migrated_db) as c:
+        rows = _events_of_type(c, scenario_id, event_type)
+        assert len(rows) == 1, (
+            f"{event_type}: a governed write must emit EXACTLY one stream event, "
+            f"got {len(rows)}"
+        )
+        ev = rows[0]
+
+        # RUN granularity: one event per run, the count in new_quantity (never
+        # one event per item — ADR-027).
+        assert ev["new_quantity"] is not None, f"{event_type}: run-level count is NULL"
+        assert int(ev["new_quantity"]) == int(expected_nq), (
+            f"{event_type}: new_quantity {ev['new_quantity']} != run-level {expected_nq}"
+        )
+
+        # The /v1/stream keyset SELECT surfaces exactly this event, and returns
+        # its rows strictly ordered by stream_seq (the cursor contract).
+        keyset = _keyset(c, scenario_id, 0)
+        assert any(
+            k["event_id"] == ev["event_id"] and k["event_type"] == event_type
+            for k in keyset
+        ), f"{event_type}: keyset SELECT (stream_seq>cursor) did not surface the event"
+        seqs = [int(k["stream_seq"]) for k in keyset]
+        assert seqs == sorted(seqs), "keyset must return rows ordered by stream_seq"
+        assert all(s > 0 for s in seqs), "migration-063 trigger must assign a stream_seq"
+
+
+# ===========================================================================
+# Case 2 — RUN granularity: 0 shortages -> calc_run_finished alone; N shortages
+# -> one shortage_detected with new_quantity=N.
+# ===========================================================================
+
+
+def test_calc_run_zero_shortage_emits_only_calc_run_finished(migrated_db):
+    """A clean calc run (safety_stock=0, closing_stock=0 -> no shortage) emits
+    calc_run_finished ALONE — no shortage_detected."""
+    with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        fork = _seed_fork(conn, "fe-zero")
+        item = _seed_item(conn)
+        loc = _seed_location(conn)
+        _seed_planning_params(conn, item, loc, safety_stock=0)
+        node = _seed_pi_bucket(conn, scenario_id=fork, item_id=item, location_id=loc)
+        conn.commit()
+        run = _run_calc(conn, fork, [node])
+
+    with _db_conn(migrated_db) as c:
+        finished = _events_of_type(c, fork, "calc_run_finished")
+        shortages = _events_of_type(c, fork, "shortage_detected")
+
+    assert len(finished) == 1, "exactly one calc_run_finished per terminal run"
+    assert finished[0]["field_changed"] == "completed"
+    assert int(finished[0]["new_quantity"]) == run.nodes_recalculated
+    assert shortages == [], "a run persisting 0 shortages must emit NO shortage_detected"
+
+
+def test_calc_run_with_n_shortages_emits_one_shortage_detected_new_quantity_n(migrated_db):
+    """ONE calc run persisting N shortages (N distinct items below safety stock)
+    emits ONE run-level shortage_detected with new_quantity=N — proof the event
+    is per-RUN, not per-shortage."""
+    n = 2
+    with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        fork = _seed_fork(conn, "fe-nshort")
+        loc = _seed_location(conn)
+        nodes = []
+        for _ in range(n):
+            item = _seed_item(conn)
+            _seed_planning_params(conn, item, loc, safety_stock=10)
+            nodes.append(_seed_pi_bucket(conn, scenario_id=fork, item_id=item, location_id=loc))
+        conn.commit()
+        run = _run_calc(conn, fork, nodes)
+
+    with _db_conn(migrated_db) as c:
+        shortages = _events_of_type(c, fork, "shortage_detected")
+        finished = _events_of_type(c, fork, "calc_run_finished")
+        persisted = c.execute(
+            "SELECT COUNT(*) AS n FROM shortages WHERE calc_run_id = %s",
+            (run.calc_run_id,),
+        ).fetchone()["n"]
+
+    assert persisted == n, "seed precondition: the run persisted N shortages"
+    assert len(shortages) == 1, "N shortages -> ONE run-level event, never N events"
+    assert int(shortages[0]["new_quantity"]) == n
+    assert len(finished) == 1
+    assert int(finished[0]["new_quantity"]) == run.nodes_recalculated == n
+
+
+# ===========================================================================
+# Case 3 — Atomicity: an emission on a rolled-back transaction leaves NO event.
+# ===========================================================================
+
+
+def test_rolled_back_transaction_leaves_no_event(migrated_db):
+    """emit_stream_event inserts on the CALLER's connection and never commits, so
+    a rollback discards it entirely — the fleet never sees a phantom row for a
+    change that did not happen. A burned stream_seq is tolerated (the keyset only
+    ever compares with `>`)."""
+    with _db_conn(migrated_db) as setup:
+        fork = _seed_fork(setup, "fe-atomic")
+
+    with psycopg.connect(migrated_db, row_factory=dict_row) as conn:  # autocommit=False
+        emit_stream_event(
+            conn, "calc_run_finished", fork,
+            field_changed="completed", new_text=str(uuid4()), new_quantity=7,
+        )
+        conn.rollback()  # cancel the transaction the event rode on
+
+    with _db_conn(migrated_db) as c:
+        rows = _events_of_type(c, fork, "calc_run_finished")
+    assert rows == [], "a rolled-back emission must leave NO event row"
+
+
+# ===========================================================================
+# Case 4 — Idempotence of recommendation_created: the count is read back by the
+# CURRENT run's agent_run_id, so an idempotent re-run inserting 0 new rows emits
+# nothing (the transfer/reschedule ON CONFLICT DO NOTHING mechanic).
+# ===========================================================================
+
+
+def test_recommendation_created_idempotent_rerun_emits_nothing(migrated_db):
+    with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        fork = _seed_fork(conn, "fe-idem")
+        item = _seed_item(conn)
+        conn.commit()
+        today = conn.execute("SELECT CURRENT_DATE AS d").fetchone()["d"]
+
+        # Run 1: inserts N=1 recommendation -> one recommendation_created, nq=1.
+        with governed_run(conn, "shortage_watcher", str(fork)) as run1:
+            run1.insert(
+                "recommendations",
+                ["agent_name", "agent_run_id", "scenario_id", "item_id",
+                 "item_external_id", "shortage_date", "deficit_qty",
+                 "recommended_qty", "action"],
+                [("shortage_watcher", run1.run_id, str(fork), item,
+                  f"EXT-{uuid4().hex[:6]}", today, 10, 12, "ORDER_NOW")],
+            )
+            run1.set_metrics({"recommendations": 1})
+
+    with _db_conn(migrated_db) as c:
+        first = _events_of_type(c, fork, "recommendation_created")
+    assert len(first) == 1, "first run of 1 reco emits exactly one event"
+    assert int(first[0]["new_quantity"]) == 1
+
+    # Run 2: an idempotent re-run that inserts ZERO new recommendations — the
+    # COUNT by run2's agent_run_id is 0, so nothing is announced.
+    with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        with governed_run(conn, "shortage_watcher", str(fork)) as run2:
+            run2.set_metrics({"recommendations": 0})
+
+    with _db_conn(migrated_db) as c:
+        after = _events_of_type(c, fork, "recommendation_created")
+    assert len(after) == 1, "an idempotent no-op re-run (0 new recos) emits NO new event"
+    assert after[0]["event_id"] == first[0]["event_id"], "still only the first run's event"
+
+
+# ===========================================================================
+# Case 5 — API request-transaction: the routers emit on the request's own get_db
+# transaction (visible from a SEPARATE connection => committed) with source='api'.
+# The DRP route shares the identical, already-proven emit_recommendation_created_
+# for_run helper (see module docstring) — covered at the helper level.
+# ===========================================================================
+
+
+def test_snapshots_endpoint_emits_on_request_transaction_source_api(api_client, migrated_db):
+    with _db_conn(migrated_db) as c:
+        fork = _seed_fork(c, "fe-snap-api")
+        item = _seed_item(c)
+        loc = _seed_location(c)
+        c.execute(
+            """
+            INSERT INTO nodes (node_id, node_type, scenario_id, item_id, location_id,
+                quantity, time_grain, time_ref, active)
+            VALUES (%s, 'OnHandSupply', %s, %s, %s, 40, 'exact_date', CURRENT_DATE, TRUE)
+            """,
+            (uuid4(), fork, item, loc),
+        )
+    clear = _mint_token(migrated_db, actor_kind="service", scopes=["ingest"])
+    resp = api_client.post(
+        "/v1/snapshots", params={"scenario_id": str(fork)}, json={}, headers=_bearer(clear)
+    )
+    assert resp.status_code == 201, resp.text
+
+    # A SEPARATE connection sees the event => it committed on the request's txn.
+    with _db_conn(migrated_db) as c:
+        rows = _events_of_type(c, fork, "snapshot_captured")
+    assert len(rows) == 1
+    assert rows[0]["source"] == "api", "the router stamps source='api'"
+    assert rows[0]["new_date"] is not None, "snapshot_captured carries as_of_date"
+    assert int(rows[0]["new_quantity"]) == resp.json()["snapshots_captured"]
+
+
+def test_outcomes_endpoint_emits_on_request_transaction_source_api(api_client, migrated_db):
+    with _db_conn(migrated_db) as c:
+        fork = _seed_fork(c, "fe-outcome-api")
+        item = _seed_item(c)
+        loc = _seed_location(c)
+        today = c.execute("SELECT CURRENT_DATE AS d").fetchone()["d"]
+        _seed_reco_row(
+            c, scenario_id=fork, item_id=item,
+            shortage_date=today + _dt.timedelta(days=20), status="APPROVED",
+        )
+        _seed_snapshot_row(c, scenario_id=fork, item_id=item, location_id=loc, as_of_date=today)
+    clear = _mint_token(migrated_db, actor_kind="service", scopes=["ingest"])
+    resp = api_client.post(
+        "/v1/outcomes/evaluate", params={"scenario_id": str(fork)}, json={}, headers=_bearer(clear)
+    )
+    assert resp.status_code == 201, resp.text
+
+    with _db_conn(migrated_db) as c:
+        rows = _events_of_type(c, fork, "outcome_evaluated")
+    assert len(rows) == 1
+    assert rows[0]["source"] == "api"
+    assert int(rows[0]["new_quantity"]) == resp.json()["evaluated"]
+
+
+# ===========================================================================
+# Case 6 — --subscribe end to end (the shortage watcher's event-driven gate).
+# ===========================================================================
+
+
+@pytest.fixture(scope="module")
+def seeded_baseline(migrated_db):
+    """Minimal FG-SHORT baseline so the shortage watcher runs and completes
+    deterministically (a proven-complete shape from test_agent_fleet_smoke:
+    bought FG, thin on-hand, near-term customer order -> a shortage -> a DRAFT).
+    All dates anchored on the DB CURRENT_DATE. BASELINE is used ONLY here (the
+    watcher is baseline-only); every other case runs on its own fork."""
+    dsn = migrated_db
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        cur = conn.cursor()
+        today = cur.execute("SELECT CURRENT_DATE").fetchone()[0]
+
+        loc_id = cur.execute(
+            "INSERT INTO locations (name, location_type, external_id) "
+            "VALUES (%s, %s, %s) RETURNING location_id",
+            ("Sub Plant", "plant", "LOC-SUB"),
+        ).fetchone()[0]
+        sup_id = cur.execute(
+            "INSERT INTO suppliers (external_id, name, reliability_score, status) "
+            "VALUES (%s, %s, %s, %s) RETURNING supplier_id",
+            ("SUP-SUB", "Sub Supplier", 0.95, "active"),
+        ).fetchone()[0]
+        item_id = cur.execute(
+            "INSERT INTO items (external_id, name, item_type, standard_cost, cost_currency) "
+            "VALUES (%s, %s, %s, %s, %s) RETURNING item_id",
+            ("FG-SUB", "FG Sub", "finished_good", 100.0, "EUR"),
+        ).fetchone()[0]
+        cur.execute(
+            "INSERT INTO item_planning_params "
+            "(item_id, location_id, is_make, lead_time_sourcing_days, "
+            " lead_time_manufacturing_days, lead_time_transit_days, safety_stock_qty, "
+            " lot_size_rule, frozen_time_fence_days, slashed_time_fence_days, "
+            " forecast_consumption_strategy) "
+            "VALUES (%s,%s,FALSE,14,0,0,0,'LOTFORLOT',0,1,'max_only')",
+            (item_id, loc_id),
+        )
+        cur.execute(
+            "INSERT INTO supplier_items "
+            "(supplier_id, item_id, lead_time_days, unit_cost, currency, is_preferred) "
+            "VALUES (%s,%s,14,100.0,'EUR',TRUE)",
+            (sup_id, item_id),
+        )
+        cur.execute(
+            "INSERT INTO nodes (node_type, scenario_id, item_id, location_id, quantity, "
+            " time_grain, time_ref, active) "
+            "VALUES ('OnHandSupply', %s, %s, %s, 5, 'exact_date', %s, TRUE)",
+            (str(BASELINE), item_id, loc_id, today),
+        )
+        cur.execute(
+            "INSERT INTO nodes (node_type, scenario_id, item_id, location_id, quantity, "
+            " time_grain, time_ref, active) "
+            "VALUES ('CustomerOrderDemand', %s, %s, %s, 50, 'exact_date', %s, TRUE)",
+            (str(BASELINE), item_id, loc_id, today + _dt.timedelta(days=21)),
+        )
+    yield dsn
+    # Teardown owned by migrated_db (drops all public tables).
+
+
+def _baseline_completed_runs(dsn) -> int:
+    with psycopg.connect(dsn, row_factory=dict_row) as conn:
+        return conn.execute(
+            "SELECT COUNT(*) AS n FROM agent_runs "
+            "WHERE agent_name='shortage_watcher' AND scenario_id=%s AND status='COMPLETED'",
+            (str(BASELINE),),
+        ).fetchone()["n"]
+
+
+def _baseline_last_run_metrics(dsn) -> dict:
+    with psycopg.connect(dsn, row_factory=dict_row) as conn:
+        row = conn.execute(
+            "SELECT metrics FROM agent_runs "
+            "WHERE agent_name='shortage_watcher' AND scenario_id=%s AND status='COMPLETED' "
+            "ORDER BY finished_at DESC NULLS LAST, started_at DESC LIMIT 1",
+            (str(BASELINE),),
+        ).fetchone()
+    return (row["metrics"] if row else None) or {}
+
+
+@pytest.mark.smoke
+def test_subscribe_gate_first_runs_then_skips_then_runs_advancing_cursor(seeded_baseline):
+    dsn = seeded_baseline
+    before = _baseline_completed_runs(dsn)
+
+    # RUN 1 — first subscribed run: no prior cursor -> seeds "from now" -> RUNS.
+    assert agent_shortage_watcher.main(["--dsn", dsn, "--subscribe", "--allow-dev"]) == 0
+    assert _baseline_completed_runs(dsn) == before + 1, "first subscribed run must execute"
+    cursor_1 = _baseline_last_run_metrics(dsn).get(agent_subscribe.STREAM_CURSOR_KEY)
+    assert cursor_1 is not None, "a subscribed run persists its stream_cursor"
+
+    # RUN 2 — a tick with no RELEVANT event since (the watcher's own
+    # recommendation_created is drained but not relevant) -> SKIP, no new run.
+    assert agent_shortage_watcher.main(["--dsn", dsn, "--subscribe", "--allow-dev"]) == 0
+    assert _baseline_completed_runs(dsn) == before + 1, (
+        "no relevant event -> skip, leaving NO agent_runs row"
+    )
+
+    # Inject a RELEVANT event (calc_run_finished) into BASELINE's stream.
+    with psycopg.connect(dsn, row_factory=dict_row) as inj:
+        emit_stream_event(
+            inj, "calc_run_finished", str(BASELINE),
+            field_changed="completed", new_text=str(uuid4()), new_quantity=1,
+        )
+        inj.commit()
+
+    # RUN 3 — a relevant event since the cursor -> RUNS and advances the cursor.
+    assert agent_shortage_watcher.main(["--dsn", dsn, "--subscribe", "--allow-dev"]) == 0
+    assert _baseline_completed_runs(dsn) == before + 2, "a relevant event must trigger a run"
+    cursor_3 = _baseline_last_run_metrics(dsn).get(agent_subscribe.STREAM_CURSOR_KEY)
+    assert cursor_3 is not None
+    assert int(cursor_3) > int(cursor_1), "the persisted cursor advanced past the relevant event"
+
+
+@pytest.mark.smoke
+def test_subscribe_flag_off_is_byte_identical_no_cursor(seeded_baseline):
+    """Without --subscribe the watcher's metrics carry NO stream_cursor key —
+    byte-identical to the legacy full-scan behaviour."""
+    dsn = seeded_baseline
+    assert agent_shortage_watcher.main(["--dsn", dsn, "--allow-dev"]) == 0
+    metrics = _baseline_last_run_metrics(dsn)
+    assert metrics, "a plain run still writes a metrics block"
+    assert agent_subscribe.STREAM_CURSOR_KEY not in metrics, (
+        "a non-subscribe run must not persist a stream_cursor (legacy shape)"
+    )
+
+
+# ===========================================================================
+# Case 7 — Migration-071 CHECK: emit_stream_event succeeds for every fleet type,
+# catching drift between the emitter set, the router set and the SQL CHECK.
+# ===========================================================================
+
+
+@pytest.mark.parametrize("event_type", sorted(FLEET_EVENT_TYPES))
+def test_migration_071_check_accepts_every_fleet_type(event_type, migrated_db):
+    """Each of the five FLEET_EVENT_TYPES must INSERT cleanly against the real
+    events.event_type CHECK (migration 071). A CHECK that lags the emitter would
+    surface here as a psycopg CheckViolation, not a silent miss."""
+    with _db_conn(migrated_db) as c:
+        fork = _seed_fork(c, "fe-071")
+        eid = emit_stream_event(
+            c, event_type, fork,
+            field_changed=event_type, new_text=str(uuid4()),
+            new_quantity=1, new_date=_dt.date.today(),
+        )
+        row = c.execute(
+            "SELECT event_type, stream_seq FROM events WHERE event_id = %s", (eid,)
+        ).fetchone()
+    assert row is not None, f"{event_type}: emit_stream_event persisted no row"
+    assert row["event_type"] == event_type
+    assert row["stream_seq"] is not None, "migration-063 trigger must assign a stream_seq"
+
+
+def test_fleet_event_types_do_not_drift_from_router_valid_set():
+    """Static cross-check: every type the emitter writes is in the events
+    router's VALID_EVENT_TYPES (which the /v1/events + /v1/stream surface use).
+    Paired with the per-type CHECK test above, this pins the three lists
+    (FLEET_EVENT_TYPES <-> VALID_EVENT_TYPES <-> migration-071 CHECK) together."""
+    from ootils_core.api.routers.events import VALID_EVENT_TYPES
+
+    assert FLEET_EVENT_TYPES <= VALID_EVENT_TYPES, (
+        "an emitter type is missing from the router's VALID_EVENT_TYPES"
+    )
+    assert FLEET_EVENT_TYPES == {
+        "recommendation_created", "shortage_detected", "calc_run_finished",
+        "snapshot_captured", "outcome_evaluated",
+    }

--- a/tests/integration/test_outcome_integration.py
+++ b/tests/integration/test_outcome_integration.py
@@ -673,6 +673,11 @@ def new_scenario(migrated_db):
             (sid,),
         )
         c.execute("DELETE FROM calc_runs WHERE scenario_id = %s", (sid,))
+        # AN-1 (#401): POST /v1/outcomes/evaluate now emits an outcome_evaluated
+        # stream event scoped to this scenario (TestEvaluatePost) — purge it
+        # before the scenario delete or events_scenario_id_fkey (ON DELETE
+        # RESTRICT, migration 032) blocks the teardown.
+        c.execute("DELETE FROM events WHERE scenario_id = %s", (sid,))
         c.execute("DELETE FROM scenarios WHERE scenario_id = %s", (sid,))
 
 
@@ -1075,6 +1080,11 @@ class TestOutcomesSummary:
             assert body["avg_fva_wape"] is None
         finally:
             with _db_conn(migrated_db) as c:
+                # `other` only ever receives a GET here (no emission), but this
+                # file's flow does emit (#401) — purge defensively so a future
+                # write against `other` never re-breaks the teardown on
+                # events_scenario_id_fkey.
+                c.execute("DELETE FROM events WHERE scenario_id = %s", (other,))
                 c.execute("DELETE FROM scenarios WHERE scenario_id = %s", (other,))
 
 

--- a/tests/test_agent_subscribe.py
+++ b/tests/test_agent_subscribe.py
@@ -1,0 +1,134 @@
+"""
+test_agent_subscribe.py — pure unit tests for the --subscribe drain helpers
+(chantier AN-1, #401; scripts/agent_subscribe.py).
+
+No DB: a fake connection returns canned rows so we assert the cursor PARSING
+(fetch_stream_cursor over agent_runs.metrics) and the keyset DRAIN counting
+(drain_stream over events) in isolation. The end-to-end skip/run gate against a
+live Postgres is left to the integration suite.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Import seam: agent_subscribe lives under scripts/ (outside the package).
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import agent_subscribe  # noqa: E402
+
+
+class _CannedConn:
+    """Fake connection: each execute() returns the next queued result set.
+
+    A result set is a list of rows; fetchone() yields its first row, fetchall()
+    the whole list. dict rows and tuple rows are both supported so the tests can
+    exercise the row-factory-agnostic accessors.
+    """
+
+    def __init__(self, results: list[list]) -> None:
+        self._results = list(results)
+
+    def execute(self, sql: str, params: tuple):  # noqa: ANN201 - test double
+        rows = self._results.pop(0) if self._results else []
+
+        class _Cur:
+            def __init__(self, rs):
+                self._rs = rs
+
+            def fetchone(self):
+                return self._rs[0] if self._rs else None
+
+            def fetchall(self):
+                return self._rs
+
+        return _Cur(rows)
+
+
+# ---------------------------------------------------------------------------
+# fetch_stream_cursor — parse agent_runs.metrics
+# ---------------------------------------------------------------------------
+
+
+def test_cursor_parsed_from_metrics_dict() -> None:
+    conn = _CannedConn([[{"metrics": {"stream_cursor": 128, "recommendations": 3}}]])
+    assert agent_subscribe.fetch_stream_cursor(conn, "shortage_watcher", "baseline") == 128
+
+
+def test_cursor_none_when_no_prior_run() -> None:
+    conn = _CannedConn([[]])  # no completed run
+    assert agent_subscribe.fetch_stream_cursor(conn, "shortage_watcher", "baseline") is None
+
+
+def test_cursor_none_when_metrics_absent_key() -> None:
+    # A pre-subscribe run stored metrics without a stream_cursor key.
+    conn = _CannedConn([[{"metrics": {"recommendations": 5}}]])
+    assert agent_subscribe.fetch_stream_cursor(conn, "material_watcher", "baseline") is None
+
+
+def test_cursor_none_when_metrics_null() -> None:
+    conn = _CannedConn([[{"metrics": None}]])
+    assert agent_subscribe.fetch_stream_cursor(conn, "material_watcher", "baseline") is None
+
+
+def test_cursor_tolerates_string_integer() -> None:
+    # JSONB may surface the number as a string depending on how it was stored.
+    conn = _CannedConn([[{"metrics": {"stream_cursor": "77"}}]])
+    assert agent_subscribe.fetch_stream_cursor(conn, "shortage_watcher", "baseline") == 77
+
+
+def test_cursor_none_on_malformed_value() -> None:
+    conn = _CannedConn([[{"metrics": {"stream_cursor": "not-a-number"}}]])
+    assert agent_subscribe.fetch_stream_cursor(conn, "shortage_watcher", "baseline") is None
+
+
+def test_cursor_parsed_from_tuple_row() -> None:
+    # tuple_row: metrics is the single selected column.
+    conn = _CannedConn([[({"stream_cursor": 9},)]])
+    assert agent_subscribe.fetch_stream_cursor(conn, "shortage_watcher", "baseline") == 9
+
+
+# ---------------------------------------------------------------------------
+# drain_stream — keyset advance + relevance counting
+# ---------------------------------------------------------------------------
+
+
+def test_drain_counts_only_relevant_types_and_advances_cursor() -> None:
+    rows = [
+        {"stream_seq": 11, "event_type": "calc_run_finished"},
+        {"stream_seq": 12, "event_type": "recommendation_created"},  # not relevant
+        {"stream_seq": 13, "event_type": "shortage_detected"},
+        {"stream_seq": 14, "event_type": "snapshot_captured"},  # not relevant
+    ]
+    conn = _CannedConn([rows])
+    new_cursor, relevant = agent_subscribe.drain_stream(conn, "baseline", 10)
+    assert new_cursor == 14  # advanced over EVERY drained row
+    assert relevant == 2  # calc_run_finished + shortage_detected only
+
+
+def test_drain_empty_keeps_cursor_and_zero_relevant() -> None:
+    conn = _CannedConn([[]])
+    new_cursor, relevant = agent_subscribe.drain_stream(conn, "baseline", 42)
+    assert new_cursor == 42
+    assert relevant == 0
+
+
+def test_drain_tuple_rows() -> None:
+    # tuple_row: (stream_seq, event_type)
+    rows = [(5, "calc_run_finished"), (6, "outcome_evaluated")]
+    conn = _CannedConn([rows])
+    new_cursor, relevant = agent_subscribe.drain_stream(conn, "baseline", 0)
+    assert new_cursor == 6
+    assert relevant == 1
+
+
+def test_current_max_seq_reads_scalar() -> None:
+    conn = _CannedConn([[{"seq": 99}]])
+    assert agent_subscribe.current_max_seq(conn, "baseline") == 99
+
+
+def test_current_max_seq_zero_on_empty_stream() -> None:
+    conn = _CannedConn([[{"seq": 0}]])
+    assert agent_subscribe.current_max_seq(conn, "baseline") == 0

--- a/tests/test_calc_run.py
+++ b/tests/test_calc_run.py
@@ -177,6 +177,16 @@ class TestStartCalcRun:
 class TestCompleteCalcRun:
     def test_completed_no_baseline(self):
         db = _mock_db()
+        # Sequence: UPDATE calc_runs, UPDATE events, SELECT COUNT shortages (0),
+        # INSERT calc_run_finished, advisory_unlock. Zero shortages -> NO
+        # shortage_detected emission (#401 AN-1).
+        _setup_execute_sequence(db, [
+            None,          # UPDATE calc_runs
+            None,          # UPDATE events
+            {"n": 0},      # SELECT COUNT(*) FROM shortages
+            None,          # INSERT calc_run_finished
+            None,          # advisory_unlock
+        ])
         run = CalcRun(
             calc_run_id=uuid4(),
             scenario_id=uuid4(),
@@ -196,8 +206,9 @@ class TestCompleteCalcRun:
 
         assert run.status == "completed"
         assert run.completed_at is not None
-        # 3 DB calls: UPDATE calc_runs, UPDATE events, advisory_unlock
-        assert db.execute.call_count == 3
+        # 5 DB calls: UPDATE calc_runs, UPDATE events, SELECT COUNT shortages,
+        # INSERT calc_run_finished, advisory_unlock (no shortage_detected: 0 rows).
+        assert db.execute.call_count == 5
 
     def test_completed_stale_with_baseline(self):
         db = _mock_db()
@@ -220,6 +231,15 @@ class TestCompleteCalcRun:
 
     def test_no_event_ids_skips_event_update(self):
         db = _mock_db()
+        # No triggered events -> the UPDATE events is skipped. Sequence: UPDATE
+        # calc_runs, SELECT COUNT shortages (0), INSERT calc_run_finished,
+        # advisory_unlock.
+        _setup_execute_sequence(db, [
+            None,          # UPDATE calc_runs
+            {"n": 0},      # SELECT COUNT(*) FROM shortages
+            None,          # INSERT calc_run_finished
+            None,          # advisory_unlock
+        ])
         run = CalcRun(
             calc_run_id=uuid4(),
             scenario_id=uuid4(),
@@ -231,8 +251,10 @@ class TestCompleteCalcRun:
         mgr = CalcRunManager()
         mgr.complete_calc_run(run, scenario, db)
 
-        # Only 2 calls: UPDATE calc_runs + advisory_unlock (no event update)
-        assert db.execute.call_count == 2
+        # 4 calls: UPDATE calc_runs, SELECT COUNT shortages, INSERT
+        # calc_run_finished, advisory_unlock (no event UPDATE, no
+        # shortage_detected: 0 rows). #401 AN-1.
+        assert db.execute.call_count == 4
 
 
 # ===========================================================================

--- a/tests/test_emit_stream_event.py
+++ b/tests/test_emit_stream_event.py
@@ -1,0 +1,237 @@
+"""
+test_emit_stream_event.py — pure unit tests for the fleet-emission helper
+(chantier AN-1, #401; src/ootils_core/engine/events/emit.py).
+
+No DB: a recording fake connection captures the SQL + params emit_stream_event
+would execute, so we assert the typed-column MAPPING and the fail-loudly
+VALIDATION without a live Postgres. The event_type CHECK / stream_seq behaviour
+against a real DB is left to the integration suite (see the module docstring
+handoff at the bottom of the AN-1 change set).
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+
+from ootils_core.engine.events.emit import (
+    FLEET_EVENT_TYPES,
+    emit_recommendation_created_for_run,
+    emit_stream_event,
+)
+
+
+class _RecordingConn:
+    """Minimal psycopg-connection stand-in.
+
+    Records every (sql, params) passed to execute; returns a cursor-like object
+    whose fetchone() yields the next queued row. Enough to exercise the pure
+    logic of emit_stream_event / emit_recommendation_created_for_run without a DB.
+    """
+
+    def __init__(self, fetch_results: list | None = None) -> None:
+        self.calls: list[tuple[str, tuple]] = []
+        self._fetch_results = list(fetch_results or [])
+
+    def execute(self, sql: str, params: tuple):  # noqa: ANN201 - test double
+        self.calls.append((sql, params))
+        row = self._fetch_results.pop(0) if self._fetch_results else None
+
+        class _Cur:
+            def __init__(self, r):
+                self._r = r
+
+            def fetchone(self):
+                return self._r
+
+        return _Cur(row)
+
+
+def _params_of(conn: _RecordingConn, index: int = -1) -> tuple:
+    return conn.calls[index][1]
+
+
+# ---------------------------------------------------------------------------
+# Validation — fail loudly
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_event_type_raises_before_any_execute() -> None:
+    conn = _RecordingConn()
+    with pytest.raises(ValueError, match="unknown fleet event_type"):
+        emit_stream_event(conn, "not_a_type", uuid4())
+    assert conn.calls == []  # no INSERT attempted
+
+
+def test_invalid_source_raises_before_any_execute() -> None:
+    conn = _RecordingConn()
+    with pytest.raises(ValueError, match="invalid source"):
+        emit_stream_event(conn, "calc_run_finished", uuid4(), source="bogus")
+    assert conn.calls == []
+
+
+@pytest.mark.parametrize("event_type", sorted(FLEET_EVENT_TYPES))
+def test_every_fleet_type_is_accepted(event_type: str) -> None:
+    conn = _RecordingConn()
+    eid = emit_stream_event(conn, event_type, uuid4())
+    assert isinstance(eid, UUID)
+    assert len(conn.calls) == 1
+    assert conn.calls[0][1][1] == event_type  # event_type is 2nd bound param
+
+
+# ---------------------------------------------------------------------------
+# Param mapping — the typed-column contract (migration 071 header)
+# ---------------------------------------------------------------------------
+
+
+def test_calc_run_finished_column_mapping() -> None:
+    conn = _RecordingConn()
+    scen = uuid4()
+    run_id = uuid4()
+    emit_stream_event(
+        conn,
+        "calc_run_finished",
+        scen,
+        field_changed="completed",
+        new_text=str(run_id),
+        new_quantity=42,
+    )
+    # INSERT column order: event_id, event_type, scenario_id, trigger_node_id,
+    # field_changed, new_date, new_quantity, old_text, new_text, source, created_at
+    p = _params_of(conn)
+    assert p[1] == "calc_run_finished"
+    assert p[2] == scen
+    assert p[3] is None  # trigger_node_id
+    assert p[4] == "completed"  # field_changed
+    assert p[5] is None  # new_date
+    assert p[6] == 42  # new_quantity
+    assert p[7] is None  # old_text
+    assert p[8] == str(run_id)  # new_text
+    assert p[9] == "engine"  # source default
+
+
+def test_snapshot_captured_carries_new_date() -> None:
+    conn = _RecordingConn()
+    d = date(2026, 7, 7)
+    emit_stream_event(
+        conn,
+        "snapshot_captured",
+        uuid4(),
+        field_changed="snapshot_captured",
+        new_date=d,
+        new_quantity=Decimal("17"),
+        source="api",
+    )
+    p = _params_of(conn)
+    assert p[4] == "snapshot_captured"
+    assert p[5] == d  # new_date
+    assert p[6] == Decimal("17")  # new_quantity
+    assert p[9] == "api"  # source override
+
+
+def test_recommendation_created_action_and_agent_mapping() -> None:
+    conn = _RecordingConn()
+    node = uuid4()
+    run_id = uuid4()
+    emit_stream_event(
+        conn,
+        "recommendation_created",
+        uuid4(),
+        trigger_node_id=node,
+        field_changed="EXPEDITE",
+        old_text="shortage_watcher",
+        new_text=str(run_id),
+        new_quantity=3,
+    )
+    p = _params_of(conn)
+    assert p[3] == node  # trigger_node_id
+    assert p[4] == "EXPEDITE"  # field_changed = action
+    assert p[7] == "shortage_watcher"  # old_text = agent
+    assert p[8] == str(run_id)  # new_text = run id
+    assert p[6] == 3  # new_quantity = count
+
+
+def test_processed_flag_is_true_in_insert_sql() -> None:
+    # Fleet notifications are terminal (nothing to compute) — processed=TRUE so
+    # they are never swept into a calc run's event coalescing.
+    conn = _RecordingConn()
+    emit_stream_event(conn, "outcome_evaluated", uuid4(), new_quantity=1)
+    sql = conn.calls[0][0]
+    assert "processed" in sql
+    assert "TRUE" in sql
+
+
+# ---------------------------------------------------------------------------
+# emit_recommendation_created_for_run — count-gated emission
+# ---------------------------------------------------------------------------
+
+
+def test_reco_created_emits_when_count_positive() -> None:
+    # Two COUNT queries (recommendations, parameter_recommendations) then the
+    # INSERT. Counts sum to 5 -> emit with new_quantity=5.
+    conn = _RecordingConn(fetch_results=[{"n": 2}, {"n": 3}])
+    run_id = uuid4()
+    scen = uuid4()
+    eid = emit_recommendation_created_for_run(conn, run_id, scen, "shortage_watcher")
+    assert isinstance(eid, UUID)
+    # last call is the INSERT; new_quantity (index 6) == 5
+    insert_params = conn.calls[-1][1]
+    assert insert_params[1] == "recommendation_created"
+    assert insert_params[6] == 5
+    assert insert_params[7] == "shortage_watcher"  # old_text = agent
+    assert insert_params[8] == str(run_id)  # new_text = run id
+
+
+def test_reco_created_no_emit_when_zero() -> None:
+    conn = _RecordingConn(fetch_results=[{"n": 0}, {"n": 0}])
+    eid = emit_recommendation_created_for_run(conn, uuid4(), uuid4(), "dq_watcher")
+    assert eid is None
+    # Only the two COUNT queries ran, no INSERT.
+    assert len(conn.calls) == 2
+    assert all("COUNT(*)" in sql for sql, _ in conn.calls)
+
+
+def test_reco_created_tolerates_tuple_rows() -> None:
+    # A watcher's psycopg.connect() default is tuple_row — COUNT comes back as a
+    # 1-tuple, not a dict. The helper must handle both.
+    conn = _RecordingConn(fetch_results=[(4,), (0,)])
+    eid = emit_recommendation_created_for_run(conn, uuid4(), uuid4(), "material_watcher")
+    assert isinstance(eid, UUID)
+    assert conn.calls[-1][1][6] == 4  # new_quantity
+
+
+def test_fleet_types_are_a_subset_of_router_valid_types() -> None:
+    """Anti-drift guard, DB-FREE — runs in the unit CI job.
+
+    The integration variant of this check sits in
+    test_fleet_events_integration.py behind the module-level requires_db
+    marker (so it never runs in the unit job); a silent divergence between
+    FLEET_EVENT_TYPES (emit helper) and VALID_EVENT_TYPES (POST /v1/events
+    validation) would otherwise ship unnoticed. The SQL CHECK itself
+    (migration 071) is locked by the integration test against real Postgres.
+    """
+    from ootils_core.api.routers.events import VALID_EVENT_TYPES
+    from ootils_core.engine.events.emit import FLEET_EVENT_TYPES
+
+    missing = set(FLEET_EVENT_TYPES) - set(VALID_EVENT_TYPES)
+    assert not missing, (
+        f"FLEET_EVENT_TYPES not accepted by the router validation: {missing}"
+    )
+
+
+def test_fleet_types_present_in_migration_071_check() -> None:
+    """Static cross-check against the migration file itself (DB-free): every
+    fleet type must appear verbatim in the 071 CHECK constraint, so the
+    Python emitter and the SQL CHECK cannot drift without a red unit test."""
+    from pathlib import Path
+
+    from ootils_core.engine.events.emit import FLEET_EVENT_TYPES
+
+    mig = Path(__file__).parent.parent / (
+        "src/ootils_core/db/migrations/071_events_fleet_types.sql"
+    )
+    sql = mig.read_text(encoding="utf-8")
+    missing = [t for t in FLEET_EVENT_TYPES if f"'{t}'" not in sql]
+    assert not missing, f"types absent from migration 071 CHECK: {missing}"


### PR DESCRIPTION
Le pari « Streamable » devient vrai au runtime (mesure de départ : 0 event pour 18 658 recos sur pilote). 5 capacités gouvernées émettent UN event typé par RUN sur la transaction du write (atomique) ; granularité RUN non négociable ; migration 071 widening pur (14→19 types) ; --subscribe opt-in avec curseur persisté COMPLETED-only, byte-identique sans flag ; garde-fou d'intégration paramétré « un write gouverné sans event = rouge » + 2 gardes anti-dérive DB-free en job unitaire. Revue adversariale GO (atomicité tracée sur les 7 sites d'émission, COUNT-back vérifié incrémental/re-run). Réf #401, ADR-027, roadmap H1/AN-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)