### PR TITLE
fix(pyramide): #433 — la FVA devient calculable (lookback découplé de l'horizon, 730 j)

### DIFF
--- a/src/ootils_core/api/routers/pyramide.py
+++ b/src/ootils_core/api/routers/pyramide.py
@@ -41,6 +41,23 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/forecast", tags=["pyramide"])
 
+# Lookback window for the backtest + FVA seasonal-naive, DECOUPLED from the
+# forecast horizon (#433). The seasonal-naive baseline (pyramide/fva.py) is
+# only computable when len(history) >= season_length + n_cutoffs measured at
+# the history's REAL cadence — get_historical_demand returns DAILY rows and
+# never re-aggregates to the requested granularity (that re-aggregation is the
+# separate DEM-1 grain/routing chantier). A weekly run therefore needs
+# season_length=52 + a 52-origin backtest tail = 104 daily points just to clear
+# fva._backtest_seasonal_naive's `min_train < season_length` guard; the old
+# max(horizon_days, 90) capped history at <= 90 points, so the FVA was
+# structurally None for every weekly item (measured: run cbee7f04, fva_basis=0).
+# 730 daily points = 2 full seasonal cycles at daily cadence: it clears the
+# guard AND gives the AUTO_SELECT 52-origin backtest a real training window so
+# the seasonality is actually LEARNED, not merely defined. Perf: 730 daily
+# points on the largest pilot series is ~2300 rows — trivial for the read, and
+# the deeper backtest is the POINT (it was previously starved by the coupling).
+BACKTEST_LOOKBACK_DAYS = 730
+
 
 class PyramideRunRequest(BaseModel):
     item_id: str
