### PR TITLE
chore(prod-qw): les 6 quick-wins de production — H1 se complète

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,52 @@ jobs:
       - name: Run mypy
         run: python -m mypy src/ootils_core
 
+  security:
+    name: pip-audit
+    runs-on: ubuntu-latest
+    # Blocking dependency-vulnerability gate (PROD-QW). Audits the RESOLVED
+    # dependency tree of the project (core + dev extras) against the OSV / PyPI
+    # advisory databases and FAILS the build on any known vulnerability.
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install pip-audit + project
+        run: |
+          pip install --upgrade pip
+          pip install pip-audit
+          pip install -e ".[dev]"
+
+      - name: Run pip-audit
+        # DOCUMENTED IGNORES — each is a vulnerability with NO fix reachable
+        # within our pinned constraints, so failing on it would be permanent
+        # noise, not an actionable signal. Keep this list SHORT and justified;
+        # anything else must be fixed by bumping the offending dependency.
+        #
+        #   starlette (CVE-2026-48817 / CVE-2026-48818 / PYSEC-2026-161 /
+        #   PYSEC-2026-248 / PYSEC-2026-249): all fixed only in starlette 1.x,
+        #   but fastapi ~= 0.128.0 pins starlette < 0.51 (see pyproject.toml:28
+        #   — bumping fastapi to a starlette-1.x line is a breaking major, out
+        #   of scope for this gate). Revisit when fastapi is upgraded.
+        #
+        # NO --strict: under --strict a SKIP (including --skip-editable on our
+        # own editable install) is promoted to a hard failure - the two flags
+        # are contradictory. Without it, found vulnerabilities still exit 1
+        # (the gate stays real); only collection skips are tolerated.
+        # If the first run surfaces additional constraint-locked CVEs, add them
+        # here WITH a one-line justification; do NOT silence a fixable one.
+        run: >-
+          pip-audit --skip-editable
+          --ignore-vuln CVE-2026-48817
+          --ignore-vuln CVE-2026-48818
+          --ignore-vuln PYSEC-2026-161
+          --ignore-vuln PYSEC-2026-248
+          --ignore-vuln PYSEC-2026-249
+
   test:
     name: pytest
     runs-on: ubuntu-latest
@@ -93,7 +139,23 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run tests
-        run: python -m pytest tests/ -q --tb=short --ignore=tests/integration --ignore=tests/smoke
+        # Coverage gate (PROD-QW). pytest-cov is already a dev dependency, so
+        # this adds a measurement + a floor, not a new install. --cov-branch
+        # counts branch coverage; term-missing:skip-covered keeps the log short
+        # (only partially-covered files are listed).
+        #
+        # --cov-fail-under=40 is a DELIBERATELY CONSERVATIVE floor: this job
+        # runs the unit suite only (integration/ + smoke/ excluded), so a lot of
+        # integration-only code (seed/, staging/, tools/, deeper engine paths)
+        # is counted as source but exercised elsewhere, dragging the TOTAL down.
+        # The floor must never break a green build; ratchet it UP toward
+        # floor(measured - 2) once the first run reports the real percentage.
+        run: >-
+          python -m pytest tests/ -q --tb=short
+          --ignore=tests/integration --ignore=tests/smoke
+          --cov=ootils_core --cov-branch
+          --cov-report=term-missing:skip-covered
+          --cov-fail-under=40
 
   integration:
     name: pytest integration

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: CodeQL
+
+# Static application security testing (PROD-QW). Standard GitHub CodeQL setup
+# for Python: analyzes the source on push/PR to main and on a weekly schedule,
+# reporting findings to the repository's Security tab (code scanning alerts).
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    # Weekly, Monday 03:27 UTC — catches newly-published query updates against
+    # code that hasn't changed.
+    - cron: "27 3 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          # security-and-quality adds maintainability/quality queries on top of
+          # the default security suite.
+          queries: security-and-quality
+
+      # Python needs no compilation; CodeQL analyzes the source directly. The
+      # autobuild step is a documented no-op for interpreted languages, kept for
+      # parity with the standard template.
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ data-input-canonique-v1-*.zip
 
 # Data-delivery notes that point at private workspace paths
 /README.txt
+.coverage

