### PR TITLE
feat(auth): #392 AN-2 PR2b — /v1/tokens + /metrics + ADR-032 (fin du chantier)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,8 @@ HTTP request → Bearer-token auth (`api/auth.py`) → router in `api/routers/<d
 ### Auth
 `api/auth.py` validates `OOTILS_API_TOKEN` at **import time** and raises `RuntimeError` if unset. Token comparison uses `hmac.compare_digest`. Don't add an "optional auth" path.
 
+**Scopes & budgets (ADR-032, #392 AN-2):** a whitelist of 8 scopes lives in `VALID_SCOPES` (`api/auth.py`) — `read`, `ingest`, `calc:run`, `graph:write`, `scenario:write`, `recommend:draft`, `recommend:approve`, `admin` (superset). Every mounted route now depends on `require_scope("...")`; there is **no `require_auth` on any write** (it survives only as a thin alias for tests / the unmounted `atp/api.py`). Doctrine is **cost ≠ reversibility**: any endpoint that invokes an engine (MRP, propagation, Pyramide, DQ, CTP, ghosts, BOM explosion) requires `calc:run` including its derived graph writes; `graph:write` is only for direct master-data mutations (firm/unfirm). Per-token `rate_per_min` is enforced (`_RateCounter`/`_enforce_rate_limit`, per-worker sliding 60 s window, 429 + `Retry-After`; legacy & NULL exempt). Token lifecycle is `POST/GET/DELETE /v1/tokens` (admin; cleartext shown once; soft-revoke + global cache invalidation); `GET /metrics` (admin, outside `/v1` and OpenAPI, bounded cardinality).
+
 ### Propagation model (ADR-003)
 Event-driven, incremental, deterministic. An event marks a subgraph dirty; compute happens in topo order; unchanged nodes stop the cascade (they do not propagate further). Every change is attributable. Determinism is a hard constraint — **no randomness in the core engine**.
 

--- a/docs/ADR-029-agent-enterprise-floor.md
+++ b/docs/ADR-029-agent-enterprise-floor.md
@@ -49,20 +49,18 @@ Le token legacy résout vers un `Principal` synthétique `human` / `admin` (supe
 - **Auth / gouvernance, transverse aux scénarios.** Un token et son `actor_kind` sont une donnée d'infrastructure, invariante par scénario. Aucune forkabilité requise — un token n'est pas un levier de simulation.
 - **Le ledger d'audit survit à la suppression d'un token.** `api_request_log.token_id → api_tokens` est `ON DELETE SET NULL` (les lignes d'audit survivent à un hard-delete de token), et `actor_kind` est **dénormalisé** sur chaque ligne d'audit à l'écriture : la trace reste répondable (« agent ou humain ? ») même après suppression du token. La dénormalisation est le bon choix pour un log immuable — il enregistre ce qui était vrai à l'instant t, pas ce que le registre dit maintenant.
 
-## Décidé mais pas encore appliqué (honnêteté — dette tracée)
+## Décidé et désormais APPLIQUÉ (chantier AN-2 — voir ADR-032)
 
-L'étage entreprise est **posé** (le substrat existe et est enforçable) mais n'est **pas encore branché partout**. À ne pas re-claimer comme livré :
+L'étage entreprise était **posé** en PR1 (substrat enforçable) mais **pas encore branché partout**. Le chantier **AN-2** (`docs/ROADMAP-AGENTS-2026-H2.md` §4) a résorbé les trois trous ci-dessous. La doctrine, la grille des 8 scopes et les caveats sont actés dans **`docs/ADR-032-scope-grid-and-budgets.md`**.
 
-- **Scopes non appliqués sur ~24 routers.** `require_auth` résout le principal mais ne vérifie **aucun** scope ; seule une poignée de routers utilisent `require_scope`. Un token read-only peut aujourd'hui déclencher un write (`POST /v1/mrp/run`, mutation de graphe). Basculer **tous** les routers d'écriture vers `require_scope` est le chantier **AN-2** de `docs/ROADMAP-AGENTS-2026-H2.md` (§4).
-- **`api_tokens.rate_per_min` est du schéma mort.** La colonne existe (budget par token) mais **aucun code ne la lit** : aucun rate-limit par token n'est appliqué. Câblage prévu en AN-2 (middleware au checkout du Principal).
-- **Endpoints issue/revoke de tokens gouvernés** et **`/metrics`** : prévus en AN-2. L'émission passe aujourd'hui par un script CLI (`scripts/issue_agent_token.py`).
-
-Ces items ne sont **pas** de la dette silencieuse : ils sont ici pour que l'écart entre « le substrat est en place » et « il est enforcé partout » soit explicite.
+- **Scopes appliqués sur 102/102 routes montées (PR2a, [#434](https://github.com/ngoineau/ootils-core/pull/434)).** Tous les routers d'écriture sont passés à `require_scope` — il ne subsiste **aucun** `require_auth` sur une route montée (`require_auth` n'est plus qu'un alias fin conservé pour les tests et le module non-monté `atp/api.py`, cf. sa docstring `api/auth.py`). La doctrine appliquée : **coût ≠ réversibilité** — un endpoint qui invoque un moteur (MRP, propagation, Pyramide, DQ…) exige `calc:run`, `graph:write` est réservé aux mutations directes de master-data (firm/unfirm). Détail et grille : ADR-032 §1–2.
+- **`api_tokens.rate_per_min` est lu et appliqué (PR2b).** `_RateCounter` + `_enforce_rate_limit` (`api/auth.py`) enforcent le budget par token (fenêtre glissante 60 s per-worker, 429 + `Retry-After`, refus non consommant, legacy/NULL exemptés). Caveat per-worker documenté : ADR-032 §4.
+- **Émission/révocation par l'API + `/metrics` (PR2b).** `POST/GET/DELETE /v1/tokens` (admin ; cleartext montré une fois ; soft-revoke + invalidation globale du cache ; 204 idempotent) via `api/token_service.py` + `api/routers/tokens.py`. `GET /metrics` (admin, hors `/v1`, hors OpenAPI, cardinalité bornée) via `api/metrics.py`. Détail : ADR-032 §5–6.
 
 ## Conséquences
 
 - **Positif :** la Decision Ladder et le gate humain #341 deviennent **réellement enforçables** — `actor_kind` n'est plus usurpable par un payload. Le kill-switch `OOTILS_AGENTS_ENABLED` donne un interrupteur global sur la flotte. L'audit reste répondable pour toujours, immunisé contre la suppression de token. Aucun appelant pré-#392 ne régresse (chemin legacy préservé à l'octet près).
-- **Négatif / dette assumée en V1 :** l'enforcement des scopes et des budgets n'est pas encore généralisé (§ ci-dessus) — un token peut, aujourd'hui, dépasser ses scopes sur les routers non encore basculés. C'est le périmètre exact d'AN-2. Le token legacy `admin`-superset reste un contournement tant qu'il n'est pas retiré.
+- **Négatif / dette assumée en V1 :** l'enforcement des scopes et des budgets est désormais généralisé (chantier AN-2, § ci-dessus / ADR-032), mais deux dettes subsistent — le rate-limit est **per-worker** (plafond effectif N × `rate_per_min` sous N workers, pas de store partagé) et le token legacy `admin`-superset reste un contournement de la grille tant qu'il n'est pas retiré.
 
 ## Références
 
@@ -71,4 +69,5 @@ Ces items ne sont **pas** de la dette silencieuse : ils sont ici pour que l'éca
 - `src/ootils_core/db/migrations/064_api_tokens_and_scopes.sql` — table `api_tokens` (SHA-256, `actor_kind` CHECK, `scopes TEXT[]`), binding audit, élargissement `recommendation_transitions.actor_kind` ; source de vérité du schéma, header détaillé.
 - `src/ootils_core/api/auth.py` — `resolve_principal`, `resolve_gate_kind`, `require_scope`, cache TTL-30 s borné LRU, kill-switch `OOTILS_AGENTS_ENABLED`, principal legacy synthétique.
 - `docs/ROADMAP-AGENTS-2026-H2.md` §4 — chantier **AN-2** (scopes bout-en-bout + budgets `rate_per_min` + endpoints issue/revoke + /metrics).
+- `docs/ADR-032-scope-grid-and-budgets.md` — l'ADR qui acte AN-2 : grille des 8 scopes, doctrine coût≠réversibilité, budgets par token, cycle de vie `/v1/tokens`, `/metrics`.
 - `docs/ADR-030-proof-machine.md` — même exigence North Star « déterministe / auditable » sur l'axe preuve ; convention FK `ON DELETE RESTRICT` explicite pour les FK vers `scenarios`.

--- a/docs/ADR-032-scope-grid-and-budgets.md
+++ b/docs/ADR-032-scope-grid-and-budgets.md
@@ -1,0 +1,131 @@
+# ADR-032 — Grille de scopes, budgets par token, cycle de vie des credentials et /metrics
+
+**Statut :** Accepté — chantier #392 **AN-2**. PR2a (enforcement des scopes bout-en-bout, [#434](https://github.com/ngoineau/ootils-core/pull/434)) mergée ; PR2b (budgets `rate_per_min` appliqués, cycle de vie des tokens par l'API, `/metrics` Prometheus) dans ce worktree. Cet ADR acte les décisions AN-2 posées en dette par ADR-029 (§« décidé mais pas encore appliqué », désormais résorbée).
+**Date :** 2026-07-08
+**Auteurs :** ootils-core team
+**Contexte mesuré :** `docs/ADR-029-agent-enterprise-floor.md` (le substrat), `docs/ROADMAP-AGENTS-2026-H2.md` §4 (chantier AN-2), et l'implémentation `src/ootils_core/api/auth.py` / `token_service.py` / `metrics.py` / `routers/tokens.py`, qui portent ces décisions.
+
+---
+
+## Contexte
+
+ADR-029 a **posé** l'étage entreprise : un registre `api_tokens` (migration 064), une identité d'acteur cryptographique (`actor_kind` dérivé du token, jamais du body), un cache de résolution borné, un kill-switch de flotte. Mais cet ADR fermait sur une section d'honnêteté — « décidé mais pas encore appliqué » — qui listait trois trous :
+
+- **Les scopes n'étaient enforcés nulle part.** `require_auth` résolvait le principal mais ne vérifiait **aucun** scope ; une poignée de routers seulement utilisaient `require_scope`. Un token read-only pouvait déclencher `POST /v1/mrp/run` ou muter le graphe. Le `scopes TEXT[]` était un grant que rien ne consommait.
+- **`api_tokens.rate_per_min` était du schéma mort.** La colonne (budget par token) existait mais aucun code ne la lisait — aucun rate-limit par token.
+- **Aucun cycle de vie par l'API, aucune observabilité.** L'émission passait par un script CLI ; il n'existait ni endpoint gouverné d'émission/révocation, ni `/metrics`.
+
+AN-2 ferme ces trois trous. Le point de doctrine central que ce chantier a dû trancher — et qui n'était pas résolu dans ADR-029 — est **quel scope exige quel endpoint**. La règle intuitive « c'est déterministe, donc ce n'est pas une décision, donc `require_auth` seul suffit » s'est révélée **fausse et dangereuse** : un run MRP est déterministe **et** coûteux **et** écrit des nœuds dérivés dans le graphe. La confondre avec une simple lecture parce qu'elle est reproductible, c'est laisser un token read-only saturer le moteur. Il fallait une doctrine explicite, orthogonale à la réversibilité (que gère déjà la Decision Ladder + le gate #341).
+
+## Décision
+
+### 1. La grille des 8 scopes — whitelist en code, validée à l'import
+
+Le vocabulaire des scopes valides est une **frozenset applicative** (`VALID_SCOPES`, `src/ootils_core/api/auth.py:111`), **jamais** un CHECK SQL (ADR-029 : la base stocke le grant, l'appli décide ce qu'un grant peut contenir — élargir un scope ne doit pas exiger une migration). Les routers câblent `Depends(require_scope("..."))` à l'import ; un scope typé faux **crashe au boot** (`require_scope` lève `ValueError` à l'appel-fabrique, `auth.py:758`) plutôt que de 403-er silencieusement à la requête — fail-loudly.
+
+| Scope | Sémantique | Exemples d'endpoints |
+|---|---|---|
+| `read` | Toute lecture. Aucune écriture, aucun moteur invoqué. | `GET /v1/nodes/{id}`, `GET /v1/issues`, `GET /v1/stream`, `GET /v1/outcomes/summary`, tous les `GET` Pyramide/DQ |
+| `ingest` | Écriture de master-data / données opérationnelles via les pipelines d'ingest. | `POST /v1/ingest/items`, `POST /v1/ingest/locations`, `POST /v1/snapshots`, `POST /v1/outcomes/evaluate` |
+| `calc:run` | **Invoquer un moteur** (calcul déterministe), y compris ses écritures graphe DÉRIVÉES. | `POST /v1/mrp/run`, `POST /v1/calc/run`, `POST /v1/pyramide/runs`, DQ engine run, CTP, ghosts, explosion BOM |
+| `graph:write` | Mutation **directe** de master-data topologique. | `POST /v1/nodes/{id}/firm`, `DELETE /v1/nodes/{id}/firm` (firm/unfirm d'un FPO) |
+| `scenario:write` | Créer / forker un scénario, écrire un overlay de scénario. | `POST /v1/simulate`, `POST /v1/scenarios`, `POST /v1/scenarios/{id}/param-overrides` |
+| `recommend:draft` | Émettre / faire transiter une reco jusqu'aux états non-terminaux. | transition d'une reco vers `DRAFT`/`REVIEWED` |
+| `recommend:approve` | Faire transiter une reco vers un état d'approbation. | transition d'une reco vers `APPROVED`/`APPLIED` |
+| `admin` | **Superset** — satisfait tout `require_scope`. Émission/révocation de tokens, `/metrics`, démos. | `POST/GET/DELETE /v1/tokens`, `GET /metrics`, `POST /v1/demo/phase1/run` |
+
+`admin` est le superset (`Principal.has_scope`, `auth.py:156`) : le token legacy y résout, donc aucun appelant pré-#392 ne régresse. Les scopes sont des **capacités orthogonales**, pas une hiérarchie : détenir `calc:run` ne confère pas `graph:write`, et inversement.
+
+### 2. LA DOCTRINE : coût ≠ réversibilité
+
+L'ancienne règle — « un endpoint déterministe n'est pas une décision, donc `require_auth` seul » — est **cassée et remplacée**. Elle confondait deux axes indépendants :
+
+- **La réversibilité / le risque** est l'axe de la **Decision Ladder** (L0–L4) et du **gate humain #341**. Il gouverne *qui* (humain vs agent) peut *approuver* une action irréversible.
+- **Le coût / la capacité** est l'axe des **scopes**. Il gouverne *quelle catégorie de travail* un token a le droit de déclencher.
+
+La doctrine gravée :
+
+- **Tout endpoint qui invoque un moteur exige `calc:run`** — MRP, propagation, Pyramide/Chronos, DQ, CTP, ghosts, explosion BOM — **y compris ses écritures graphe DÉRIVÉES du calcul**. Un run MRP qui écrit des nœuds `PlannedSupply` reste `calc:run`, pas `graph:write` : ces nœuds sont un *produit du calcul*, pas une mutation directe de master-data. Vérifié : `POST /v1/mrp/run` → `calc:run` (`routers/mrp.py:325`), Pyramide run → `calc:run` (`routers/pyramide.py:296,414`), DQ engine → `calc:run` (`routers/dq.py:92,351`).
+- **`graph:write` est réservé aux mutations DIRECTES de master-data topologique** — aujourd'hui firm/unfirm d'un FPO (`POST`/`DELETE /v1/nodes/{id}/firm`, `routers/graph.py:430,446`). Ce sont des écritures que l'opérateur pose à la main sur le graphe, pas dérivées d'un moteur.
+- **`ingest` est l'écriture de données, pas l'invocation de moteur** : charger des items, des locations, un snapshot, persister un verdict d'outcome.
+
+La conséquence pratique : un token de watcher qui a besoin de *simuler* (fork + propagation) porte `scenario:write` + `calc:run`, jamais `graph:write` ; un opérateur qui *firme* une commande porte `graph:write` sans avoir le droit de lancer un MRP complet. Chaque token porte le strict nécessaire à sa mission.
+
+### 3. Deux planchers empilés sur la gouvernance
+
+Une écriture gouvernée (L3+, ex. `CANCEL`, approbation d'une reco) franchit **deux planchers successifs**, jamais un seul :
+
+1. **Le plancher de scope (403)** — `require_scope` vérifie que le token détient la capacité (ex. `recommend:approve`). Résolu **avant** d'atteindre le corps de l'endpoint.
+2. **Le gate humain #341 (403)** — inchangé par AN-2. Même un token qui a franchi le plancher de scope se voit refuser une transition `HUMAN_ONLY` si son `actor_kind` (lu du **token**, pas du body) n'est pas `human`.
+
+Les deux sont indépendants et cumulatifs : un token `agent` + `recommend:approve` franchit le plancher de scope **mais** est arrêté par le gate humain (test `test_human_gate_blocks_agent_even_with_approve_scope_and_lying_body`, `tests/integration/test_agent_floor_integration.py`). Le gate #341 **ne bouge pas** — AN-2 ajoute un plancher *en amont*, il ne remplace rien.
+
+### 4. Budgets — `rate_per_min` par token, fenêtre glissante per-worker
+
+`_RateCounter` (`auth.py:376`) applique le budget `api_tokens.rate_per_min` : une fenêtre glissante de 60 s, un deque de timestamps monotoniques par `token_id`, purge des timestamps hors fenêtre à chaque touche, refus dès que le compte atteint la limite.
+
+- **Per-worker, PAS global — caveat documenté (jumeau du cache TTL).** Comme `_TokenCache`, le compteur vit dans la mémoire d'**un** process. Sous N workers uvicorn, le plafond effectif d'un token est N × `rate_per_min` (chaque worker ne compte que ce qu'il a servi). C'est un arbitrage V1 délibéré : aucun store partagé sur le chemin d'auth chaud ; un limiteur global exigerait Redis/DB. Le budget est **approximatif, pas exact**, et documenté comme tel dans la docstring de `_RateCounter`.
+- **Refus non consommant — backoff exact admis.** Une requête refusée n'est **pas** enregistrée (elle n'étend pas la fenêtre) : un appelant qui recule exactement `Retry-After` secondes est admis au prochain essai (`_RateCounter.check`, `auth.py:418`). Le refus renvoie **429 + `Retry-After`** en secondes entières, planché à 1 (`_enforce_rate_limit`, `auth.py:620`).
+- **Ordre 401 → kill-switch → rate.** Dans `resolve_principal` : token manquant/invalide → **401** d'abord ; puis `request.state` posé (attribution d'audit) ; puis kill-switch flotte → **503** (une flotte désactivée répond sans dépenser de slot de rate) ; puis rate limit → **429** en dernier (`auth.py:711–715`). Le plancher de scope (403) suit, dans `require_scope`.
+- **Legacy et NULL exemptés — opt-in à l'émission.** Le token legacy (`token_id is None`) et tout token minté à `rate_per_min = NULL` ne sont **jamais** rate-limités (fail-open : un budget absent = « illimité », jamais « bloqué » — `auth.py:632`). 🎯 Défaut pilote : **NULL = illimité** ; le pilote peut instaurer un défaut prudent à l'émission (`rate_per_min` doit être `> 0`, gardé côté `mint_token` et côté CHECK migration 064).
+
+### 5. Cycle de vie des tokens par l'API — `POST/GET/DELETE /v1/tokens` (admin)
+
+Le router `routers/tokens.py` remplace les INSERT à la main et le CLI comme voie principale d'émission/révocation. **Chaque verbe exige `admin`** : émettre ou tuer une credential est l'opération la plus privilégiée du système.
+
+- **`POST /v1/tokens`** — émet une credential ; le **cleartext est montré exactement UNE fois** dans la réponse (`TokenCreateResponse.token`) et n'est jamais restituable (seul le SHA-256 vit en base). La logique de génération/hash/persist est centralisée dans `token_service.mint_token` (`token_service.py:59`), partagée avec `scripts/demo_e2e.py` — une seule place sait fabriquer un token. `actor_kind`/`scopes` invalides → **422 hand-authored** (message nommant la valeur fautive + la whitelist, jamais une chaîne psycopg — même carve-out que `param_overrides.py`/`staging.py`).
+- **`GET /v1/tokens`** — liste les credentials **sans aucun matériel secret** (ni cleartext, ni hash), seulement le `prefix` non-secret.
+- **`DELETE /v1/tokens/{id}`** — **soft-revoke** (`revoked_at = now()`, la ligne survit pour l'audit) + **invalidation globale du cache** de principal (`invalidate_token_cache`, `auth.py:351`, appelée par `revoke_token`, `token_service.py:118`) pour que la révocation prenne effet à la requête suivante au lieu de traîner jusqu'à 30 s derrière une entrée de cache encore positive. **Caveat multi-worker (miroir du §4)** : le cache de principal est per-process — le clear ne touche que le worker qui traite le DELETE ; sous N workers uvicorn, les N−1 autres conservent le principal jusqu'au TTL, donc **la révocation se propage en ≤ 30 s** au reste de la flotte de workers. Borné, assumé en V1 (le pilote tourne single-worker → effet immédiat en pratique) ; une invalidation cross-worker exigerait un bus partagé (Redis/pg_notify), hors périmètre. **Clear global, justifié** : le cache est indexé par le **hash du cleartext**, la révocation est adressée par `token_id` — l'appelant ne détient pas le cleartext, il ne peut donc pas calculer le hash pour évincer une entrée ciblée ; un revoke est un événement administratif rare, le cache est petit, le seul coût d'un clear est une poignée de cache-miss. **204 idempotent** : révoquer un token déjà révoqué renvoie quand même 204 ; **404** seulement si le `token_id` est inconnu (décidé par un SELECT d'existence).
+
+### 6. `/metrics` Prometheus — admin, hors `/v1`, cardinalité bornée
+
+L'endpoint `GET /metrics` (`app.py:399`) expose les collecteurs Prometheus.
+
+- **Admin (🎯 défaut).** Gaté sur `require_scope("admin")` — la cible de scrape s'authentifie avec un Bearer admin ; les métriques ne sont **pas** world-readable, il n'existe aucun chemin non-authentifié (miroir du reste de l'API). Le choix « admin » est un 🎯 réglage pilote (un déploiement peut vouloir un scope de scrape dédié).
+- **Hors `/v1` et hors OpenAPI.** Servi à la racine (`/metrics`, convention Prometheus de facto), **pas** sous `/v1` : c'est une surface ops, pas le contrat d'API versionné. `include_in_schema=False` → absent de `openapi.json`.
+- **Cardinalité bornée par construction** (`metrics.py`). Le label `route` est le **template de route** (`/v1/tokens/{token_id}`), jamais le path brut (`/v1/tokens/9f3a...`) — un flot d'UUID distincts exploserait sinon le nombre de séries. Une requête qui n'a matché aucune route s'effondre sur le littéral `"unmatched"`. `method`/`status`/`actor_kind` sont des enums finis bornés.
+- **Compteurs :** requêtes totales (`ootils_http_requests_total`, par route/méthode/statut/actor_kind), latence (`ootils_http_request_duration_seconds`), refus 429 (`ootils_rate_limited_total` par actor_kind), refus kill-switch 503 (`ootils_fleet_killswitch_total`). Instrumentation **best-effort** : un échec de métrique ne casse jamais une réponse (garde dans le middleware, `app.py:346`).
+
+### 7. Carve-out assumé : le cycle de vie des tokens n'émet PAS d'event stream
+
+Émettre/révoquer un token **n'écrit aucune ligne `events`** et n'apparaît donc **pas** dans `GET /v1/stream` (SSE). C'est un **carve-out délibéré** à la règle North Star « streamable » : le cycle de vie des credentials est de la **gouvernance administrative**, pas un delta de supply-chain qu'un agent devrait consommer en subscribe. Il est **audité** — chaque appel `/v1/tokens` passe par `api_request_log` (avec `token_id` + `actor_kind` dénormalisé, migration 064) comme toute requête `/v1/*`, et `mint`/`revoke` loguent au niveau INFO. La traçabilité passe par le ledger d'audit, pas par le stream d'agents.
+
+## Portée
+
+- **Auth / gouvernance, transverse aux scénarios.** Un token, ses scopes et son budget sont de l'infrastructure, invariante par scénario. Aucune forkabilité requise — un token n'est pas un levier de simulation (même portée qu'ADR-029).
+- **PR2b n'ajoute aucune migration.** `rate_per_min` et `scopes` existent déjà (migration 064). Le budget, le cycle de vie API et `/metrics` sont **purement applicatifs** au-dessus du schéma posé par ADR-029.
+
+## Alternatives rejetées
+
+- **Garder `require_auth` (auth sans scope) sur les writes déterministes.** Rejeté : c'est exactement le trou d'ADR-029 §« pas appliqué ». Un token read-only pouvait saturer le moteur MRP. Le coût n'est pas la réversibilité.
+- **Un CHECK SQL sur le contenu de `scopes`.** Rejeté (ADR-029) : figerait le vocabulaire dans le schéma ; chaque nouveau scope exigerait une migration. La whitelist vit en code, au même point de revue que le `require_scope` qui l'enforce.
+- **Une hiérarchie de scopes (`graph:write` implique `calc:run`, etc.).** Rejeté : les scopes sont orthogonaux. Un opérateur qui firme n'a aucune raison de pouvoir lancer un MRP complet ; les coupler élargirait silencieusement la surface d'un token.
+- **Un limiteur de rate global (Redis/DB).** Rejeté en V1 : exigerait un store partagé sur le chemin d'auth chaud. Le per-worker (plafond effectif N × limite) est l'arbitrage V1 documenté, jumeau du cache TTL per-worker.
+- **Éviction ciblée d'une entrée de cache au revoke.** Rejeté : le cache est indexé par le hash du cleartext, que l'appelant ne détient pas (il révoque par `token_id`). Un clear global est correct, simple et bon marché pour un événement rare.
+- **`/metrics` sous `/v1` et dans OpenAPI.** Rejeté : c'est une surface ops, pas le contrat versionné. La racine + `include_in_schema=False` est la convention.
+- **Émettre un event stream à l'émission/révocation d'un token.** Rejeté : gouvernance admin, pas un delta supply-chain. Audité via `api_request_log` (§7).
+
+## Conséquences
+
+- **Positif :** la dette AN-2 d'ADR-029 est résorbée. Toute route montée exige désormais un scope (plus aucun `require_auth`) ; les budgets par token sont réels ; le cycle de vie passe par une surface gouvernée ; `/metrics` donne l'observabilité. La doctrine coût≠réversibilité est explicite et testée (matrice `test_agent_floor_integration.py` §12).
+- **Négatif / dette assumée en V1 :**
+  - Le rate-limit est **per-worker, approximatif** (plafond N × limite sous N workers) — pas de store partagé (§4).
+  - 🎯 Le défaut `rate_per_min = NULL` (illimité) laisse un token minté sans budget tant que le pilote n'en fixe pas un à l'émission.
+  - Le token legacy `admin`-superset reste un contournement de la grille tant qu'il n'est pas retiré (dette héritée d'ADR-029).
+  - Le cycle de vie des tokens n'émet pas d'event stream (carve-out assumé, §7).
+- **Reste à faire (hors AN-2) :** retrait du token legacy ; défaut prudent de `rate_per_min` au niveau du pilote ; éventuel limiteur global si le déploiement multi-worker l'exige.
+
+## Références
+
+- **#392** — chantier « étage entreprise agents » ; **AN-2** = scopes bout-en-bout + budgets + cycle de vie + `/metrics`.
+- **PR [#434](https://github.com/ngoineau/ootils-core/pull/434)** — AN-2 PR2a : enforcement des scopes sur toutes les routes montées (plus aucun `require_auth` sur une route).
+- `docs/ADR-029-agent-enterprise-floor.md` — le substrat (registre `api_tokens`, `actor_kind` cryptographique, cache borné, kill-switch) ; sa section « décidé mais pas appliqué » que cet ADR résorbe.
+- `docs/ROADMAP-AGENTS-2026-H2.md` §4 (AN-2) — livrables et critères d'acceptation du chantier.
+- `src/ootils_core/db/migrations/064_api_tokens_and_scopes.sql` — `api_tokens.scopes TEXT[]` (no CHECK, whitelist en code) + `rate_per_min` + binding audit `api_request_log`.
+- `src/ootils_core/api/auth.py` — `VALID_SCOPES` (grille des 8), `require_scope` (validation à l'import), `_RateCounter` + `_enforce_rate_limit` (429 + Retry-After, ordre 401→kill-switch→rate), `invalidate_token_cache` (clear global au revoke), `_ADMIN_SCOPE` superset.
+- `src/ootils_core/api/token_service.py` — `mint_token` (cleartext montré une fois, 256 bits, validation whitelist), `revoke_token` (soft-revoke + invalidation cache).
+- `src/ootils_core/api/routers/tokens.py` — `POST/GET/DELETE /v1/tokens` (admin), 204 idempotent, 404 inconnu, 422 hand-authored.
+- `src/ootils_core/api/metrics.py` — collecteurs Prometheus, `route_template` à cardinalité bornée.
+- `src/ootils_core/api/app.py` — `GET /metrics` (admin, `include_in_schema=False`), instrumentation best-effort dans le middleware.
+- `tests/integration/test_agent_floor_integration.py` §12 — la matrice d'enforcement (un write représentatif par famille de scope, les deux planchers).
+- `tests/test_rate_counter_and_scopes.py` — tests unitaires purs du `_RateCounter` et de la validation `require_scope`.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4133,6 +4133,144 @@
         }
       }
     },
+    "/v1/tokens": {
+      "post": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Mint an API token",
+        "description": "Issue a new credential. Returns the cleartext token EXACTLY ONCE — it is never stored (only its SHA-256 hash) and cannot be recovered later. Requires the `admin` scope.",
+        "operationId": "create_token_v1_tokens_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TokenCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenCreateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "List API tokens",
+        "description": "List issued credentials WITHOUT any secret material (no cleartext, no hash). By default only live tokens are returned; pass `include_revoked=true` to include revoked rows. Requires the `admin` scope.",
+        "operationId": "list_tokens_v1_tokens_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "include_revoked",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Include revoked tokens in the listing.",
+              "default": false,
+              "title": "Include Revoked"
+            },
+            "description": "Include revoked tokens in the listing."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/tokens/{token_id}": {
+      "delete": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Revoke an API token",
+        "description": "Soft-revoke a credential (sets `revoked_at`; the row is kept for audit). Idempotent: revoking an already-revoked token still returns 204. Returns 404 only when the token_id is unknown. Requires the `admin` scope.",
+        "operationId": "delete_token_v1_tokens__token_id__delete",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "token_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Token Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/calc/run": {
       "post": {
         "tags": [
@@ -4347,7 +4485,7 @@
           "mrp-apics"
         ],
         "summary": "Run Mrp Apics",
-        "description": "[DEPRECATED] Execute a full APICS-compliant multi-level MRP run.\n\n⚠️  DEPRECATED: Use POST /v1/mrp/run with apics_mode=true instead.\nThis endpoint is a thin alias kept for backward compatibility; it has no\nbehaviour the unified endpoint lacks and will be removed in a future\nrelease (date TBD). The route is flagged `deprecated` in the OpenAPI schema\nand every response carries RFC 8594 deprecation headers.\n\nProcesses items from LLC 0 (finished goods) through LLC N (raw materials),\nconsuming forecast, calculating gross-to-net, applying lot sizing and time fences,\nand exploding dependent demand through the BOM.",
+        "description": "[DEPRECATED] Execute a full APICS-compliant multi-level MRP run.\n\n⚠️  DEPRECATED: Use POST /v1/mrp/run with apics_mode=true instead.\nThis endpoint is a thin alias kept for backward compatibility; it has no\nbehaviour the unified endpoint lacks and will be removed in a future\nrelease (date TBD). The route is flagged `deprecated` in the OpenAPI schema\nand every response carries RFC 8594 deprecation headers.\n\nSince #423 (ADR-020 PAS 4) the underlying engine DELEGATES its whole\ncalculation to the consolidated core (forecast consumption, gross-to-net\nLLC cascade, lot sizing, BOM explosion); this endpoint only wires the\nrequest through and materializes the core's plan into the graph.",
         "operationId": "run_mrp_apics_v1_mrp_apics_run_post",
         "requestBody": {
           "content": {
@@ -12536,6 +12674,7 @@
             "type": "string",
             "pattern": "^(day|week|month)$",
             "title": "Bucket Grain",
+            "description": "The consolidated MRP core plans exclusively in weekly buckets (ADR-020); day/month grains were removed with the #423 delegation and are rejected with 422 (the pattern still accepts them so the 422 carries an explicit message).",
             "default": "week"
           },
           "start_date": {
@@ -12558,6 +12697,7 @@
             "type": "string",
             "pattern": "^(MAX|FORECAST_ONLY|ORDERS_ONLY|PRIORITY|max_only|consume_forward|consume_backward|consume_both)$",
             "title": "Forecast Strategy",
+            "description": "ADVISORY since #423: the delegated core reads forecast_consumption_strategy from each item's item_planning_params row, not this field. Kept for backward compatibility; explicitly setting it is echoed as a warning.",
             "default": "MAX"
           },
           "consumption_window_days": {
@@ -12565,6 +12705,7 @@
             "maximum": 90.0,
             "minimum": 1.0,
             "title": "Consumption Window Days",
+            "description": "ADVISORY since #423: the delegated core reads consumption_window_days from each item's item_planning_params row, not this field. Kept for backward compatibility; explicitly setting it is echoed as a warning.",
             "default": 7
           }
         },
@@ -12619,6 +12760,14 @@
             },
             "type": "array",
             "title": "Errors",
+            "default": []
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Warnings",
             "default": []
           }
         },
@@ -12678,12 +12827,14 @@
             "type": "string",
             "pattern": "^(day|week|month)$",
             "title": "Bucket Grain",
+            "description": "APICS mode only. The consolidated MRP core plans exclusively in weekly buckets (ADR-020); day/month grains were removed with the #423 delegation and are rejected with 422 when apics_mode=true (the pattern still accepts them so the 422 carries an explicit message instead of a generic schema-validation error).",
             "default": "week"
           },
           "forecast_strategy": {
             "type": "string",
             "pattern": "^(MAX|FORECAST_ONLY|ORDERS_ONLY|PRIORITY|max_only|consume_forward|consume_backward|consume_both)$",
             "title": "Forecast Strategy",
+            "description": "ADVISORY since #423 (APICS mode): the delegated core reads forecast_consumption_strategy from each item's item_planning_params row, not this field. Kept for backward compatibility; explicitly setting it is echoed as a warning in the response.",
             "default": "MAX"
           },
           "consumption_window_days": {
@@ -12691,6 +12842,7 @@
             "maximum": 90.0,
             "minimum": 1.0,
             "title": "Consumption Window Days",
+            "description": "ADVISORY since #423 (APICS mode): the delegated core reads consumption_window_days from each item's item_planning_params row, not this field. Kept for backward compatibility; explicitly setting it is echoed as a warning in the response.",
             "default": 7
           },
           "recalculate_llc": {
@@ -16735,6 +16887,252 @@
           "time_ref"
         ],
         "title": "SupplyDetail"
+      },
+      "TokenCreateRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Name",
+            "description": "Human label, e.g. 'shortage-watcher'."
+          },
+          "actor_kind": {
+            "type": "string",
+            "title": "Actor Kind",
+            "description": "agent | human | service."
+          },
+          "scopes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scopes",
+            "description": "Granted scopes (subset of the auth whitelist)."
+          },
+          "rate_per_min": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "exclusiveMinimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Per Min",
+            "description": "Per-token request budget; null = uncapped."
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At",
+            "description": "Expiry timestamp (UTC); null = no expiry."
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "actor_kind"
+        ],
+        "title": "TokenCreateRequest",
+        "description": "Body of POST /v1/tokens. ``actor_kind`` and ``scopes`` are validated in\n``token_service.mint_token`` against the auth whitelists — an invalid value\nsurfaces as a hand-authored 422, not a Pydantic-enum 422, so the message can\nname the full valid set."
+      },
+      "TokenCreateResponse": {
+        "properties": {
+          "token_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Token Id"
+          },
+          "token": {
+            "type": "string",
+            "title": "Token"
+          },
+          "prefix": {
+            "type": "string",
+            "title": "Prefix"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "actor_kind": {
+            "type": "string",
+            "title": "Actor Kind"
+          },
+          "scopes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scopes"
+          },
+          "rate_per_min": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Per Min"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "token_id",
+          "token",
+          "prefix",
+          "name",
+          "actor_kind",
+          "scopes",
+          "rate_per_min",
+          "created_at",
+          "expires_at"
+        ],
+        "title": "TokenCreateResponse",
+        "description": "Response of a mint. ``token`` is the CLEARTEXT, shown ONCE and never\nretrievable again — store it now or re-mint."
+      },
+      "TokenListResponse": {
+        "properties": {
+          "tokens": {
+            "items": {
+              "$ref": "#/components/schemas/TokenOut"
+            },
+            "type": "array",
+            "title": "Tokens"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tokens",
+          "total"
+        ],
+        "title": "TokenListResponse"
+      },
+      "TokenOut": {
+        "properties": {
+          "token_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Token Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "prefix": {
+            "type": "string",
+            "title": "Prefix"
+          },
+          "actor_kind": {
+            "type": "string",
+            "title": "Actor Kind"
+          },
+          "scopes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scopes"
+          },
+          "rate_per_min": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Per Min"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "last_used_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Used At"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "revoked_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revoked At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "token_id",
+          "name",
+          "prefix",
+          "actor_kind",
+          "scopes",
+          "rate_per_min",
+          "created_at",
+          "last_used_at",
+          "expires_at",
+          "revoked_at"
+        ],
+        "title": "TokenOut",
+        "description": "One registry row for listing. Carries NO secret material — neither the\ncleartext (never stored) nor the ``token_hash`` (a lookup key we do not\nsurface); only the non-secret ``prefix``."
       },
       "TransferRow": {
         "properties": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dependencies = [
     "pydantic ~= 2.12",
     "openai ~= 2.15",
     "slowapi ~= 0.1",
+    # Prometheus metrics for /metrics (#392 AN-2). Run dependency, not an extra:
+    # the request middleware records counters/histograms unconditionally.
+    "prometheus-client ~= 0.21",
     # Staging file parsers (ADR-013): TSV/CSV via stdlib csv, XLSX via openpyxl.
     "openpyxl ~= 3.1",
     "python-multipart ~= 0.0.20",  # FastAPI file uploads (multipart/form-data)

--- a/scripts/demo_e2e.py
+++ b/scripts/demo_e2e.py
@@ -50,7 +50,7 @@ import traceback
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Optional
-from uuid import UUID, uuid4
+from uuid import UUID
 
 # The watchers (and their mrp_core / agent_simulation deps) do a bare
 # ``import mrp_core``; scripts/ must be on sys.path for the in-process watcher
@@ -356,32 +356,21 @@ def _find_token_id_by_name(dsn: str, name: str) -> Optional[str]:
 def _mint_token(
     dsn: str, *, name: str, actor_kind: str, scopes: list[str]
 ) -> tuple[str, str]:
-    """Insert one live api_tokens row; return (cleartext, token_id).
+    """Mint one live api_tokens row via the shared helper; return (cleartext,
+    token_id).
 
-    The cleartext exists ONLY in this process (the DB stores its SHA-256 via
-    the same hash_token/token_prefix the auth layer uses on lookup — the exact
-    pattern of tests/integration/test_agent_floor_integration.py::_mint_token).
-    High-entropy: ootk_ + 32 random hex chars.
-    """
-    from ootils_core.api.auth import hash_token, token_prefix
+    Delegates to ``ootils_core.api.token_service.mint_token`` — the SINGLE place
+    that knows how a token is generated (256-bit os.urandom), hashed (SHA-256)
+    and persisted (#392 AN-2 PR2b). The cleartext exists ONLY in this process;
+    the DB stores its hash + prefix. The ``with _connect(dsn)`` block commits on
+    exit (psycopg3 connection context manager), so the row is durable before we
+    return. Note the argument order swap: mint_token returns (token_id, clear),
+    this demo helper keeps its historical (clear, token_id) contract."""
+    from ootils_core.api.token_service import mint_token
 
-    clear = f"ootk_{uuid4().hex}{uuid4().hex}"
-    token_id = uuid4()
     with _connect(dsn) as conn:
-        conn.execute(
-            """
-            INSERT INTO api_tokens (
-                token_id, name, actor_kind, token_hash, token_prefix, scopes
-            ) VALUES (%s, %s, %s, %s, %s, %s)
-            """,
-            (
-                token_id,
-                name,
-                actor_kind,
-                hash_token(clear),
-                token_prefix(clear),
-                scopes,
-            ),
+        token_id, clear = mint_token(
+            conn, name=name, actor_kind=actor_kind, scopes=scopes
         )
     return clear, str(token_id)
 

--- a/src/ootils_core/api/app.py
+++ b/src/ootils_core/api/app.py
@@ -16,7 +16,7 @@ from uuid import uuid4
 from anyio import to_thread
 import psycopg
 
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -32,9 +32,10 @@ try:
 except ImportError:
     _SLOWAPI_AVAILABLE = False
 
-from ootils_core.api.auth import _expected_token
+from ootils_core.api import metrics
+from ootils_core.api.auth import Principal, _expected_token, require_scope
 from ootils_core.api.dependencies import _get_ootils_db, get_db
-from ootils_core.api.routers import bom, calc, calendars, demo, dq, drp, events, explain, forecasting, ghosts, graph, ingest, issues, mrp, mrp_apics, outcomes, param_overrides, planning_params, projection, pyramide, rccp, recommendations, scenarios, simulate, snapshots, staging, stream
+from ootils_core.api.routers import bom, calc, calendars, demo, dq, drp, events, explain, forecasting, ghosts, graph, ingest, issues, mrp, mrp_apics, outcomes, param_overrides, planning_params, projection, pyramide, rccp, recommendations, scenarios, simulate, snapshots, staging, stream, tokens
 from ootils_core.api.routers.graph import nodes_router
 from ootils_core.mps import router as mps_router
 from ootils_core.atp import atp_router
@@ -334,9 +335,20 @@ def create_app() -> FastAPI:
                 content={"error": "internal_error", "message": "An internal error occurred.", "status": 500},
             )
 
-        latency_ms = int((time.perf_counter() - started) * 1000)
+        elapsed = time.perf_counter() - started
+        latency_ms = int(elapsed * 1000)
         response.headers["X-Correlation-ID"] = correlation_id
         response.headers["X-API-Version"] = API_VERSION
+
+        # Prometheus instrumentation (#392 AN-2). Best-effort: a metrics failure
+        # must never break a response. route = matched TEMPLATE (bounded
+        # cardinality); read here, AFTER call_next has routed the request.
+        try:
+            metrics.observe_request(
+                request, status_code=response.status_code, duration_seconds=elapsed
+            )
+        except Exception as exc:
+            logger.warning("metrics.observe_failed error=%s", exc)
 
         if _security_headers_enabled():
             response.headers.setdefault("X-Content-Type-Options", "nosniff")
@@ -378,6 +390,19 @@ def create_app() -> FastAPI:
     async def health() -> dict:
         return {"status": "ok", "version": API_VERSION}
 
+    # Prometheus scrape endpoint (#392 AN-2). Deliberately at the ROOT path (the
+    # de-facto Prometheus convention), NOT under /v1 — it is an ops surface, not
+    # part of the versioned API contract, hence include_in_schema=False (kept out
+    # of openapi.json). Gated on the `admin` scope (🎯 pilot default: the scrape
+    # target authenticates with an admin Bearer token) so metrics are not world-
+    # readable; there is no unauthenticated path, mirroring the rest of the API.
+    @application.get("/metrics", include_in_schema=False)
+    async def metrics_endpoint(
+        _principal: Principal = Depends(require_scope("admin")),
+    ) -> Response:
+        body, content_type = metrics.render_latest()
+        return Response(content=body, media_type=content_type)
+
     # Register routers
     application.include_router(events.router)
     application.include_router(stream.router)
@@ -398,6 +423,7 @@ def create_app() -> FastAPI:
     application.include_router(recommendations.router)
     application.include_router(scenarios.router)
     application.include_router(param_overrides.router)
+    application.include_router(tokens.router)
     application.include_router(calc.router)
     application.include_router(demo.router)
     application.include_router(mrp.router)

--- a/src/ootils_core/api/auth.py
+++ b/src/ootils_core/api/auth.py
@@ -55,6 +55,7 @@ from anyio import to_thread
 from fastapi import Depends, HTTPException, Request, Security, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
+from ootils_core.api import metrics
 from ootils_core.db.types import DictRowConnection
 
 logger = logging.getLogger(__name__)
@@ -347,6 +348,26 @@ class _TokenCache:
 _token_cache = _TokenCache()
 
 
+def invalidate_token_cache() -> None:
+    """Drop every memoised minted-token principal so the NEXT request for any
+    token re-resolves against the DB.
+
+    The single public seam the token-lifecycle path (``token_service.revoke_token``)
+    uses to make a revoke take effect immediately instead of lingering up to
+    ``_CACHE_TTL_SECONDS`` (30 s) behind a still-positive cache entry.
+
+    Why a GLOBAL clear rather than a targeted per-token eviction: ``_TokenCache``
+    is keyed by ``token_hash`` (the presented secret's hash), NOT by ``token_id``.
+    Revocation is addressed by ``token_id`` — the caller never holds the cleartext
+    (only its SHA-256 lives in the DB), so it CANNOT compute the hash to evict one
+    entry. A global ``clear()`` is the correct, simple choice: a revoke is a rare
+    administrative event, the cache is small (≤ ``_CACHE_MAX_ENTRIES``), and the
+    only cost of clearing it is a handful of cache misses that re-hit the DB once
+    each within the next TTL window. Correctness (a revoked token stops
+    authenticating at once) beats sparing those misses."""
+    _token_cache.clear()
+
+
 # ---------------------------------------------------------------------------
 # Per-token sliding-window rate counter (clock injectable for tests)
 # ---------------------------------------------------------------------------
@@ -589,6 +610,7 @@ def _enforce_fleet_kill_switch(principal: Principal, client_id: str) -> None:
             principal.token_id,
             client_id,
         )
+        metrics.record_fleet_killswitch()
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Agent fleet is disabled (OOTILS_AGENTS_ENABLED).",
@@ -621,6 +643,7 @@ def _enforce_rate_limit(principal: Principal, client_id: str) -> None:
         principal.rate_per_min,
         retry_seconds,
     )