@@ -321,11 +338,18 @@ def create_pyramide_run(
     # The reader falls back to past CustomerOrderDemand nodes (scoped to
     # scenario_uuid) when demand_history is empty — so this runs BEFORE the
     # history-empty 422 below.
+    #
+    # lookback is decoupled from the horizon (#433): the FVA/backtest needs a
+    # window sized by the seasonal cycle, NOT by how far ahead we forecast.
+    # max() keeps the historical "at least as much history as horizon"
+    # intent while flooring at BACKTEST_LOOKBACK_DAYS; with horizon_days
+    # capped at 365 the floor always wins today — the max stays as the honest
+    # invariant should the horizon cap ever be raised.
     history = get_historical_demand(
         db=db,
         item_id=item_uuid,
         location_id=location_uuid,
-        lookback_days=max(body.horizon_days, 90),
+        lookback_days=max(body.horizon_days, BACKTEST_LOOKBACK_DAYS),
         scenario_id=scenario_uuid,
     )
     if not history:

--- a/tests/test_fva.py
+++ b/tests/test_fva.py
@@ -178,6 +178,37 @@ def test_fva_none_when_history_shorter_than_one_season_at_first_origin():
     assert result.fva_mase is None
 
 
+def test_fva_weekly_threshold_none_below_104_computable_at_104():
+    # #433 regression, pinned to literals: the weekly seasonal-naive threshold.
+    # With season_length=52 and a 52-origin backtest (n_cutoffs=52), the guard
+    # in _backtest_seasonal_naive is min_train = len(history) - n_cutoffs, and
+    # it demands min_train >= season_length, i.e.
+    #   len(history) >= season_length + n_cutoffs = 52 + 52 = 104.
+    # This is the exact arithmetic that made the weekly FVA structurally None
+    # under the old max(horizon_days, 90) lookback (<= 90 daily points) —
+    # issue #433. Positive, non-constant seasonal series so WAPE is defined
+    # once the baseline clears the guard.
+    season, cutoffs = 52, 52
+
+    def series_of(length: int) -> list[Decimal]:
+        return [D(10 + (i % season)) for i in range(length)]
+
+    stat = _stat_report(wape=D("0.2"), mase=D("1.0"), n_cutoffs=cutoffs, horizon=1)
+
+    # 103 points: min_train = 103 - 52 = 51 < 52 -> baseline undefined at the
+    # first shared origin -> None (None-honest, never a fabricated 0).
+    below = compute_fva(series_of(103), season, stat_report=stat)
+    assert below.naive_wape is None
+    assert below.fva_wape is None
+
+    # 104 points: min_train = 104 - 52 = 52 == season -> baseline computable,
+    # aligned to the 52 stat cutoffs -> a real, comparable FVA number.
+    at = compute_fva(series_of(104), season, stat_report=stat)
+    assert at.naive_wape is not None
+    assert at.fva_wape is not None
+    assert at.fva_wape == at.naive_wape - D("0.2")
+
+
 def test_fva_none_when_stat_operand_none_but_naive_stays_computable():
     # The distinctive None-honest case: the stat WAPE is None (migration 055
     # — e.g. an all-zero pooled window), yet the naive baseline IS computable.

--- a/tests/test_pyramide_api.py
+++ b/tests/test_pyramide_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from uuid import uuid4
 
+import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
@@ -11,6 +12,7 @@ os.environ["OOTILS_API_TOKEN"] = "test-token"
 from ootils_core.api.app import create_app
 from ootils_core.api.auth import require_auth
 from ootils_core.api.dependencies import get_db
+from ootils_core.api.routers import pyramide as pyramide_router
 
 
 AUTH_HEADERS = {"Authorization": "Bearer test-token"}
@@ -132,6 +134,68 @@ def test_snapshot_diff_requires_compare_to_before_db():
     response = client.get(f"/v1/forecast/snapshots/{uuid4()}/diff", headers=AUTH_HEADERS)
 
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
+@pytest.fixture
+def _lookback_capture(monkeypatch):
+    """Capture the lookback_days the leaf run passes to get_historical_demand,
+    stubbing every DB-touching resolver so no real Postgres is needed. The stub
+    returns an EMPTY history so the endpoint short-circuits at the 422 before
+    any persistence — the lookback decision (#433) is what's under test, not the
+    downstream run."""
+    captured: dict[str, int] = {}
+
+    def fake_get_historical_demand(*, db, item_id, location_id, lookback_days, scenario_id):
+        captured["lookback_days"] = lookback_days
+        return []  # empty -> 422 "Historical demand is required", no further DB
+
+    monkeypatch.setattr(pyramide_router, "resolve_item_uuid", lambda db, ext: uuid4())
+    monkeypatch.setattr(pyramide_router, "resolve_location_uuid", lambda db, ext: uuid4())
+    monkeypatch.setattr(
+        pyramide_router, "get_historical_demand", fake_get_historical_demand
+    )
+    return captured
+
+
+def test_leaf_run_lookback_decoupled_from_horizon(_lookback_capture):
+    # #433: a short horizon must NOT starve the FVA/backtest window. horizon=90
+    # used to cap history at 90 daily points (max(horizon, 90)); it now floors
+    # at the 2-cycle backtest window (730), decoupled from the horizon.
+    client = _make_client_no_db()
+    response = client.post(
+        "/v1/forecast/runs",
+        json={"item_id": "ITEM-001", "location_id": "LOC-001", "horizon_days": 90},
+        headers=AUTH_HEADERS,
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert _lookback_capture["lookback_days"] == pyramide_router.BACKTEST_LOOKBACK_DAYS
+    assert _lookback_capture["lookback_days"] == 730
+
+
+def test_leaf_run_lookback_floors_at_backtest_window_for_max_horizon(_lookback_capture):
+    # horizon_days is capped at 365 (< the 730 floor), so the floor wins through
+    # the endpoint even for the largest allowed horizon: the full backtest
+    # window is always pulled.
+    client = _make_client_no_db()
+    response = client.post(
+        "/v1/forecast/runs",
+        json={"item_id": "ITEM-001", "location_id": "LOC-001", "horizon_days": 365},
+        headers=AUTH_HEADERS,
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert _lookback_capture["lookback_days"] == 730
+
+
+def test_lookback_expression_preserves_at_least_horizon_intent():
+    # The endpoint floors at BACKTEST_LOOKBACK_DAYS but keeps max() so the
+    # "at least as much history as the horizon" invariant survives a future
+    # horizon-cap raise. That branch is unreachable via HTTP today (horizon_days
+    # <= 365 < 730), so it is pinned here at the expression level.
+    floor = pyramide_router.BACKTEST_LOOKBACK_DAYS
+    assert max(90, floor) == floor
+    assert max(floor + 100, floor) == floor + 100
 
 
 def test_pyramide_router_registered_in_app():


### PR DESCRIPTION
La FVA était structurellement incalculable en weekly (lookback ≤90 points vs 104 requis — mesuré fva_basis=0 sur le premier forecast réel). Fix : constante dérivée BACKTEST_LOOKBACK_DAYS=730, seuil verrouillé par test (103→None/104→calculée, re-dérivé en revue), 3 tests routeur. Le fond grain/cadence référencé DEM-1. Revue éclair GO. La preuve end-to-end suivra par re-run démo sur la VM post-merge (fva_basis>0 attendu). Ferme #433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)