### PR TITLE
feat(auth): #392 PR2a — grille de scopes sur les 102 endpoints + rate_per_min câblé (AN-2)

### DIFF
--- a/scripts/demo_e2e.py
+++ b/scripts/demo_e2e.py
@@ -68,8 +68,27 @@ BASELINE_SCENARIO_ID = "00000000-0000-0000-0000-000000000001"
 # find and revoke everything this script created with one query.
 _AGENT_TOKEN_NAME = "DEMO-E2E-agent"
 _HUMAN_TOKEN_NAME = "DEMO-E2E-human"
+# AN-2 (#392, PR2a) scope enforcement is now live end-to-end, so these grants
+# must cover every call each token makes:
+#   * AGENT — reads (step1/step8) + drafts (step4 DRP run is recommend:draft;
+#     step5 DRAFT->REVIEWED is recommend:draft). It deliberately does NOT hold
+#     recommend:approve, so step5's REVIEWED->APPROVED is refused (403) — the
+#     whole point of the governance gate demo. No calc:run: no agent step
+#     launches a run through the API (the watchers in step3 are DB-direct).
+#   * HUMAN — the full operator superset (all scopes except `admin`): the
+#     forecast run (step2) is calc:run; simulate / param-overrides / archive
+#     (step7) and scenario delete are scenario:write; snapshots + outcomes
+#     evaluate (step6) are ingest; the L3 approval (step5) is recommend:approve.
 _AGENT_SCOPES = ["read", "recommend:draft"]
-_HUMAN_SCOPES = ["read", "ingest", "recommend:draft", "recommend:approve"]
+_HUMAN_SCOPES = [
+    "read",
+    "ingest",
+    "calc:run",
+    "graph:write",
+    "scenario:write",
+    "recommend:draft",
+    "recommend:approve",
+]
 
 # The dedicated demo distribution link (step 4) is tagged so it is
 # identifiable and idempotent. Name only — the row itself is keyed on its own

--- a/src/ootils_core/api/auth.py
+++ b/src/ootils_core/api/auth.py
@@ -41,12 +41,13 @@ from __future__ import annotations
 import hashlib
 import hmac
 import logging
+import math
 import os
 import threading
 import time
-from collections import OrderedDict
+from collections import OrderedDict, deque
 from dataclasses import dataclass
-from typing import Awaitable, Callable, Optional
+from typing import Awaitable, Callable, Deque, Optional
 from uuid import UUID
 
 from anyio import to_thread
@@ -97,6 +98,39 @@ _ADMIN_SCOPE = "admin"
 # path (issue_agent_token.py, PR2) validates against this before insert.
 VALID_ACTOR_KINDS: frozenset[str] = frozenset({"agent", "human", "service"})
 
+# The application-code scope whitelist (ADR-029: "the set of valid scope
+# strings is validated in APPLICATION code, never by a SQL CHECK" — see
+# migration 064's header). This is the single source of truth for what a
+# `scopes TEXT[]` grant is allowed to contain and for what a route may
+# `require_scope(...)`. Deliberately NOT enforced by a DB CHECK so new scopes
+# ship with the code that enforces them, at the same review boundary, with no
+# schema churn. ``admin`` is the superset that satisfies every require_scope
+# check (see ``Principal.has_scope``). Kept in sync with the token-minting
+# path (scripts/demo_e2e.py, issue_agent_token.py) and ROADMAP AN-2 (#392).
+VALID_SCOPES: frozenset[str] = frozenset(
+    {
+        "read",
+        "ingest",
+        "calc:run",
+        "graph:write",
+        "scenario:write",
+        "recommend:draft",
+        "recommend:approve",
+        "admin",
+    }
+)
+
+# Sliding-window length for the per-token rate limit (api_tokens.rate_per_min).
+_RATE_WINDOW_SECONDS = 60.0
+
+# Hard cap on the number of token_id buckets the rate counter tracks. Same
+# rationale as _CACHE_MAX_ENTRIES: a bounded memory ceiling with LRU eviction,
+# not a security control. Sized well above realistic live-token churn; if more
+# than this many DISTINCT tokens are rate-tracked concurrently, the
+# least-recently-seen bucket is evicted (its window resets — a mild
+# under-count, never unbounded growth).
+_RATE_MAX_ENTRIES = 10_000
+
 _TRUTHY = {"1", "true", "yes", "on"}
 
 
@@ -107,6 +141,8 @@ class Principal:
     ``token_id`` is None for the legacy single token (it has no DB row).
     ``is_legacy`` distinguishes that synthetic principal from a minted one.
     ``scopes`` is the authoritative capability set; ``'admin'`` is a superset.
+    ``rate_per_min`` is the per-token budget (api_tokens.rate_per_min); None
+    means no cap (and the legacy token is always None → uncapped).
     """
 
     token_id: Optional[UUID]
@@ -114,6 +150,7 @@ class Principal:
     actor_kind: str  # 'agent' | 'human' | 'service'
     scopes: frozenset[str]
     is_legacy: bool
+    rate_per_min: Optional[int] = None
 
     def has_scope(self, scope: str) -> bool:
         return _ADMIN_SCOPE in self.scopes or scope in self.scopes
@@ -169,12 +206,14 @@ def principal_from_row(row: dict) -> Principal:
     revoked_at IS NULL AND not-expired by the SELECT). ``scopes`` may arrive as
     a Python list (psycopg maps ``TEXT[]``) or None → empty frozenset."""
     raw_scopes = row.get("scopes") or []
+    raw_rate = row.get("rate_per_min")
     return Principal(
         token_id=UUID(str(row["token_id"])),
         name=row["name"],
         actor_kind=row["actor_kind"],
         scopes=frozenset(raw_scopes),
         is_legacy=False,
+        rate_per_min=int(raw_rate) if raw_rate is not None else None,
     )
 
 
@@ -188,6 +227,7 @@ def legacy_principal() -> Principal:
         actor_kind="human",
         scopes=frozenset({_ADMIN_SCOPE}),
         is_legacy=True,
+        rate_per_min=None,
     )
 
 
@@ -308,6 +348,87 @@ _token_cache = _TokenCache()
 
 
 # ---------------------------------------------------------------------------
+# Per-token sliding-window rate counter (clock injectable for tests)
+# ---------------------------------------------------------------------------
+
+
+class _RateCounter:
+    """Sliding-window request counter keyed by ``token_id`` (api_tokens.
+    rate_per_min, #392 AN-2).
+
+    Records one monotonic timestamp per allowed request in a per-token deque,
+    drops timestamps older than ``window_seconds`` on each touch, and refuses
+    once the surviving count reaches the token's limit — returning the seconds
+    until the oldest in-window request ages out (the ``Retry-After`` value).
+
+    PER-WORKER, NOT GLOBAL: like ``_TokenCache``, this lives in one process's
+    memory. Under N uvicorn workers a token's effective ceiling is N ×
+    rate_per_min, because each worker counts only the requests it served. This
+    is a deliberate V1 trade-off (no shared store on the hot auth path); a
+    global limiter would need Redis/DB coordination. Documented so the budget
+    is understood as approximate, not exact.
+
+    SIZE-bounded (``max_entries``, LRU eviction) for the same reason the cache
+    is: the keyspace (token_id) is bounded by live tokens, but eviction caps
+    worst-case memory regardless. Evicting an active token's bucket resets its
+    window (a mild under-count), never unbounded growth — a memory ceiling,
+    not a security control.
+
+    Guarded by a plain ``threading.Lock`` because enforcement runs inside
+    ``resolve_principal``, itself reachable from the worker threadpool (a
+    minted-token cache-miss dispatches to ``to_thread``). The clock is injected
+    (``time.monotonic`` by default) so tests drive the window without sleeping.
+    """
+
+    __slots__ = ("_store", "_lock", "_window", "_clock", "_max_entries")
+
+    def __init__(
+        self,
+        window_seconds: float = _RATE_WINDOW_SECONDS,
+        clock: Callable[[], float] = time.monotonic,
+        max_entries: int = _RATE_MAX_ENTRIES,
+    ) -> None:
+        self._store: OrderedDict[UUID, Deque[float]] = OrderedDict()
+        self._lock = threading.Lock()
+        self._window = window_seconds
+        self._clock = clock
+        self._max_entries = max_entries
+
+    def check(self, token_id: UUID, limit: int) -> Optional[float]:
+        """Record one request for ``token_id`` under ``limit`` requests per
+        window. Return None when the request is allowed; otherwise the seconds
+        until a slot frees (Retry-After), never negative.
+
+        A rejected request is NOT recorded (it does not extend the window), so
+        a caller that backs off exactly ``Retry-After`` seconds is admitted."""
+        now = self._clock()
+        cutoff = now - self._window
+        with self._lock:
+            bucket = self._store.get(token_id)
+            if bucket is None:
+                bucket = deque()
+                self._store[token_id] = bucket
+            while bucket and bucket[0] <= cutoff:
+                bucket.popleft()
+            if len(bucket) >= limit:
+                self._store.move_to_end(token_id)
+                return max(bucket[0] + self._window - now, 0.0)
+            bucket.append(now)
+            self._store.move_to_end(token_id)
+            while len(self._store) > self._max_entries:
+                self._store.popitem(last=False)
+            return None
+
+    def clear(self) -> None:
+        with self._lock:
+            self._store.clear()
+
+
+# Module-level counter, same non-anti-pattern rationale as _token_cache.
+_rate_counter = _RateCounter()
+
+
+# ---------------------------------------------------------------------------
 # Minted-token DB lookup (rare — cache-miss only)
 # ---------------------------------------------------------------------------
 