--- a/docs/INFRA-RUNBOOK.md
+++ b/docs/INFRA-RUNBOOK.md
@@ -654,12 +654,58 @@ ls -lah ~/ootils-backups/postgres
 crontab -l
 ```
 
+#### Restauration prouvee (#192)
+
+Un backup jamais restaure n'est pas un backup. `scripts/restore_postgres.sh`
+restaure un dump dans une base JETABLE (`ootils_restore_test` par defaut, jamais
+la base live) via le service compose `postgres`, verifie que la restauration est
+non vide (compte des tables du schema `public` + `SELECT` sur `schema_migrations`)
+puis DROP la base jetable. Le passer regulierement (idealement en cron, apres le
+backup) prouve que les dumps sont exploitables.
+
+```bash
+chmod +x scripts/restore_postgres.sh
+# Restaure le dump le plus recent, verifie, puis drop la base jetable:
+scripts/restore_postgres.sh
+# Ou un dump precis, en gardant la base restauree pour inspection:
+scripts/restore_postgres.sh ~/ootils-backups/postgres/ootils-postgres-<host>-<ts>.dump --keep
+```
+
+Sortie attendue en fin de run: `RESTORE OK: ... (<N> tables, <M> migrations).`
+
+#### Copie hors machine (#192)
+
+`scripts/backup_offhost.sh` mirroir le repertoire de backups vers une
+destination distante via `rsync` (ssh/rsync). La destination est fournie par le
+pilote via `OOTILS_BACKUP_REMOTE` (pas de defaut -- le script refuse de tourner
+sans). A enchainer apres le backup (meme cron):
+
+```bash
+chmod +x scripts/backup_offhost.sh
+OOTILS_BACKUP_REMOTE="user@host:/srv/ootils-backups" scripts/backup_offhost.sh
+# Cle/port ssh custom si besoin:
+OOTILS_BACKUP_REMOTE="user@host:/srv/ootils-backups" \
+  OOTILS_BACKUP_SSH_OPTS="-i ~/.ssh/backup_key -p 2222" \
+  scripts/backup_offhost.sh
+```
+
+#### Garde-fous du pool de connexions API (PROD-QW)
+
+Le pool psycopg de l'API applique des timeouts SERVEUR à ses seules connexions
+(les scripts/watchers en `psycopg.connect()` direct ne sont jamais plafonnés) :
+
+| Variable env | Défaut | Rôle |
+|---|---|---|
+| `OOTILS_DB_STATEMENT_TIMEOUT_MS` | `900000` (15 min) | Plafond par requête SQL du pool — calibré sur le pire calc run pilote mesuré (464 s) + marge. À relever si un fork plus gros dépasse ; le vrai fix est #193 (workers async). `0` = désactivé. |
+| `OOTILS_DB_IDLE_IN_TXN_TIMEOUT_MS` | `60000` | Tue une transaction laissée ouverte inactive. |
+| `OOTILS_DB_POOL_MAX_LIFETIME` / `OOTILS_DB_POOL_MAX_IDLE` | 1800 / 600 s | Recyclage des connexions (post-failover). |
+
 ## 12. Risques et points faibles restants
 
 1. VM 200 en DHCP: risque de changement d'IP si pas de reservation
 2. Tunnel Windows: solution pratique mais pas ideale structurellement
 3. Secrets distribues sur plusieurs emplacements: necessite un vrai coffre de secrets (issue ouverte)
-4. Dump Postgres quotidien local OK si `scripts/install_backup_cron.sh` est installe sur VM 201; la copie hors machine reste a faire.
+4. Dump Postgres quotidien local OK si `scripts/install_backup_cron.sh` est installe sur VM 201. Copie hors machine outillee (`scripts/backup_offhost.sh`, #192) : le pilote doit fournir la destination `OOTILS_BACKUP_REMOTE` et l'enchainer au cron de backup. Restauration prouvee outillee (`scripts/restore_postgres.sh`, #192) : a passer regulierement pour valider les dumps.
 5. Snapshots Proxmox VM 200 + VM 201 non encore automatises (a faire)
 
 ## 13. Checklist rapide post-reconstruction

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4271,6 +4271,162 @@
         }
       }
     },
+    "/v1/audit": {
+      "get": {
+        "tags": [
+          "audit"
+        ],
+        "summary": "Read the API request audit trail",
+        "description": "List audit rows newest-first. All filters are optional and combine with\nAND; every value is bound as a parameter (never interpolated into SQL text).\nThe ``path_prefix`` filter uses ``starts_with`` (not LIKE) so a caller's\n``%``/``_`` are treated literally, not as wildcards.",
+        "operationId": "list_audit_log_v1_audit_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "actor_kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by the denormalised actor_kind ('agent' | 'human' | 'service').",
+              "title": "Actor Kind"
+            },
+            "description": "Filter by the denormalised actor_kind ('agent' | 'human' | 'service')."
+          },
+          {
+            "name": "path_prefix",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only rows whose request path starts with this prefix (e.g. '/v1/recommendations').",
+              "title": "Path Prefix"
+            },
+            "description": "Return only rows whose request path starts with this prefix (e.g. '/v1/recommendations')."
+          },
+          {
+            "name": "status_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "maximum": 599,
+                  "minimum": 100
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by exact HTTP status code.",
+              "title": "Status Code"
+            },
+            "description": "Filter by exact HTTP status code."
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Window start (inclusive) on created_at (ISO 8601 date or datetime).",
+              "title": "From"
+            },
+            "description": "Window start (inclusive) on created_at (ISO 8601 date or datetime)."
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Window end (inclusive) on created_at (ISO 8601 date or datetime).",
+              "title": "To"
+            },
+            "description": "Window end (inclusive) on created_at (ISO 8601 date or datetime)."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/calc/run": {
       "post": {
         "tags": [
@@ -7903,6 +8059,134 @@
         "title": "ApproveRequest",
         "description": "Body of POST /v1/staging/batches/{id}/approve.\n\n`force` is required (set to True) when the diff's deletion ratio\nexceeds the 20% threshold — see ADR-013 D4. `notes` is optional but\nstrongly recommended when forcing, as it becomes the audit trail\nrationale in staging.transform_runs.approval_notes."
       },
+      "AuditLogEntry": {
+        "properties": {
+          "request_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Request Id"
+          },
+          "correlation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Correlation Id"
+          },
+          "token_prefix": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Token Prefix"
+          },
+          "token_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Token Id"
+          },
+          "actor_kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actor Kind"
+          },
+          "method": {
+            "type": "string",
+            "title": "Method"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "status_code": {
+            "type": "integer",
+            "title": "Status Code"
+          },
+          "latency_ms": {
+            "type": "integer",
+            "title": "Latency Ms"
+          },
+          "client_ip": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Ip"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "request_id",
+          "method",
+          "path",
+          "status_code",
+          "latency_ms",
+          "created_at"
+        ],
+        "title": "AuditLogEntry",
+        "description": "One ``api_request_log`` row. Carries the non-secret ``token_prefix`` and\nthe denormalised ``actor_kind``/``token_id`` for attribution — never a token\nor a token hash (the table stores neither)."
+      },
+      "AuditLogListResponse": {
+        "properties": {
+          "entries": {
+            "items": {
+              "$ref": "#/components/schemas/AuditLogEntry"
+            },
+            "type": "array",
+            "title": "Entries"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "entries",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "AuditLogListResponse"
+      },
       "BOMComponentInput": {
         "properties": {
           "component_external_id": {
@@ -8406,7 +8690,7 @@
           },
           "violations": {
             "items": {
-              "$ref": "#/components/schemas/CapacityViolationOut"
+              "$ref": "#/components/schemas/ootils_core__atp__routers__CapacityViolationOut"
             },
             "type": "array",
             "title": "Violations",
@@ -8806,7 +9090,7 @@
           },
           "violations": {
             "items": {
-              "$ref": "#/components/schemas/ootils_core__mps__api__CapacityViolationOut"
+              "$ref": "#/components/schemas/CapacityViolationOut"
             },
             "type": "array",
             "title": "Violations"
@@ -8836,43 +9120,74 @@
       },
       "CapacityViolationOut": {
         "properties": {
+          "violation_type": {
+            "type": "string",
+            "title": "Violation Type"
+          },
           "resource_id": {
             "type": "string",
+            "format": "uuid",
             "title": "Resource Id"
+          },
+          "resource_external_id": {
+            "type": "string",
+            "title": "Resource External Id"
           },
           "resource_name": {
             "type": "string",
             "title": "Resource Name"
           },
-          "violation_date": {
+          "period_start": {
             "type": "string",
             "format": "date",
-            "title": "Violation Date"
+            "title": "Period Start"
+          },
+          "period_end": {
+            "type": "string",
+            "format": "date",
+            "title": "Period End"
           },
           "required_capacity": {
-            "type": "number",
+            "type": "string",
             "title": "Required Capacity"
           },
           "available_capacity": {
-            "type": "number",
+            "type": "string",
             "title": "Available Capacity"
           },
           "overload_pct": {
-            "type": "number",
+            "type": "string",
             "title": "Overload Pct"
+          },
+          "affected_mps_ids": {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array",
+            "title": "Affected Mps Ids"
+          },
+          "severity": {
+            "type": "string",
+            "title": "Severity"
           }
         },
         "type": "object",
         "required": [
+          "violation_type",
           "resource_id",
+          "resource_external_id",
           "resource_name",
-          "violation_date",
+          "period_start",
+          "period_end",
           "required_capacity",
           "available_capacity",
-          "overload_pct"
+          "overload_pct",
+          "affected_mps_ids",
+          "severity"
         ],
         "title": "CapacityViolationOut",
-        "description": "Capacity violation details for API response."
+        "description": "Output model for capacity violation."
       },
       "CausalStepOut": {
         "properties": {
@@ -17490,76 +17805,45 @@
         ],
         "title": "WorkingDaysResponse"
       },
-      "ootils_core__mps__api__CapacityViolationOut": {
+      "ootils_core__atp__routers__CapacityViolationOut": {
         "properties": {
-          "violation_type": {
-            "type": "string",
-            "title": "Violation Type"
-          },
           "resource_id": {
             "type": "string",
-            "format": "uuid",
             "title": "Resource Id"
-          },
-          "resource_external_id": {
-            "type": "string",
-            "title": "Resource External Id"
           },
           "resource_name": {
             "type": "string",
             "title": "Resource Name"
           },
-          "period_start": {
+          "violation_date": {
             "type": "string",
             "format": "date",
-            "title": "Period Start"
-          },
-          "period_end": {
-            "type": "string",
-            "format": "date",
-            "title": "Period End"
+            "title": "Violation Date"
           },
           "required_capacity": {
-            "type": "string",
+            "type": "number",
             "title": "Required Capacity"
           },
           "available_capacity": {
-            "type": "string",
+            "type": "number",
             "title": "Available Capacity"
           },
           "overload_pct": {
-            "type": "string",
+            "type": "number",
             "title": "Overload Pct"
-          },
-          "affected_mps_ids": {
-            "items": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "type": "array",
-            "title": "Affected Mps Ids"
-          },
-          "severity": {
-            "type": "string",
-            "title": "Severity"
           }
         },
         "type": "object",
         "required": [
-          "violation_type",
           "resource_id",
-          "resource_external_id",
           "resource_name",
-          "period_start",
-          "period_end",
+          "violation_date",
           "required_capacity",
           "available_capacity",
-          "overload_pct",
-          "affected_mps_ids",
-          "severity"
+          "overload_pct"
         ],
         "title": "CapacityViolationOut",
-        "description": "Output model for capacity violation."
+        "description": "Capacity violation details for API response."
       }
     },
     "securitySchemes": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,14 @@ dependencies = [
     # stubs are generated with protobuf 6.31, so pin the 6.x runtime.
     "grpcio ~= 1.71",
     "protobuf >= 6.31,< 8.0",
+    # L3 outbound webhook (notifications/l3_webhook.py): the human-in-the-loop
+    # ping must work in a LEAN watcher install, not only under [dev] — a core
+    # runtime dependency by design (PROD-QW review finding).
+    "httpx ~= 0.28",
 ]
 
 [project.optional-dependencies]
-dev = ["pytest ~= 9.0", "pytest-cov ~= 7.1", "httpx ~= 0.28"]
+dev = ["pytest ~= 9.0", "pytest-cov ~= 7.1"]
 forecast = [
     "statsforecast ~= 2.0",
     "mlforecast ~= 1.0",

--- a/scripts/agent_reschedule_watcher.py
+++ b/scripts/agent_reschedule_watcher.py
@@ -58,7 +58,11 @@ from psycopg.types.json import Jsonb
 import mrp_core as core
 from agent_governance import decision_level, governed_run
 
-from ootils_core.engine.recommendation.reschedule import build_recommendation
+from ootils_core.engine.recommendation.reschedule import (
+    RescheduleRecommendation,
+    build_recommendation,
+)
+from ootils_core.notifications.l3_webhook import notify_l3_pending
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
 logger = logging.getLogger("reschedule_watcher")
@@ -89,17 +93,20 @@ _COLUMNS = (
 )
 
 
-def _upsert(conn: psycopg.Connection, rows: list[tuple]) -> tuple[int, list]:
+def _upsert(conn: psycopg.Connection, rows: list[tuple]) -> tuple[list, list]:
     """Idempotent insert of reschedule recommendations.
 
     ON CONFLICT (recommendation_id) DO NOTHING: a re-emitted identical signal
-    (same deterministic id) is a no-op. Returns (inserted_count, affirmed_ids)
-    where affirmed_ids is EVERY id we tried to write (inserted or already
-    present) — the caller uses it to NOT expire the still-valid prior DRAFTs.
-    SQL is composed via psycopg.sql (no f-strings in the SQL path).
+    (same deterministic id) is a no-op. Returns (inserted_ids, affirmed_ids):
+    inserted_ids are the rows ACTUALLY written this run (RETURNING yields a row
+    only on a real insert, not on a conflict no-op) — used to fire the L3
+    webhook exactly once per genuinely-new row; affirmed_ids is EVERY id we
+    tried to write (inserted or already present) — the caller uses it to NOT
+    expire the still-valid prior DRAFTs. SQL is composed via psycopg.sql (no
+    f-strings in the SQL path).
     """
     if not rows:
-        return 0, []
+        return [], []
     col_ids = sql.SQL(", ").join(sql.Identifier(c) for c in _COLUMNS)
     placeholders = sql.SQL(", ").join(sql.Placeholder() for _ in _COLUMNS)
     query = sql.SQL(
@@ -107,14 +114,25 @@ def _upsert(conn: psycopg.Connection, rows: list[tuple]) -> tuple[int, list]:
         "ON CONFLICT (recommendation_id) DO NOTHING "
         "RETURNING recommendation_id"
     ).format(cols=col_ids, vals=placeholders)
-    inserted = 0
+    inserted_ids: list = []
     cur = conn.cursor()
     for r in rows:
         got = cur.execute(query, r).fetchone()
         if got is not None:
-            inserted += 1
+            inserted_ids.append(got[0])
     affirmed = [r[0] for r in rows]
-    return inserted, affirmed
+    return inserted_ids, affirmed
+
+
+def _l3_message(reco: RescheduleRecommendation) -> str:
+    """Human-readable one-liner for the L3 webhook (no secret)."""
+    prop = reco.proposed_date.isoformat() if reco.proposed_date is not None else "cancel"
+    return (
+        f"{reco.action} firm receipt {reco.target_node_id} "
+        f"(item {reco.item_external_id}) qty {reco.recommended_qty}, "
+        f"current date {reco.current_receipt_date.isoformat()} -> {prop}. "
+        f"L3 human approval required."
+    )
 
 
 def _expire_stale_drafts(
@@ -177,6 +195,8 @@ def main(argv=None) -> int:
         display: list[dict] = []
         by_action: defaultdict[str, int] = defaultdict(int)
         by_level: defaultdict[str, int] = defaultdict(int)
+        recos_by_id: dict = {}
+        l3_pending: list[RescheduleRecommendation] = []
 
         with governed_run(conn, AGENT_NAME, scenario, t0=t0) as run:
             for sig in signals:
@@ -202,6 +222,7 @@ def main(argv=None) -> int:
                     reco.current_receipt_date, reco.proposed_date, "DRAFT",
                     reco.confidence, Jsonb(reco.evidence),
                 ))
+                recos_by_id[reco.recommendation_id] = reco
                 by_action[action] += 1
                 by_level[reco.decision_level] += 1
                 delta = (
@@ -215,8 +236,16 @@ def main(argv=None) -> int:
                     "delta": delta, "qty": sig.qty,
                 })
 
-            inserted, affirmed = _upsert(conn, rows)
+            inserted_ids, affirmed = _upsert(conn, rows)
+            inserted = len(inserted_ids)
             expired = _expire_stale_drafts(conn, scenario, affirmed)
+            # Collect the genuinely-new recos for the L3 webhook (fired AFTER
+            # commit, below). notify_l3_pending self-gates to L3+ so only CANCEL
+            # rows actually notify; a re-run on an unchanged plan inserts nothing
+            # and therefore pings nothing.
+            l3_pending = [
+                recos_by_id[rid] for rid in inserted_ids if rid in recos_by_id
+            ]
             metrics = {
                 "signals": len(signals),
                 "recommendations_affirmed": len(affirmed),
@@ -227,6 +256,27 @@ def main(argv=None) -> int:
                 "by_decision_level": dict(by_level),
             }
             run.set_metrics(metrics)
+
+    # Best-effort L3 webhook, POST-COMMIT (the recommendations are durably
+    # persisted by governed_run's commit before we ping): the exception finds
+    # the human without a UI. Never raises — a webhook failure is swallowed and
+    # logged inside notify_l3_pending, so it cannot affect the completed run.
+    notified = 0
+    for reco in l3_pending:
+        if notify_l3_pending(
+            recommendation_id=reco.recommendation_id,
+            action=reco.action,
+            decision_level=reco.decision_level,
+            message=_l3_message(reco),
+            item_external_id=reco.item_external_id,
+            location_external_id=None,
+        ):
+            notified += 1
+    if l3_pending:
+        logger.info(
+            "L3 webhook: %d/%d new L3+ recommendation(s) notified",
+            notified, len(l3_pending),
+        )
 
     m = metrics
     elapsed = round(time.perf_counter() - t0, 2)

--- a/scripts/backup_offhost.sh
+++ b/scripts/backup_offhost.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# backup_offhost.sh — copy the local Postgres backups off the host (#192).
+#
+# A local dump on the same VM as the database does not survive a loss of that
+# VM. This script mirrors the backup directory to a REMOTE destination via
+# rsync, closing the "copie hors machine reste a faire" gap in INFRA-RUNBOOK.
+#
+# The destination is provided by the pilot (an rsync/ssh target such as
+# user@host:/srv/ootils-backups, or any rsync-writable path) through
+# OOTILS_BACKUP_REMOTE — there is no default: the script refuses to run without
+# it rather than silently copying nowhere.
+#
+# Usage:
+#   OOTILS_BACKUP_REMOTE=user@host:/srv/ootils-backups scripts/backup_offhost.sh
+#
+# Environment:
+#   OOTILS_BACKUP_REMOTE  REQUIRED. rsync destination (ssh target or path).
+#   BACKUP_DIR            Local backup dir (default: ~/ootils-backups/postgres).
+#   OOTILS_BACKUP_SSH_OPTS Optional extra ssh options, e.g. "-i ~/.ssh/backup_key -p 2222".
+#   RSYNC_EXTRA_OPTS      Optional extra rsync flags.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+BACKUP_DIR="${BACKUP_DIR:-$HOME/ootils-backups/postgres}"
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+require_cmd rsync
+
+: "${OOTILS_BACKUP_REMOTE:?OOTILS_BACKUP_REMOTE must be set to the off-host rsync destination, e.g. user@host:/srv/ootils-backups}"
+
+if [[ ! -d "$BACKUP_DIR" ]]; then
+  echo "Local backup dir does not exist: $BACKUP_DIR — run scripts/backup_postgres.sh first." >&2
+  exit 1
+fi
+
+# Build rsync args. -a archive, -z compress, --partial resume, --stats summary.
+# A trailing slash on the source mirrors the CONTENTS of BACKUP_DIR into the
+# destination (not a nested BACKUP_DIR/ subdir).
+rsync_args=(-az --partial --human-readable --stats)
+
+# When the destination is an ssh target, allow custom ssh options (key, port).
+if [[ -n "${OOTILS_BACKUP_SSH_OPTS:-}" ]]; then
+  require_cmd ssh
+  rsync_args+=(-e "ssh ${OOTILS_BACKUP_SSH_OPTS}")
+fi
+
+if [[ -n "${RSYNC_EXTRA_OPTS:-}" ]]; then
+  # shellcheck disable=SC2206 — intentional word-splitting of caller-provided flags
+  rsync_args+=(${RSYNC_EXTRA_OPTS})
+fi
+
+echo "Mirroring $BACKUP_DIR/ -> $OOTILS_BACKUP_REMOTE"
+rsync "${rsync_args[@]}" "$BACKUP_DIR/" "$OOTILS_BACKUP_REMOTE"
+echo "Off-host copy complete."

--- a/scripts/restore_postgres.sh
+++ b/scripts/restore_postgres.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# restore_postgres.sh — prove a backup is restorable (#192).
+#
+# "A backup that was never restored is not a backup." This script takes a dump
+# produced by scripts/backup_postgres.sh (pg_dump -Fc custom format, optionally
+# gzipped) and restores it into a DISPOSABLE database (default
+# ootils_restore_test) that is DROPPED at the end. It then verifies the restore
+# is non-empty: a public-schema table count and a SELECT on schema_migrations.
+#
+# It runs entirely against the docker-compose 'postgres' service, exactly like
+# the backup script, so it needs no host-side Postgres client. It NEVER touches
+# the live database (POSTGRES_DB) — it refuses if RESTORE_DB collides with it.
+#
+# Usage:
+#   scripts/restore_postgres.sh [DUMP_FILE] [--keep]
+#
+#   DUMP_FILE   Path to a .dump (or .dump.gz) file. Defaults to the most recent
+#               ootils-postgres-*.dump under BACKUP_DIR.
+#   --keep      Do not drop the disposable database after verification (leave it
+#               for inspection). Default: drop it.
+#
+# Environment:
+#   ENV_FILE     Path to the compose env file (default: <repo>/.env).
+#   BACKUP_DIR   Where dumps live (default: ~/ootils-backups/postgres).
+#   RESTORE_DB   Disposable database name (default: ootils_restore_test).
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$REPO_ROOT/.env}"
+BACKUP_DIR="${BACKUP_DIR:-$HOME/ootils-backups/postgres}"
+RESTORE_DB="${RESTORE_DB:-ootils_restore_test}"
+
+KEEP=0
+DUMP_FILE=""
+for arg in "$@"; do
+  case "$arg" in
+    --keep) KEEP=1 ;;
+    -*) echo "Unknown option: $arg" >&2; exit 2 ;;
+    *) DUMP_FILE="$arg" ;;
+  esac
+done
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+compose_cmd() {
+  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    printf '%s\n' "docker compose"
+    return 0
+  fi
+  if command -v docker-compose >/dev/null 2>&1; then
+    printf '%s\n' "docker-compose"
+    return 0
+  fi
+  echo "Neither 'docker compose' nor 'docker-compose' is available" >&2
+  exit 1
+}
+
+require_cmd find
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing env file: $ENV_FILE" >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+
+: "${POSTGRES_USER:?POSTGRES_USER must be set in $ENV_FILE}"
+: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in $ENV_FILE}"
+: "${POSTGRES_DB:?POSTGRES_DB must be set in $ENV_FILE}"
+
+if [[ "$RESTORE_DB" == "$POSTGRES_DB" ]]; then
+  echo "Refusing to restore over the live database ($POSTGRES_DB). Set RESTORE_DB to a disposable name." >&2
+  exit 1
+fi
+
+# Pick the most recent dump if none was given.
+if [[ -z "$DUMP_FILE" ]]; then
+  DUMP_FILE="$(find "$BACKUP_DIR" -type f -name 'ootils-postgres-*.dump' -print0 2>/dev/null \
+    | xargs -0 ls -1t 2>/dev/null | head -n1 || true)"
+  if [[ -z "$DUMP_FILE" ]]; then
+    echo "No dump file found under $BACKUP_DIR and none provided." >&2
+    exit 1
+  fi
+  echo "Using most recent dump: $DUMP_FILE"
+fi
+
+if [[ ! -f "$DUMP_FILE" ]]; then
+  echo "Dump file not found: $DUMP_FILE" >&2
+  exit 1
+fi
+
+compose="$(compose_cmd)"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.yml"
+
+# Helper: run a command inside the postgres service with PGPASSWORD exported.
+pg_exec() {
+  $compose -f "$COMPOSE_FILE" exec -T postgres \
+    sh -lc "export PGPASSWORD=\"\$POSTGRES_PASSWORD\"; $1"
+}
+
+cleanup() {
+  if [[ "$KEEP" -eq 1 ]]; then
+    echo "Keeping disposable database: $RESTORE_DB (--keep)"
+    return
+  fi
+  echo "Dropping disposable database: $RESTORE_DB"
+  pg_exec "dropdb -U \"\$POSTGRES_USER\" --if-exists \"$RESTORE_DB\"" || \
+    echo "Warning: failed to drop $RESTORE_DB — drop it manually." >&2
+}
+trap cleanup EXIT
+
+echo "Preparing disposable database: $RESTORE_DB"
+pg_exec "dropdb -U \"\$POSTGRES_USER\" --if-exists \"$RESTORE_DB\""
+pg_exec "createdb -U \"\$POSTGRES_USER\" \"$RESTORE_DB\""
+
+echo "Restoring dump into $RESTORE_DB ..."
+# pg_dump -Fc dumps are read from stdin by pg_restore (custom format). A .gz
+# archive is gunzipped on the host first, then streamed in. --no-owner /
+# --no-privileges keep the restore independent of the source role grants;
+# --exit-on-error makes a genuine restore failure fail this proof loudly.
+RESTORE_CMD="pg_restore -U \"\$POSTGRES_USER\" -d \"$RESTORE_DB\" --no-owner --no-privileges --exit-on-error"
+case "$DUMP_FILE" in
+  *.gz)
+    require_cmd gunzip
+    gunzip -c "$DUMP_FILE" | pg_exec "$RESTORE_CMD"
+    ;;
+  *)
+    pg_exec "$RESTORE_CMD" < "$DUMP_FILE"
+    ;;
+esac
+
+echo "Verifying restore ..."
+table_count="$(pg_exec "psql -U \"\$POSTGRES_USER\" -d \"$RESTORE_DB\" -tAc \"SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public'\"" | tr -d '[:space:]')"
+migration_count="$(pg_exec "psql -U \"\$POSTGRES_USER\" -d \"$RESTORE_DB\" -tAc 'SELECT count(*) FROM schema_migrations'" | tr -d '[:space:]')"
+
+echo "  public tables restored : ${table_count:-0}"
+echo "  schema_migrations rows : ${migration_count:-0}"
+
+if [[ -z "$table_count" || "$table_count" -eq 0 ]]; then
+  echo "RESTORE FAILED: no tables in the restored database." >&2
+  exit 1
+fi
+if [[ -z "$migration_count" || "$migration_count" -eq 0 ]]; then
+  echo "RESTORE FAILED: schema_migrations is empty or missing — restore is not trustworthy." >&2
+  exit 1
+fi
+
+echo "RESTORE OK: $DUMP_FILE restores cleanly into $RESTORE_DB ($table_count tables, $migration_count migrations)."

--- a/src/ootils_core/api/app.py
+++ b/src/ootils_core/api/app.py
@@ -35,7 +35,7 @@ except ImportError:
 from ootils_core.api import metrics
 from ootils_core.api.auth import Principal, _expected_token, require_scope
 from ootils_core.api.dependencies import _get_ootils_db, get_db
-from ootils_core.api.routers import bom, calc, calendars, demo, dq, drp, events, explain, forecasting, ghosts, graph, ingest, issues, mrp, mrp_apics, outcomes, param_overrides, planning_params, projection, pyramide, rccp, recommendations, scenarios, simulate, snapshots, staging, stream, tokens
+from ootils_core.api.routers import audit, bom, calc, calendars, demo, dq, drp, events, explain, forecasting, ghosts, graph, ingest, issues, mrp, mrp_apics, outcomes, param_overrides, planning_params, projection, pyramide, rccp, recommendations, scenarios, simulate, snapshots, staging, stream, tokens
 from ootils_core.api.routers.graph import nodes_router
 from ootils_core.mps import router as mps_router
 from ootils_core.atp import atp_router
@@ -424,6 +424,7 @@ def create_app() -> FastAPI:
     application.include_router(scenarios.router)
     application.include_router(param_overrides.router)
     application.include_router(tokens.router)
+    application.include_router(audit.router)
     application.include_router(calc.router)
     application.include_router(demo.router)
     application.include_router(mrp.router)

--- a/src/ootils_core/api/routers/audit.py
+++ b/src/ootils_core/api/routers/audit.py
@@ -1,0 +1,169 @@
+"""
+/v1/audit — read the API request audit trail (PROD-QW, #192-adjacent).
+
+``api_request_log`` (migration 023, widened by 064) is written by the request
+middleware in ``api/app.py`` on every ``/health`` and ``/v1/*`` call, but until
+now NOTHING read it back — "Audit is a feature, not telemetry" (North Star)
+stayed aspirational. This router exposes it:
+
+  GET /v1/audit   paginated, filtered (actor_kind, path prefix, status, date
+                  window), newest first, ADMIN scope.
+
+NOT scenario-scoped: this is a cross-cutting INFRASTRUCTURE audit surface (who
+called what, when, with which status/latency), not a business read path — the
+North Star "scenario_id on every read path" rule targets graph/plan reads, not
+the request log. Access is therefore gated on the ``admin`` scope instead: the
+trail can reveal call patterns across every scenario and actor, so it is an
+operator-only view.
+
+NO SECRET IN THE RESPONSE: the table never stored the raw token or its hash —
+only ``token_prefix`` (the non-secret leading slice minted for correlation, see
+auth.py:token_prefix) and the denormalised ``actor_kind``/``token_id``. The
+response model surfaces exactly those; there is no token_hash column to leak.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+from typing import Any, List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
+
+from ootils_core.api.auth import VALID_ACTOR_KINDS, Principal, require_scope
+from ootils_core.api.dependencies import get_db
+from ootils_core.db.types import DictRowConnection
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/audit", tags=["audit"])
+
+# Upper bound on a single page — mirrors the recommendations router (le=200) so
+# an admin cannot pull the whole (unbounded, ever-growing) log in one query.
+_MAX_LIMIT = 200
+
+
+class AuditLogEntry(BaseModel):
+    """One ``api_request_log`` row. Carries the non-secret ``token_prefix`` and
+    the denormalised ``actor_kind``/``token_id`` for attribution — never a token
+    or a token hash (the table stores neither)."""
+
+    request_id: UUID
+    correlation_id: Optional[str] = None
+    token_prefix: Optional[str] = None
+    token_id: Optional[UUID] = None
+    actor_kind: Optional[str] = None
+    method: str
+    path: str
+    status_code: int
+    latency_ms: int
+    client_ip: Optional[str] = None
+    created_at: _dt.datetime
+
+
+class AuditLogListResponse(BaseModel):
+    entries: List[AuditLogEntry]
+    total: int
+    limit: int
+    offset: int
+
+
+@router.get("", response_model=AuditLogListResponse, summary="Read the API request audit trail")
+def list_audit_log(
+    _principal: Principal = Depends(require_scope("admin")),
+    actor_kind: Optional[str] = Query(
+        default=None,
+        description="Filter by the denormalised actor_kind ('agent' | 'human' | 'service').",
+    ),
+    path_prefix: Optional[str] = Query(
+        default=None,
+        description="Return only rows whose request path starts with this prefix (e.g. '/v1/recommendations').",
+    ),
+    status_code: Optional[int] = Query(
+        default=None, ge=100, le=599, description="Filter by exact HTTP status code."
+    ),
+    from_: Optional[_dt.datetime] = Query(
+        default=None,
+        alias="from",
+        description="Window start (inclusive) on created_at (ISO 8601 date or datetime).",
+    ),
+    to: Optional[_dt.datetime] = Query(
+        default=None,
+        description="Window end (inclusive) on created_at (ISO 8601 date or datetime).",
+    ),
+    limit: int = Query(default=50, ge=1, le=_MAX_LIMIT),
+    offset: int = Query(default=0, ge=0),
+    db: DictRowConnection = Depends(get_db),
+) -> AuditLogListResponse:
+    """List audit rows newest-first. All filters are optional and combine with
+    AND; every value is bound as a parameter (never interpolated into SQL text).
+    The ``path_prefix`` filter uses ``starts_with`` (not LIKE) so a caller's
+    ``%``/``_`` are treated literally, not as wildcards."""
+    if actor_kind is not None and actor_kind not in VALID_ACTOR_KINDS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Unknown actor_kind '{actor_kind}'. Valid: {sorted(VALID_ACTOR_KINDS)}",
+        )
+
+    conditions: list[str] = []
+    params: list[Any] = []
+    if actor_kind is not None:
+        conditions.append("actor_kind = %s")
+        params.append(actor_kind)
+    if path_prefix is not None:
+        conditions.append("starts_with(path, %s)")
+        params.append(path_prefix)
+    if status_code is not None:
+        conditions.append("status_code = %s")
+        params.append(status_code)
+    if from_ is not None:
+        conditions.append("created_at >= %s")
+        params.append(from_)
+    if to is not None:
+        conditions.append("created_at <= %s")
+        params.append(to)
+
+    where_clause = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+
+    count_row = db.execute(
+        f"SELECT COUNT(*) AS total FROM api_request_log {where_clause}",  # noqa: S608 — static text, parameterized values
+        params,
+    ).fetchone()
+    total = int(count_row["total"]) if count_row else 0
+
+    rows = db.execute(
+        f"""
+        SELECT request_id, correlation_id, token_prefix, token_id, actor_kind,
+               method, path, status_code, latency_ms, client_ip, created_at
+        FROM api_request_log
+        {where_clause}
+        ORDER BY created_at DESC, request_id
+        LIMIT %s OFFSET %s
+        """,  # noqa: S608 — static text, parameterized values
+        params + [limit, offset],
+    ).fetchall()
+
+    return AuditLogListResponse(
+        entries=[_row_to_entry(r) for r in rows],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+def _row_to_entry(row: dict[str, Any]) -> AuditLogEntry:
+    token_id = row.get("token_id")
+    return AuditLogEntry(
+        request_id=UUID(str(row["request_id"])),
+        correlation_id=row.get("correlation_id"),
+        token_prefix=row.get("token_prefix"),
+        token_id=UUID(str(token_id)) if token_id is not None else None,
+        actor_kind=row.get("actor_kind"),
+        method=row["method"],
+        path=row["path"],
+        status_code=int(row["status_code"]),
+        latency_ms=int(row["latency_ms"]),
+        client_ip=row.get("client_ip"),
+        created_at=row["created_at"],
+    )

--- a/src/ootils_core/db/connection.py
+++ b/src/ootils_core/db/connection.py
@@ -54,6 +54,47 @@ def _env_float(name: str, default: float) -> float:
     return float(raw)
 
 
+# Server-side session guards applied to POOL connections ONLY (the API hot
+# path). Direct psycopg.connect() calls made by scripts/watchers (the heavy
+# offline MRP/calc runs) and by the migration runner deliberately do NOT
+# inherit these — they open their own connections outside the pool.
+#
+#   statement_timeout — kill a runaway query. TENSION with the calc-run path:
+#   an HTTP calc run (POST /v1/events, POST /v1/calc/...) borrows a POOL
+#   connection, so its statement_timeout is THIS value. The longest legitimate
+#   pilot calc run measured was 464 s; the ceiling is set to 900 s (15 min) so
+#   the worst observed run plus generous margin cannot be tripped, while a
+#   genuinely hung query still eventually dies. This is a stop-gap: the real
+#   fix is moving long calc runs off the synchronous request path onto async
+#   workers (#193) — once landed, the API pool can drop back to a tight ~5 min
+#   web timeout. The heavy offline runs invoked from scripts/*.py are NOT
+#   affected (they use their own psycopg.connect), so this ceiling never caps a
+#   batch/CLI run.
+#
+#   idle_in_transaction_session_timeout — a request that opens a transaction
+#   and then stalls (client gone, handler wedged) must not pin a pooled
+#   connection and its locks indefinitely. 60 s is well above any normal
+#   request-scoped transaction and reclaims a leaked one quickly.
+_DEFAULT_STATEMENT_TIMEOUT_MS = 900_000
+_DEFAULT_IDLE_IN_TXN_TIMEOUT_MS = 60_000
+
+
+def _pool_session_options() -> str:
+    """libpq ``options`` string of the per-connection session guards for the
+    pool. Both values are env-overridable (0 disables a guard, matching the
+    Postgres convention) but default to the documented ceilings above."""
+    statement_timeout = _env_int(
+        "OOTILS_DB_STATEMENT_TIMEOUT_MS", _DEFAULT_STATEMENT_TIMEOUT_MS
+    )
+    idle_in_txn_timeout = _env_int(
+        "OOTILS_DB_IDLE_IN_TXN_TIMEOUT_MS", _DEFAULT_IDLE_IN_TXN_TIMEOUT_MS
+    )
+    return (
+        f"-c statement_timeout={statement_timeout} "
+        f"-c idle_in_transaction_session_timeout={idle_in_txn_timeout}"
+    )
+
+
 def _make_connection_pool(database_url: str):
     try:
         from psycopg_pool import ConnectionPool
@@ -63,20 +104,40 @@ def _make_connection_pool(database_url: str):
     min_size = _env_int("OOTILS_DB_POOL_MIN_SIZE", 1)
     max_size = _env_int("OOTILS_DB_POOL_MAX_SIZE", 10)
     timeout = _env_float("OOTILS_DB_POOL_TIMEOUT_SECONDS", 10.0)
+    # Recycle long-lived / long-idle connections so a stale server-side
+    # connection (network blip, server restart, PgBouncer churn) is retired
+    # rather than handed to a request. max_lifetime caps total age; max_idle
+    # caps idle time in the pool.
+    max_lifetime = _env_float("OOTILS_DB_POOL_MAX_LIFETIME_SECONDS", 1800.0)
+    max_idle = _env_float("OOTILS_DB_POOL_MAX_IDLE_SECONDS", 600.0)
     if min_size < 1:
         raise ValueError("OOTILS_DB_POOL_MIN_SIZE must be >= 1")
     if max_size < min_size:
         raise ValueError("OOTILS_DB_POOL_MAX_SIZE must be >= OOTILS_DB_POOL_MIN_SIZE")
     if timeout <= 0:
         raise ValueError("OOTILS_DB_POOL_TIMEOUT_SECONDS must be > 0")
+    if max_lifetime <= 0:
+        raise ValueError("OOTILS_DB_POOL_MAX_LIFETIME_SECONDS must be > 0")
+    if max_idle <= 0:
+        raise ValueError("OOTILS_DB_POOL_MAX_IDLE_SECONDS must be > 0")
 
     return ConnectionPool(
         conninfo=database_url,
         min_size=min_size,
         max_size=max_size,
         timeout=timeout,
+        # check=check_connection: run a lightweight liveness probe on every
+        # connection borrowed from the pool, so a connection the server closed
+        # under us is detected and replaced BEFORE a handler tries to use it
+        # (turns a mid-request OperationalError into a transparent reconnect).
+        check=ConnectionPool.check_connection,
+        max_lifetime=max_lifetime,
+        max_idle=max_idle,
         open=True,
-        kwargs={"row_factory": dict_row},
+        # options: server-side session guards (statement_timeout,
+        # idle_in_transaction_session_timeout) — POOL connections only, see
+        # _pool_session_options.
+        kwargs={"row_factory": dict_row, "options": _pool_session_options()},
     )
 
 

--- a/src/ootils_core/notifications/__init__.py
+++ b/src/ootils_core/notifications/__init__.py
@@ -1,0 +1,1 @@
+"""Outbound notifications (best-effort, V1). See l3_webhook for the L3 hook."""

--- a/src/ootils_core/notifications/l3_webhook.py
+++ b/src/ootils_core/notifications/l3_webhook.py
@@ -1,0 +1,193 @@
+"""
+l3_webhook.py — minimal outbound webhook for L3+ recommendations awaiting a
+human (PROD-QW, North Star "the exception finds you", no UI).
+
+WHY HERE (the hook point). The Decision Ladder reserves L3+ actions for a human
+(engine/recommendation/state_machine.py: HUMAN_ONLY_TARGETS — a non-human actor
+can never reach APPROVED/APPLIED). The fleet's first L3 emitter is the reschedule
+watcher's CANCEL (agent_governance.decision_level('CANCEL') == 'L3'), and it is
+BORN as a ``DRAFT`` row: there is no separate PENDING_APPROVAL status in this
+state machine, so for an L3 recommendation the DRAFT state IS "awaiting human
+approval" (an agent cannot self-approve it). The moment "the human must now act"
+is therefore the EMISSION of a new L3+ DRAFT — that is the single point this
+webhook fires from (the watcher calls it only for rows it actually inserted, so a
+re-run on an unchanged plan sends nothing, consistent with #346's zero-new-rows
+idempotence). Firing on a later API transition would be too late — a human would
+already have looked at the row.
+
+CONTRACT (deliberately minimal, V1):
+  * BEST-EFFORT: a POST failure (unreachable endpoint, timeout, missing httpx)
+    is swallowed and logged at WARNING — it never breaks the caller or the DB
+    transaction that emitted the recommendation.
+  * NO RETRY: one attempt, ``timeout=5`` s. The recommendation is already
+    durably persisted; the webhook is a courtesy ping, not the source of truth.
+  * ENV-ONLY, NO SECRET: the destination is ``OOTILS_WEBHOOK_L3_URL`` (unset =>
+    silent no-op — the feature is opt-in, the pilot supplies the URL, e.g. a
+    Slack incoming-webhook). The payload carries NO token and NO secret: only
+    the recommendation id, action, decision level, the external item/location
+    ids and a human-readable message.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+# httpx is a light dependency (dev extra). Import it lazily/defensively so
+# importing this module never fails in an environment that omits it — the
+# webhook simply degrades to a logged no-op there (same pattern as slowapi in
+# api/app.py).
+try:  # pragma: no cover - import guard
+    import httpx
+
+    _HTTPX_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only where httpx is absent
+    _HTTPX_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+WEBHOOK_URL_ENV = "OOTILS_WEBHOOK_L3_URL"
+L3_TIMEOUT_SECONDS = 5.0
+
+
+class L3PendingPayload(BaseModel):
+    """The minimal typed body POSTed when an L3+ recommendation awaits a human.
+
+    No secret, no token: attribution is via the recommendation id and the
+    external (source-system) item/location ids a human can act on."""
+
+    event: str = Field(default="l3_recommendation_pending")
+    recommendation_id: UUID
+    action: str
+    decision_level: str
+    item_external_id: Optional[str] = None
+    location_external_id: Optional[str] = None
+    message: str
+
+
+def decision_level_rank(decision_level: str) -> int:
+    """Numeric rank of an ``L<n>`` decision level (L0->0 .. L4->4).
+
+    Returns -1 for an unparseable value (defensive: a malformed level must not
+    crash the notify path — it simply fails the >= L3 test and stays silent)."""
+    text = decision_level.strip().upper()
+    if len(text) >= 2 and text[0] == "L" and text[1:].isdigit():
+        return int(text[1:])
+    return -1
+
+
+def is_l3_or_higher(decision_level: str) -> bool:
+    """True when the decision level is L3 or above (the human-gated, webhook tier)."""
+    return decision_level_rank(decision_level) >= 3
+
+
+def resolve_webhook_url(url: Optional[str] = None) -> Optional[str]:
+    """Return the configured webhook URL: the explicit ``url`` if given, else
+    ``OOTILS_WEBHOOK_L3_URL``. An empty/whitespace value resolves to None (unset
+    => opt-out)."""
+    candidate = url if url is not None else os.environ.get(WEBHOOK_URL_ENV)
+    if candidate is None:
+        return None
+    candidate = candidate.strip()
+    return candidate or None
+
+
+def build_l3_payload(
+    *,
+    recommendation_id: UUID,
+    action: str,
+    decision_level: str,
+    message: str,
+    item_external_id: Optional[str] = None,
+    location_external_id: Optional[str] = None,
+) -> L3PendingPayload:
+    """Pure builder for the webhook body (no IO)."""
+    return L3PendingPayload(
+        recommendation_id=recommendation_id,
+        action=action,
+        decision_level=decision_level,
+        item_external_id=item_external_id,
+        location_external_id=location_external_id,
+        message=message,
+    )
+
+
+def post_l3_pending(payload: L3PendingPayload, *, url: Optional[str] = None) -> bool:
+    """POST ``payload`` to the L3 webhook, best-effort.
+
+    Returns True when the request was actually sent (completed without raising),
+    False when it was skipped (no URL configured, httpx unavailable) or failed.
+    Every failure is swallowed and logged at WARNING — this MUST NEVER raise, so
+    a caller can invoke it inside or around a DB transaction without risk."""
+    target = resolve_webhook_url(url)
+    if target is None:
+        # Opt-out: no destination configured. Silent by design.
+        return False
+    if not _HTTPX_AVAILABLE:
+        logger.warning(
+            "l3_webhook.skipped reason=httpx_unavailable recommendation_id=%s",
+            payload.recommendation_id,
+        )
+        return False
+
+    try:
+        response = httpx.post(
+            target,
+            json=payload.model_dump(mode="json"),
+            timeout=L3_TIMEOUT_SECONDS,
+        )
+        if response.status_code >= 400:
+            logger.warning(
+                "l3_webhook.non_2xx recommendation_id=%s status=%s",
+                payload.recommendation_id,
+                response.status_code,
+            )
+        else:
+            logger.info(
+                "l3_webhook.sent recommendation_id=%s action=%s level=%s status=%s",
+                payload.recommendation_id,
+                payload.action,
+                payload.decision_level,
+                response.status_code,
+            )
+        return True
+    except Exception as exc:
+        # Best-effort: never propagate. A missing/unreachable endpoint or a
+        # timeout must not affect the recommendation that was just persisted.
+        logger.warning(
+            "l3_webhook.failed recommendation_id=%s error=%s",
+            payload.recommendation_id,
+            exc,
+        )
+        return False
+
+
+def notify_l3_pending(
+    *,
+    recommendation_id: UUID,
+    action: str,
+    decision_level: str,
+    message: str,
+    item_external_id: Optional[str] = None,
+    location_external_id: Optional[str] = None,
+    url: Optional[str] = None,
+) -> bool:
+    """Gate + build + post in one call.
+
+    Fires the webhook ONLY when ``decision_level`` is L3 or higher (the
+    human-gated, irreversible tier). Below L3 it returns False without touching
+    the network. Best-effort throughout (see ``post_l3_pending``)."""
+    if not is_l3_or_higher(decision_level):
+        return False
+    payload = build_l3_payload(
+        recommendation_id=recommendation_id,
+        action=action,
+        decision_level=decision_level,
+        message=message,
+        item_external_id=item_external_id,
+        location_external_id=location_external_id,
+    )
+    return post_l3_pending(payload, url=url)

--- a/tests/integration/test_prod_qw_integration.py
+++ b/tests/integration/test_prod_qw_integration.py
@@ -1,0 +1,497 @@
+"""
+tests/integration/test_prod_qw_integration.py — PROD-QW package, DB-backed
+(real PostgreSQL, no mocks). Three capability areas the pure unit tests
+(tests/test_l3_webhook.py, tests/test_router_audit.py) cannot reach:
+
+  A. GET /v1/audit end to end — real authenticated requests write api_request_log
+     via the app middleware (audit_client has NO get_db override, so
+     _should_audit_request() is True and the middleware actually runs); the
+     admin-scoped router then reads them back, with the actor_kind / path_prefix
+     / status / from-to filters, the literal-% (starts_with, not LIKE) guard,
+     newest-first ordering, and the admin-scope floor.
+
+  B. The hardened pool session guards — a connection borrowed from the OotilsDB
+     pool carries statement_timeout=900s (env-overridable, 0 = disabled), while a
+     bare psycopg.connect() (the path scripts/watchers use) inherits the server
+     default (0/unlimited) — proving the guard is POOL-only.
+
+  C. Reschedule watcher × L3 webhook — a genuinely-new CANCEL (the first
+     watcher-emitted L3) fires notify_l3_pending exactly once; a re-run on the
+     unchanged plan (ON CONFLICT DO NOTHING → zero new rows) fires nothing; an
+     L2-only plan fires no L3 webhook. notify_l3_pending is monkeypatched to a
+     recording spy, so nothing leaves the process.
+
+Determinism: every date anchors on the DB-side CURRENT_DATE, never Python now();
+the api_request_log assertions filter on entities THIS module creates (a
+uuid4-suffixed agent token, a distinct path) so the ever-growing log never makes
+them flaky.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+BASELINE = "00000000-0000-0000-0000-000000000001"
+LEGACY_TOKEN = "integration-test-token"
+
+
+# ---------------------------------------------------------------------------
+# Import seam: mrp_core + the watcher live under scripts/ (outside the package).
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+
+def _db_conn(dsn):
+    import psycopg
+    from psycopg.rows import dict_row
+
+    return psycopg.connect(dsn, row_factory=dict_row, autocommit=True)
+
+
+def _bearer(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ===========================================================================
+# A. GET /v1/audit — real authenticated traffic → api_request_log → router
+# ===========================================================================
+
+
+@pytest.fixture(scope="module")
+def audit_client(migrated_db):
+    """TestClient WITHOUT a get_db override, so the api_request_log middleware
+    (api/app.py:_log_api_request) actually runs — mirrors
+    test_agent_floor_integration.py::audit_client. Binds to the real DB via
+    DATABASE_URL exactly as the app resolves its pool in production."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = LEGACY_TOKEN
+
+    from fastapi.testclient import TestClient
+
+    from ootils_core.api.app import create_app
+
+    app = create_app()
+    with TestClient(app) as client:
+        yield client
+
+
+@pytest.fixture(autouse=True)
+def _clear_token_cache():
+    """The minted-token lookup + rate counter are in-process singletons shared
+    by the app; clear both around every test so a seed/revoke never leaks a
+    cached decision (and revocation is observable without a TTL sleep)."""
+    import ootils_core.api.auth as auth
+
+    auth._token_cache.clear()
+    auth._rate_counter.clear()
+    yield
+    auth._token_cache.clear()
+    auth._rate_counter.clear()
+
+
+def _mint_token(dsn, *, actor_kind: str, scopes: list[str]) -> tuple[str, str]:
+    """Insert one api_tokens row; return (cleartext, token_id). The cleartext
+    exists only here — the DB stores hash_token(clear), like the auth path."""
+    from uuid import uuid4
+
+    from ootils_core.api.auth import hash_token, token_prefix
+
+    clear = f"ootk_{actor_kind}_{uuid4().hex}"
+    token_id = uuid4()
+    with _db_conn(dsn) as conn:
+        conn.execute(
+            "INSERT INTO api_tokens (token_id, name, actor_kind, token_hash, "
+            "token_prefix, scopes) VALUES (%s, %s, %s, %s, %s, %s)",
+            (token_id, f"prodqw-{token_id}", actor_kind, hash_token(clear),
+             token_prefix(clear), scopes),
+        )
+    return clear, str(token_id)
+
+
+@pytest.fixture
+def token_tracker(migrated_db):
+    """Mint api_tokens rows and scrub them (and their audit rows) at teardown."""
+    created: list[str] = []
+
+    def _make(*, actor_kind: str, scopes: list[str]) -> str:
+        clear, token_id = _mint_token(migrated_db, actor_kind=actor_kind, scopes=scopes)
+        created.append(token_id)
+        return clear
+
+    yield _make
+
+    with _db_conn(migrated_db) as conn:
+        if created:
+            conn.execute(
+                "DELETE FROM api_request_log WHERE token_id = ANY(%s::uuid[])", (created,)
+            )
+            conn.execute(
+                "DELETE FROM api_tokens WHERE token_id = ANY(%s::uuid[])", (created,)
+            )
+
+
+class TestAuditReadPath:
+    def test_authenticated_requests_populate_the_paginated_audit_trail(
+        self, audit_client
+    ):
+        """A handful of real authenticated calls write api_request_log rows the
+        admin-scoped GET /v1/audit then pages back, newest-first."""
+        for _ in range(3):
+            r = audit_client.get("/v1/recommendations", headers=_bearer(LEGACY_TOKEN))
+            assert r.status_code == 200, r.text
+
+        resp = audit_client.get(
+            "/v1/audit?path_prefix=/v1/recommendations&limit=50",
+            headers=_bearer(LEGACY_TOKEN),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["total"] >= 3
+        assert len(body["entries"]) >= 3
+        for e in body["entries"]:
+            assert e["path"].startswith("/v1/recommendations")
+            assert e["method"] == "GET"
+            # Never a raw token / hash — only the non-secret correlation fields.
+            assert "token" not in e and "token_hash" not in e
+            assert "token_prefix" in e and "token_id" in e
+
+    def test_newest_first_ordering(self, audit_client):
+        for _ in range(3):
+            audit_client.get("/v1/recommendations", headers=_bearer(LEGACY_TOKEN))
+        body = audit_client.get(
+            "/v1/audit?path_prefix=/v1/recommendations&limit=10",
+            headers=_bearer(LEGACY_TOKEN),
+        ).json()
+        stamps = [e["created_at"] for e in body["entries"]]
+        assert stamps == sorted(stamps, reverse=True), "ORDER BY created_at DESC"
+
+    def test_pagination_limit_is_honoured(self, audit_client):
+        for _ in range(3):
+            audit_client.get("/v1/recommendations", headers=_bearer(LEGACY_TOKEN))
+        page = audit_client.get(
+            "/v1/audit?path_prefix=/v1/recommendations&limit=2",
+            headers=_bearer(LEGACY_TOKEN),
+        ).json()
+        assert page["limit"] == 2
+        assert len(page["entries"]) <= 2
+        assert page["total"] >= 3  # total counts beyond the page
+
+    def test_actor_kind_filter_is_applied(self, audit_client, token_tracker):
+        # An agent token makes a call → an agent-kind audit row exists.
+        agent_clear = token_tracker(actor_kind="agent", scopes=["read"])
+        assert (
+            audit_client.get("/v1/recommendations", headers=_bearer(agent_clear)).status_code
+            == 200
+        )
+        # A legacy (human) call too.
+        audit_client.get("/v1/recommendations", headers=_bearer(LEGACY_TOKEN))
+
+        agents = audit_client.get(
+            "/v1/audit?actor_kind=agent&limit=100", headers=_bearer(LEGACY_TOKEN)
+        ).json()
+        assert agents["total"] >= 1
+        assert all(e["actor_kind"] == "agent" for e in agents["entries"])
+
+        humans = audit_client.get(
+            "/v1/audit?actor_kind=human&limit=100", headers=_bearer(LEGACY_TOKEN)
+        ).json()
+        assert all(e["actor_kind"] == "human" for e in humans["entries"])
+
+    def test_status_code_filter_is_applied(self, audit_client):
+        # An unauthenticated /v1/* call is still audited, with status 401.
+        bad = audit_client.get("/v1/recommendations", headers=_bearer("wrong-token"))
+        assert bad.status_code == 401
+        rows = audit_client.get(
+            "/v1/audit?status_code=401&limit=100", headers=_bearer(LEGACY_TOKEN)
+        ).json()
+        assert rows["total"] >= 1
+        assert all(e["status_code"] == 401 for e in rows["entries"])
+
+    def test_path_prefix_treats_percent_literally_not_as_wildcard(self, audit_client):
+        """starts_with(), not LIKE: a '%' in path_prefix is a literal char, so a
+        prefix no real path starts with returns ZERO rows (a LIKE wildcard would
+        have matched everything)."""
+        audit_client.get("/v1/recommendations", headers=_bearer(LEGACY_TOKEN))
+        # '%25' is the URL-encoding of a literal '%'.
+        resp = audit_client.get(
+            "/v1/audit?path_prefix=/v1/recommendations%25", headers=_bearer(LEGACY_TOKEN)
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["total"] == 0
+
+    def test_from_to_window_bounds(self, audit_client):
+        audit_client.get("/v1/recommendations", headers=_bearer(LEGACY_TOKEN))
+        # A far-past upper bound excludes everything.
+        past = audit_client.get(
+            "/v1/audit?to=2000-01-01T00:00:00Z&limit=10", headers=_bearer(LEGACY_TOKEN)
+        ).json()
+        assert past["total"] == 0
+        # An epoch lower bound includes the recent rows.
+        recent = audit_client.get(
+            "/v1/audit?from=1970-01-01T00:00:00Z&limit=10", headers=_bearer(LEGACY_TOKEN)
+        ).json()
+        assert recent["total"] >= 1
+
+    def test_admin_scope_required(self, audit_client, token_tracker):
+        # No auth → 401.
+        assert audit_client.get("/v1/audit").status_code == 401
+        # A non-admin (read-only agent) token → 403 with the scope named.
+        reader = token_tracker(actor_kind="agent", scopes=["read"])
+        denied = audit_client.get("/v1/audit", headers=_bearer(reader))
+        assert denied.status_code == 403, denied.text
+        assert denied.json()["detail"] == "missing scope 'admin'"
+        # Legacy admin token → 200.
+        assert audit_client.get("/v1/audit", headers=_bearer(LEGACY_TOKEN)).status_code == 200
+
+
+# ===========================================================================
+# B. Pool session guards — statement_timeout is POOL-only, env-overridable.
+# ===========================================================================
+
+
+class TestPoolSessionGuards:
+    def _current(self, conn, setting: str) -> str:
+        return conn.execute(
+            "SELECT current_setting(%s) AS v", (setting,)
+        ).fetchone()["v"]
+
+    def _skip_if_no_pool(self, db):
+        if db._get_pool() is None:
+            pytest.skip("psycopg_pool unavailable — no pool path to exercise")
+
+    def test_pool_connection_carries_the_default_statement_timeout(self, migrated_db):
+        from ootils_core.db.connection import OotilsDB
+
+        db = OotilsDB(migrated_db)
+        try:
+            self._skip_if_no_pool(db)
+            with db.conn() as conn:
+                # 900_000 ms → Postgres renders it "15min"; idle guard 60_000 → "1min".
+                assert self._current(conn, "statement_timeout") == "15min"
+                assert (
+                    self._current(conn, "idle_in_transaction_session_timeout") == "1min"
+                )
+        finally:
+            db.close()
+
+    def test_statement_timeout_is_env_overridable(self, migrated_db, monkeypatch):
+        from ootils_core.db.connection import OotilsDB
+
+        monkeypatch.setenv("OOTILS_DB_STATEMENT_TIMEOUT_MS", "300000")  # 5 min
+        db = OotilsDB(migrated_db)
+        try:
+            self._skip_if_no_pool(db)
+            with db.conn() as conn:
+                assert self._current(conn, "statement_timeout") == "5min"
+        finally:
+            db.close()
+
+    def test_statement_timeout_zero_disables_the_guard(self, migrated_db, monkeypatch):
+        from ootils_core.db.connection import OotilsDB
+
+        monkeypatch.setenv("OOTILS_DB_STATEMENT_TIMEOUT_MS", "0")  # Postgres: disabled
+        db = OotilsDB(migrated_db)
+        try:
+            self._skip_if_no_pool(db)
+            with db.conn() as conn:
+                assert self._current(conn, "statement_timeout") == "0"
+        finally:
+            db.close()
+
+    def test_direct_connect_does_not_inherit_the_guard(self, migrated_db):
+        """A bare psycopg.connect() (scripts/watchers path) gets the SERVER
+        default — 0/unlimited — never the pool's session guard."""
+        import psycopg
+        from psycopg.rows import dict_row
+
+        with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+            value = conn.execute(
+                "SELECT current_setting('statement_timeout') AS v"
+            ).fetchone()["v"]
+        assert value == "0", (
+            "a direct connection must inherit the server default, not the pool guard"
+        )
+
+
+# ===========================================================================
+# C. Reschedule watcher × L3 webhook — CANCEL fires once, idempotent, L2 silent.
+# ===========================================================================
+
+import agent_reschedule_watcher  # noqa: E402
+import mrp_core as core  # noqa: E402
+import psycopg  # noqa: E402
+from psycopg.rows import dict_row  # noqa: E402
+
+from ootils_core.notifications.l3_webhook import is_l3_or_higher  # noqa: E402
+
+_WEEK = 7
+_RESCHED_BASELINE = core.BASELINE
+
+
+class _WebhookSpy:
+    """Records every notify_l3_pending invocation. The reschedule watcher calls
+    notify_l3_pending for EVERY genuinely-new insert and the L3 gate lives
+    INSIDE notify_l3_pending (which we replace here) — so "an L3 webhook fired"
+    is precisely the subset of calls whose decision_level is L3+. The spy
+    returns the real gate result so the watcher's own `notified` counter/log
+    stay honest."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def __call__(self, **kwargs) -> bool:
+        self.calls.append(kwargs)
+        return is_l3_or_higher(kwargs["decision_level"])
+
+    @property
+    def l3_fired(self) -> list[dict]:
+        return [c for c in self.calls if is_l3_or_higher(c["decision_level"])]
+
+
+def _run_watcher(dsn, scenario=None) -> int:
+    argv = ["--dsn", dsn, "--allow-dev"]
+    if scenario is not None:
+        argv += ["--scenario", str(scenario)]
+    return agent_reschedule_watcher.main(argv)
+
+
+def _reset_graph(conn) -> None:
+    conn.execute(
+        "TRUNCATE nodes, edges, recommendations, agent_runs, "
+        "item_planning_params, supplier_items, items, suppliers, locations, "
+        "scenario_planning_overrides RESTART IDENTITY CASCADE"
+    )
+    conn.execute("TRUNCATE shortages RESTART IDENTITY CASCADE")
+
+
+def _seed_common(conn) -> tuple:
+    loc_id = conn.execute(
+        "INSERT INTO locations (name, location_type, external_id) "
+        "VALUES (%s, %s, %s) RETURNING location_id",
+        ("PRODQW Plant", "plant", "LOC-PQW"),
+    ).fetchone()["location_id"]
+    sup_id = conn.execute(
+        "INSERT INTO suppliers (external_id, name, reliability_score, status) "
+        "VALUES (%s, %s, %s, %s) RETURNING supplier_id",
+        ("SUP-PQW", "PRODQW Supplier", 0.95, "active"),
+    ).fetchone()["supplier_id"]
+    item_id = conn.execute(
+        "INSERT INTO items (external_id, name, item_type, standard_cost, cost_currency) "
+        "VALUES (%s, %s, %s, %s, %s) RETURNING item_id",
+        ("ITM-PQW", "PRODQW Item", "component", 40.0, "EUR"),
+    ).fetchone()["item_id"]
+    conn.execute(
+        "INSERT INTO item_planning_params "
+        "(item_id, location_id, is_make, lead_time_sourcing_days, "
+        " lead_time_manufacturing_days, lead_time_transit_days, safety_stock_qty, "
+        " lot_size_rule, frozen_time_fence_days, slashed_time_fence_days, "
+        " forecast_consumption_strategy) "
+        "VALUES (%s,%s,FALSE,14,0,0,0,%s,0,1,%s)",
+        (item_id, loc_id, "LOTFORLOT", "max_only"),
+    )
+    conn.execute(
+        "INSERT INTO supplier_items "
+        "(supplier_id, item_id, lead_time_days, unit_cost, currency, is_preferred) "
+        "VALUES (%s,%s,14,4.0,%s,TRUE)",
+        (sup_id, item_id, "EUR"),
+    )
+    return loc_id, item_id
+
+
+def _node(conn, ntype, item_id, loc_id, today, days_out, qty, is_firm=False) -> None:
+    conn.execute(
+        "INSERT INTO nodes (node_type, scenario_id, item_id, location_id, quantity, "
+        " time_grain, time_ref, active, is_firm) "
+        "VALUES (%s, %s, %s, %s, %s, 'exact_date', %s, TRUE, %s)",
+        (ntype, _RESCHED_BASELINE, item_id, loc_id, qty,
+         today + _dt.timedelta(days=days_out), is_firm),
+    )
+
+
+def _onhand(conn, item_id, loc_id, today, qty) -> None:
+    _node(conn, "OnHandSupply", item_id, loc_id, today, 0, qty)
+
+
+def _demand(conn, item_id, loc_id, today, weeks_out, qty) -> None:
+    _node(conn, "CustomerOrderDemand", item_id, loc_id, today, weeks_out * _WEEK, qty)
+
+
+def _receipt(conn, item_id, loc_id, today, weeks_out, qty) -> None:
+    _node(conn, "PurchaseOrderSupply", item_id, loc_id, today,
+          weeks_out * _WEEK, qty, is_firm=True)
+
+
+class TestRescheduleWebhook:
+    def test_new_cancel_fires_the_l3_webhook_exactly_once(self, migrated_db, monkeypatch):
+        """A surplus firm receipt (no demand) → CANCEL at L3 → notify_l3_pending
+        fires exactly once for a genuinely-new L3 row."""
+        dsn = migrated_db
+        with psycopg.connect(dsn, autocommit=True, row_factory=dict_row) as conn:
+            today = conn.execute("SELECT CURRENT_DATE").fetchone()["current_date"]
+            _reset_graph(conn)
+            loc_id, item_id = _seed_common(conn)
+            _onhand(conn, item_id, loc_id, today, 0)
+            _receipt(conn, item_id, loc_id, today, 10, 50)  # no demand → CANCEL
+
+        spy = _WebhookSpy()
+        monkeypatch.setattr(agent_reschedule_watcher, "notify_l3_pending", spy)
+
+        assert _run_watcher(dsn) == 0
+        assert len(spy.l3_fired) == 1, "exactly one L3 webhook for the new CANCEL"
+        fired = spy.l3_fired[0]
+        assert fired["action"] == "CANCEL"
+        assert fired["decision_level"] == "L3"
+
+    def test_rerun_on_unchanged_plan_fires_nothing(self, migrated_db, monkeypatch):
+        """ON CONFLICT DO NOTHING → the re-run inserts zero new rows → the
+        webhook (fired only for genuinely-new inserts) fires nothing."""
+        dsn = migrated_db
+        with psycopg.connect(dsn, autocommit=True, row_factory=dict_row) as conn:
+            today = conn.execute("SELECT CURRENT_DATE").fetchone()["current_date"]
+            _reset_graph(conn)
+            loc_id, item_id = _seed_common(conn)
+            _onhand(conn, item_id, loc_id, today, 0)
+            _receipt(conn, item_id, loc_id, today, 10, 50)
+
+        spy = _WebhookSpy()
+        monkeypatch.setattr(agent_reschedule_watcher, "notify_l3_pending", spy)
+
+        assert _run_watcher(dsn) == 0
+        assert len(spy.l3_fired) == 1  # run 1 fired the CANCEL once
+        first_run_calls = len(spy.calls)
+
+        assert _run_watcher(dsn) == 0  # identical plan
+        assert len(spy.calls) == first_run_calls, "re-run must not invoke the webhook"
+        assert len(spy.l3_fired) == 1  # still just the one from run 1
+
+    def test_l2_only_plan_fires_no_l3_webhook(self, migrated_db, monkeypatch):
+        """A mis-dated receipt → RESCHEDULE_OUT (L2). The watcher calls
+        notify_l3_pending for the L2 insert, but the L3 gate (inside
+        notify_l3_pending) means NO L3 webhook fires — assert on the L3 subset."""
+        dsn = migrated_db
+        with psycopg.connect(dsn, autocommit=True, row_factory=dict_row) as conn:
+            today = conn.execute("SELECT CURRENT_DATE").fetchone()["current_date"]
+            _reset_graph(conn)
+            loc_id, item_id = _seed_common(conn)
+            _onhand(conn, item_id, loc_id, today, 0)
+            _demand(conn, item_id, loc_id, today, 20, 100)  # need at week 20
+            _receipt(conn, item_id, loc_id, today, 4, 100)   # far too early → RESCHEDULE_OUT
+
+        spy = _WebhookSpy()
+        monkeypatch.setattr(agent_reschedule_watcher, "notify_l3_pending", spy)
+
+        assert _run_watcher(dsn) == 0
+        assert spy.l3_fired == [], "an L2 plan must fire no L3 webhook"
+        # The watcher DID hand the L2 insert to notify_l3_pending (gate is inside it).
+        assert spy.calls, "sanity: the run emitted at least one recommendation"
+        assert all(c["decision_level"] == "L2" for c in spy.calls)

--- a/tests/test_l3_webhook.py
+++ b/tests/test_l3_webhook.py
@@ -1,0 +1,299 @@
+"""
+tests/test_l3_webhook.py — PURE unit tests (no PostgreSQL, no real network) for
+the best-effort L3+ outbound webhook (PROD-QW,
+src/ootils_core/notifications/l3_webhook.py).
+
+The webhook is the fleet's "the exception finds you" ping: when the reschedule
+watcher emits a genuinely-new L3+ DRAFT (a CANCEL — the first watcher-emitted
+L3, human-only by the #341 state machine), it POSTs a minimal, secret-free
+payload to an operator-supplied endpoint. Everything here is exercised WITHOUT a
+real network: httpx.post is patched, so timeout / 5xx / exception paths are all
+driven deterministically. The single hard contract under test:
+
+  * BEST-EFFORT — post_l3_pending / notify_l3_pending MUST NEVER raise (a
+    missing endpoint, a timeout, a 5xx or a hard exception are swallowed and
+    logged), so the caller can invoke them around a committed DB transaction.
+  * GATED — notify_l3_pending fires ONLY at L3+; below L3 it never touches the
+    network.
+  * NO SECRET — the payload carries the recommendation id + action + level +
+    external ids + a human message, and NOTHING that looks like a credential.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import httpx
+import pytest
+
+import ootils_core.notifications.l3_webhook as l3
+from ootils_core.notifications.l3_webhook import (
+    L3PendingPayload,
+    L3_TIMEOUT_SECONDS,
+    WEBHOOK_URL_ENV,
+    build_l3_payload,
+    decision_level_rank,
+    is_l3_or_higher,
+    notify_l3_pending,
+    post_l3_pending,
+    resolve_webhook_url,
+)
+
+
+# ===========================================================================
+# 1. decision_level_rank / is_l3_or_higher — the gate predicate
+# ===========================================================================
+
+
+class TestDecisionLevelRank:
+    @pytest.mark.parametrize(
+        "level,expected",
+        [("L0", 0), ("L1", 1), ("L2", 2), ("L3", 3), ("L4", 4), ("L10", 10)],
+    )
+    def test_well_formed_levels_parse_to_their_number(self, level, expected):
+        assert decision_level_rank(level) == expected
+
+    def test_rank_is_case_insensitive_and_strips(self):
+        assert decision_level_rank("  l3 ") == 3
+
+    @pytest.mark.parametrize("bad", ["", "L", "LX", "3", "foo", "L-1", "L 3", "level3"])
+    def test_malformed_levels_rank_minus_one(self, bad):
+        # A malformed level must NOT crash the notify path — it degrades to -1,
+        # which fails the >= L3 test and stays silent.
+        assert decision_level_rank(bad) == -1
+
+
+class TestIsL3OrHigher:
+    @pytest.mark.parametrize("level", ["L0", "L1", "L2"])
+    def test_below_l3_is_false(self, level):
+        assert is_l3_or_higher(level) is False
+
+    @pytest.mark.parametrize("level", ["L3", "L4", "L10"])
+    def test_l3_and_above_is_true(self, level):
+        assert is_l3_or_higher(level) is True
+
+    @pytest.mark.parametrize("bad", ["", "L", "LX", "foo", "L-1"])
+    def test_malformed_is_false(self, bad):
+        assert is_l3_or_higher(bad) is False
+
+
+# ===========================================================================
+# 2. resolve_webhook_url — env / param / empty precedence
+# ===========================================================================
+
+
+class TestResolveWebhookUrl:
+    def test_explicit_param_wins_over_env(self, monkeypatch):
+        monkeypatch.setenv(WEBHOOK_URL_ENV, "https://env.example/hook")
+        assert resolve_webhook_url("https://param.example/hook") == "https://param.example/hook"
+
+    def test_env_used_when_no_param(self, monkeypatch):
+        monkeypatch.setenv(WEBHOOK_URL_ENV, "https://env.example/hook")
+        assert resolve_webhook_url() == "https://env.example/hook"
+
+    def test_unset_env_and_no_param_is_none(self, monkeypatch):
+        monkeypatch.delenv(WEBHOOK_URL_ENV, raising=False)
+        assert resolve_webhook_url() is None
+
+    def test_empty_param_resolves_to_none(self, monkeypatch):
+        monkeypatch.delenv(WEBHOOK_URL_ENV, raising=False)
+        assert resolve_webhook_url("   ") is None
+
+    def test_whitespace_env_resolves_to_none(self, monkeypatch):
+        monkeypatch.setenv(WEBHOOK_URL_ENV, "   ")
+        assert resolve_webhook_url() is None
+
+    def test_param_is_stripped(self, monkeypatch):
+        monkeypatch.delenv(WEBHOOK_URL_ENV, raising=False)
+        assert resolve_webhook_url("  https://x.example/h  ") == "https://x.example/h"
+
+
+# ===========================================================================
+# 3. post_l3_pending — best-effort POST, every branch (httpx patched)
+# ===========================================================================
+
+
+def _payload(**over) -> L3PendingPayload:
+    base = dict(
+        recommendation_id=uuid4(),
+        action="CANCEL",
+        decision_level="L3",
+        message="CANCEL firm receipt X. L3 human approval required.",
+    )
+    base.update(over)
+    return build_l3_payload(**base)
+
+
+class TestPostL3Pending:
+    def test_emits_when_url_configured_and_returns_true(self, monkeypatch):
+        fake_post = MagicMock(return_value=MagicMock(status_code=200))
+        monkeypatch.setattr(l3.httpx, "post", fake_post)
+        monkeypatch.setattr(l3, "_HTTPX_AVAILABLE", True)
+
+        p = _payload()
+        assert post_l3_pending(p, url="https://x.example/hook") is True
+        # Exactly one attempt, no retry, with the documented timeout + JSON body.
+        assert fake_post.call_count == 1
+        args, kwargs = fake_post.call_args
+        assert args[0] == "https://x.example/hook"
+        assert kwargs["timeout"] == L3_TIMEOUT_SECONDS
+        assert kwargs["json"]["action"] == "CANCEL"
+        assert kwargs["json"]["decision_level"] == "L3"
+
+    def test_silent_no_op_when_no_url(self, monkeypatch):
+        monkeypatch.delenv(WEBHOOK_URL_ENV, raising=False)
+        fake_post = MagicMock()
+        monkeypatch.setattr(l3.httpx, "post", fake_post)
+
+        # No URL configured (param None, env unset) → opt-out, never touches
+        # the network, returns False.
+        assert post_l3_pending(_payload(), url=None) is False
+        fake_post.assert_not_called()
+
+    def test_returns_false_and_does_not_post_when_httpx_unavailable(self, monkeypatch):
+        fake_post = MagicMock()
+        monkeypatch.setattr(l3.httpx, "post", fake_post)
+        monkeypatch.setattr(l3, "_HTTPX_AVAILABLE", False)
+
+        assert post_l3_pending(_payload(), url="https://x.example/hook") is False
+        fake_post.assert_not_called()
+
+    def test_swallows_timeout_without_raising(self, monkeypatch):
+        fake_post = MagicMock(side_effect=httpx.TimeoutException("slow"))
+        monkeypatch.setattr(l3.httpx, "post", fake_post)
+        monkeypatch.setattr(l3, "_HTTPX_AVAILABLE", True)
+
+        # MUST NOT raise — a timeout is swallowed and logged; returns False.
+        assert post_l3_pending(_payload(), url="https://x.example/hook") is False
+
+    def test_swallows_generic_exception_without_raising(self, monkeypatch):
+        fake_post = MagicMock(side_effect=RuntimeError("connection refused"))
+        monkeypatch.setattr(l3.httpx, "post", fake_post)
+        monkeypatch.setattr(l3, "_HTTPX_AVAILABLE", True)
+
+        assert post_l3_pending(_payload(), url="https://x.example/hook") is False
+
+    def test_5xx_is_not_an_exception_and_does_not_raise(self, monkeypatch):
+        fake_post = MagicMock(return_value=MagicMock(status_code=503))
+        monkeypatch.setattr(l3.httpx, "post", fake_post)
+        monkeypatch.setattr(l3, "_HTTPX_AVAILABLE", True)
+
+        # A 5xx response is a completed request (it was sent) — the contract is
+        # "never raise", and post_l3_pending returns True (sent) while logging
+        # the non-2xx. The point of the test: no exception escapes.
+        assert post_l3_pending(_payload(), url="https://x.example/hook") is True
+        assert fake_post.call_count == 1
+
+    def test_uses_env_url_when_param_absent(self, monkeypatch):
+        fake_post = MagicMock(return_value=MagicMock(status_code=204))
+        monkeypatch.setattr(l3.httpx, "post", fake_post)
+        monkeypatch.setattr(l3, "_HTTPX_AVAILABLE", True)
+        monkeypatch.setenv(WEBHOOK_URL_ENV, "https://env.example/hook")
+
+        assert post_l3_pending(_payload()) is True
+        assert fake_post.call_args[0][0] == "https://env.example/hook"
+
+
+# ===========================================================================
+# 4. notify_l3_pending — gate + build + post in one call
+# ===========================================================================
+
+
+class TestNotifyL3Pending:
+    @pytest.mark.parametrize("level", ["L0", "L1", "L2"])
+    def test_below_l3_posts_nothing(self, monkeypatch, level):
+        fake_post = MagicMock(return_value=MagicMock(status_code=200))
+        monkeypatch.setattr(l3.httpx, "post", fake_post)
+        monkeypatch.setattr(l3, "_HTTPX_AVAILABLE", True)
+        monkeypatch.setenv(WEBHOOK_URL_ENV, "https://x.example/hook")
+
+        result = notify_l3_pending(
+            recommendation_id=uuid4(),
+            action="RESCHEDULE_OUT",
+            decision_level=level,
+            message="reschedule",
+        )
+        assert result is False
+        fake_post.assert_not_called()  # gated below L3 → no network at all
+
+    def test_l3_with_url_posts(self, monkeypatch):
+        fake_post = MagicMock(return_value=MagicMock(status_code=200))
+        monkeypatch.setattr(l3.httpx, "post", fake_post)
+        monkeypatch.setattr(l3, "_HTTPX_AVAILABLE", True)
+
+        result = notify_l3_pending(
+            recommendation_id=uuid4(),
+            action="CANCEL",
+            decision_level="L3",
+            message="CANCEL firm receipt",
+            item_external_id="ITM-1",
+            location_external_id="LOC-1",
+            url="https://x.example/hook",
+        )
+        assert result is True
+        assert fake_post.call_count == 1
+        body = fake_post.call_args.kwargs["json"]
+        assert body["item_external_id"] == "ITM-1"
+        assert body["location_external_id"] == "LOC-1"
+
+    def test_l3_without_url_is_silent_false(self, monkeypatch):
+        monkeypatch.delenv(WEBHOOK_URL_ENV, raising=False)
+        fake_post = MagicMock()
+        monkeypatch.setattr(l3.httpx, "post", fake_post)
+        monkeypatch.setattr(l3, "_HTTPX_AVAILABLE", True)
+
+        result = notify_l3_pending(
+            recommendation_id=uuid4(),
+            action="CANCEL",
+            decision_level="L3",
+            message="CANCEL",
+        )
+        assert result is False
+        fake_post.assert_not_called()
+
+
+# ===========================================================================
+# 5. Payload carries NO secret (assert on the exact key set)
+# ===========================================================================
+
+
+class TestPayloadHasNoSecret:
+    def test_payload_keys_are_exactly_the_non_secret_fields(self):
+        p = build_l3_payload(
+            recommendation_id=uuid4(),
+            action="CANCEL",
+            decision_level="L3",
+            message="CANCEL firm receipt",
+            item_external_id="ITM-1",
+            location_external_id="LOC-1",
+        )
+        body = p.model_dump(mode="json")
+        assert set(body.keys()) == {
+            "event",
+            "recommendation_id",
+            "action",
+            "decision_level",
+            "item_external_id",
+            "location_external_id",
+            "message",
+        }
+        # No credential-shaped key leaks into the body.
+        lowered = {k.lower() for k in body.keys()}
+        for forbidden in ("token", "token_hash", "secret", "authorization", "password", "api_key"):
+            assert forbidden not in lowered
+
+    def test_no_payload_value_is_a_bearer_or_token(self):
+        p = build_l3_payload(
+            recommendation_id=uuid4(),
+            action="CANCEL",
+            decision_level="L3",
+            message="a human-readable message with no credential",
+        )
+        for value in p.model_dump(mode="json").values():
+            text = str(value).lower()
+            assert "bearer" not in text
+            assert "ootk_" not in text
+
+    def test_event_defaults_to_the_stable_type(self):
+        p = _payload()
+        assert p.event == "l3_recommendation_pending"

--- a/tests/test_router_audit.py
+++ b/tests/test_router_audit.py
@@ -1,0 +1,257 @@
+"""
+tests/test_router_audit.py — Unit tests for src/ootils_core/api/routers/audit.py
+(PROD-QW: GET /v1/audit, the admin-scoped read of the api_request_log trail).
+
+Pure unit tests: the DB is a MagicMock (get_db override), so nothing here needs
+PostgreSQL. Because get_db is overridden, _should_audit_request() returns False
+and the request-log middleware never fires — the router logic is exercised in
+isolation. The DB-backed pagination/filter behaviour is covered blind in
+tests/integration/test_prod_qw_integration.py.
+
+What this file pins:
+  * ADMIN scope required — the legacy token (admin superset) passes; a non-admin
+    principal (resolve_principal override) is 403; no token is 401.
+  * 422 on an unknown actor_kind (before any DB access).
+  * limit is bounded by FastAPI validation (le=200, ge=1) → 422, not a clamp.
+  * The response entries carry token_prefix / token_id but NEVER a raw token or
+    a token_hash (the table stores neither — the shape must not invent them).
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+# auth.py validates OOTILS_API_TOKEN at import time — set before importing app.
+os.environ.setdefault("OOTILS_API_TOKEN", "test-token")
+
+from ootils_core.api.app import create_app
+from ootils_core.api.auth import Principal, resolve_principal
+from ootils_core.api.dependencies import get_db
+
+AUTH = {"Authorization": "Bearer test-token"}
+
+
+# ─────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────
+
+
+def _make_db_mock() -> MagicMock:
+    conn = MagicMock(name="psycopg_conn")
+    conn.execute.return_value = MagicMock()
+    return conn
+
+
+def _make_client(db_mock: MagicMock) -> TestClient:
+    app = create_app()
+
+    def override_db():
+        yield db_mock
+
+    app.dependency_overrides[get_db] = override_db
+    return TestClient(app)
+
+
+def _setup_count_then_rows(db_mock: MagicMock, total: int, rows: list) -> None:
+    """Wire two sequential execute() calls: the COUNT(*), then the page SELECT."""
+    count_cur = MagicMock()
+    count_cur.fetchone.return_value = {"total": total}
+    rows_cur = MagicMock()
+    rows_cur.fetchall.return_value = rows
+    db_mock.execute.side_effect = [count_cur, rows_cur]
+
+
+def _audit_row(**over) -> dict:
+    row = {
+        "request_id": uuid4(),
+        "correlation_id": "req_abc",
+        "token_prefix": "ootk_ABCDEFG",
+        "token_id": uuid4(),
+        "actor_kind": "agent",
+        "method": "GET",
+        "path": "/v1/recommendations",
+        "status_code": 200,
+        "latency_ms": 12,
+        "client_ip": "127.0.0.1",
+        "created_at": datetime.now(timezone.utc),
+    }
+    row.update(over)
+    return row
+
+
+# ─────────────────────────────────────────────────────────────
+# Auth / scope floor
+# ─────────────────────────────────────────────────────────────
+
+
+def test_audit_requires_auth():
+    db = _make_db_mock()
+    client = _make_client(db)
+    resp = client.get("/v1/audit")
+    assert resp.status_code == 401
+
+
+def test_audit_non_admin_principal_is_403():
+    """A resolved principal WITHOUT the admin scope is denied. require_scope
+    ('admin') depends on resolve_principal, so overriding it with a read-only
+    agent principal exercises the real 403 path."""
+    db = _make_db_mock()
+    app = create_app()
+
+    def override_db():
+        yield db
+
+    def override_principal():
+        return Principal(
+            token_id=uuid4(),
+            name="watcher",
+            actor_kind="agent",
+            scopes=frozenset({"read"}),  # lacks admin
+            is_legacy=False,
+        )
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[resolve_principal] = override_principal
+    client = TestClient(app)
+
+    resp = client.get("/v1/audit", headers=AUTH)
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["detail"] == "missing scope 'admin'"
+
+
+def test_audit_legacy_admin_token_passes():
+    db = _make_db_mock()
+    _setup_count_then_rows(db, total=0, rows=[])
+    client = _make_client(db)
+    resp = client.get("/v1/audit", headers=AUTH)
+    assert resp.status_code == 200, resp.text
+
+
+# ─────────────────────────────────────────────────────────────
+# Validation: actor_kind + limit bounds
+# ─────────────────────────────────────────────────────────────
+
+
+def test_audit_invalid_actor_kind_is_422():
+    db = _make_db_mock()
+    client = _make_client(db)
+    resp = client.get("/v1/audit?actor_kind=robot", headers=AUTH)
+    assert resp.status_code == 422, resp.text
+    # Raised before any DB access.
+    db.execute.assert_not_called()
+
+
+def test_audit_valid_actor_kind_filter_passes():
+    db = _make_db_mock()
+    _setup_count_then_rows(db, total=1, rows=[_audit_row(actor_kind="human")])
+    client = _make_client(db)
+    resp = client.get("/v1/audit?actor_kind=human", headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["total"] == 1
+
+
+def test_audit_limit_over_max_is_422():
+    """limit is bounded by FastAPI validation (le=200) → 422, NOT clamped."""
+    db = _make_db_mock()
+    client = _make_client(db)
+    resp = client.get("/v1/audit?limit=201", headers=AUTH)
+    assert resp.status_code == 422, resp.text
+
+
+def test_audit_limit_zero_is_422():
+    db = _make_db_mock()
+    client = _make_client(db)
+    resp = client.get("/v1/audit?limit=0", headers=AUTH)
+    assert resp.status_code == 422, resp.text
+
+
+def test_audit_limit_at_max_is_accepted():
+    db = _make_db_mock()
+    _setup_count_then_rows(db, total=0, rows=[])
+    client = _make_client(db)
+    resp = client.get("/v1/audit?limit=200", headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["limit"] == 200
+
+
+def test_audit_negative_status_code_filter_is_422():
+    db = _make_db_mock()
+    client = _make_client(db)
+    # status_code Query is ge=100/le=599.
+    resp = client.get("/v1/audit?status_code=42", headers=AUTH)
+    assert resp.status_code == 422, resp.text
+
+
+# ─────────────────────────────────────────────────────────────
+# Response shape: never a token / token_hash
+# ─────────────────────────────────────────────────────────────
+
+
+def test_audit_response_never_exposes_token_or_hash():
+    db = _make_db_mock()
+    _setup_count_then_rows(db, total=1, rows=[_audit_row()])
+    client = _make_client(db)
+    resp = client.get("/v1/audit", headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total"] == 1
+    assert len(body["entries"]) == 1
+    entry = body["entries"][0]
+    # The non-secret correlation fields ARE present …
+    assert "token_prefix" in entry
+    assert "token_id" in entry
+    # … but no raw token or token hash is ever surfaced (the table stores none).
+    assert "token" not in entry
+    assert "token_hash" not in entry
+    for key in entry.keys():
+        assert "hash" not in key.lower()
+        assert key.lower() != "token"
+
+
+def test_audit_pagination_echoes_limit_and_offset():
+    db = _make_db_mock()
+    _setup_count_then_rows(db, total=5, rows=[_audit_row(), _audit_row()])
+    client = _make_client(db)
+    resp = client.get("/v1/audit?limit=2&offset=2", headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total"] == 5
+    assert body["limit"] == 2
+    assert body["offset"] == 2
+    assert len(body["entries"]) == 2
+
+
+def test_audit_count_row_none_defaults_total_zero():
+    """Defensive branch: a None count row → total 0."""
+    db = _make_db_mock()
+    count_cur = MagicMock()
+    count_cur.fetchone.return_value = None
+    rows_cur = MagicMock()
+    rows_cur.fetchall.return_value = []
+    db.execute.side_effect = [count_cur, rows_cur]
+
+    client = _make_client(db)
+    resp = client.get("/v1/audit", headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["total"] == 0
+
+
+def test_audit_row_with_null_token_id_serialises():
+    """A legacy-token audit row (token_id NULL) must serialise cleanly."""
+    db = _make_db_mock()
+    _setup_count_then_rows(
+        db,
+        total=1,
+        rows=[_audit_row(token_id=None, token_prefix="global_token", actor_kind=None)],
+    )
+    client = _make_client(db)
+    resp = client.get("/v1/audit", headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    entry = resp.json()["entries"][0]
+    assert entry["token_id"] is None
+    assert entry["token_prefix"] == "global_token"
+    assert entry["actor_kind"] is None


### PR DESCRIPTION
Le paquet PROD-QW de la roadmap : **restore enfin prouvé** (#192, DB jetable + off-host), pool durci (timeouts pool-only calibrés sur le pire run mesuré, env-overridables), **pip-audit + CodeQL en CI** (piège --strict×--skip-editable découvert au rejeu et corrigé), gate de couverture (plancher 40, baseline réelle 66), **GET /v1/audit** (le ledger devient requêtable), **webhook L3 best-effort** (httpx promu cœur post-revue — l'exception te trouve, post-commit, idempotent). 60 tests unit + 15 intégration. Revue adversariale : NO-GO initial corrigé (4 fixes appliqués et re-validés). La CI de cette PR est le juge final des ignores pip-audit en environnement propre. Réf #192, roadmap H1/PROD-QW — **avec ce merge, H1 est complet**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)