+    metrics.record_rate_limited(principal.actor_kind)
     raise HTTPException(
         status_code=status.HTTP_429_TOO_MANY_REQUESTS,
         detail="Rate limit exceeded",

--- a/src/ootils_core/api/metrics.py
+++ b/src/ootils_core/api/metrics.py
@@ -1,0 +1,115 @@
+"""
+metrics.py — Prometheus instrumentation for the Ootils Core API (#392 AN-2 PR2b).
+
+Defines the process-global metric collectors and the thin helpers the request
+middleware / auth layer call to record them. Kept in its OWN module (no import
+of ``auth`` / ``app``) so it can be imported from both without a cycle.
+
+The metric objects are module-level singletons on purpose: prometheus-client
+registers each collector in the default ``REGISTRY`` at construction, and
+constructing the SAME metric twice raises ``Duplicated timeseries``. Defining
+them once at import time (rather than inside ``create_app``) is what makes the
+app safe to build more than once in a process — tests build several apps, and
+``scripts/export_openapi.py`` builds one too. These are effectively constants
+(registered collectors with a fixed shape), not the mutable-module-global
+anti-pattern the repo forbids.
+
+CARDINALITY IS BOUNDED BY CONSTRUCTION — the golden rule for a metrics label
+set. ``route`` is the matched ROUTE TEMPLATE (``/v1/tokens/{token_id}``), never
+the raw request path (``/v1/tokens/9f3a...``): an unbounded stream of distinct
+UUIDs in the path would otherwise explode the time-series count. A request that
+matched no route collapses to the single literal ``"unmatched"``. ``method`` /
+``status`` are small finite enums; ``actor_kind`` is one of
+{agent, human, service, none}.
+"""
+from __future__ import annotations
+
+from fastapi import Request
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+
+# actor_kind label value for a request with no resolved principal (an
+# unauthenticated /health probe, or a 401 that never reached a Principal).
+_ACTOR_KIND_NONE = "none"
+
+# Route-template label value for a request that matched no route (404 on an
+# unknown path). Keeps cardinality bounded — every unmatched path collapses here.
+_ROUTE_UNMATCHED = "unmatched"
+
+
+http_requests_total = Counter(
+    "ootils_http_requests_total",
+    "Total HTTP requests handled, by route template, method, status and actor kind.",
+    ["route", "method", "status", "actor_kind"],
+)
+
+http_request_duration_seconds = Histogram(
+    "ootils_http_request_duration_seconds",
+    "HTTP request handling latency in seconds, by route template and method.",
+    ["route", "method"],
+)
+
+rate_limited_total = Counter(
+    "ootils_rate_limited_total",
+    "Requests rejected with 429 by the per-token rate limiter, by actor kind.",
+    ["actor_kind"],
+)
+
+fleet_killswitch_total = Counter(
+    "ootils_fleet_killswitch_total",
+    "Agent requests rejected with 503 by the fleet kill switch (OOTILS_AGENTS_ENABLED).",
+)
+
+
+def route_template(request: Request) -> str:
+    """Return the matched route TEMPLATE for cardinality-safe labelling.
+
+    FastAPI's ``APIRoute.matches`` stores the matched route on
+    ``request.scope["route"]`` (its ``.path`` is the template, e.g.
+    ``/v1/tokens/{token_id}``). Read AFTER the downstream app has routed the
+    request (i.e. after ``call_next`` in the middleware). No match → the literal
+    ``"unmatched"`` so an unknown path never mints a new label value."""
+    route = request.scope.get("route")
+    path = getattr(route, "path", None)
+    return path if isinstance(path, str) and path else _ROUTE_UNMATCHED
+
+
+def _actor_kind(request: Request) -> str:
+    principal = getattr(request.state, "principal", None)
+    kind = getattr(principal, "actor_kind", None)
+    return kind if isinstance(kind, str) and kind else _ACTOR_KIND_NONE
+
+
+def observe_request(
+    request: Request, *, status_code: int, duration_seconds: float
+) -> None:
+    """Record one completed request into the counter + latency histogram.
+
+    Best-effort: instrumentation must never break a response, so any failure
+    here is swallowed by the middleware's own guard (see app.py). Called once
+    per request from ``request_context_middleware``."""
+    route = route_template(request)
+    method = request.method
+    http_requests_total.labels(
+        route=route,
+        method=method,
+        status=str(status_code),
+        actor_kind=_actor_kind(request),
+    ).inc()
+    http_request_duration_seconds.labels(route=route, method=method).observe(
+        duration_seconds
+    )
+
+
+def record_rate_limited(actor_kind: str) -> None:
+    """Increment the 429 counter (called from ``auth._enforce_rate_limit``)."""
+    rate_limited_total.labels(actor_kind=actor_kind).inc()
+
+
+def record_fleet_killswitch() -> None:
+    """Increment the fleet-kill-switch 503 counter (from ``auth._enforce_fleet_kill_switch``)."""
+    fleet_killswitch_total.inc()
+
+
+def render_latest() -> tuple[bytes, str]:
+    """Return ``(body, content_type)`` for the ``/metrics`` scrape endpoint."""
+    return generate_latest(), CONTENT_TYPE_LATEST

--- a/src/ootils_core/api/routers/tokens.py
+++ b/src/ootils_core/api/routers/tokens.py
@@ -1,0 +1,248 @@
+"""
+/v1/tokens — API-token lifecycle over HTTP (#392 AN-2 PR2b, ADR-029).
+
+The admin surface that replaces the hand-rolled INSERTs and the
+``scripts/issue_agent_token.py`` CLI as the primary way to mint / list / revoke
+credentials. Every verb requires the ``admin`` scope: issuing or killing a
+credential is itself the most privileged operation in the system (a mis-issued
+token can mint an agent that walks a governed action), so it is gated on the
+superset scope, never a narrower one.
+
+  * POST   /v1/tokens             — mint a credential; returns the CLEARTEXT ONCE.
+  * GET    /v1/tokens             — list credentials WITHOUT any secret material.
+  * DELETE /v1/tokens/{token_id}  — soft-revoke; 204 idempotent, 404 if unknown.
+
+The cleartext token is shown exactly once, in the POST response, and is never
+retrievable again (only its SHA-256 hash lives in the DB — see migration 064 /
+``token_service``). GET and the list rows deliberately expose neither the hash
+nor the cleartext, only the non-secret ``prefix``.
+
+Validation (invalid ``actor_kind`` / ``scopes``) is raised by ``token_service``
+as ``ValueError`` and mapped here to a hand-authored 422 — the message names the
+offending value and the whitelist, never a raw psycopg / DSN string (same
+carve-out discipline as ``param_overrides.py`` / ``staging.py``).
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from pydantic import BaseModel, Field
+
+from ootils_core.api.auth import Principal, require_scope
+from ootils_core.api.dependencies import get_db
+from ootils_core.api.token_service import mint_token, revoke_token
+from ootils_core.db.types import DictRowConnection
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/tokens", tags=["tokens"])
+
+
+class TokenCreateRequest(BaseModel):
+    """Body of POST /v1/tokens. ``actor_kind`` and ``scopes`` are validated in
+    ``token_service.mint_token`` against the auth whitelists — an invalid value
+    surfaces as a hand-authored 422, not a Pydantic-enum 422, so the message can
+    name the full valid set."""
+
+    name: str = Field(min_length=1, description="Human label, e.g. 'shortage-watcher'.")
+    actor_kind: str = Field(description="agent | human | service.")
+    scopes: list[str] = Field(
+        default_factory=list, description="Granted scopes (subset of the auth whitelist)."
+    )
+    rate_per_min: Optional[int] = Field(
+        default=None, gt=0, description="Per-token request budget; null = uncapped."
+    )
+    expires_at: Optional[_dt.datetime] = Field(
+        default=None, description="Expiry timestamp (UTC); null = no expiry."
+    )
+
+
+class TokenCreateResponse(BaseModel):
+    """Response of a mint. ``token`` is the CLEARTEXT, shown ONCE and never
+    retrievable again — store it now or re-mint."""
+
+    token_id: UUID
+    token: str
+    prefix: str
+    name: str
+    actor_kind: str
+    scopes: list[str]
+    rate_per_min: Optional[int]
+    created_at: _dt.datetime
+    expires_at: Optional[_dt.datetime]
+
+
+class TokenOut(BaseModel):
+    """One registry row for listing. Carries NO secret material — neither the
+    cleartext (never stored) nor the ``token_hash`` (a lookup key we do not
+    surface); only the non-secret ``prefix``."""
+
+    token_id: UUID
+    name: str
+    prefix: str
+    actor_kind: str
+    scopes: list[str]
+    rate_per_min: Optional[int]
+    created_at: _dt.datetime
+    last_used_at: Optional[_dt.datetime]
+    expires_at: Optional[_dt.datetime]
+    revoked_at: Optional[_dt.datetime]
+
+
+class TokenListResponse(BaseModel):
+    tokens: list[TokenOut]
+    total: int
+
+
+def _row_to_out(row: dict) -> TokenOut:
+    return TokenOut(
+        token_id=UUID(str(row["token_id"])),
+        name=row["name"],
+        prefix=row["token_prefix"],
+        actor_kind=row["actor_kind"],
+        scopes=list(row["scopes"] or []),
+        rate_per_min=row["rate_per_min"],
+        created_at=row["created_at"],
+        last_used_at=row["last_used_at"],
+        expires_at=row["expires_at"],
+        revoked_at=row["revoked_at"],
+    )
+
+
+@router.post(
+    "",
+    response_model=TokenCreateResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Mint an API token",
+    description=(
+        "Issue a new credential. Returns the cleartext token EXACTLY ONCE — it "
+        "is never stored (only its SHA-256 hash) and cannot be recovered later. "
+        "Requires the `admin` scope."
+    ),
+)
+def create_token(
+    body: TokenCreateRequest,
+    _principal: Principal = Depends(require_scope("admin")),
+    db: DictRowConnection = Depends(get_db),
+) -> TokenCreateResponse:
+    """Mint one token. ``get_db`` owns commit/rollback; ``mint_token`` only
+    executes the INSERT. The follow-up SELECT reads the persisted row (visible on
+    the same connection before commit) so the response reflects the DB defaults
+    (created_at) alongside the once-shown cleartext."""
+    try:
+        token_id, cleartext = mint_token(
+            db,
+            name=body.name,
+            actor_kind=body.actor_kind,
+            scopes=body.scopes,
+            rate_per_min=body.rate_per_min,
+            expires_at=body.expires_at,
+        )
+    except ValueError as exc:
+        # Hand-authored message from token_service (names the offending value +
+        # the whitelist). Safe to echo: no DSN, no psycopg text.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        )
+
+    row = db.execute(
+        """
+        SELECT token_id, name, token_prefix, actor_kind, scopes,
+               rate_per_min, created_at, expires_at
+        FROM api_tokens
+        WHERE token_id = %s
+        """,
+        (token_id,),
+    ).fetchone()
+    if row is None:
+        raise RuntimeError("create_token: minted row not found on read-back")
+
+    return TokenCreateResponse(
+        token_id=token_id,
+        token=cleartext,
+        prefix=row["token_prefix"],
+        name=row["name"],
+        actor_kind=row["actor_kind"],
+        scopes=list(row["scopes"] or []),
+        rate_per_min=row["rate_per_min"],
+        created_at=row["created_at"],
+        expires_at=row["expires_at"],
+    )
+
+
+@router.get(
+    "",
+    response_model=TokenListResponse,
+    summary="List API tokens",
+    description=(
+        "List issued credentials WITHOUT any secret material (no cleartext, no "
+        "hash). By default only live tokens are returned; pass "
+        "`include_revoked=true` to include revoked rows. Requires the `admin` scope."
+    ),
+)
+def list_tokens(
+    _principal: Principal = Depends(require_scope("admin")),
+    include_revoked: bool = Query(
+        default=False, description="Include revoked tokens in the listing."
+    ),
+    db: DictRowConnection = Depends(get_db),
+) -> TokenListResponse:
+    """List tokens. The optional ``include_revoked`` toggles a single static
+    ``revoked_at IS NULL`` predicate — no caller data ever reaches the SQL text."""
+    if include_revoked:
+        where_clause = ""
+    else:
+        where_clause = "WHERE revoked_at IS NULL"
+
+    rows = db.execute(
+        f"""
+        SELECT token_id, name, token_prefix, actor_kind, scopes,
+               rate_per_min, created_at, last_used_at, expires_at, revoked_at
+        FROM api_tokens
+        {where_clause}
+        ORDER BY created_at DESC
+        """,  # noqa: S608 — static predicate, no interpolated caller data
+    ).fetchall()
+
+    out = [_row_to_out(r) for r in rows]
+    return TokenListResponse(tokens=out, total=len(out))
+
+
+@router.delete(
+    "/{token_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Revoke an API token",
+    description=(
+        "Soft-revoke a credential (sets `revoked_at`; the row is kept for audit). "
+        "Idempotent: revoking an already-revoked token still returns 204. Returns "
+        "404 only when the token_id is unknown. Requires the `admin` scope."
+    ),
+)
+def delete_token(
+    token_id: UUID,
+    _principal: Principal = Depends(require_scope("admin")),
+    db: DictRowConnection = Depends(get_db),
+) -> Response:
+    """Soft-revoke a token.
+
+    404 vs 204 is decided by an existence SELECT (revoke_token's bool cannot tell
+    "unknown" from "already revoked" apart): unknown token_id → 404; known token
+    (live or already revoked) → 204 idempotent. ``revoke_token`` clears the
+    principal cache on the flip so a live token stops authenticating at once."""
+    exists = db.execute(
+        "SELECT 1 FROM api_tokens WHERE token_id = %s",
+        (token_id,),
+    ).fetchone()
+    if exists is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"token {token_id} not found",
+        )
+
+    revoke_token(db, token_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/ootils_core/api/token_service.py
+++ b/src/ootils_core/api/token_service.py
@@ -1,0 +1,148 @@
+"""
+token_service.py — API-token lifecycle helpers (mint / revoke) for #392 AN-2.
+
+The single, shared implementation of "create a credential" and "kill a
+credential", used by BOTH the REST surface (``api/routers/tokens.py``) and the
+demo runbook (``scripts/demo_e2e.py``) so there is exactly one place that knows
+how a token is generated, hashed and persisted — no more hand-rolled INSERTs
+scattered across scripts.
+
+Design invariants (mirrors migration 064's header + ``api/auth.py``):
+  * The CLEARTEXT token is generated here and returned to the caller ONCE; it is
+    NEVER stored. Only its SHA-256 hex (``token_hash``, lookup/uniqueness) and a
+    non-secret leading ``token_prefix`` are persisted. A leak of ``api_tokens``
+    leaks no usable credential.
+  * ``actor_kind`` and ``scopes`` are validated in APPLICATION code against the
+    auth layer's whitelists (``VALID_ACTOR_KINDS`` / ``VALID_SCOPES``) — the DB
+    has no CHECK on scope contents by design (scopes evolve with the code that
+    enforces them). A bad value raises ``ValueError`` (the router maps it to a
+    hand-authored 422; never a raw psycopg error string to the client).
+  * 256 bits of entropy (``secrets.token_urlsafe(32)`` → 32 os.urandom bytes),
+    rendered ``ootk_<base64url>``. A fast hash (SHA-256, no KDF) is correct for
+    high-entropy keys — see migration 064.
+
+Transaction ownership: these helpers only ``execute`` on the connection they are
+given; they NEVER commit or rollback. The caller owns the transaction (the REST
+path via ``Depends(get_db)``, the demo via its own ``with connect()`` block).
+"""
+from __future__ import annotations
+
+import logging
+import secrets
+from typing import Optional
+from uuid import UUID
+
+from datetime import datetime
+
+from ootils_core.api.auth import (
+    VALID_ACTOR_KINDS,
+    VALID_SCOPES,
+    _MINTED_PREFIX,
+    hash_token,
+    invalidate_token_cache,
+    token_prefix,
+)
+from ootils_core.db.types import DictRowConnection
+
+logger = logging.getLogger(__name__)
+
+# 32 bytes → 256 bits of entropy, the size migration 064's header commits to.
+_TOKEN_ENTROPY_BYTES = 32
+
+
+def _generate_cleartext() -> str:
+    """``ootk_`` + 256 bits of URL-safe randomness. The only place a cleartext
+    token is born; it is returned to the caller once and never persisted."""
+    return f"{_MINTED_PREFIX}{secrets.token_urlsafe(_TOKEN_ENTROPY_BYTES)}"
+
+
+def mint_token(
+    conn: DictRowConnection,
+    *,
+    name: str,
+    actor_kind: str,
+    scopes: list[str],
+    rate_per_min: Optional[int] = None,
+    expires_at: Optional[datetime] = None,
+) -> tuple[UUID, str]:
+    """Insert one live ``api_tokens`` row and return ``(token_id, cleartext)``.
+
+    The cleartext is shown ONCE (this return value) and never stored. Validates
+    ``actor_kind`` and every scope against the auth-layer whitelists BEFORE the
+    INSERT so an invalid grant fails loudly (``ValueError``) instead of writing a
+    half-valid row. Does not commit — the caller owns the transaction.
+    """
+    if actor_kind not in VALID_ACTOR_KINDS:
+        raise ValueError(
+            f"unknown actor_kind {actor_kind!r}; "
+            f"valid actor kinds are {sorted(VALID_ACTOR_KINDS)}"
+        )
+    invalid = sorted(set(scopes) - VALID_SCOPES)
+    if invalid:
+        raise ValueError(
+            f"unknown scope(s) {invalid}; valid scopes are {sorted(VALID_SCOPES)}"
+        )
+    if rate_per_min is not None and rate_per_min <= 0:
+        raise ValueError(f"rate_per_min must be a positive integer, got {rate_per_min}")
+
+    cleartext = _generate_cleartext()
+    row = conn.execute(
+        """
+        INSERT INTO api_tokens (
+            name, actor_kind, token_hash, token_prefix,
+            scopes, rate_per_min, expires_at
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+        RETURNING token_id
+        """,
+        (
+            name,
+            actor_kind,
+            hash_token(cleartext),
+            token_prefix(cleartext),
+            scopes,
+            rate_per_min,
+            expires_at,
+        ),
+    ).fetchone()
+    if row is None:
+        raise RuntimeError("mint_token: INSERT ... RETURNING yielded no row")
+
+    token_id = UUID(str(row["token_id"]))
+    logger.info(
+        "token.minted token_id=%s name=%s actor_kind=%s scopes=%s",
+        token_id, name, actor_kind, sorted(scopes),
+    )
+    return token_id, cleartext
+
+
+def revoke_token(conn: DictRowConnection, token_id: UUID) -> bool:
+    """Soft-revoke a token (set ``api_tokens.revoked_at = now()``).
+
+    Returns True if THIS call flipped a live token to revoked; False if the token
+    is unknown OR was already revoked (the UPDATE matched no live row). The
+    caller distinguishes "unknown" from "already revoked" itself if it needs to
+    (the router does an existence SELECT for its 404) — this helper only reports
+    whether it changed anything.
+
+    Invalidates the in-process principal cache on a successful flip so the revoke
+    takes effect on the very next request instead of lingering up to the cache
+    TTL. Does not commit — the caller owns the transaction; the cache clear is
+    done here (not deferred to commit) because a global clear is cheap and idempotent,
+    and a caller that rolls back simply re-populates the cache on the next lookup.
+    """
+    result = conn.execute(
+        """
+        UPDATE api_tokens
+        SET revoked_at = now()
+        WHERE token_id = %s
+          AND revoked_at IS NULL
+        """,
+        (token_id,),
+    )
+    changed = result.rowcount > 0
+    if changed:
+        invalidate_token_cache()
+        logger.info("token.revoked token_id=%s", token_id)
+    else:
+        logger.info("token.revoke_noop token_id=%s (unknown or already revoked)", token_id)
+    return changed

--- a/tests/integration/test_agent_floor_integration.py
+++ b/tests/integration/test_agent_floor_integration.py
@@ -1029,3 +1029,314 @@ class TestKillSwitchBeforeRate:
         # OBSERVABLE proof the counter never moved: the kill switch runs before
         # _enforce_rate_limit, so this token_id has NO bucket in the counter.
         assert UUID(token_id) not in auth._rate_counter._store
+
+
+# ===========================================================================
+# AN-2 (#392 PR2b) — the /v1/tokens REST lifecycle + /metrics scrape, driven
+# END TO END (mint / list / revoke through HTTP, then USE the returned
+# cleartext against the real auth path). Distinct from sections 1-15, which
+# fabricate tokens with direct SQL: here the credential is BORN over the API
+# (token_service.mint_token behind POST /v1/tokens) and every field of the
+# lifecycle is observed through the same TestClient the fleet would use.
+#
+#   16. A token minted via POST works IN its granted scope (200) and is denied
+#       OUT of it (403) — and an agent minted with recommend:approve is still
+#       stopped by the human GATE on APPROVED (actor_kind from the token).
+#   17. DELETE (revoke) takes effect on the VERY NEXT call → 401, with no TTL
+#       sleep: revoke_token clears the in-process cache, which is the point.
+#   18. last_used_at is bumped after a real authenticated call (cache-miss path).
+#   19. GET ?include_revoked shows a revoked row (revoked_at set); the default
+#       listing hides it.
+#   20. /metrics (admin Bearer) exposes ootils_http_requests_total with a REAL
+#       route-template label, and ootils_rate_limited_total climbs after a 429
+#       (deltas — the collectors are process-global).
+#   21. DELETE is idempotent (2nd → 204) and 404s an unknown token_id.
+#
+# Tokens minted here are NOT tracked by the `tracker` fixture (which only knows
+# its own direct-SQL mints); the `api_token_ids` fixture below scrubs them.
+# ===========================================================================
+
+
+@pytest.fixture
+def api_token_ids(migrated_db):
+    """Collect token_ids minted THROUGH the API during a test and scrub them
+    (and any audit rows) at teardown — the parallel of `tracker` for the
+    HTTP-minted credentials the REST-lifecycle tests create."""
+    ids: list[str] = []
+    yield ids
+    with _db_conn(migrated_db) as conn:
+        if ids:
+            conn.execute(
+                "DELETE FROM api_request_log WHERE token_id = ANY(%s::uuid[])", (ids,)
+            )
+            conn.execute(
+                "DELETE FROM api_tokens WHERE token_id = ANY(%s::uuid[])", (ids,)
+            )
+
+
+def _api_mint(
+    api_client,
+    *,
+    actor_kind: str,
+    scopes: list[str],
+    rate_per_min: int | None = None,
+    register: list[str] | None = None,
+) -> dict:
+    """Mint a token over POST /v1/tokens with the LEGACY admin token; return the
+    parsed 201 body (carries the once-shown ``token`` cleartext + ``token_id``).
+    Registers the token_id for teardown when ``register`` is supplied."""
+    body: dict = {
+        "name": f"api-{actor_kind}-{uuid4().hex[:8]}",
+        "actor_kind": actor_kind,
+        "scopes": scopes,
+    }
+    if rate_per_min is not None:
+        body["rate_per_min"] = rate_per_min
+    resp = api_client.post("/v1/tokens", headers=_bearer(LEGACY_TOKEN), json=body)
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    if register is not None:
+        register.append(data["token_id"])
+    return data
+
+
+def _metric_value(exposition_text: str, needle: str) -> float:
+    """Value of the first non-comment sample line containing ``needle``, or 0.0
+    when no such line exists yet (an untouched counter emits no series). Used to
+    read DELTAS around a call, since the Prometheus collectors are process-global
+    and accumulate across every test in the run."""
+    for line in exposition_text.splitlines():
+        if line.startswith("#") or needle not in line:
+            continue
+        return float(line.rsplit(" ", 1)[1])
+    return 0.0
+
+
+# ===========================================================================
+# 16. A minted token is usable in-scope, denied out-of-scope; the gate reads
+#     the TOKEN's actor_kind even for an API-minted agent.
+# ===========================================================================
+
+
+class TestApiMintedTokenIsUsable:
+    def test_in_scope_200_and_out_of_scope_403(self, api_client, tracker, api_token_ids):
+        data = _api_mint(
+            api_client, actor_kind="agent", scopes=["read"], register=api_token_ids
+        )
+        assert data["actor_kind"] == "agent"
+        clear = data["token"]
+
+        # IN scope: reading recommendations only needs `read`.
+        ok = api_client.get("/v1/recommendations", headers=_bearer(clear))
+        assert ok.status_code == 200, ok.text
+
+        # OUT of scope: DRAFT -> REVIEWED needs recommend:draft, which this
+        # read-only token lacks.
+        reco_id = tracker.reco(status="DRAFT")
+        denied = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={"to_status": "REVIEWED", "actor": "watcher", "actor_kind": "agent"},
+            headers=_bearer(clear),
+        )
+        assert denied.status_code == 403, denied.text
+        assert denied.json()["detail"] == "missing scope 'recommend:draft'"
+
+    def test_api_minted_agent_is_stopped_by_the_human_gate_on_approve(
+        self, api_client, tracker, api_token_ids
+    ):
+        """Even minted (abnormally) WITH recommend:approve, an API-born AGENT
+        token clears the scope floor but is stopped by the human GATE on
+        APPROVED — the actor_kind is the token's, not the lying body's. The
+        end-to-end proof that minting over the API grants no self-declaration
+        loophole."""
+        data = _api_mint(
+            api_client,
+            actor_kind="agent",
+            scopes=["recommend:approve"],
+            register=api_token_ids,
+        )
+        clear = data["token"]
+        reco_id = tracker.reco(status="REVIEWED")
+
+        resp = api_client.post(
+            f"/v1/recommendations/{reco_id}/transition",
+            json={"to_status": "APPROVED", "actor": "rogue", "actor_kind": "human"},
+            headers=_bearer(clear),
+        )
+        assert resp.status_code == 403, resp.text
+        assert "human" in resp.json()["detail"].lower()
+
+
+# ===========================================================================
+# 17. DELETE (revoke) is observed on the NEXT call — cache clear, not TTL sleep.
+# ===========================================================================
+
+
+class TestApiRevokeTakesEffectImmediately:
+    def test_revoke_then_next_call_is_401(self, api_client, api_token_ids):
+        data = _api_mint(
+            api_client, actor_kind="agent", scopes=["read"], register=api_token_ids
+        )
+        clear, token_id = data["token"], data["token_id"]
+
+        # Warm the process cache with one successful auth.
+        warm = api_client.get("/v1/recommendations", headers=_bearer(clear))
+        assert warm.status_code == 200, warm.text
+
+        # Revoke over HTTP: revoke_token flips revoked_at (committed by get_db)
+        # AND clears the in-process principal cache — so the very next request
+        # re-resolves against the DB, with no 30 s TTL wait.
+        deleted = api_client.delete(
+            f"/v1/tokens/{token_id}", headers=_bearer(LEGACY_TOKEN)
+        )
+        assert deleted.status_code == 204, deleted.text
+
+        revoked = api_client.get("/v1/recommendations", headers=_bearer(clear))
+        assert revoked.status_code == 401, revoked.text
+
+
+# ===========================================================================
+# 18. last_used_at bumped after a real call (the cache-miss bump path).
+# ===========================================================================
+
+
+class TestLastUsedAtBumped:
+    def test_last_used_at_advances_after_one_authenticated_call(
+        self, api_client, api_token_ids, migrated_db
+    ):
+        data = _api_mint(
+            api_client, actor_kind="agent", scopes=["read"], register=api_token_ids
+        )
+        clear, token_id = data["token"], data["token_id"]
+
+        with _db_conn(migrated_db) as conn:
+            before = conn.execute(
+                "SELECT last_used_at FROM api_tokens WHERE token_id = %s", (token_id,)
+            ).fetchone()
+        assert before["last_used_at"] is None  # never presented yet
+
+        # First presentation of this token is a cache miss -> DB lookup ->
+        # _bump_last_used_best_effort runs in its own connection.
+        r = api_client.get("/v1/recommendations", headers=_bearer(clear))
+        assert r.status_code == 200, r.text
+
+        with _db_conn(migrated_db) as conn:
+            after = conn.execute(
+                "SELECT last_used_at FROM api_tokens WHERE token_id = %s", (token_id,)
+            ).fetchone()
+        assert after["last_used_at"] is not None  # bumped
+
+
+# ===========================================================================
+# 19. GET ?include_revoked toggles the visibility of a revoked row.
+# ===========================================================================
+
+
+class TestListIncludeRevoked:
+    def test_revoked_row_visible_only_with_include_revoked(
+        self, api_client, api_token_ids
+    ):
+        data = _api_mint(
+            api_client, actor_kind="agent", scopes=["read"], register=api_token_ids
+        )
+        token_id = data["token_id"]
+
+        deleted = api_client.delete(
+            f"/v1/tokens/{token_id}", headers=_bearer(LEGACY_TOKEN)
+        )
+        assert deleted.status_code == 204, deleted.text
+
+        # Default listing hides the revoked row.
+        default = api_client.get("/v1/tokens", headers=_bearer(LEGACY_TOKEN))
+        assert default.status_code == 200, default.text
+        default_ids = {t["token_id"] for t in default.json()["tokens"]}
+        assert token_id not in default_ids
+
+        # include_revoked=true surfaces it, with revoked_at stamped.
+        incl = api_client.get(
+            "/v1/tokens?include_revoked=true", headers=_bearer(LEGACY_TOKEN)
+        )
+        assert incl.status_code == 200, incl.text
+        by_id = {t["token_id"]: t for t in incl.json()["tokens"]}
+        assert token_id in by_id
+        assert by_id[token_id]["revoked_at"] is not None
+
+
+# ===========================================================================
+# 20. /metrics scrape — request counter with a real route template, and the
+#     rate-limited counter climbing on a provoked 429 (deltas).
+# ===========================================================================
+
+
+class TestMetricsScrape:
+    def test_http_requests_total_carries_a_real_route_template(self, api_client):
+        # A couple of real requests so the counter has a labelled series.
+        for _ in range(2):
+            r = api_client.get("/v1/recommendations", headers=_bearer(LEGACY_TOKEN))
+            assert r.status_code == 200, r.text
+
+        scrape = api_client.get("/metrics", headers=_bearer(LEGACY_TOKEN))
+        assert scrape.status_code == 200, scrape.text
+        assert scrape.headers["content-type"].startswith("text/plain")
+        body = scrape.text
+        assert "ootils_http_requests_total" in body
+        # A matched route TEMPLATE, never a raw path or "unmatched".
+        assert 'route="/v1/recommendations"' in body
+
+    def test_rate_limited_total_increments_on_a_429(self, api_client, api_token_ids):
+        needle = 'ootils_rate_limited_total{actor_kind="agent"}'
+        before = _metric_value(
+            api_client.get("/metrics", headers=_bearer(LEGACY_TOKEN)).text, needle
+        )
+
+        # rate_per_min=1 → the 2nd call in the same window is a 429 (the
+        # per-test autouse fixture cleared the rate counter, so the bucket
+        # starts empty).
+        data = _api_mint(
+            api_client,
+            actor_kind="agent",
+            scopes=["read"],
+            rate_per_min=1,
+            register=api_token_ids,
+        )
+        clear = data["token"]
+
+        first = api_client.get("/v1/recommendations", headers=_bearer(clear))
+        assert first.status_code == 200, first.text
+        blocked = api_client.get("/v1/recommendations", headers=_bearer(clear))
+        assert blocked.status_code == 429, blocked.text
+
+        after = _metric_value(
+            api_client.get("/metrics", headers=_bearer(LEGACY_TOKEN)).text, needle
+        )
+        assert after - before >= 1
+
+
+# ===========================================================================
+# 21. DELETE idempotency + 404 on an unknown token_id.
+# ===========================================================================
+
+
+class TestDeleteIdempotent:
+    def test_second_delete_is_204_and_unknown_is_404(self, api_client, api_token_ids):
+        data = _api_mint(
+            api_client, actor_kind="agent", scopes=["read"], register=api_token_ids
+        )
+        token_id = data["token_id"]
+
+        first = api_client.delete(
+            f"/v1/tokens/{token_id}", headers=_bearer(LEGACY_TOKEN)
+        )
+        assert first.status_code == 204, first.text
+
+        # Idempotent: revoking an already-revoked token still returns 204.
+        second = api_client.delete(
+            f"/v1/tokens/{token_id}", headers=_bearer(LEGACY_TOKEN)
+        )
+        assert second.status_code == 204, second.text
+
+        # Unknown token_id → 404 (existence SELECT misses).
+        unknown = api_client.delete(
+            f"/v1/tokens/{uuid4()}", headers=_bearer(LEGACY_TOKEN)
+        )
+        assert unknown.status_code == 404, unknown.text

--- a/tests/test_token_service_and_metrics.py
+++ b/tests/test_token_service_and_metrics.py
@@ -1,0 +1,463 @@
+"""
+Unit tests for the AN-2 PR2b token/metrics surface (#392) — PURE: no PostgreSQL,
+no live pool. Three modules under test:
+
+  * ``api/token_service.py`` — mint_token / revoke_token. Validation
+    (actor_kind / scopes / rate_per_min) is asserted to run BEFORE any DB access
+    via a conn-spy that must record ZERO execute() calls on the failure paths;
+    revoke_token's cache-invalidation side-effect is asserted to fire ONLY on a
+    real flip (rowcount>0), never on a no-op re-revoke.
+  * ``api/metrics.py`` — the process-global Prometheus collectors + helpers.
+    Counters are process-GLOBAL singletons (constructed once at import), so every
+    increment assertion reads a DELTA around the call, and uses a UNIQUE label
+    value so the pre-call baseline is a clean 0.
+  * ``api/routers/tokens.py`` — driven through a real ``create_app()`` +
+    TestClient with ``resolve_principal`` and ``get_db`` overridden. The DB is a
+    duck-typed fake conn dispatching canned results on the SQL text (no Postgres).
+    Proves: POST returns the cleartext ONCE and never a hash; GET/list carries no
+    secret material; DELETE is 204; every token verb AND the root /metrics route
+    are 403 without the admin scope; an invalid scope is a hand-authored 422.
+
+No pytest-asyncio in this repo; the router is exercised synchronously through
+TestClient. auth.py validates OOTILS_API_TOKEN at import time and app.py builds a
+module-level app at import — so the env token is set before the first import.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+import pytest
+
+# auth.py validates OOTILS_API_TOKEN at IMPORT time, and importing app.py builds
+# a module-level `app = create_app()` (which calls _expected_token()) — set the
+# token before any ootils import below.
+os.environ.setdefault("OOTILS_API_TOKEN", "unit-legacy-token")
+
+import ootils_core.api.auth as auth  # noqa: E402
+import ootils_core.api.metrics as metrics  # noqa: E402
+import ootils_core.api.token_service as token_service  # noqa: E402
+from ootils_core.api.auth import (  # noqa: E402
+    Principal,
+    resolve_principal,
+)
+from ootils_core.api.token_service import mint_token, revoke_token  # noqa: E402
+
+
+# ===========================================================================
+# Shared fakes / helpers
+# ===========================================================================
+
+
+class _Result:
+    """Duck-typed psycopg cursor-result: fetchone / fetchall / rowcount."""
+
+    def __init__(self, *, one=None, many=None, rowcount=0) -> None:
+        self._one = one
+        self._many = [] if many is None else many
+        self.rowcount = rowcount
+
+    def fetchone(self):
+        return self._one
+
+    def fetchall(self):
+        return self._many
+
+
+class _SpyConn:
+    """Minimal duck-typed stand-in for a dict_row connection.
+
+    Records every execute() (``calls``) so the validation-before-IO contract can
+    be asserted (zero calls on a rejected mint). Dispatches canned results on the
+    SQL text so it can back mint_token, revoke_token AND the router's read-backs
+    without a database.
+    """
+
+    def __init__(
+        self,
+        *,
+        mint_token_id: UUID | None = None,
+        revoke_rowcount: int = 1,
+        exists: bool = True,
+        list_rows=None,
+        readback=None,
+    ) -> None:
+        self.calls: list[tuple[str, object]] = []
+        self.mint_token_id = mint_token_id or uuid4()
+        self.revoke_rowcount = revoke_rowcount
+        self.exists = exists
+        self.list_rows = [] if list_rows is None else list_rows
+        self.readback = readback
+
+    def execute(self, sql, params=None):
+        s = " ".join(str(sql).split())
+        self.calls.append((s, params))
+        if "INSERT INTO api_tokens" in s:
+            return _Result(one={"token_id": self.mint_token_id})
+        if "UPDATE api_tokens SET revoked_at" in s:
+            return _Result(rowcount=self.revoke_rowcount)
+        if "SELECT 1 FROM api_tokens" in s:
+            return _Result(one={"?column?": 1} if self.exists else None)
+        if "last_used_at" in s:  # list_tokens SELECT (has last_used_at column)
+            return _Result(many=self.list_rows)
+        if "SELECT token_id, name, token_prefix" in s:  # create read-back
+            return _Result(one=self.readback)
+        raise AssertionError(f"unexpected SQL: {s}")
+
+
+def _principal(actor_kind: str = "agent", scopes=("read",)) -> Principal:
+    return Principal(
+        token_id=uuid4(),
+        name="unit",
+        actor_kind=actor_kind,
+        scopes=frozenset(scopes),
+        is_legacy=False,
+    )
+
+
+def _admin() -> Principal:
+    """The legacy-style admin principal (superset scope) the token router gates on."""
+    return Principal(
+        token_id=None,
+        name="admin",
+        actor_kind="human",
+        scopes=frozenset({"admin"}),
+        is_legacy=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_token_cache():
+    """token_service.revoke_token clears the module-level auth._token_cache on a
+    flip; keep it clean around every test so nothing leaks between them."""
+    auth._token_cache.clear()
+    yield
+    auth._token_cache.clear()
+
+
+# ===========================================================================
+# 1. mint_token — cleartext + entropy, validation BEFORE any DB access
+# ===========================================================================
+
+
+class TestMintToken:
+    def test_returns_ootk_cleartext_with_entropy(self):
+        conn = _SpyConn()
+        token_id, cleartext = mint_token(
+            conn, name="watcher", actor_kind="agent", scopes=["read"]
+        )
+        assert token_id == UUID(str(conn.mint_token_id))
+        assert cleartext.startswith("ootk_")
+        # 256 bits of urlsafe entropy → well beyond the 5-char prefix.
+        assert len(cleartext) > len("ootk_") + 30
+        # Exactly one INSERT reached the DB.
+        assert sum("INSERT INTO api_tokens" in c[0] for c in conn.calls) == 1
+
+    def test_two_mints_have_distinct_cleartext(self):
+        conn = _SpyConn()
+        _, a = mint_token(conn, name="n", actor_kind="agent", scopes=["read"])
+        _, b = mint_token(conn, name="n", actor_kind="agent", scopes=["read"])
+        assert a != b
+
+    def test_unknown_actor_kind_raises_before_any_db_access(self):
+        conn = _SpyConn()
+        with pytest.raises(ValueError) as ei:
+            mint_token(conn, name="n", actor_kind="robot", scopes=["read"])
+        assert "actor_kind" in str(ei.value)
+        assert conn.calls == []  # conn-spy: zero DB access on rejection
+
+    def test_unknown_scope_raises_before_any_db_access(self):
+        conn = _SpyConn()
+        with pytest.raises(ValueError) as ei:
+            mint_token(conn, name="n", actor_kind="agent", scopes=["bogus:scope"])
+        assert "bogus:scope" in str(ei.value)
+        assert "scope" in str(ei.value).lower()
+        assert conn.calls == []
+
+    def test_non_positive_rate_per_min_raises_before_any_db_access(self):
+        conn = _SpyConn()
+        with pytest.raises(ValueError) as ei:
+            mint_token(
+                conn, name="n", actor_kind="agent", scopes=["read"], rate_per_min=0
+            )
+        assert "rate_per_min" in str(ei.value)
+        assert conn.calls == []
+
+
+# ===========================================================================
+# 2. revoke_token — flip semantics + cache invalidation ONLY on flip
+# ===========================================================================
+
+
+class TestRevokeToken:
+    def test_first_flip_returns_true_and_invalidates_cache(self, monkeypatch):
+        calls: list[int] = []
+        monkeypatch.setattr(
+            token_service, "invalidate_token_cache", lambda: calls.append(1)
+        )
+        conn = _SpyConn(revoke_rowcount=1)
+
+        assert revoke_token(conn, uuid4()) is True
+        assert calls == [1]  # invalidated exactly once, on the flip
+
+    def test_re_revoke_or_unknown_returns_false_and_does_not_invalidate(
+        self, monkeypatch
+    ):
+        calls: list[int] = []
+        monkeypatch.setattr(
+            token_service, "invalidate_token_cache", lambda: calls.append(1)
+        )
+        conn = _SpyConn(revoke_rowcount=0)  # UPDATE matched no live row
+
+        assert revoke_token(conn, uuid4()) is False
+        assert calls == []  # no-op flip → cache untouched
+
+
+# ===========================================================================
+# 3. invalidate_token_cache — the real cache API round-trips to a miss
+# ===========================================================================
+
+
+class TestInvalidateTokenCache:
+    def test_cached_entry_then_clear_is_a_miss(self):
+        key = "unit-" + uuid4().hex
+        auth._token_cache.put(key, _principal())
+        assert auth._token_cache.get(key)[0] is True  # cached
+
+        token_service.invalidate_token_cache()
+
+        hit, value = auth._token_cache.get(key)
+        assert hit is False and value is None  # cleared → miss
+
+
+# ===========================================================================
+# 4. metrics — route_template, collector deltas, render content-type
+# ===========================================================================
+
+
+class _FakeRoute:
+    def __init__(self, path) -> None:
+        self.path = path
+
+
+class _FakeState:
+    pass
+
+
+class _FakeReq:
+    """Duck-typed Request: only .scope / .method / .state.principal are read."""
+
+    def __init__(self, route_path=None, method="GET", actor_kind=None) -> None:
+        self.scope = {"route": _FakeRoute(route_path)} if route_path is not None else {}
+        self.method = method
+        self.state = _FakeState()
+        if actor_kind is not None:
+            self.state.principal = _principal(actor_kind=actor_kind)
+
+
+class TestRouteTemplate:
+    def test_matched_route_returns_template(self):
+        req = _FakeReq("/v1/tokens/{token_id}")
+        assert metrics.route_template(req) == "/v1/tokens/{token_id}"
+
+    def test_unmatched_request_returns_literal_unmatched(self):
+        req = _FakeReq(route_path=None)  # no route on the scope
+        assert metrics.route_template(req) == "unmatched"
+
+    def test_empty_path_collapses_to_unmatched(self):
+        req = _FakeReq(route_path="")  # a route object with an empty path
+        assert metrics.route_template(req) == "unmatched"
+
+
+class TestCollectorDeltas:
+    def test_observe_request_increments_counter(self):
+        # Unique route → the pre-call baseline for this label set is a clean 0.
+        route = f"/unit/{uuid4().hex}/{{id}}"
+        req = _FakeReq(route, method="GET", actor_kind="agent")
+        labels = dict(route=route, method="GET", status="201", actor_kind="agent")
+
+        before = metrics.http_requests_total.labels(**labels)._value.get()
+        metrics.observe_request(req, status_code=201, duration_seconds=0.02)
+        after = metrics.http_requests_total.labels(**labels)._value.get()
+        assert after - before == 1
+
+    def test_observe_request_records_latency_sample(self):
+        route = f"/unit/{uuid4().hex}/{{id}}"
+        req = _FakeReq(route, method="POST", actor_kind="agent")
+        hist = metrics.http_request_duration_seconds.labels(route=route, method="POST")
+
+        before = hist._sum.get()
+        metrics.observe_request(req, status_code=200, duration_seconds=0.25)
+        after = hist._sum.get()
+        assert after - before == pytest.approx(0.25)
+
+    def test_no_principal_labels_actor_kind_none(self):
+        route = f"/unit/{uuid4().hex}/{{id}}"
+        req = _FakeReq(route, method="GET", actor_kind=None)  # no principal posed
+        labels = dict(route=route, method="GET", status="200", actor_kind="none")
+
+        before = metrics.http_requests_total.labels(**labels)._value.get()
+        metrics.observe_request(req, status_code=200, duration_seconds=0.01)
+        after = metrics.http_requests_total.labels(**labels)._value.get()
+        assert after - before == 1
+
+    def test_record_rate_limited_increments(self):
+        kind = "unit-" + uuid4().hex
+        before = metrics.rate_limited_total.labels(actor_kind=kind)._value.get()
+        metrics.record_rate_limited(kind)
+        after = metrics.rate_limited_total.labels(actor_kind=kind)._value.get()
+        assert after - before == 1
+
+    def test_record_fleet_killswitch_increments(self):
+        before = metrics.fleet_killswitch_total._value.get()
+        metrics.record_fleet_killswitch()
+        after = metrics.fleet_killswitch_total._value.get()
+        assert after - before == 1
+
+
+class TestRenderLatest:
+    def test_content_type_and_known_metric_present(self):
+        from prometheus_client import CONTENT_TYPE_LATEST
+
+        body, content_type = metrics.render_latest()
+        assert content_type == CONTENT_TYPE_LATEST
+        assert isinstance(body, bytes)
+        assert b"ootils_http_requests_total" in body
+
+
+# ===========================================================================
+# 5. /v1/tokens router — TestClient + dependency overrides (no Postgres)
+# ===========================================================================
+
+
+def _make_client(principal: Principal, conn: _SpyConn):
+    """A TestClient over the REAL create_app() app with resolve_principal + get_db
+    overridden. resolve_principal is the sub-dependency of require_scope('admin'),
+    so overriding it drives the scope gate off ``principal``; get_db yields the
+    fake conn so no Postgres is touched."""
+    from fastapi.testclient import TestClient
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+
+    app = create_app()
+
+    async def _fake_principal():
+        return principal
+
+    def _fake_db():
+        yield conn
+
+    app.dependency_overrides[resolve_principal] = _fake_principal
+    app.dependency_overrides[get_db] = _fake_db
+    return TestClient(app)
+
+
+def _readback_row(token_id: UUID) -> dict:
+    return {
+        "token_id": token_id,
+        "name": "unit-token",
+        "token_prefix": "ootk_unittes",
+        "actor_kind": "agent",
+        "scopes": ["read"],
+        "rate_per_min": None,
+        "created_at": datetime(2026, 7, 8, tzinfo=timezone.utc),
+        "expires_at": None,
+    }
+
+
+def _list_row(token_id: UUID) -> dict:
+    return {
+        "token_id": token_id,
+        "name": "unit-token",
+        "token_prefix": "ootk_unittes",
+        "actor_kind": "agent",
+        "scopes": ["read"],
+        "rate_per_min": None,
+        "created_at": datetime(2026, 7, 8, tzinfo=timezone.utc),
+        "last_used_at": None,
+        "expires_at": None,
+        "revoked_at": None,
+    }
+
+
+class TestTokensRouterAdmin:
+    def test_post_returns_cleartext_once_and_never_a_hash(self):
+        conn = _SpyConn()
+        conn.readback = _readback_row(conn.mint_token_id)
+        with _make_client(_admin(), conn) as client:
+            resp = client.post(
+                "/v1/tokens",
+                json={"name": "unit-token", "actor_kind": "agent", "scopes": ["read"]},
+            )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        # The cleartext is present, exactly once, under `token`; and it is a
+        # real minted ootk_ secret, not the stored hash.
+        assert body["token"].startswith("ootk_")
+        assert len(body["token"]) > len("ootk_") + 30
+        assert "token_hash" not in body
+        assert body["prefix"] == "ootk_unittes"
+        assert body["token_id"] == str(conn.mint_token_id)
+
+    def test_get_list_carries_no_secret_material(self):
+        tid = uuid4()
+        conn = _SpyConn(list_rows=[_list_row(tid)])
+        with _make_client(_admin(), conn) as client:
+            resp = client.get("/v1/tokens")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["total"] == 1
+        tok = body["tokens"][0]
+        # Neither the cleartext (never stored) nor the hash (a lookup key we do
+        # not surface) appears — only the non-secret prefix.
+        assert "token" not in tok
+        assert "token_hash" not in tok
+        assert tok["prefix"] == "ootk_unittes"
+
+    def test_delete_revokes_with_204(self):
+        conn = _SpyConn(exists=True, revoke_rowcount=1)
+        with _make_client(_admin(), conn) as client:
+            resp = client.delete(f"/v1/tokens/{uuid4()}")
+        assert resp.status_code == 204, resp.text
+        assert resp.content == b""
+
+    def test_post_invalid_scope_is_hand_authored_422_before_any_write(self):
+        conn = _SpyConn()
+        with _make_client(_admin(), conn) as client:
+            resp = client.post(
+                "/v1/tokens",
+                json={
+                    "name": "x",
+                    "actor_kind": "agent",
+                    "scopes": ["bogus:scope"],
+                },
+            )
+        assert resp.status_code == 422, resp.text
+        detail = resp.json()["detail"]
+        assert isinstance(detail, str)  # hand-authored string, not a Pydantic list
+        assert "bogus:scope" in detail
+        assert "scope" in detail.lower()
+        # Validation happened in mint_token BEFORE the INSERT — no DB write.
+        assert conn.calls == []
+
+
+class TestTokensRouterScopeFloor:
+    def test_all_token_verbs_and_metrics_are_403_without_admin(self):
+        # A read-only agent lacks the admin superset the whole surface requires.
+        conn = _SpyConn()
+        with _make_client(_principal(actor_kind="agent", scopes=("read",)), conn) as client:
+            post = client.post(
+                "/v1/tokens",
+                json={"name": "x", "actor_kind": "agent", "scopes": ["read"]},
+            )
+            get = client.get("/v1/tokens")
+            dele = client.delete(f"/v1/tokens/{uuid4()}")
+            metr = client.get("/metrics")
+
+        for resp in (post, get, dele, metr):
+            assert resp.status_code == 403, resp.text
+            assert resp.json()["detail"] == "missing scope 'admin'"
+        # Auth stopped every call at the scope floor → no DB access.
+        assert conn.calls == []


### PR DESCRIPTION
Dernier morceau de l'étage entreprise agents : le cycle de vie des credentials passe par l'API (mint cleartext-montré-une-fois, soft-revoke avec invalidation cache — fenêtre multi-worker ≤30 s divulguée dans l'ADR post-revue, DELETE 204 idempotent, admin partout), /metrics Prometheus à cardinalité bornée (requêtes/latence/429/kill-switch), la démo abandonne son mint SQL brut, ADR-032 grave la grille et la doctrine coût≠réversibilité, ADR-029 solde sa dette « décidé mais pas appliqué ». Revue adversariale GO : cleartext à chemin de sortie unique, revoke vérifié, zéro escalade. 22 tests unit neufs + 8 intégration. Ferme le périmètre code de #392 (PR1 #403 → PR2a #434 → PR2b). Réf ADR-029/ADR-032, roadmap AN-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)