@@ -394,7 +515,7 @@ def _select_token_row(conn: DictRowConnection, token_hash: str) -> Optional[dict
     """SELECT the live token row (not revoked, not expired) for a hash."""
     return conn.execute(
         """
-        SELECT token_id, name, actor_kind, scopes, token_prefix
+        SELECT token_id, name, actor_kind, scopes, token_prefix, rate_per_min
         FROM api_tokens
         WHERE token_hash = %s
           AND revoked_at IS NULL
@@ -474,6 +595,39 @@ def _enforce_fleet_kill_switch(principal: Principal, client_id: str) -> None:
         )
 
 
+def _enforce_rate_limit(principal: Principal, client_id: str) -> None:
+    """429 when a minted token exceeds its ``rate_per_min`` budget (#392 AN-2).
+
+    Exemptions, both fail-open by design (a missing budget is "uncapped", never
+    "blocked"):
+      * the legacy token (``token_id is None``) — the shared bootstrap
+        credential is never rate-limited, preserving pre-#392 behaviour;
+      * any minted token whose ``rate_per_min`` is NULL — no cap configured.
+
+    The Retry-After header is whole seconds (HTTP spec), floored at 1 so a
+    sub-second remainder never advertises "retry immediately". Per-worker, not
+    global — see ``_RateCounter``."""
+    if principal.token_id is None or principal.rate_per_min is None:
+        return
+    retry_after = _rate_counter.check(principal.token_id, principal.rate_per_min)
+    if retry_after is None:
+        return
+    retry_seconds = max(1, math.ceil(retry_after))
+    logger.warning(
+        "auth.rate_limited name=%s token_id=%s prefix=%s limit=%s retry_after=%s",
+        principal.name,
+        principal.token_id,
+        client_id,
+        principal.rate_per_min,
+        retry_seconds,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        detail="Rate limit exceeded",
+        headers={"Retry-After": str(retry_seconds)},
+    )
+
+
 async def resolve_principal(
     credentials: HTTPAuthorizationCredentials | None = Security(_bearer),
     request: Request = None,  # type: ignore[assignment]  # FastAPI injects; Optional confuses dep resolver
@@ -532,6 +686,10 @@ async def resolve_principal(
         request.state.client_id = client_id
 
     _enforce_fleet_kill_switch(principal, client_id)
+    # Rate limit LAST — after the kill switch (a disabled fleet answers 503
+    # without spending a rate slot) and after request.state is posed (a 429 is
+    # audited with full attribution, same as the kill-switch 503).
+    _enforce_rate_limit(principal, client_id)
 
     return principal
 
@@ -543,10 +701,13 @@ async def require_auth(
     """Backward-compatible dependency — resolves the principal (populating
     ``request.state``) and RETURNS THE TOKEN STRING, exactly as before #392.
 
-    Every one of the ~24 ``_token: str = Depends(require_auth)`` routers keeps
-    its return contract; the new capability (principal on request.state) rides
-    alongside it. Kept as a thin alias over ``resolve_principal`` so there is a
-    single authentication implementation.
+    As of AN-2 (#392, PR2a) every mounted ``/v1/*`` endpoint has migrated to
+    ``Depends(require_scope("..."))``; ``require_auth`` is retained as a thin
+    alias over ``resolve_principal`` for the remaining callers (tests that
+    override it via ``dependency_overrides``, and the unmounted models module
+    ``atp/api.py``). It preserves the token-string return contract. New code
+    should depend on ``require_scope`` (or ``resolve_principal`` directly), not
+    on this alias.
     """
     await resolve_principal(credentials=credentials, request=request)
     # credentials is non-None here (resolve_principal raises 401 otherwise).
@@ -566,7 +727,15 @@ def require_scope(scope: str) -> Callable[..., Awaitable[Principal]]:
     An overridden ``resolve_principal`` (as tests do for ``require_auth``) that
     returns a Principal flows straight through; only a None/absent principal
     yields 401.
+
+    ``scope`` is validated against ``VALID_SCOPES`` at factory-call time —
+    routers wire ``Depends(require_scope("..."))`` at import, so a typo'd or
+    retired scope fails LOUDLY at app import, never silently at request time.
     """
+    if scope not in VALID_SCOPES:
+        raise ValueError(
+            f"unknown scope {scope!r}; valid scopes are {sorted(VALID_SCOPES)}"
+        )
 
     async def _dependency(
         principal: Optional[Principal] = Depends(resolve_principal),

--- a/src/ootils_core/api/routers/bom.py
+++ b/src/ootils_core/api/routers/bom.py
@@ -17,7 +17,7 @@ from uuid import UUID, uuid4
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID, get_db
 from ootils_core.db.types import DictRowConnection
 
@@ -320,7 +320,7 @@ def _recalculate_llc(db: DictRowConnection, affected_item_ids: list[UUID]) -> in
 def ingest_bom(
     body: IngestBOMRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> IngestBOMResponse:
     """Import a complete BOM for a parent item. Upsert with cycle detection."""
 
@@ -457,7 +457,7 @@ def ingest_bom(
 def get_bom(
     parent_external_id: str,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> BOMResponse:
     """Return the active BOM for a given item."""
     parent_item_id = _resolve_item_id(db, parent_external_id)
@@ -503,7 +503,7 @@ def get_bom(
 def explode_bom(
     body: ExplodeRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ) -> ExplodeResponse:
     """
     MRP explosion: compute gross and net requirements for a given quantity of a parent item.

--- a/src/ootils_core/api/routers/calc.py
+++ b/src/ootils_core/api/routers/calc.py
@@ -11,7 +11,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
 from ootils_core.db.types import DictRowConnection
 
@@ -32,17 +32,18 @@ class CalcRunResponse(BaseModel):
     message: str
 
 
-# governance PR2: not applicable — #392 security-review audit (PR1):
-# propagation is deterministic recalculation (ADR-003), not a decision;
-# it re-derives ProjectedInventory/shortage state from events already
-# committed to the graph, it does not introduce new baseline facts. Left
-# require_auth-only; outside the L3 apply-to-baseline class this chantier
-# targets.
+# governance AN-2 (#392, PR2a): scoped `calc:run`. Propagation is
+# deterministic recalculation (ADR-003), not a decision — it re-derives
+# ProjectedInventory/shortage state from events already committed to the graph,
+# it introduces no new baseline facts, so no Decision Ladder human gate. But
+# "deterministic != free": triggering a recompute is a costly run, so it sits
+# behind the calc:run scope (an agent needs it explicitly; a read-only token
+# cannot launch it).
 @router.post("/run", response_model=CalcRunResponse)
 def trigger_calc_run(
     body: CalcRunRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
     scenario_id: UUID = Depends(resolve_scenario_id),
 ) -> CalcRunResponse:
     """Consume all unprocessed events for a scenario and run propagation."""

--- a/src/ootils_core/api/routers/calendars.py
+++ b/src/ootils_core/api/routers/calendars.py
@@ -16,7 +16,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, field_validator
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db
 from ootils_core.db.types import DictRowConnection
 
@@ -121,7 +121,7 @@ class WorkingDaysResponse(BaseModel):
 def ingest_calendars(
     body: IngestCalendarsRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> IngestCalendarsResponse:
     """
     Upsert non-working days (and other calendar entries) for a location.
@@ -224,7 +224,7 @@ def get_calendars(
     to_date: Optional[date] = Query(default=None),
     working_only: bool = Query(default=False),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> GetCalendarsResponse:
     """
     Return calendar entries for a location.
@@ -292,7 +292,7 @@ def get_calendars(
 def compute_working_days(
     body: WorkingDaysRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> WorkingDaysResponse:
     """
     Compute a delivery date by adding N working days to a start date.

--- a/src/ootils_core/api/routers/demo.py
+++ b/src/ootils_core/api/routers/demo.py
@@ -10,7 +10,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db
 from ootils_core.db.types import DictRowConnection
 from ootils_core.demo.phase1 import run_phase1_demo_from_env
@@ -66,7 +66,9 @@ def _json_safe(value: Any) -> Any:
     summary="Run Phase 1 planning demo",
     description="Run the live Forecast -> MPS -> Approve -> MRP -> CRP -> ATP demo flow with unique seeded demo data.",
 )
-def run_phase1_demo_endpoint(token: str = Depends(require_auth)) -> dict:
+def run_phase1_demo_endpoint(
+    _principal: Principal = Depends(require_scope("admin")),
+) -> dict:
     """Run the executable Phase 1 demo flow."""
     try:
         return _json_safe(run_phase1_demo_from_env())
@@ -87,7 +89,7 @@ def run_phase1_demo_endpoint(token: str = Depends(require_auth)) -> dict:
 def list_phase1_demo_runs(
     limit: int = Query(default=5, ge=1, le=50),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> DemoRunListResponse:
     rows = db.execute(
         """

--- a/src/ootils_core/api/routers/dq.py
+++ b/src/ootils_core/api/routers/dq.py
@@ -17,7 +17,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db
 from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.dq.engine import run_dq
@@ -74,11 +74,11 @@ class DQIssuesResponse(BaseModel):
 # ─────────────────────────────────────────────────────────────
 # POST /v1/dq/run/{batch_id}
 # ─────────────────────────────────────────────────────────────
-# governance PR2: ingest scope — deferred. #392 security-review audit
-# (PR1): this runs deterministic L1/L2 checks and writes only into
-# data_quality_issues (staging-side diagnostics), never into canonical
-# master data — not an apply-to-baseline action, unlike staging/approve.py.
-# Left require_auth-only; not the L3 class this chantier targets.
+# governance AN-2 (#392, PR2a): scoped `calc:run`. This runs deterministic
+# L1/L2 checks and writes only into data_quality_issues (staging-side
+# diagnostics), never into canonical master data — no Decision Ladder human
+# gate. But a DQ scan is a costly run ("deterministic != free"), so it sits
+# behind calc:run, not read: a read-only token cannot launch a scan.
 
 @router.post(
     "/run/{batch_id}",
@@ -89,7 +89,7 @@ class DQIssuesResponse(BaseModel):
 def run_dq_batch(
     batch_id: UUID,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ) -> DQRunResponse:
     # Verify batch exists
     batch = db.execute(
@@ -140,7 +140,7 @@ def list_issues(
     limit: int = Query(default=200, ge=1, le=1000, description="Max results"),
     offset: int = Query(default=0, ge=0, description="Pagination offset"),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> DQIssuesResponse:
     conditions: list[str] = ["i.resolved = FALSE"]
     params: list[Any] = []
@@ -219,7 +219,7 @@ def list_issues(
 def get_batch_dq(
     batch_id: UUID,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> DQBatchResponse:
     batch = db.execute(
         "SELECT batch_id, entity_type, dq_status, total_rows FROM ingest_batches WHERE batch_id = %s",
@@ -331,10 +331,10 @@ class AgentRunsResponse(BaseModel):
 # ─────────────────────────────────────────────────────────────
 # POST /v1/dq/agent/run/{batch_id}
 # ─────────────────────────────────────────────────────────────
-# governance PR2: ingest scope — deferred. #392 security-review audit
-# (PR1): the agent enriches data_quality_issues (impact_score, LLM
-# insights) — staging-side diagnostics only, no canonical write. Same
-# reasoning as /run/{batch_id} above. Left require_auth-only.
+# governance AN-2 (#392, PR2a): scoped `calc:run`. The agent enriches
+# data_quality_issues (impact_score, LLM insights) — staging-side diagnostics
+# only, no canonical write, so no human gate. Same "deterministic != free"
+# reasoning as /run/{batch_id} above: a costly run, behind calc:run.
 
 @router.post(
     "/agent/run/{batch_id}",
@@ -348,7 +348,7 @@ class AgentRunsResponse(BaseModel):
 def run_agent_batch(
     batch_id: UUID,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ) -> AgentRunResponse:
     # Verify batch exists
     batch = db.execute(
@@ -392,7 +392,7 @@ def run_agent_batch(
 def get_agent_report(
     batch_id: UUID,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> AgentReportResponse:
     batch = db.execute(
         "SELECT batch_id, entity_type FROM ingest_batches WHERE batch_id = %s",
@@ -494,7 +494,7 @@ def list_agent_runs(
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> AgentRunsResponse:
     count_row = db.execute(
         "SELECT COUNT(*) AS cnt FROM dq_agent_runs"

--- a/src/ootils_core/api/routers/events.py
+++ b/src/ootils_core/api/routers/events.py
@@ -13,7 +13,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
 from ootils_core.db.types import DictRowConnection
 
@@ -171,7 +171,7 @@ class EventListResponse(BaseModel):
 def create_event(
     body: EventRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
     scenario_id: UUID = Depends(resolve_scenario_id),
 ) -> EventResponse:
     """Submit a planning event that triggers recalculation."""
@@ -277,7 +277,7 @@ def create_event(
 @router.get("", response_model=EventListResponse)
 def list_events(
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
     limit: int = Query(default=50, ge=1, le=500, description="Max events to return"),
     offset: int = Query(default=0, ge=0, description="Pagination offset"),
     event_type: Optional[str] = Query(default=None, description="Filter by event type"),

--- a/src/ootils_core/api/routers/explain.py
+++ b/src/ootils_core/api/routers/explain.py
@@ -15,7 +15,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
 from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.kernel.explanation.builder import ExplanationBuilder
@@ -46,7 +46,7 @@ class ExplainResponse(BaseModel):
 def get_explanation(
     node_id: str = Query(..., description="Target node UUID to explain"),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
     scenario_id: UUID = Depends(resolve_scenario_id),
 ) -> ExplainResponse:
     """Return the causal explanation for a planning node."""

--- a/src/ootils_core/api/routers/forecasting.py
+++ b/src/ootils_core/api/routers/forecasting.py
@@ -25,7 +25,7 @@ from uuid import UUID, uuid4
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID, get_db
 from ootils_core.db.types import DictRowConnection
 from ootils_core.forecasting.algorithms import ForecastingError
@@ -295,7 +295,7 @@ def _soft_delete_forecast(db: DictRowConnection, forecast_id: UUID) -> None:
 def generate_forecast(
     body: ForecastGenerateRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ) -> ForecastOut:
     """
     Generate a forecast for an item/location.
@@ -521,7 +521,7 @@ def generate_forecast(
 def get_forecast(
     forecast_id: UUID,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> ForecastOut:
     """
     Retrieve a forecast by ID with all values and adjustments.
@@ -670,7 +670,7 @@ def list_forecasts(
     method: Optional[str] = Query(default=None, pattern="^(MA|EXP_SMOOTHING|CROSTON|SEASONAL)$"),
     limit: int = Query(default=50, ge=1, le=500),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> ForecastListResponse:
     """
     List forecasts with optional filters.
@@ -804,7 +804,7 @@ def adjust_forecast(
     forecast_id: UUID,
     body: ForecastAdjustRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> ForecastAdjustResponse:
     """
     Apply an adjustment to a forecast.
@@ -920,7 +920,7 @@ def adjust_forecast(
 def delete_forecast(
     forecast_id: UUID,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> dict:
     """
     Soft delete a forecast.

--- a/src/ootils_core/api/routers/ghosts.py
+++ b/src/ootils_core/api/routers/ghosts.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from psycopg import sql
 from pydantic import BaseModel, Field, field_validator
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID, get_db
 from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.ghost.ghost_engine import run_ghost
@@ -157,7 +157,7 @@ def _validate_membership(ghost_type: str, members: list[GhostMemberInput]) -> li
 def ingest_ghost(
     body: IngestGhostRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> dict[str, Any]:
     """
     Upsert ghost + members. Validates membership constraints before any write.
@@ -323,7 +323,7 @@ def list_ghosts(
     scenario_id: Optional[UUID] = None,
     ghost_status: Optional[str] = None,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> dict[str, Any]:
     """Return all ghosts filtered by optional ghost_type, scenario_id, status.
 
@@ -422,7 +422,7 @@ def list_ghosts(
 def get_ghost(
     ghost_id: UUID,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> dict[str, Any]:
     """Return a single ghost with its members and graph node."""
     g = db.execute(
@@ -511,7 +511,7 @@ def run_ghost_endpoint(
     ghost_id: UUID,
     body: GhostRunRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ) -> dict[str, Any]:
     """
     Execute ghost logic (phase_transition or capacity_aggregate) over [from_date, to_date].

--- a/src/ootils_core/api/routers/graph.py
+++ b/src/ootils_core/api/routers/graph.py
@@ -12,7 +12,7 @@ from uuid import UUID, uuid4
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
 from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.kernel.graph.store import GraphStore
@@ -60,7 +60,7 @@ def get_graph(
     from_date: Optional[date] = Query(default=None, alias="from"),
     to_date: Optional[date] = Query(default=None, alias="to"),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
     scenario_id: UUID = Depends(resolve_scenario_id),
 ) -> GraphResponse:
     """Return nodes and edges for the planning graph at (item, location, scenario)."""
@@ -210,7 +210,7 @@ def list_nodes(
     scenario_id: Optional[UUID] = Query(default=None),
     limit: int = Query(default=100, ge=1, le=500),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> NodeListResponse:
     """List nodes with optional filters — used for UI dropdowns (e.g. Simulate page)."""
     effective_scenario_id = scenario_id or UUID("00000000-0000-0000-0000-000000000001")
@@ -306,9 +306,11 @@ def list_nodes(
 # reversed by DELETE) — no approval gate for V1, audited via `events` is
 # sufficient. Revisit if firm/unfirm ever needs L2+ governance.
 #
-# governance PR2: not a silent gap re-audited under #392 — this pre-existing
-# decision (reversible, event-audited, deliberately gate-free) stands. Left
-# require_auth-only; explicitly reviewed, not deferred by oversight.
+# governance AN-2 (#392): firm/unfirm now require the `graph:write` scope
+# (they mutate nodes.is_firm). No Decision Ladder HUMAN gate is added: this
+# pre-existing decision (reversible via DELETE, event-audited, deliberately
+# gate-free) stands — the scope floor is the right control level for an L1-class
+# reversible node mutation. Explicitly reviewed, not deferred by oversight.
 # ---------------------------------------------------------------------------
 
 class FirmRequest(BaseModel):
@@ -425,7 +427,7 @@ def firm_node(
     node_id: UUID,
     body: FirmRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("graph:write")),
 ) -> FirmResponse:
     """Firm a PlannedSupply into a Firm Planned Order (is_firm=TRUE, #346).
 
@@ -441,7 +443,7 @@ def unfirm_node(
     node_id: UUID,
     actor: str = Query(..., min_length=1, max_length=200),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("graph:write")),
 ) -> FirmResponse:
     """Un-firm a Firm Planned Order back into an ordinary PlannedSupply
     (is_firm=FALSE, #346).

--- a/src/ootils_core/api/routers/ingest.py
+++ b/src/ootils_core/api/routers/ingest.py
@@ -30,7 +30,7 @@ from psycopg import sql
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, Field, field_validator
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID, get_db
 from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.dq.engine import run_dq
@@ -476,7 +476,7 @@ def ingest_items(
     request: Request,
     response: Response,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> IngestResponse:
     """Upsert items by external_id. All-or-nothing: any validation error → HTTP 422."""
     errors: list[dict] = []
@@ -657,7 +657,7 @@ def ingest_locations(
     request: Request,
     response: Response,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> IngestResponse:
     """Upsert locations by external_id. All-or-nothing: any validation error → HTTP 422."""
     errors: list[dict] = []
@@ -947,7 +947,7 @@ def ingest_suppliers(
     request: Request,
     response: Response,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> IngestResponse:
     """Upsert suppliers by external_id. All-or-nothing: any validation error → HTTP 422."""
     errors: list[dict] = []
@@ -1047,7 +1047,7 @@ def ingest_supplier_items(
     request: Request,
     response: Response,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> IngestResponse:
     """Upsert supplier_items by (supplier_id, item_id). All-or-nothing: any error → HTTP 422."""
     # W-01: resolve FKs first, collect ALL errors before any write
@@ -1186,7 +1186,7 @@ def ingest_on_hand(
     request: Request,
     response: Response,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> IngestResponse:
     """Upsert OnHandSupply nodes in the baseline scenario. All-or-nothing: any error → HTTP 422."""
     # W-01: resolve FKs first, collect ALL errors before any write
@@ -1350,7 +1350,7 @@ def ingest_purchase_orders(
     request: Request,
     response: Response,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> IngestResponse:
     """Upsert PurchaseOrderSupply nodes, tracked via external_references. All-or-nothing: any error → HTTP 422."""
     # W-01: resolve FKs first, collect ALL errors before any write
@@ -1511,7 +1511,7 @@ def ingest_forecast_demand(
     request: Request,
     response: Response,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> IngestResponse:
     """Upsert ForecastDemand nodes. Keyed by (item, location, bucket_date, time_grain, scenario).
     All-or-nothing: any validation or FK error → HTTP 422.
@@ -1698,7 +1698,7 @@ def ingest_resources(
     request: Request,
     response: Response,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> IngestResponse:
     """Upsert resources by external_id. Also maintains a Resource node in the graph."""
     errors: list[dict] = []
@@ -1868,7 +1868,7 @@ def ingest_work_orders(
     request: Request,
     response: Response,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> IngestResponse:
     """Upsert WorkOrderSupply nodes, tracked via external_references. All-or-nothing: any error → HTTP 422."""
     item_ext_ids = list({wo.item_external_id for wo in body.work_orders})
@@ -2022,7 +2022,7 @@ def ingest_customer_orders(
     request: Request,
     response: Response,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> IngestResponse:
     """Upsert CustomerOrderDemand nodes, tracked via external_references. All-or-nothing: any error → HTTP 422."""
     item_ext_ids = list({co.item_external_id for co in body.customer_orders})
@@ -2180,7 +2180,7 @@ def ingest_transfers(
     request: Request,
     response: Response,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> IngestResponse:
     """Upsert TransferSupply nodes, tracked via external_references. All-or-nothing: any error → HTTP 422."""
     item_ext_ids = list({t.item_external_id for t in body.transfers})
@@ -2500,7 +2500,7 @@ def ingest_planning_params(
     request: Request,
     response: Response,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> IngestResponse:
     """SCD2-transparent upsert of item_planning_params (ADR-014 D3)."""
     from datetime import date
@@ -2777,7 +2777,7 @@ def ingest_routings(
     request: Request,
     response: Response,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> IngestResponse:
     """Full-reload routings + operations per (item, sequence). ADR-014 D2 unit checks at ingest."""
     # 1. Resolve item + resource external_ids in batch

--- a/src/ootils_core/api/routers/issues.py
+++ b/src/ootils_core/api/routers/issues.py
@@ -12,7 +12,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
 from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.kernel.shortage.detector import ShortageDetector
@@ -62,7 +62,7 @@ def get_issues(
     limit: int = Query(default=200, ge=1, le=1000, description="Max results to return (1–1000)"),
     offset: int = Query(default=0, ge=0, description="Result offset for pagination"),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
     scenario_id: UUID = Depends(resolve_scenario_id),
 ) -> IssuesResponse:
     """Return active shortages filtered by severity, horizon, item, and location with pagination."""

--- a/src/ootils_core/api/routers/mrp.py
+++ b/src/ootils_core/api/routers/mrp.py
@@ -19,7 +19,7 @@ from uuid import UUID, uuid4
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID, get_db
 from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.scenario.param_overlay import resolved_field_lateral_sql
@@ -322,7 +322,7 @@ def _clear_existing_planned_supply(
 def run_mrp(
     body: MrpRunRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ) -> MrpRunResponse | MrpRunResponseApics:
     """
     Unified MRP endpoint with optional APICS mode.

--- a/src/ootils_core/api/routers/mrp_apics.py
+++ b/src/ootils_core/api/routers/mrp_apics.py
@@ -24,7 +24,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from pydantic import BaseModel, Field
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db, resolve_scenario_id, BASELINE_SCENARIO_ID
 from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.mrp.mrp_apics_engine import (
@@ -193,7 +193,7 @@ def run_mrp_apics(
     request: MrpApicsRunRequest,
     response: Response,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ):
     """
     [DEPRECATED] Execute a full APICS-compliant multi-level MRP run.
@@ -280,7 +280,7 @@ def run_mrp_apics(
 def run_consumption(
     request: ConsumptionRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ):
     """
     Run forecast consumption against customer orders.
@@ -384,7 +384,7 @@ def run_consumption(
 def calculate_lot_sizing(
     request: LotSizingRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ):
     """
     Calculate lot sizing for a given net requirement.
@@ -429,7 +429,7 @@ def calculate_lot_sizing(
 def get_llc(
     recalculate: bool = Query(default=False, description="Recalculate LLCs from BOM"),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ):
     """
     Get Low-Level Codes for all items.

--- a/src/ootils_core/api/routers/param_overrides.py
+++ b/src/ootils_core/api/routers/param_overrides.py
@@ -32,7 +32,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.db.types import DictRowConnection
 from ootils_core.api.dependencies import get_db
 from ootils_core.engine.scenario.param_overlay import (
@@ -54,8 +54,8 @@ def _param_overlay_enabled() -> bool:
 
 
 def require_param_overlay_enabled() -> None:
-    """FastAPI dependency — checked AFTER ``Depends(require_auth)`` but BEFORE
-    ``Depends(get_db)`` in every endpoint's signature below (FastAPI resolves
+    """FastAPI dependency — checked AFTER ``Depends(require_scope(...))`` but
+    BEFORE ``Depends(get_db)`` in every endpoint's signature below (FastAPI resolves
     synchronous dependencies in signature order and short-circuits on the first
     HTTPException). Auth-first ensures an unauthenticated caller always gets 401
     and cannot distinguish 503-vs-401 to probe the kill switch's operational
@@ -118,7 +118,7 @@ def _row_to_out(row: dict) -> ParamOverrideOut:
 def set_param_override_endpoint(
     scenario_id: UUID,
     body: ParamOverrideIn,
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("scenario:write")),
     _enabled: None = Depends(require_param_overlay_enabled),
     db: DictRowConnection = Depends(get_db),
 ) -> ParamOverrideOut:
@@ -170,7 +170,7 @@ def set_param_override_endpoint(
 )
 def list_param_overrides_endpoint(
     scenario_id: UUID,
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
     _enabled: None = Depends(require_param_overlay_enabled),
     db: DictRowConnection = Depends(get_db),
 ) -> ParamOverridesListResponse:
@@ -199,7 +199,7 @@ def clear_param_override_endpoint(
     field_name: str,
     item_id: UUID = Query(...),
     location_id: Optional[UUID] = Query(default=None),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("scenario:write")),
     _enabled: None = Depends(require_param_overlay_enabled),
     db: DictRowConnection = Depends(get_db),
 ) -> None:

--- a/src/ootils_core/api/routers/planning_params.py
+++ b/src/ootils_core/api/routers/planning_params.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Depends, Query
 from psycopg import sql
 from pydantic import BaseModel
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db
 from ootils_core.db.types import DictRowConnection
 
@@ -41,7 +41,7 @@ def get_planning_params(
     item_id: Optional[str] = Query(default=None, description="Filter by item UUID"),
     location_id: Optional[str] = Query(default=None, description="Filter by location UUID"),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> PlanningParamsResponse:
     """Return the latest active planning parameters per (item, location)."""
     # Build query — get most recent params per (item_id, location_id)

--- a/src/ootils_core/api/routers/projection.py
+++ b/src/ootils_core/api/routers/projection.py
@@ -15,7 +15,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
 from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.kernel.graph.store import GraphStore
@@ -226,7 +226,7 @@ def get_projection(
     location_id: str = Query(..., description="Location identifier (UUID or external_id)"),
     grain: Optional[str] = Query(default=None, description="day / week / month — aggregates daily buckets"),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
     scenario_id: UUID = Depends(resolve_scenario_id),
 ) -> ProjectionResponse:
     """Return projected inventory buckets for an item/location pair, with supply/demand breakdown."""
@@ -346,7 +346,7 @@ def get_projection(
 @router.get("/portfolio", response_model=PortfolioResponse)
 def get_portfolio(
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
     scenario_id: UUID = Depends(resolve_scenario_id),
 ) -> PortfolioResponse:
     """Return a shortage summary across all items/locations for a scenario."""
@@ -404,7 +404,7 @@ def get_pegging(
     node_id: str,
     depth: int = Query(default=3, ge=1, le=5, description="Max traversal depth"),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
     scenario_id: UUID = Depends(resolve_scenario_id),
 ) -> PeggingResponse:
     """Trace the pegging tree from a node — which demand consumed which supply."""

--- a/src/ootils_core/api/routers/pyramide.py
+++ b/src/ootils_core/api/routers/pyramide.py
@@ -9,7 +9,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db
 from ootils_core.db.types import DictRowConnection
 from ootils_core.pyramide import PyramideError, PyramideRunConfig, PyramideRunner, SUPPORTED_METHODS
@@ -293,7 +293,7 @@ class PyramideSnapshotDiffOut(BaseModel):
 def create_pyramide_run(
     body: PyramideRunRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ) -> PyramideRunOut:
     body.method = body.method.upper()
     if body.method not in SUPPORTED_METHODS:
@@ -411,7 +411,7 @@ def create_pyramide_run(
 def create_hierarchical_run(
     body: HierarchicalRunRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ) -> HierarchicalRunResultOut:
     """Forecast and reconcile ONE summing block of the hierarchy registry
     (HierarchicalRunner, #348). Every level is persisted as its own
@@ -519,7 +519,7 @@ def create_hierarchical_run(
 def get_pyramide_run(
     run_id: UUID,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> PyramideRunOut:
     summary = fetch_run_summary(db, run_id)
     if summary is None:
@@ -540,7 +540,7 @@ def get_pyramide_run(
 def get_pyramide_run_result(
     run_id: UUID,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> PyramideRunResultOut:
     summary = fetch_run_summary(db, run_id)
     values = fetch_run_values(db, run_id)
@@ -560,7 +560,7 @@ def get_pyramide_run_result(
 def commit_pyramide_run(
     run_id: UUID,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("ingest")),
 ) -> PyramideCommitOut:
     try:
         summary = commit_run(db, run_id)
@@ -586,7 +586,7 @@ def commit_pyramide_run(
 def list_pyramide_snapshots(
     limit: int = Query(default=100, ge=1, le=500),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> PyramideSnapshotListOut:
     snapshots = list_snapshots(db, limit=limit)
     return PyramideSnapshotListOut(
@@ -604,7 +604,7 @@ def diff_pyramide_snapshots(
     snapshot_id: UUID,
     compare_to: UUID = Query(...),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> PyramideSnapshotDiffOut:
     base_values = fetch_snapshot_values(db, snapshot_id)
     compare_values = fetch_snapshot_values(db, compare_to)

--- a/src/ootils_core/api/routers/rccp.py
+++ b/src/ootils_core/api/routers/rccp.py
@@ -37,7 +37,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
 from ootils_core.db.types import DictRowConnection
 
@@ -188,7 +188,7 @@ def get_rccp(
     grain: str = Query(default="week", description="Granularité : day | week | month."),
     scenario_id: UUID = Depends(resolve_scenario_id),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> RCCPResponse:
     """RCCP endpoint — charge vs capacité par bucket."""
 

--- a/src/ootils_core/api/routers/scenarios.py
+++ b/src/ootils_core/api/routers/scenarios.py
@@ -36,7 +36,7 @@ from psycopg import sql
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from ootils_core.api.auth import Principal, require_auth, require_scope, resolve_gate_kind
+from ootils_core.api.auth import Principal, require_scope, resolve_gate_kind
 from ootils_core.api.dependencies import get_db, BASELINE_SCENARIO_ID
 from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.recommendation.state_machine import (
@@ -70,7 +70,7 @@ class ScenariosListResponse(BaseModel):
 @router.get("", response_model=ScenariosListResponse)
 def list_scenarios(
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
     status_filter: Optional[str] = Query(default=None, alias="status"),
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
@@ -115,7 +115,7 @@ def list_scenarios(
 def get_scenario(
     scenario_id: UUID,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> ScenarioOut:
     row = db.execute("SELECT * FROM scenarios WHERE scenario_id = %s", (scenario_id,)).fetchone()
     if not row:
@@ -135,7 +135,7 @@ def get_scenario(
 def delete_scenario(
     scenario_id: UUID,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("scenario:write")),
 ) -> None:
     if scenario_id == BASELINE_SCENARIO_ID:
         raise HTTPException(status_code=400, detail="Cannot delete the baseline scenario")
@@ -234,7 +234,7 @@ def _load_scenario_or_404(scenario_id: UUID, db: DictRowConnection) -> dict:
 def diff_scenario(
     scenario_id: UUID,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
     baseline_id: UUID = Query(default=BASELINE_SCENARIO_ID),
 ) -> ScenarioDiffResponse:
     """Field-level diff of a scenario vs a baseline (latest completed calc_runs).
@@ -470,7 +470,7 @@ def _engine_unavailable_response(exc: Exception) -> HTTPException:
 )
 def create_sandbox_scenario(
     body: SandboxScenarioCreateRequest,
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("scenario:write")),
 ) -> SandboxScenarioOut:
     """Create a fresh ephemeral what-if scenario in the engine.
 
@@ -525,7 +525,7 @@ def create_sandbox_scenario(
     response_model=SandboxScenariosListResponse,
 )
 def list_sandbox_scenarios(
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> SandboxScenariosListResponse:
     """List all ephemeral scenarios currently in the engine's RAM.
 
@@ -560,7 +560,7 @@ def list_sandbox_scenarios(
 @router.delete("/sandbox/{scenario_id}", status_code=204)
 def delete_sandbox_scenario(
     scenario_id: UUID,
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("scenario:write")),
 ) -> None:
     """Drop an ephemeral scenario from the engine's RAM immediately.
 

--- a/src/ootils_core/api/routers/simulate.py
+++ b/src/ootils_core/api/routers/simulate.py
@@ -10,7 +10,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, field_validator
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID, get_db
 from ootils_core.db.types import DictRowConnection
 from ootils_core.engine.scenario.manager import ScenarioManager, _ALLOWED_FIELDS
@@ -94,7 +94,7 @@ class SimulateResponse(BaseModel):
 def create_simulation(
     body: SimulateRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("scenario:write")),
 ) -> SimulateResponse:
     """Create a new scenario with overrides and compute the delta vs base.
 

--- a/src/ootils_core/atp/routers.py
+++ b/src/ootils_core/atp/routers.py
@@ -17,7 +17,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
 from ootils_core.atp.api import (
     ATPCheckRequest,
@@ -115,7 +115,7 @@ async def check_atp(
     body: ATPCheckRequest,
     scenario_id: UUID = Depends(resolve_scenario_id),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ) -> ATPCheckResponse:
     """
     Check ATP availability for an item at a location.
@@ -205,7 +205,7 @@ async def check_ctp(
     body: CTPCheckRequest,
     scenario_id: UUID = Depends(resolve_scenario_id),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ) -> CTPCheckResponse:
     """
     Check CTP availability for an item at a location.
@@ -309,7 +309,7 @@ async def simulate_ctp(
     body: CTPSimulateRequest,
     scenario_id: UUID = Depends(resolve_scenario_id),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ) -> CTPSimulateResponse:
     """
     Simulate CTP to find the first feasible date.

--- a/src/ootils_core/crp/routers.py
+++ b/src/ootils_core/crp/routers.py
@@ -16,7 +16,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, status, Path
 from pydantic import BaseModel, ConfigDict, Field
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import get_db, resolve_scenario_id
 from ootils_core.crp.engine import CRPEngine
 from ootils_core.db.types import DictRowConnection
@@ -120,7 +120,7 @@ async def calculate_crp(
     body: CRPCalculateRequest,
     scenario_id: UUID = Depends(resolve_scenario_id),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ) -> CRPCalculateResponse:
     """
     Calculate CRP load profiles and detect overloads.
@@ -235,7 +235,7 @@ async def get_load_profile(
     horizon_days: int = Query(default=90, ge=1, le=365, description="Planning horizon in days"),
     scenario_id: UUID = Depends(resolve_scenario_id),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> LoadProfileOut:
     """
     Get load profile for a specific work center.
@@ -313,7 +313,7 @@ async def get_overloads(
     work_center_ids: Optional[str] = Query(None, description="Comma-separated list of work center IDs to filter"),
     scenario_id: UUID = Depends(resolve_scenario_id),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> CRPOverloadsResponse:
     """
     List all detected overloads.
@@ -434,7 +434,7 @@ async def suggest_resolutions(
     body: CRPSuggestResolutionsRequest,
     scenario_id: UUID = Depends(resolve_scenario_id),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ) -> CRPSuggestResolutionsResponse:
     """
     Suggest resolutions for CRP overloads.

--- a/src/ootils_core/mps/api.py
+++ b/src/ootils_core/mps/api.py
@@ -21,7 +21,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, field_validator
 
-from ootils_core.api.auth import require_auth
+from ootils_core.api.auth import Principal, require_scope
 from ootils_core.api.dependencies import BASELINE_SCENARIO_ID, get_db
 from ootils_core.db.types import DictRowConnection
 from ootils_core.mps.engine import AggregateDemandEngine
@@ -271,7 +271,7 @@ def _resolve_scenario_uuid(db: DictRowConnection, scenario_id_str: str | None) -
 async def aggregate_demand(
     body: AggregateDemandRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ) -> AggregateDemandResponse:
     """
     Aggregate demand and create MPS nodes.
@@ -430,7 +430,7 @@ async def list_mps_nodes(
     status: Optional[str] = Query(default=None, pattern="^(DRAFT|REVIEWED|APPROVED|RELEASED)$"),
     limit: int = Query(default=100, ge=1, le=1000),
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> MPSNodeListResponse:
     """
     List MPS nodes with optional filters.
@@ -537,7 +537,7 @@ async def list_mps_nodes(
 async def get_mps_node(
     mps_id: UUID,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("read")),
 ) -> MPSNodeDetailOut:
     """
     Retrieve a specific MPS node by ID.
@@ -629,7 +629,7 @@ async def get_mps_node(
 async def capacity_check(
     body: CapacityCheckRequest,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ) -> CapacityCheckResponse:
     """
     Check capacity feasibility for MPS nodes before release.
@@ -718,7 +718,7 @@ async def capacity_check(
 async def suggest_adjustments(
     mps_id: UUID,
     db: DictRowConnection = Depends(get_db),
-    _token: str = Depends(require_auth),
+    _principal: Principal = Depends(require_scope("calc:run")),
 ) -> List[AdjustmentSuggestionOut]:
     """
     Get adjustment suggestions for a specific MPS node.
@@ -790,13 +790,13 @@ class ApproveMPSResponse(BaseModel):
     notes: Optional[str]
 
 
-# governance PR2: recommend:approve or a dedicated mps:approve scope —
-# deferred. #392 security-review audit (PR1): this transitions an MPS node
-# DRAFT/REVIEWED -> APPROVED, gating entry into /promote-to-mrp below. It does
-# NOT itself write canonical master data (unlike staging/approve.py, which is
-# gated in this same PR1) — the write-to-baseline happens one step later, at
-# promote-to-mrp. Scoped as require_auth-only for now; not a silent gap, an
-# explicitly deferred one, tracked alongside promote-to-mrp below.
+# governance AN-2 (#392, PR2a): now scoped `recommend:approve` — this
+# transitions an MPS node DRAFT/REVIEWED -> APPROVED, gating entry into
+# /promote-to-mrp below. It is an operational approval, so it rides the same
+# approval scope as scenarios/promote and recommendations' human-only targets;
+# an agent token (read + recommend:draft) is refused with 403. No separate
+# Decision Ladder human GATE is stacked here (the write-to-baseline happens one
+# step later, at promote-to-mrp) — the scope floor is the control level for V1.
 @router.post(
     "/{mps_id}/approve",
     response_model=ApproveMPSResponse,
@@ -813,7 +813,7 @@ async def approve_mps_node(
     mps_id: UUID,
     body: ApproveMPSRequest,
     db: DictRowConnection = Depends(get_db),
-    token: str = Depends(require_auth),
+    principal: Principal = Depends(require_scope("recommend:approve")),
 ) -> ApproveMPSResponse:
     """Approve an MPS node for MRP promotion."""
     row = db.execute(
@@ -844,7 +844,7 @@ async def approve_mps_node(
             detail=f"MPS node cannot be approved from status {previous_status}",
         )
 
-    approver = body.approved_by or token
+    approver = body.approved_by or principal.name
     reviewer = body.reviewed_by or row["reviewed_by"] or approver
     now = datetime.now(timezone.utc)
     notes = body.notes if body.notes is not None else row["notes"]
@@ -932,18 +932,16 @@ class PromoteToMRPResponse(BaseModel):
     crp_peak_load_date: Optional[date] = Field(None, description="Date of peak load (if CRP triggered)")
 
 
-# governance PR2: recommend:approve or a dedicated mps:approve scope +
-# Decision Ladder human gate — deferred. #392 security-review audit (PR1):
-# this DOES write planned_supply (creates a scheduled receipt on the MPS
-# node's own scenario — since #398, no longer forced onto baseline) and flips
-# the MPS node to the terminal RELEASED status, an apply-to-plan action in the
-# same family as staging/approve.py (gated in this PR1) and scenarios/promote
-# (gated in PR1's prior pass). A promotion of a baseline MPS still writes
-# baseline; a fork MPS writes its fork, so the governance gate matters equally
-# on both. Left require_auth-only here deliberately: closing it needs the same
-# scope+human-gate stacking pattern already applied to
-# staging/scenarios/recommendations, tracked as PR2 follow-up rather than
-# folded silently into this pass.
+# governance AN-2 (#392, PR2a): now scoped `recommend:approve`. This DOES
+# write planned_supply (creates a scheduled receipt on the MPS node's own
+# scenario — since #398, no longer forced onto baseline) and flips the MPS node
+# to the terminal RELEASED status, an apply-to-plan action in the same family
+# as staging/approve.py and scenarios/promote (both `recommend:approve`). A
+# promotion of a baseline MPS still writes baseline; a fork MPS writes its fork,
+# so the approval scope matters equally on both. A future Decision Ladder human
+# GATE (stacking the actor_kind check on top of the scope, as recommendations'
+# HUMAN_ONLY_TARGETS do) can be added if promote-to-mrp is reclassified L3+;
+# for V1 the approval scope is the control level.
 @router.post(
     "/{mps_id}/promote-to-mrp",
     response_model=PromoteToMRPResponse,
@@ -968,7 +966,7 @@ async def promote_to_mrp(
     mps_id: UUID,
     body: PromoteToMRPRequest,
     db: DictRowConnection = Depends(get_db),
-    token: str = Depends(require_auth),
+    principal: Principal = Depends(require_scope("recommend:approve")),
 ) -> PromoteToMRPResponse:
     """
     Promote MPS to MRP and trigger BOM explosion.
@@ -1005,7 +1003,7 @@ async def promote_to_mrp(
         mps_id=mps_id,
         explode_components=body.explode_components,
         dry_run=body.dry_run,
-        user_id=token,  # Use token as user identifier for audit
+        user_id=principal.name,  # principal identity for audit (AN-2 #392)
     )
     
     # CRP integration: trigger CRP calculation if requested

--- a/tests/integration/test_agent_floor_integration.py
+++ b/tests/integration/test_agent_floor_integration.py
@@ -44,6 +44,18 @@ Plus the #392 security-review fixes:
       end) can draft-transition a recommendation with no CHECK violation, and
       the audit trail correctly attributes actor_kind='service'.
 
+Plus the AN-2 (#392 PR2a) scope-floor + rate-limit rollout:
+  12. THE SCOPE MATRIX (roadmap acceptance criterion): one representative write
+      per scope family — a {read}-only token is denied with the missing scope
+      NAMED, the family-scoped token clears the auth floor.
+  13. The per-token rate limit: rate_per_min=3 → 3×200 then 429 + integer
+      Retry-After ≥ 1, the sliding window driven by the injected counter clock
+      (no wall-clock sleep) so the token recovers after the window.
+  14. Legacy non-regression: the shared env token clears every family write and
+      is never rate-limited (token_id is None → exempt by design).
+  15. Kill-switch precedes rate: a disabled fleet 503s an agent BEFORE the rate
+      counter is ever touched (observable — no bucket for that token_id).
+
 Tokens are inserted DIRECTLY in SQL: only the test knows the cleartext; the DB
 holds ``hash_token(clear)``. Each test seeds its own uuid4-suffixed tokens so
 there are no inter-test collisions. No wall-clock timing assertions anywhere.
@@ -52,7 +64,7 @@ from __future__ import annotations
 
 import io
 import os
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -121,14 +133,20 @@ def audit_client(migrated_db):
 
 @pytest.fixture(autouse=True)
 def _clear_token_cache():
-    """The minted-token lookup is memoised in-process; clear it around every
-    test so a seed/revoke in one test never leaks a cached decision into
-    another (and so revocation is observable without a TTL sleep)."""
+    """The minted-token lookup is memoised in-process AND the per-token rate
+    counter accumulates in-process; clear BOTH around every test so a
+    seed/revoke in one test never leaks a cached decision into another (and so
+    revocation is observable without a TTL sleep), and so a token that spent
+    rate slots in one test never carries them into the next. Both are
+    module-level singletons in ootils_core.api.auth, shared by the app the
+    api_client fixture drives."""
     import ootils_core.api.auth as auth
 
     auth._token_cache.clear()
+    auth._rate_counter.clear()
     yield
     auth._token_cache.clear()
+    auth._rate_counter.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -150,11 +168,17 @@ def _mint_token(
     scopes: list[str],
     expires_at: str | None = None,
     revoked_at: str | None = None,
+    rate_per_min: int | None = None,
 ) -> tuple[str, str]:
     """Insert one api_tokens row; return (cleartext_token, token_id).
 
     The cleartext exists ONLY here in the test — the DB stores its SHA-256 via
     the same hash_token the auth layer uses on lookup.
+
+    ``rate_per_min`` defaults to None (NULL = no per-token cap), so every token
+    minted by the pre-existing tests stays UNCAPPED and can never 429 — the
+    AN-2 rate counter is exercised only by the tokens that explicitly ask for a
+    budget (see TestRateLimit429 / TestKillSwitchBeforeRate below).
     """
     from ootils_core.api.auth import hash_token, token_prefix
 
@@ -165,8 +189,8 @@ def _mint_token(
             """
             INSERT INTO api_tokens (
                 token_id, name, actor_kind, token_hash, token_prefix,
-                scopes, expires_at, revoked_at
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                scopes, expires_at, revoked_at, rate_per_min
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 token_id,
@@ -177,6 +201,7 @@ def _mint_token(
                 scopes,
                 expires_at,
                 revoked_at,
+                rate_per_min,
             ),
         )
     return clear, str(token_id)
@@ -757,3 +782,250 @@ class TestServiceActorKind:
                 (reco_id,),
             ).fetchone()
         assert audit["actor_kind"] == "service"
+
+
+# ===========================================================================
+# 12. AN-2 (#392 PR2a) — the scope-enforcement MATRIX (roadmap acceptance
+#     criterion): one representative WRITE per scope family, both floors.
+#
+#     The read-only token is denied with the missing scope NAMED (the
+#     acceptance criterion); the family-scoped token clears the auth floor (a
+#     2xx, a business/validation 422, or a 404 all prove auth let it through —
+#     only a 403 would be an auth block, scope or human gate).
+#
+#     PREREQUISITE / minimal-valid-payload notes, per family:
+#       * ingest         POST /v1/ingest/items   — dry_run=True + a valid ItemRow
+#                        (external_id + name non-empty) → 200 with NO DB writes.
+#       * calc:run       POST /v1/calc/run        — {full_recompute: False} on
+#                        baseline → deterministic recompute (200; an engine 500
+#                        is still != 403).
+#       * graph:write    POST /v1/nodes/{id}/firm — the require_scope ROUTE
+#                        dependency fires before the body, so a read-only token
+#                        is 403 regardless of node existence; the granted token
+#                        reaches the body → 404 (random node_id), != 403.
+#       * scenario:write POST /v1/simulate        — {scenario_name, overrides:[]}
+#                        forks baseline → 201.
+#       * recommend:approve POST /v1/recommendations/{id}/transition APPROVED —
+#                        the scope check is IN-BODY (runtime target → runtime
+#                        scope), so the body MUST be valid (else a 422 pre-empts
+#                        the scope check); a REVIEWED reco is seeded. The GRANTED
+#                        token here is a HUMAN: APPROVED is a HUMAN_ONLY target,
+#                        so an agent+approve token would clear the scope floor
+#                        but hit the human GATE (403) — only a human clears both.
+#       * admin          POST /v1/demo/phase1/run — the ONLY admin-scoped write.
+#                        DENIED hits the real endpoint (require_scope('admin')
+#                        403s BEFORE the body → the demo never runs). GRANTED /
+#                        legacy stub the demo body (_stub_phase1_demo) so the
+#                        test isolates the AUTH-FLOOR grant from the heavy nested
+#                        Phase-1 chain (covered by test_phase1_e2e.py).
+# ===========================================================================
+
+
+_MATRIX_FAMILIES = [
+    "ingest",
+    "calc:run",
+    "graph:write",
+    "scenario:write",
+    "recommend:approve",
+    "admin",
+]
+
+
+def _grant_actor_kind(family: str) -> str:
+    """The actor_kind a GRANTED token must carry to clear BOTH auth floors for
+    a family. recommend:approve targets APPROVED (a HUMAN_ONLY target), so an
+    agent+approve token clears the scope floor but is stopped by the human GATE
+    — only a human clears both. Every other family's write carries no human
+    gate, so an agent (the ordinary fleet caller) is representative."""
+    return "human" if family == "recommend:approve" else "agent"
+
+
+def _do_family_write(api_client, tracker, family: str, token: str):
+    """Perform ONE representative write for ``family`` with ``token``; return
+    the raw response. Seeds only the prerequisite that family needs."""
+    headers = _bearer(token)
+    if family == "ingest":
+        return api_client.post(
+            "/v1/ingest/items",
+            headers=headers,
+            json={
+                "items": [
+                    {"external_id": f"FLOOR-{uuid4().hex[:8]}", "name": "Floor Item"}
+                ],
+                "dry_run": True,
+            },
+        )
+    if family == "calc:run":
+        return api_client.post(
+            "/v1/calc/run", headers=headers, json={"full_recompute": False}
+        )
+    if family == "graph:write":
+        return api_client.post(
+            f"/v1/nodes/{uuid4()}/firm", headers=headers, json={"actor": "floor-test"}
+        )
+    if family == "scenario:write":
+        return api_client.post(
+            "/v1/simulate",
+            headers=headers,
+            json={"scenario_name": f"floor-{uuid4().hex[:8]}", "overrides": []},
+        )
+    if family == "recommend:approve":
+        reco_id = tracker.reco(status="REVIEWED")
+        return api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            headers=headers,
+            json={
+                "to_status": "APPROVED",
+                "actor": "floor-approver",
+                "actor_kind": "human",
+            },
+        )
+    if family == "admin":
+        return api_client.post("/v1/demo/phase1/run", headers=headers)
+    raise AssertionError(f"unknown matrix family {family!r}")
+
+
+def _stub_phase1_demo(monkeypatch):
+    """Replace the heavy Phase-1 demo body with a cheap stub for the GRANTED
+    admin cases. The scope-enforcement test proves the ADMIN SCOPE grants access
+    to the admin-only endpoint — NOT that the demo chain runs (that is
+    test_phase1_e2e.py's job). Left unstubbed, the granted case would execute a
+    full nested-TestClient demo run (create_app + its own TestClient + the whole
+    Forecast→…→ATP chain) with no integration precedent. The DENIED admin case
+    needs no stub: require_scope('admin') is a route dependency that 403s BEFORE
+    the body, so the real demo body is never reached there.
+
+    The endpoint calls ``run_phase1_demo_from_env`` as a module global of
+    ``routers.demo`` resolved at call time, so rebinding that name reaches the
+    already-constructed api_client app."""
+    import ootils_core.api.routers.demo as demo_router
+
+    monkeypatch.setattr(
+        demo_router, "run_phase1_demo_from_env", lambda: {"stubbed": True}
+    )
+
+
+class TestScopeMatrix:
+    """The roadmap acceptance criterion, both floors of the matrix."""
+
+    @pytest.mark.parametrize("family", _MATRIX_FAMILIES)
+    def test_read_only_token_denied_with_named_scope(self, api_client, tracker, family):
+        # A single {read}-only agent token attempts each family's write.
+        clear, _ = tracker.token(actor_kind="agent", scopes=["read"])
+        resp = _do_family_write(api_client, tracker, family, clear)
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["detail"] == f"missing scope '{family}'"
+
+    @pytest.mark.parametrize("family", _MATRIX_FAMILIES)
+    def test_family_scoped_token_clears_the_auth_floor(
+        self, api_client, tracker, family, monkeypatch
+    ):
+        if family == "admin":
+            _stub_phase1_demo(monkeypatch)
+        clear, _ = tracker.token(
+            actor_kind=_grant_actor_kind(family), scopes=[family]
+        )
+        resp = _do_family_write(api_client, tracker, family, clear)
+        # 2xx / business-422 / 404 all mean the auth floor let the request
+        # THROUGH; only a 403 would be an auth (scope or gate) block.
+        assert resp.status_code != 403, resp.text
+
+
+# ===========================================================================
+# 13. AN-2 per-token rate limit — 429 + integer Retry-After, window driven by
+#     the injected clock (no wall-clock sleep).
+# ===========================================================================
+
+
+class TestRateLimit429:
+    def test_capped_token_429s_after_its_budget_then_recovers_after_the_window(
+        self, api_client, tracker, monkeypatch
+    ):
+        """rate_per_min=3 → 3×200, then the 4th → 429 with an integer
+        Retry-After ≥ 1. The counter's clock IS injectable from the test:
+        ``_RateCounter._clock`` is an instance slot on the module-level
+        ``auth._rate_counter`` singleton the app uses, so the 60 s sliding
+        window is advanced HERE without sleeping — after crossing the window
+        the same token is admitted again."""
+        import ootils_core.api.auth as auth
+
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(auth._rate_counter, "_clock", lambda: clock["t"])
+
+        clear, _ = tracker.token(
+            actor_kind="agent", scopes=["read"], rate_per_min=3
+        )
+        headers = _bearer(clear)
+
+        # 3 requests inside the budget, same instant → 200.
+        for _ in range(3):
+            r = api_client.get("/v1/recommendations", headers=headers)
+            assert r.status_code == 200, r.text
+
+        # 4th, still the same instant → over budget → 429 + Retry-After.
+        blocked = api_client.get("/v1/recommendations", headers=headers)
+        assert blocked.status_code == 429, blocked.text
+        assert "Retry-After" in blocked.headers
+        assert int(blocked.headers["Retry-After"]) >= 1
+
+        # Advance PAST the window (injected clock, no sleep): the three
+        # in-window timestamps age out → the token is admitted again.
+        clock["t"] += 61.0
+        after = api_client.get("/v1/recommendations", headers=headers)
+        assert after.status_code == 200, after.text
+
+
+# ===========================================================================
+# 14. Legacy non-regression — the shared env token clears every family write
+#     and is NEVER rate-limited (token_id is None → exempt by design).
+# ===========================================================================
+
+
+class TestLegacyNonRegression:
+    @pytest.mark.parametrize("family", _MATRIX_FAMILIES)
+    def test_legacy_token_clears_every_family_write(
+        self, api_client, tracker, family, monkeypatch
+    ):
+        # The legacy token is admin (superset scope) + human (clears the human
+        # gate), so it must pass every family's auth floor unchanged.
+        if family == "admin":
+            _stub_phase1_demo(monkeypatch)
+        resp = _do_family_write(api_client, tracker, family, LEGACY_TOKEN)
+        assert resp.status_code != 403, resp.text
+
+    def test_legacy_token_is_never_rate_limited(self, api_client):
+        """A tight burst on the shared legacy token never 429s — token_id is
+        None, so _enforce_rate_limit returns before ever consulting the
+        counter (pre-#392 behaviour preserved)."""
+        for _ in range(5):
+            r = api_client.get("/v1/recommendations", headers=_bearer(LEGACY_TOKEN))
+            assert r.status_code == 200, r.text
+            assert r.status_code != 429
+
+
+# ===========================================================================
+# 15. Kill-switch precedes rate — a disabled fleet 503s an agent BEFORE the
+#     rate counter is ever touched (resolve_principal ordering: kill switch,
+#     then rate limit).
+# ===========================================================================
+
+
+class TestKillSwitchBeforeRate:
+    def test_disabled_fleet_503s_agent_and_never_spends_a_rate_slot(
+        self, api_client, tracker, monkeypatch
+    ):
+        import ootils_core.api.auth as auth
+
+        clear, token_id = tracker.token(
+            actor_kind="agent", scopes=["read"], rate_per_min=3
+        )
+        # Start from a clean counter (the autouse fixture already cleared it),
+        # then disable the fleet for THIS request only (monkeypatch restores).
+        monkeypatch.setenv("OOTILS_AGENTS_ENABLED", "false")
+
+        resp = api_client.get("/v1/recommendations", headers=_bearer(clear))
+        assert resp.status_code == 503, resp.text
+
+        # OBSERVABLE proof the counter never moved: the kill switch runs before
+        # _enforce_rate_limit, so this token_id has NO bucket in the counter.
+        assert UUID(token_id) not in auth._rate_counter._store

--- a/tests/integration/test_demo_e2e_integration.py
+++ b/tests/integration/test_demo_e2e_integration.py
@@ -33,7 +33,8 @@ Premises verified in the script + seed before writing (not assumed):
     040; the human approval stamps actor_kind='human'.
   * api_tokens: name / actor_kind / scopes(TEXT[]) columns, migration 064; the
     demo mints DEMO-E2E-agent (['read','recommend:draft']) and DEMO-E2E-human
-    (['read','ingest','recommend:draft','recommend:approve']).
+    (the full operator superset: read, ingest, calc:run, graph:write,
+    scenario:write, recommend:draft, recommend:approve — AN-2 #392 PR2a).
   * inventory_snapshots / recommendation_outcomes exist (migrations 067/069).
 
 The seed is driven exactly as scripts/seed_demo_data.py's __main__ does
@@ -281,9 +282,17 @@ def test_demo_tokens_exist_with_expected_scopes(first_run):
 
     human = by_name["DEMO-E2E-human"]
     assert human["actor_kind"] == "human"
+    # AN-2 (#392, PR2a): the human token is the full operator superset (all
+    # scopes except `admin`) — the forecast run is calc:run, simulate /
+    # param-overrides / scenario delete are scenario:write, so the pre-AN-2
+    # {read, ingest, recommend:draft, recommend:approve} set no longer covers
+    # the demo's own calls.
     assert set(human["scopes"]) == {
         "read",
         "ingest",
+        "calc:run",
+        "graph:write",
+        "scenario:write",
         "recommend:draft",
         "recommend:approve",
     }

--- a/tests/test_atp_api.py
+++ b/tests/test_atp_api.py
@@ -67,9 +67,10 @@ class TestATPCheckValidation:
     """422 boundary tests for POST /v1/atp/check."""
 
     def test_atp_check_requires_auth_dependency_configured(self):
-        """ATP routers module exposes require_auth — used as endpoint dependency."""
+        """ATP routers module exposes require_scope — the AN-2 (#392) scope
+        dependency wired on every endpoint (calc:run for the ATP/CTP compute)."""
         from ootils_core.atp import routers
-        assert hasattr(routers, "require_auth")
+        assert hasattr(routers, "require_scope")
 
     def test_atp_check_validation_quantity_zero(self):
         client = _make_client_no_db()
@@ -114,7 +115,7 @@ class TestATPCheckValidation:
 class TestCTPCheckValidation:
     def test_ctp_check_requires_auth_dependency_configured(self):
         from ootils_core.atp import routers
-        assert hasattr(routers, "require_auth")
+        assert hasattr(routers, "require_scope")
 
 
 # ─────────────────────────────────────────────────────────────
@@ -125,7 +126,7 @@ class TestCTPCheckValidation:
 class TestCTPSimulateValidation:
     def test_ctp_simulate_requires_auth_dependency_configured(self):
         from ootils_core.atp import routers
-        assert hasattr(routers, "require_auth")
+        assert hasattr(routers, "require_scope")
 
     def test_ctp_simulate_validation_max_days_too_high(self):
         client = _make_client_no_db()

--- a/tests/test_m6_api.py
+++ b/tests/test_m6_api.py
@@ -285,11 +285,11 @@ class TestRouterConfiguration:
 
     def test_simulate_router_uses_auth(self):
         from ootils_core.api.routers import simulate
-        assert hasattr(simulate, "require_auth")
+        assert hasattr(simulate, "require_scope")
 
     def test_events_router_uses_auth(self):
         from ootils_core.api.routers import events
-        assert hasattr(events, "require_auth")
+        assert hasattr(events, "require_scope")
 
 
 if __name__ == "__main__":

--- a/tests/test_mps_approve.py
+++ b/tests/test_mps_approve.py
@@ -10,7 +10,20 @@ import psycopg
 import pytest
 from fastapi import HTTPException
 
+from ootils_core.api.auth import Principal
 from ootils_core.mps.api import ApproveMPSRequest, approve_mps_node
+
+# AN-2 (#392): approve_mps_node now takes a Principal (require_scope
+# "recommend:approve") instead of a raw token string. Its `name` is used as the
+# audit actor fallback when the body carries no approved_by — mirroring the old
+# `token` value so these unit tests keep their exact assertions.
+_HUMAN_PRINCIPAL = Principal(
+    token_id=None,
+    name="token-user",
+    actor_kind="human",
+    scopes=frozenset({"recommend:approve"}),
+    is_legacy=False,
+)
 
 
 def _make_result(row):
@@ -50,7 +63,7 @@ def test_approve_draft_records_review_and_approval():
         mps_id=mps_id,
         body=ApproveMPSRequest(approved_by="director", notes="go"),
         db=db,
-        token="token-user",
+        principal=_HUMAN_PRINCIPAL,
     ))
 
     assert resp.mps_id == mps_id
@@ -88,7 +101,7 @@ def test_approve_reviewed_preserves_reviewer():
         mps_id=mps_id,
         body=ApproveMPSRequest(approved_by="director"),
         db=db,
-        token="token-user",
+        principal=_HUMAN_PRINCIPAL,
     ))
 
     assert resp.previous_status == "REVIEWED"
@@ -116,7 +129,7 @@ def test_approve_already_approved_is_idempotent():
         mps_id=mps_id,
         body=ApproveMPSRequest(),
         db=db,
-        token="token-user",
+        principal=_HUMAN_PRINCIPAL,
     ))
 
     assert resp.previous_status == "APPROVED"
@@ -134,7 +147,7 @@ def test_approve_not_found_returns_404():
             mps_id=mps_id,
             body=ApproveMPSRequest(),
             db=db,
-            token="token-user",
+            principal=_HUMAN_PRINCIPAL,
         ))
 
     assert exc.value.status_code == 404
@@ -157,7 +170,7 @@ def test_approve_released_returns_409():
             mps_id=mps_id,
             body=ApproveMPSRequest(),
             db=db,
-            token="token-user",
+            principal=_HUMAN_PRINCIPAL,
         ))
 
     assert exc.value.status_code == 409

--- a/tests/test_rate_counter_and_scopes.py
+++ b/tests/test_rate_counter_and_scopes.py
@@ -1,0 +1,335 @@
+"""
+tests/test_rate_counter_and_scopes.py — PURE unit tests (no PostgreSQL) for the
+AN-2 (#392 PR2a) per-token rate counter and scope-enforcement helpers.
+
+Complements test_auth_principal.py (which already covers the pure helpers,
+_TokenCache, resolve_principal, resolve_gate_kind, the last_used bump and the
+require_scope 401/403 mapping through a file-local app). This file targets the
+pieces PR2a added that that file does NOT exercise:
+
+  * ``_RateCounter`` — the per-token sliding-window counter, driven with an
+    INJECTED clock so the 60 s window rolls over deterministically (no sleep):
+    under-limit allow, over-limit refuse + Retry-After, a REFUSED request that
+    does NOT consume a slot, window rollover, LRU size-bound eviction, and a
+    lock-serialised concurrency smoke test.
+  * ``require_scope`` FACTORY validation — an unknown scope raises ValueError at
+    factory-call time (import time for the real routers), the ``admin`` superset
+    satisfies every scope in VALID_SCOPES, and the 403 detail names the scope.
+  * ``Principal.rate_per_min`` / ``_enforce_rate_limit`` exemptions — a NULL
+    budget (and the legacy token's None token_id) never even consults the
+    counter (fail-open "uncapped", never "blocked").
+
+No pytest-asyncio in this repo: the async require_scope dependency is driven
+with ``asyncio.run()`` inside sync tests (same pattern as test_auth_principal.py).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+from uuid import uuid4
+
+import pytest
+
+# auth.py validates OOTILS_API_TOKEN at IMPORT time — set it before importing.
+os.environ.setdefault("OOTILS_API_TOKEN", "unit-legacy-token")
+
+from fastapi import HTTPException  # noqa: E402
+
+import ootils_core.api.auth as auth  # noqa: E402
+from ootils_core.api.auth import (  # noqa: E402
+    Principal,
+    VALID_SCOPES,
+    _RATE_MAX_ENTRIES,
+    _RATE_WINDOW_SECONDS,
+    _RateCounter,
+    _enforce_rate_limit,
+    legacy_principal,
+    require_scope,
+)
+
+
+class _FakeClock:
+    """Manually advanced monotonic-like clock (mirrors test_auth_principal)."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+class _SpyCounter:
+    """Stand-in for the module-level _rate_counter that records every call, so a
+    test can prove an exempt principal never consults the counter at all."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    def check(self, token_id, limit):
+        self.calls.append((token_id, limit))
+        return None
+
+
+def _minted(scopes, *, rate_per_min=None, token_id=None):
+    return Principal(
+        token_id=token_id or uuid4(),
+        name="agent",
+        actor_kind="agent",
+        scopes=frozenset(scopes),
+        is_legacy=False,
+        rate_per_min=rate_per_min,
+    )
+
+
+# ===========================================================================
+# 1. _RateCounter — under the limit
+# ===========================================================================
+
+
+class TestRateCounterUnderLimit:
+    def test_first_n_calls_at_the_limit_are_allowed(self):
+        rc = _RateCounter(window_seconds=60.0, clock=_FakeClock())
+        tid = uuid4()
+        # Exactly `limit` allowed calls, each returns None (admitted).
+        for _ in range(5):
+            assert rc.check(tid, 5) is None
+
+    def test_calls_strictly_below_limit_never_refuse(self):
+        rc = _RateCounter(window_seconds=60.0, clock=_FakeClock())
+        tid = uuid4()
+        assert rc.check(tid, 3) is None
+        assert rc.check(tid, 3) is None  # 2 < 3 → still admitted
+
+
+# ===========================================================================
+# 2. _RateCounter — over the limit + Retry-After semantics
+# ===========================================================================
+
+
+class TestRateCounterOverLimit:
+    def test_n_plus_one_refused_with_positive_retry(self):
+        clock = _FakeClock(1000.0)
+        rc = _RateCounter(window_seconds=60.0, clock=clock)
+        tid = uuid4()
+        assert rc.check(tid, 3) is None
+        assert rc.check(tid, 3) is None
+        assert rc.check(tid, 3) is None
+        retry = rc.check(tid, 3)  # 4th → refused
+        assert retry is not None
+        assert retry >= 1
+        # All three landed at t=1000; the oldest ages out at t=1060 → retry=60.
+        assert retry == pytest.approx(60.0)
+
+    def test_refused_request_does_not_consume_a_slot(self):
+        clock = _FakeClock(1000.0)
+        rc = _RateCounter(window_seconds=60.0, clock=clock)
+        tid = uuid4()
+        for _ in range(3):
+            rc.check(tid, 3)
+        assert len(rc._store[tid]) == 3
+        # A refused call must NOT append a 4th timestamp (it would extend the
+        # window and punish a caller that then backs off exactly Retry-After).
+        assert rc.check(tid, 3) is not None
+        assert len(rc._store[tid]) == 3
+
+    def test_backing_off_exactly_retry_after_is_admitted(self):
+        clock = _FakeClock(1000.0)
+        rc = _RateCounter(window_seconds=60.0, clock=clock)
+        tid = uuid4()
+        rc.check(tid, 3)                      # t=1000
+        clock.advance(10.0)
+        rc.check(tid, 3)                      # t=1010
+        clock.advance(10.0)
+        rc.check(tid, 3)                      # t=1020 → full [1000, 1010, 1020]
+        retry = rc.check(tid, 3)             # refused at t=1020
+        assert retry == pytest.approx(40.0)  # 1000 + 60 − 1020
+        clock.advance(retry)                 # back off EXACTLY retry → t=1060
+        # The oldest (t=1000) has aged out → one slot freed → admitted.
+        assert rc.check(tid, 3) is None
+
+    def test_full_window_rollover_resets_allowance(self):
+        clock = _FakeClock(1000.0)
+        rc = _RateCounter(window_seconds=60.0, clock=clock)
+        tid = uuid4()
+        for _ in range(3):
+            assert rc.check(tid, 3) is None
+        assert rc.check(tid, 3) is not None  # window full → refused
+        clock.advance(60.0)                  # the entire window elapses
+        # Every timestamp (all at t=1000) is now <= cutoff (1000) → dropped.
+        assert rc.check(tid, 3) is None
+        assert rc.check(tid, 3) is None
+        assert rc.check(tid, 3) is None
+
+
+# ===========================================================================
+# 3. _RateCounter — LRU size bound (memory ceiling, not a security control)
+# ===========================================================================
+
+
+class TestRateCounterSizeBound:
+    def test_eviction_at_the_bound_drops_the_oldest_token(self):
+        rc = _RateCounter(window_seconds=60.0, clock=_FakeClock(), max_entries=2)
+        t1, t2, t3 = uuid4(), uuid4(), uuid4()
+        rc.check(t1, 5)
+        rc.check(t2, 5)
+        rc.check(t3, 5)  # over budget → evicts t1 (least-recently-seen)
+        assert t1 not in rc._store
+        assert t2 in rc._store and t3 in rc._store
+        assert len(rc._store) == 2
+
+    def test_store_never_exceeds_max_entries(self):
+        rc = _RateCounter(window_seconds=60.0, clock=_FakeClock(), max_entries=5)
+        for _ in range(50):  # a flood of distinct token_ids
+            rc.check(uuid4(), 5)
+            assert len(rc._store) <= 5
+        assert len(rc._store) == 5
+
+    def test_recently_seen_token_survives_eviction(self):
+        rc = _RateCounter(window_seconds=60.0, clock=_FakeClock(), max_entries=2)
+        t1, t2, t3 = uuid4(), uuid4(), uuid4()
+        rc.check(t1, 5)
+        rc.check(t2, 5)
+        rc.check(t1, 5)   # touch t1 → moves it to the MRU end
+        rc.check(t3, 5)   # over budget → evicts t2 (now oldest), NOT t1
+        assert t2 not in rc._store
+        assert t1 in rc._store and t3 in rc._store
+
+    def test_default_window_and_max_are_the_module_constants(self):
+        rc = _RateCounter(clock=_FakeClock())
+        assert rc._window == _RATE_WINDOW_SECONDS
+        assert rc._max_entries == _RATE_MAX_ENTRIES
+
+    def test_clear_drops_all_buckets(self):
+        rc = _RateCounter(window_seconds=60.0, clock=_FakeClock())
+        rc.check(uuid4(), 5)
+        rc.check(uuid4(), 5)
+        rc.clear()
+        assert len(rc._store) == 0
+
+
+# ===========================================================================
+# 4. _RateCounter — basic thread safety (lock present + no lost updates)
+# ===========================================================================
+
+
+class TestRateCounterThreadSafety:
+    def test_has_a_lock(self):
+        rc = _RateCounter()
+        # A real threading.Lock exposes acquire/release and context-manager use.
+        assert hasattr(rc._lock, "acquire")
+        assert hasattr(rc._lock, "release")
+
+    def test_concurrent_checks_do_not_lose_updates(self):
+        # A constant clock keeps every append inside the window, and a huge
+        # limit keeps every request allowed — so the surviving count MUST equal
+        # the total number of allowed calls IFF the lock serialises the append
+        # (a lost update under a race would leave fewer than that).
+        rc = _RateCounter(window_seconds=60.0, clock=lambda: 1000.0)
+        tid = uuid4()
+        n_threads, per_thread = 16, 50
+
+        def worker():
+            for _ in range(per_thread):
+                rc.check(tid, 10_000)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(rc._store[tid]) == n_threads * per_thread
+
+
+# ===========================================================================
+# 5. require_scope — factory-time validation + admin superset + 403 detail
+# ===========================================================================
+
+
+class TestRequireScopeFactory:
+    def test_unknown_scope_raises_valueerror_at_the_factory(self):
+        # Routers wire Depends(require_scope("...")) at import, so a typo fails
+        # LOUDLY at app import, never silently at request time.
+        with pytest.raises(ValueError) as ei:
+            require_scope("scope-inconnu")
+        assert "unknown scope" in str(ei.value).lower()
+
+    @pytest.mark.parametrize("scope", sorted(VALID_SCOPES))
+    def test_every_valid_scope_is_constructible(self, scope):
+        dep = require_scope(scope)
+        assert callable(dep)
+
+    @pytest.mark.parametrize("scope", sorted(VALID_SCOPES))
+    def test_admin_principal_satisfies_every_valid_scope(self, scope):
+        admin = Principal(
+            token_id=None,
+            name="legacy",
+            actor_kind="human",
+            scopes=frozenset({"admin"}),
+            is_legacy=True,
+        )
+        dep = require_scope(scope)
+        # Passing principal= explicitly bypasses Depends(resolve_principal); the
+        # body runs against our controlled principal.
+        result = asyncio.run(dep(principal=admin))
+        assert result is admin  # cleared the scope check → returns the principal
+
+    def test_missing_scope_403_names_the_scope(self):
+        agent = Principal(
+            token_id=uuid4(),
+            name="watcher",
+            actor_kind="agent",
+            scopes=frozenset({"read"}),  # lacks recommend:approve
+            is_legacy=False,
+        )
+        dep = require_scope("recommend:approve")
+        with pytest.raises(HTTPException) as ei:
+            asyncio.run(dep(principal=agent))
+        assert ei.value.status_code == 403
+        assert ei.value.detail == "missing scope 'recommend:approve'"
+
+
+# ===========================================================================
+# 6. Principal.rate_per_min / _enforce_rate_limit — fail-open exemptions
+# ===========================================================================
+
+
+class TestRatePerMinExemptions:
+    def test_legacy_principal_has_no_rate_cap(self):
+        assert legacy_principal().rate_per_min is None
+
+    def test_null_rate_never_consults_the_counter(self, monkeypatch):
+        spy = _SpyCounter()
+        monkeypatch.setattr(auth, "_rate_counter", spy)
+        p = _minted({"read"}, rate_per_min=None)  # capped budget absent
+        _enforce_rate_limit(p, "ootk_prefix")     # must be a pure no-op
+        assert spy.calls == []                     # the counter was never touched
+
+    def test_legacy_token_id_none_never_consults_the_counter(self, monkeypatch):
+        spy = _SpyCounter()
+        monkeypatch.setattr(auth, "_rate_counter", spy)
+        _enforce_rate_limit(legacy_principal(), "global_token")
+        assert spy.calls == []
+
+    def test_capped_token_over_budget_raises_429_with_retry_after(self, monkeypatch):
+        fake = _RateCounter(window_seconds=60.0, clock=_FakeClock(1000.0))
+        monkeypatch.setattr(auth, "_rate_counter", fake)
+        p = _minted({"read"}, rate_per_min=2)
+        _enforce_rate_limit(p, "c")  # 1st — under budget
+        _enforce_rate_limit(p, "c")  # 2nd — at budget
+        with pytest.raises(HTTPException) as ei:
+            _enforce_rate_limit(p, "c")  # 3rd — over budget → 429
+        assert ei.value.status_code == 429
+        # Whole-seconds Retry-After (HTTP spec), floored at 1.
+        assert int(ei.value.headers["Retry-After"]) >= 1
+
+    def test_capped_token_under_budget_passes(self, monkeypatch):
+        fake = _RateCounter(window_seconds=60.0, clock=_FakeClock(1000.0))
+        monkeypatch.setattr(auth, "_rate_counter", fake)
+        p = _minted({"read"}, rate_per_min=5)
+        for _ in range(5):  # exactly the budget — none refused
+            _enforce_rate_limit(p, "c")


### PR DESCRIPTION
**Le verrou de sécurité de la flotte.** Constat d'audit : 7 routers sur ~30 vérifiaient les scopes — un token read-only pouvait lancer un MRP run ou muter le graphe. Cette PR : grille 8 scopes appliquée aux **102/102 routes montées** (scan AST indépendant en revue : zéro route sans auth), doctrine « coût ≠ réversibilité » actée (calc:run requis pour tout moteur), rate_per_min enfin lu (fenêtre glissante par token, 429+Retry-After, refus non consommant, legacy exempt), ordre des gates prouvé (401 → kill-switch → rate). Zéro migration. Rétro-compat totale (legacy admin-superset, démo 7/3/0 retracée). 36 tests unit neufs + 21 intégration (matrice 403 par famille = LE critère d'acceptation roadmap). Revue adversariale : GO zéro bloquant. Réf #392, ADR-029 ; PR2b ensuite (tokens/metrics/ADR-032).

🤖 Generated with [Claude Code](https://claude.com/claude-code)