### PR TITLE
feat(pyramide): câblage opt-in du routage tête/traîne (DEM-1 PR-1)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11479,6 +11479,11 @@
             "minLength": 1,
             "title": "Code Version",
             "default": "local"
+          },
+          "auto_route": {
+            "type": "boolean",
+            "title": "Auto Route",
+            "default": false
           }
         },
         "type": "object",
@@ -15327,6 +15332,39 @@
             "type": "boolean",
             "title": "Stale Demand",
             "default": false
+          },
+          "routed_method": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Routed Method"
+          },
+          "routed_level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Routed Level"
+          },
+          "routing_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Routing Reason"
           }
         },
         "type": "object",
@@ -15428,6 +15466,11 @@
             "minimum": 1.0,
             "title": "Freshness Sla Days",
             "default": 7
+          },
+          "auto_route": {
+            "type": "boolean",
+            "title": "Auto Route",
+            "default": false
           }
         },
         "type": "object",

--- a/src/ootils_core/api/routers/pyramide.py
+++ b/src/ootils_core/api/routers/pyramide.py
@@ -20,8 +20,11 @@ from ootils_core.pyramide.hierarchy import (
     HierarchicalRunConfig,
     HierarchicalRunner,
 )
+from ootils_core.pyramide.models import METHOD_AUTO_SELECT
 from ootils_core.pyramide.repository import (
     PyramideAggregateCommitError,
+    build_routing_decisions,
+    build_series_features,
     commit_run,
     fetch_accuracy_metrics,
     fetch_run_summary,
@@ -36,6 +39,7 @@ from ootils_core.pyramide.repository import (
     resolve_location_uuid,
     resolve_scenario_uuid,
 )
+from ootils_core.pyramide.routing import LEVEL_LEAF, RoutingDecision, route
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +87,12 @@ class PyramideRunRequest(BaseModel):
     # STALE_DEMAND row. A PARAMETER (pilot default 7 days), never a
     # hard-coded business constant.
     freshness_sla_days: int = Field(default=DEFAULT_SLA_DAYS, ge=1, le=365)
+    # Head/tail routing (DEM-1) — OPT-IN, default False = byte-identical to the
+    # historical behaviour (natural kill switch). When True the router computes
+    # this series' features and records its recommendation as routing
+    # provenance; the recommended method REPLACES ``method`` only when the
+    # caller left it AUTO_SELECT (an explicit method is never overwritten).
+    auto_route: bool = False
 
     @staticmethod
     def _method_error() -> str:
@@ -158,6 +168,14 @@ class PyramideRunOut(BaseModel):
     # demand_history ingest age exceeded the freshness SLA. Additive,
     # backward-compatible — agents must not auto-act (L0-L2) on TRUE.
     stale_demand: bool = False
+    # Routing provenance (migration 058, DEM-1). Populated when the run was
+    # auto-routed; all three NULL together for a non-routed run (migration
+    # 058's all-or-none CHECK). routed_method is the router's RECOMMENDATION —
+    # ``method`` above stays the executed contract (they differ when the caller
+    # forced an explicit method with auto_route on). Additive, backward-compatible.
+    routed_method: str | None = None
+    routed_level: str | None = None
+    routing_reason: str | None = None
 
 
 class PyramideValueOut(BaseModel):
@@ -220,6 +238,12 @@ class HierarchicalRunRequest(BaseModel):
     lookback_days: int = Field(default=365, ge=1, le=3650)
     random_seed: int = Field(default=0, ge=0)
     code_version: str = Field(default="local", min_length=1, max_length=64)
+    # Head/tail routing (DEM-1) — OPT-IN, default False = byte-identical to the
+    # historical behaviour (natural kill switch). When True the router computes
+    # a decision for EVERY series of the block (aggregates + leaves) and the
+    # runner persists routed_method/routed_level/routing_reason per series and
+    # drives the reconciliation-level base-forecast method from it.
+    auto_route: bool = False
 
     @staticmethod
     def _method_error() -> str:
@@ -358,6 +382,28 @@ def create_pyramide_run(
             detail="Historical demand is required to create a Pyramide forecast run",
         )
 
+    routing_decision: RoutingDecision | None = None
+    if body.auto_route:
+        features = build_series_features(db, item_uuid, location_uuid)
+        raw_decision = route(features)
+        # Single-series endpoint has NO hierarchy: the only honest forecast
+        # LEVEL is 'leaf' (nothing to disaggregate). aggregate_signal_ok
+        # defaults False here, so route() already returns leaf on every branch;
+        # we pin it explicitly rather than ever persist an 'aggregate'
+        # provenance that would be meaningless for a standalone series.
+        routing_decision = RoutingDecision(
+            method=raw_decision.method,
+            level=LEVEL_LEAF,
+            reason=raw_decision.reason,
+            features_used=raw_decision.features_used,
+        )
+        # Never overwrite an explicit method choice: the recommendation
+        # replaces the EXECUTED method only for an unopinionated AUTO_SELECT
+        # request. The provenance (routed_method) is recorded either way, so a
+        # forced explicit method still carries "the router would have picked X".
+        if body.method == METHOD_AUTO_SELECT:
+            body.method = routing_decision.method
+
     config = PyramideRunConfig(
         item_id=item_uuid,
         location_id=location_uuid,
@@ -398,7 +444,11 @@ def create_pyramide_run(
     # history feeds the FVA seasonal-naive baseline (migration 068): it is
     # the SAME series the run was computed on, so the naive is backtested on
     # identical cutoffs (methodological consistency — see fva.compute_fva).
-    persisted = persist_run(db, result, stale_demand=stale, history=history)
+    # routing_decision (DEM-1) is None unless auto_route was set — persist_run
+    # then writes the routed_method/routed_level/routing_reason provenance.
+    persisted = persist_run(
+        db, result, stale_demand=stale, routing=routing_decision, history=history
+    )
     if stale:
         # Exactly once per run (this endpoint is the only writer and the
         # run is created exactly once) — no spam, evidence carries run_id.
@@ -478,35 +528,50 @@ def create_hierarchical_run(
             detail=f"Invalid scenario_id '{body.scenario_id}'",
         ) from exc
 
-    config = HierarchicalRunConfig(
-        hierarchy_id=body.hierarchy_id,
-        block_code=body.block_code,
-        leaf_location_id=location_uuid,
-        scenario_id=scenario_uuid,
-        horizon_start=date.today() + timedelta(days=1),
-        horizon_days=body.horizon_days,
-        block_level=body.block_level,
-        recon_level=body.recon_level,
-        granularity=body.granularity,
-        method=body.method,
-        method_params=body.method_params,
-        model_strategy=body.model_strategy,
-        recon_method=body.recon_method,
-        lookback_days=body.lookback_days,
-        random_seed=body.random_seed,
-        code_version=body.code_version,
-    )
-
     try:
+        # Head/tail routing (DEM-1), opt-in: build a decision for EVERY series
+        # of the block BEFORE the run and inject it as routing_decisions, so
+        # the runner persists routed_method/routed_level/routing_reason per
+        # series and drives the reconciliation-level base-forecast method from
+        # it. Empty ({}) when not auto-routed = historical behaviour unchanged.
+        routing_decisions = (
+            build_routing_decisions(
+                db,
+                hierarchy_id=body.hierarchy_id,
+                block_code=body.block_code,
+                block_level=body.block_level,
+            )
+            if body.auto_route
+            else {}
+        )
+        config = HierarchicalRunConfig(
+            hierarchy_id=body.hierarchy_id,
+            block_code=body.block_code,
+            leaf_location_id=location_uuid,
+            scenario_id=scenario_uuid,
+            horizon_start=date.today() + timedelta(days=1),
+            horizon_days=body.horizon_days,
+            block_level=body.block_level,
+            recon_level=body.recon_level,
+            granularity=body.granularity,
+            method=body.method,
+            method_params=body.method_params,
+            model_strategy=body.model_strategy,
+            recon_method=body.recon_method,
+            lookback_days=body.lookback_days,
+            random_seed=body.random_seed,
+            code_version=body.code_version,
+            routing_decisions=routing_decisions,
+        )
         result = HierarchicalRunner().run(db, config)
     except (PyramideError, ValueError) as exc:
         # Typed domain-exception carve-out (cf. CLAUDE.md): hand-authored
-        # message from config validation (unknown block/level/method,
-        # empty node history) — DB-free, no SQL/DSN can reach this string.
-        # ValueError is included for the hierarchy registry validation layer
-        # (pyramide/hierarchy/summing.py: unknown hierarchy_id, no levels,
-        # duplicate codes...) which predates PyramideError and is asserted as
-        # ValueError by its own unit tests — its messages are equally
+        # message from config validation or the routing build (unknown block/
+        # level/method, empty node history) — DB-free, no SQL/DSN can reach
+        # this string. ValueError is included for the hierarchy registry
+        # validation layer (pyramide/hierarchy/summing.py: unknown
+        # hierarchy_id, no levels, duplicate codes...) and the block-not-found
+        # raised by build_routing_decisions — its messages are equally
         # hand-authored (they interpolate only caller-supplied identifiers).
         # Without this, an unknown hierarchy_id surfaced as a generic 500.
         raise HTTPException(
@@ -693,6 +758,9 @@ def _run_out(summary) -> PyramideRunOut:
         created_at=summary.created_at,
         committed_at=summary.committed_at,
         stale_demand=summary.stale_demand,
+        routed_method=summary.routed_method,
+        routed_level=summary.routed_level,
+        routing_reason=summary.routing_reason,
     )
 
 

--- a/src/ootils_core/pyramide/repository.py
+++ b/src/ootils_core/pyramide/repository.py
@@ -5,7 +5,7 @@ import logging
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
-from typing import Sequence
+from typing import Any, Sequence
 from uuid import UUID, uuid4
 
 from psycopg.types.json import Jsonb
@@ -16,7 +16,13 @@ from ootils_core.db.types import DictRowConnection
 from .accuracy import AccuracyReport
 from .fva import FvaResult, compute_fva, resolve_season_length
 from .models import PyramideRunResult
-from .routing import RoutingDecision
+from .routing import (
+    RoutingDecision,
+    RoutingThresholds,
+    SeriesFeatures,
+    route,
+    seasonal_strength,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +86,14 @@ class PyramideRunSummary:
     # demand_history ingest age exceeded the freshness SLA. FALSE means
     # "not proven stale at run time", never "proven fresh".
     stale_demand: bool
+    # Routing provenance (migration 058, DEM-1): the head/tail router's
+    # recommendation for this series when the run was auto-routed. All three
+    # are NULL together for a non-routed run (method requested explicitly) —
+    # migration 058's all-or-none CHECK. routed_method is the RECOMMENDATION,
+    # not necessarily what ran (``method`` stays the executed contract).
+    routed_method: str | None = None
+    routed_level: str | None = None
+    routing_reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -645,6 +659,274 @@ def get_historical_demand_totals_by_items(
     return {str(row["item_id"]): Decimal(str(row["total_qty"])) for row in rows}
 
 
+# ---------------------------------------------------------------------------
+# Head/tail routing features (DEM-1) — the CALLER side of the DB-free router.
+# ---------------------------------------------------------------------------
+# routing.py is DB-free by contract: it only sees a SeriesFeatures computed by
+# the caller. These builders are that caller — the ONLY place that turns raw
+# demand_history / item_asp facts into the router's feature vector.
+_ZERO_DEC = Decimal("0")
+
+# Season length of the seasonal_strength probe (routing.seasonal_strength).
+# V1 APPROXIMATION: 7 = weekly seasonality on the DAILY booking series. The
+# series is sparse (missing days absent, not zero-filled) so the probe is
+# positional, not calendar-aligned — it UNDER-states the seasonal signal, which
+# only ever routes a series AWAY from the head branch (conservative: a real head
+# series is never mis-forecast as tail because of this). The honest annual
+# season needs the granularity re-aggregation of #433 (get_historical_demand
+# returns daily rows and never re-buckets); until then this is the documented
+# proxy the router feeds on.
+_ROUTING_SEASON_LENGTH = 7
+
+
+def _features_from_daily_rows(
+    rows: Sequence[dict[str, Any]],
+    *,
+    annual_value: Decimal | None,
+    aggregate_signal_ok: bool,
+) -> SeriesFeatures:
+    """Turn a sparse daily booking series (rows of demand_date + total_qty,
+    date ASC) into the router's SeriesFeatures. Shared by the leaf and node
+    builders so the feature arithmetic is defined exactly once.
+
+    - history_depth_days: calendar span first..last booking (inclusive).
+    - zero_ratio: (span days − days that carry a booking) / span days — the
+      share of zero-demand days over the observed span. NOTE: bookings are
+      lumpy in calendar days even for high-volume items, so this daily ratio
+      runs high; RoutingThresholds.intermittent_zero_ratio is the calibration
+      knob, and the honest bucket-level intermittence awaits #433.
+    - seasonal_strength: routing.seasonal_strength over the quantities.
+    - lifecycle stays None: the schema carries no item-master lifecycle flag,
+      and inferring launch/end_of_life from a demand-recency cutoff would
+      hardcode a business constant the router deliberately keeps out of the
+      feature layer. classify() already routes a short history to cold-start
+      via history_depth_days, so nothing is lost by leaving it unknown.
+    - has_twin stays False: there is no twin/predecessor registry yet.
+    """
+    if not rows:
+        # No booking at all -> cold-start (classify() decides on
+        # history_depth_days=0 before any other axis). zero_ratio is a neutral
+        # 0: there is no span to measure intermittence over.
+        return SeriesFeatures(
+            history_depth_days=0,
+            zero_ratio=_ZERO_DEC,
+            annual_value=annual_value,
+            seasonal_strength=None,
+            aggregate_signal_ok=aggregate_signal_ok,
+        )
+    first_date = rows[0]["demand_date"]
+    last_date = rows[-1]["demand_date"]
+    span_days = (last_date - first_date).days + 1
+    demand_days = len(rows)
+    zero_ratio = (
+        Decimal(span_days - demand_days) / Decimal(span_days)
+        if span_days > 0
+        else _ZERO_DEC
+    )
+    quantities = [Decimal(str(row["total_qty"])) for row in rows]
+    strength = seasonal_strength(quantities, _ROUTING_SEASON_LENGTH)
+    return SeriesFeatures(
+        history_depth_days=span_days,
+        zero_ratio=zero_ratio,
+        annual_value=annual_value,
+        seasonal_strength=strength,
+        aggregate_signal_ok=aggregate_signal_ok,
+    )
+
+
+def _item_annual_value(db: DictRowConnection, item_id: UUID) -> Decimal | None:
+    """SUM(item_asp.value_12m) for one item (across orgs), or None.
+
+    DOCUMENTED FALLBACK: no item_asp row (or every value_12m NULL) -> None,
+    NOT 0. route() treats a None annual_value natively as an unknown ABC
+    class and stays conservative (tail / cheap aggregate path). A masked 0
+    would instead force C-class and could mis-rank a genuinely valuable item.
+    """
+    row = db.execute(
+        "SELECT SUM(value_12m) AS annual_value FROM item_asp WHERE item_id = %s",
+        (item_id,),
+    ).fetchone()
+    if row is None or row["annual_value"] is None:
+        return None
+    return Decimal(str(row["annual_value"]))
+
+
+def build_series_features(
+    db: DictRowConnection,
+    item_id: UUID,
+    location_id: UUID | None,
+    *,
+    aggregate_signal_ok: bool = False,
+) -> SeriesFeatures:
+    """Compute the head/tail router's SeriesFeatures for ONE leaf series.
+
+    ``location_id`` set = the series is site-scoped (single-series leaf run):
+    demand_history is filtered to that site's accepted warehouse codes through
+    the single-source ``_warehouse_codes_subquery`` (external_id ∪ aliases,
+    #414/ADR-031). ``location_id`` None = the item across ALL sites (the
+    hierarchy-leaf reading, site-agnostic like every hierarchy reader) — no
+    warehouse filter.
+
+    Source: demand_history bookings ONLY, same business predicates as the
+    forecast readers (stream='regular', inter-entity excluded, strict past).
+    No graph fallback: a degraded install whose demand_history is empty (orders
+    live only as CustomerOrderDemand nodes) yields an empty series here and
+    routes conservatively to cold-start — the routing provenance never invents
+    a history the fact table does not carry.
+
+    See ``_features_from_daily_rows`` and ``_item_annual_value`` for the exact
+    per-feature semantics (span, zero_ratio, annual_value fallback, seasonal
+    approximation, lifecycle/has_twin defaults).
+    """
+    params: dict[str, Any] = {"item_id": item_id}
+    site_filter = ""
+    if location_id is not None:
+        site_filter = f"AND dh.warehouse_id IN ({_warehouse_codes_subquery()})"
+        params["location_id"] = location_id
+
+    rows = db.execute(
+        f"""
+        SELECT dh.booked_date AS demand_date,
+               COALESCE(SUM(dh.ordered_quantity), 0) AS total_qty
+        FROM demand_history dh
+        WHERE dh.item_id = %(item_id)s
+          {site_filter}
+          AND {_DEMAND_HISTORY_STREAM_PREDICATES}
+          AND dh.booked_date < CURRENT_DATE
+        GROUP BY dh.booked_date
+        ORDER BY dh.booked_date ASC
+        """,
+        params,
+    ).fetchall()
+    return _features_from_daily_rows(
+        rows,
+        annual_value=_item_annual_value(db, item_id),
+        aggregate_signal_ok=aggregate_signal_ok,
+    )
+
+
+# Subtree of a hierarchy node — SAME recursion contract as
+# get_historical_demand_by_node (UNION, not UNION ALL: hierarchy_node has no
+# self-FK, so dedup guarantees termination on a bad parent cycle).
+_NODE_SUBTREE_CTE = """
+        WITH RECURSIVE subtree AS (
+            SELECT code
+            FROM hierarchy_node
+            WHERE hierarchy_id = %(hierarchy_id)s AND code = %(node_code)s
+            UNION
+            SELECT hn.code
+            FROM hierarchy_node hn
+            JOIN subtree st ON hn.parent_code = st.code
+            WHERE hn.hierarchy_id = %(hierarchy_id)s
+        )
+"""
+
+
+def _build_node_features(
+    db: DictRowConnection,
+    hierarchy_id: str,
+    node_code: str,
+    *,
+    aggregate_signal_ok: bool = False,
+) -> SeriesFeatures:
+    """SeriesFeatures for an AGGREGATE (hierarchy-node) series: same feature
+    vector as ``build_series_features`` but summed over every item attached to
+    the node's subtree (item_hierarchy), across all sites — the reading the
+    hierarchical runner base-forecasts at the reconciliation level.
+
+    ``aggregate_signal_ok`` defaults False: an aggregate is forecast at its OWN
+    level by the runner, there is no higher node to defer to inside the block.
+    """
+    params: dict[str, Any] = {"hierarchy_id": hierarchy_id, "node_code": node_code}
+    rows = db.execute(
+        _NODE_SUBTREE_CTE
+        + f"""
+        SELECT dh.booked_date AS demand_date,
+               COALESCE(SUM(dh.ordered_quantity), 0) AS total_qty
+        FROM demand_history dh
+        JOIN item_hierarchy ih
+          ON ih.item_id = dh.item_id AND ih.hierarchy_id = %(hierarchy_id)s
+        JOIN subtree st ON st.code = ih.leaf_code
+        WHERE {_DEMAND_HISTORY_STREAM_PREDICATES}
+          AND dh.booked_date < CURRENT_DATE
+        GROUP BY dh.booked_date
+        ORDER BY dh.booked_date ASC
+        """,
+        params,
+    ).fetchall()
+    annual_row = db.execute(
+        _NODE_SUBTREE_CTE
+        + """
+        SELECT SUM(a.value_12m) AS annual_value
+        FROM item_asp a
+        JOIN item_hierarchy ih
+          ON ih.item_id = a.item_id AND ih.hierarchy_id = %(hierarchy_id)s
+        JOIN subtree st ON st.code = ih.leaf_code
+        """,
+        params,
+    ).fetchone()
+    annual_value = (
+        Decimal(str(annual_row["annual_value"]))
+        if annual_row is not None and annual_row["annual_value"] is not None
+        else None
+    )
+    return _features_from_daily_rows(
+        rows, annual_value=annual_value, aggregate_signal_ok=aggregate_signal_ok
+    )
+
+
+def build_routing_decisions(
+    db: DictRowConnection,
+    *,
+    hierarchy_id: str,
+    block_code: str,
+    block_level: str | None = None,
+    thresholds: RoutingThresholds | None = None,
+) -> dict[str, RoutingDecision]:
+    """Route EVERY series of a summing block: features -> route() -> decision,
+    keyed exactly like ``HierarchicalRunConfig.routing_decisions`` (aggregate =
+    hierarchy_node code, leaf = item UUID string). The runner consumes this map
+    to persist routed_method/routed_level/routing_reason on each series and to
+    drive the base-forecast method at the reconciliation level.
+
+    Aggregate series use ``_build_node_features`` (subtree demand); leaves use
+    ``build_series_features`` with no site filter and ``aggregate_signal_ok=True``
+    — in a summing block every leaf HAS a signal-bearing reconciliation parent,
+    so a tail/cold-start leaf routes to the aggregate level, exactly the
+    disaggregation the runner performs.
+
+    The block is (re)loaded here from the same registry the runner reads, so the
+    keys match by construction; the extra load of the small migration-047 tables
+    is negligible at demo scale.
+    """
+    # Local import: repository <-> hierarchy.runner is a genuine import cycle
+    # (runner imports the feature builders above). By call time both modules
+    # are fully initialised, so the deferred import is safe.
+    from .hierarchy.summing import AGGREGATE, load_summing_blocks
+
+    blocks = load_summing_blocks(
+        db, hierarchy_id=hierarchy_id, block_level=block_level
+    )
+    block = next((b for b in blocks if b.block_code == block_code), None)
+    if block is None:
+        raise ValueError(
+            f"block '{block_code}' not found at level '{block_level or 'root'}' "
+            f"of hierarchy '{hierarchy_id}' "
+            f"(blocks: {[b.block_code for b in blocks]})"
+        )
+
+    decisions: dict[str, RoutingDecision] = {}
+    for ref in block.series:
+        if ref.kind == AGGREGATE:
+            features = _build_node_features(db, hierarchy_id, ref.key)
+        else:
+            features = build_series_features(
+                db, UUID(ref.key), None, aggregate_signal_ok=True
+            )
+        decisions[ref.key] = route(features, thresholds=thresholds)
+    return decisions
+
+
 _ONE = Decimal("1")
 
 
@@ -1199,6 +1481,7 @@ def fetch_run_summary(db: DictRowConnection, run_id: UUID) -> PyramideRunSummary
             pr.source_history_count, pr.status,
             pr.deterministic_artifact, pr.created_at, pr.committed_at,
             pr.stale_demand,
+            pr.routed_method, pr.routed_level, pr.routing_reason,
             COALESCE(ps.value_count, vc.value_count) AS value_count,
             COALESCE(ps.total_quantity, vc.total_quantity) AS total_quantity
         FROM pyramide_runs pr
@@ -1374,6 +1657,9 @@ def _summary_from_row(row) -> PyramideRunSummary:
         created_at=row["created_at"],
         committed_at=row["committed_at"],
         stale_demand=row["stale_demand"],
+        routed_method=row["routed_method"],
+        routed_level=row["routed_level"],
+        routing_reason=row["routing_reason"],
     )
 
 

--- a/tests/integration/test_routing_wiring_integration.py
+++ b/tests/integration/test_routing_wiring_integration.py
@@ -1,0 +1,542 @@
+"""
+Integration tests for the DEM-1 head/tail routing WIRING (PR-1) against a real
+PostgreSQL database (no mocks). This is the backend counterpart of the DB-free
+unit suite tests/test_pyramide_routing_wiring.py: there the seams are
+monkeypatched, here the whole chain runs end to end through the two Pyramide
+forecast endpoints and lands routed_method/routed_level/routing_reason
+(migration 058) on real pyramide_runs rows.
+
+Six cases (the wiring the unit suite can only assert in isolation):
+
+  1. POST /v1/forecast/hierarchical-runs with auto_route=True on a seeded
+     block -> routed_method/routed_level/routing_reason are non-NULL on 100 %
+     of the block's series (aggregates AND leaves), read back through
+     GET /runs/{run_id} for every persisted series.
+  2. Single-series method=AUTO_SELECT + auto_route=True -> the routed method
+     REPLACES the executed method and is traced: pyramide_runs.method ==
+     routed_method (a concrete method, not AUTO_SELECT).
+  3. Single-series with an EXPLICIT method + auto_route=True -> the executed
+     method is NOT overwritten, yet the router's recommendation is still
+     recorded as provenance (routed_method present and != the executed one).
+  4. auto_route=False (the default) -> routed_* stay NULL: the opt-in is a
+     byte-identical kill switch.
+  5. Cold-start (an item with only 3 demand points) -> the router picks the
+     conservative cold-start branch and the run completes WITHOUT crashing
+     (the FM recommendation executes via its deterministic AUTO_SELECT
+     fallback — the FM backend is optional and absent here).
+  6. A series routed to a concrete executable method runs WITH it: the frozen
+     forecast values (GET /runs/{run_id}/result) all carry that method.
+
+PREMISES verified against the code before writing (blind — this file was never
+executed):
+  - build_series_features / build_routing_decisions live in
+    pyramide/repository.py; auto_route is an opt-in bool on BOTH
+    PyramideRunRequest and HierarchicalRunRequest (api/routers/pyramide.py).
+    On the single-series endpoint the router pins level='leaf' and only
+    overwrites method when the caller left it AUTO_SELECT. On the
+    hierarchical endpoint build_routing_decisions produces one decision per
+    series of the block and HierarchicalRunner persists routing per series
+    (routing=config.routing_decisions.get(ref.key)) — so a routed run stamps
+    provenance on every series.
+  - Routing is DETERMINISTIC from features computed off demand_history:
+      * a sparse-CALENDAR series (bookings on few days over a wide span,
+        span >= cold_start_days=60) -> zero_ratio > intermittent_zero_ratio
+        (0.6) -> INTERMITTENT -> CROSTON at leaf (a concrete, executable
+        method != AUTO_SELECT); CROSTON is robust on the dense positive-only
+        series get_historical_demand returns (validate min_length=1).
+      * a very short series (span < 60) -> COLD_START -> FM_CHRONOS at leaf.
+        FM_CHRONOS with no strict_backend falls back to a deterministic
+        AUTO_SELECT (engines.PyramideForecastEngine.forecast_foundation_batch)
+        — so the run never 422s on the absent optional FM backend.
+  - The seeded block reuses the family/product shape of
+    test_pyramide_hierarchy_integration.py / test_pyramide_b1_integration.py
+    (hierarchy / hierarchy_node / item_hierarchy + demand_history), with a
+    reconciliation node that cold-starts to FM_CHRONOS and executes via the
+    same AUTO_SELECT fallback (recon_method stays 'middleout', so no MinT
+    batch-only refusal).
+  - migration 058 columns are routed_method / routed_level / routing_reason
+    on pyramide_runs, exposed on PyramideRunOut; all-or-none, routed_level in
+    ('leaf','aggregate').
+  - demand_history.ingested_at DEFAULTS now() -> every seed reads FRESH, so
+    the ADR-023 freshness gate never marks these runs stale.
+
+Conventions mirror test_pyramide_b1_integration.py: an AUTOCOMMIT _db_conn for
+seeding/teardown (the FastAPI TestClient opens its OWN connection via the
+get_db override, so it only sees committed rows), FK-ordered cleanup PER TEST
+in a finally block, and the anti-flake rule — every seeded booking sits at
+TODAY-6 or earlier (booked_date < server CURRENT_DATE), never on a same-day
+edge.
+"""
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+BASELINE_SCENARIO_ID = UUID("00000000-0000-0000-0000-000000000001")
+TODAY = date.today()
+
+# Weekly-seasonal block pattern (mirrors test_pyramide_b1_integration.py):
+# a KNOWN 7-day pattern scaled per leaf, seeded over 8 full weeks.
+WEEK_PATTERN = (2, 1, 1, 1, 3, 4, 2)
+AMPLITUDES = {"A1": 10, "A2": 6, "A3": 4}
+HISTORY_DAYS = range(4, 60)  # 56 consecutive days = 8 full weeks
+
+
+# ---------------------------------------------------------------------------
+# DB access + seeding helpers (dedicated entities, unique codes per test)
+# ---------------------------------------------------------------------------
+
+
+def _db_conn(dsn):
+    import psycopg
+    from psycopg.rows import dict_row
+
+    return psycopg.connect(dsn, row_factory=dict_row, autocommit=True)
+
+
+def _create_item(conn, ext_id: str) -> UUID:
+    item_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO items (item_id, name, item_type, uom, status, external_id)
+        VALUES (%s, %s, 'finished_good', 'EA', 'active', %s)
+        """,
+        (item_id, f"{ext_id} dem1 routing item", ext_id),
+    )
+    return item_id
+
+
+def _create_location(conn, ext_id: str) -> UUID:
+    loc_id = uuid4()
+    conn.execute(
+        """
+        INSERT INTO locations (location_id, name, location_type, country, external_id)
+        VALUES (%s, %s, 'dc', 'US', %s)
+        """,
+        (loc_id, f"{ext_id} dem1 routing DC", ext_id),
+    )
+    return loc_id
+
+
+def _seed_booking(conn, item_id: UUID, item_code: str, warehouse_id: str,
+                  booked_date: date, qty) -> None:
+    """One demand_history booking. warehouse_id must equal the leaf location's
+    external_id so the single-series site filter (_warehouse_codes_subquery)
+    resolves the row. ingested_at defaults now() -> fresh."""
+    conn.execute(
+        """
+        INSERT INTO demand_history (
+            item_id, item_code, stream, booked_date, ordered_quantity,
+            value_ext, counts_for_asp, fulfillment, order_number, warehouse_id
+        ) VALUES (%s, %s, 'regular', %s, %s, 0, FALSE, 'standard', 'DEM1-RW', %s)
+        """,
+        (item_id, item_code, booked_date, qty, warehouse_id),
+    )
+
+
+def _seed_intermittent(conn, item_id: UUID, code: str, warehouse_id: str) -> None:
+    """A sparse-CALENDAR series: 6 bookings over a ~92-day span. The router
+    reads history_depth_days = span (>= cold_start_days=60, so NOT cold-start)
+    and zero_ratio = (span - 6)/span ~ 0.94 (> intermittent_zero_ratio=0.6),
+    so it classifies INTERMITTENT and routes to CROSTON at leaf — a concrete
+    executable method distinct from AUTO_SELECT."""
+    days_back = (100, 80, 60, 40, 20, 8)
+    quantities = (10, 12, 8, 15, 9, 11)
+    for back, qty in zip(days_back, quantities):
+        _seed_booking(conn, item_id, code, warehouse_id,
+                      TODAY - timedelta(days=back), qty)
+
+
+def _seed_cold_start(conn, item_id: UUID, code: str, warehouse_id: str) -> None:
+    """An item with only 3 demand points, clustered over a 4-day span
+    (span < cold_start_days=60) -> the router classifies COLD_START and routes
+    to FM_CHRONOS at leaf (no twin, no aggregate signal on a standalone
+    series)."""
+    for back, qty in ((10, 5), (8, 7), (6, 6)):
+        _seed_booking(conn, item_id, code, warehouse_id,
+                      TODAY - timedelta(days=back), qty)
+
+
+def _cleanup_item(conn, item_id: UUID, location_id: UUID | None) -> None:
+    """FK-ordered teardown (mirrors test_pyramide_b1_integration.py). Deleting
+    pyramide_runs / forecasts cascades to snapshots, forecast_values and
+    accuracy_metrics; demand_history and forecasts must go before the item
+    (ON DELETE RESTRICT)."""
+    conn.execute(
+        "DELETE FROM pyramide_snapshots WHERE forecast_id IN "
+        "(SELECT forecast_id FROM forecasts WHERE item_id = %s)",
+        (item_id,),
+    )
+    conn.execute(
+        "DELETE FROM pyramide_runs WHERE forecast_id IN "
+        "(SELECT forecast_id FROM forecasts WHERE item_id = %s)",
+        (item_id,),
+    )
+    conn.execute("DELETE FROM forecasts WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM demand_history WHERE item_id = %s", (item_id,))
+    conn.execute("DELETE FROM items WHERE item_id = %s", (item_id,))
+    if location_id is not None:
+        conn.execute("DELETE FROM locations WHERE location_id = %s", (location_id,))
+
+
+def _seed_block(conn, h: str, tag: str):
+    """FAM-<tag> (family) -> PRD-<tag>1 (2 items) + PRD-<tag>2 (1 item), each
+    leaf carrying 8 weeks of dense weekly-seasonal demand (mirrors
+    test_pyramide_b1_integration.py:_seed_block). The reconciliation node
+    (family) reads a 56-day span < cold_start_days=60 with no ASP, so it
+    routes to FM_CHRONOS and executes via the deterministic AUTO_SELECT
+    fallback — no strict backend, no MinT (recon stays middleout). AUTOCOMMIT
+    variant so the API TestClient's own connection sees the rows."""
+    conn.execute(
+        """
+        INSERT INTO hierarchy (hierarchy_id, domain, scope, levels, is_default)
+        VALUES (%s, 'product', 'local', %s, FALSE)
+        """,
+        (h, ["family", "product"]),
+    )
+    fam, prd1, prd2 = f"FAM-{tag}", f"PRD-{tag}1", f"PRD-{tag}2"
+    for code, level, parent in [
+        (fam, "family", None),
+        (prd1, "product", fam),
+        (prd2, "product", fam),
+    ]:
+        conn.execute(
+            "INSERT INTO hierarchy_node (hierarchy_id, code, level, parent_code) "
+            "VALUES (%s, %s, %s, %s)",
+            (h, code, level, parent),
+        )
+
+    items: dict[str, UUID] = {}
+    for suffix, leaf_code in [("A1", prd1), ("A2", prd1), ("A3", prd2)]:
+        item_id = uuid4()
+        ext = f"DEM1-{tag}-{suffix}"
+        conn.execute(
+            "INSERT INTO items (item_id, name, item_type, uom, status, external_id) "
+            "VALUES (%s, %s, 'finished_good', 'EA', 'active', %s)",
+            (item_id, f"{ext} item", ext),
+        )
+        conn.execute(
+            "INSERT INTO item_hierarchy (item_id, hierarchy_id, leaf_code) "
+            "VALUES (%s, %s, %s)",
+            (item_id, h, leaf_code),
+        )
+        items[suffix] = item_id
+        for back in HISTORY_DAYS:
+            day = TODAY - timedelta(days=back)
+            qty = AMPLITUDES[suffix] * WEEK_PATTERN[day.weekday()]
+            conn.execute(
+                """
+                INSERT INTO demand_history (
+                    item_id, item_code, stream, booked_date,
+                    ordered_quantity, value_ext, counts_for_asp,
+                    fulfillment, order_number
+                ) VALUES (%s, %s, 'regular', %s, %s, 0, FALSE, 'standard', 'DEM1')
+                """,
+                (item_id, ext, day, qty),
+            )
+
+    loc_id = uuid4()
+    conn.execute(
+        "INSERT INTO locations (location_id, name, location_type, country, external_id) "
+        "VALUES (%s, %s, 'dc', 'US', %s)",
+        (loc_id, f"DEM1-{tag} DC", f"DEM1-{tag}-DC"),
+    )
+    return fam, prd1, prd2, items, loc_id
+
+
+def _cleanup_block(conn, h: str, items: dict[str, UUID], loc_id: UUID) -> None:
+    """FK-safe teardown of a seeded block (mirrors
+    test_pyramide_b1_integration.py:_cleanup_block)."""
+    item_ids = list(items.values())
+    conn.execute(
+        "DELETE FROM pyramide_snapshots WHERE forecast_id IN "
+        "(SELECT forecast_id FROM forecasts WHERE hierarchy_id = %s "
+        " OR item_id = ANY(%s))",
+        (h, item_ids),
+    )
+    conn.execute(
+        "DELETE FROM pyramide_runs WHERE forecast_id IN "
+        "(SELECT forecast_id FROM forecasts WHERE hierarchy_id = %s "
+        " OR item_id = ANY(%s))",
+        (h, item_ids),
+    )
+    conn.execute(
+        "DELETE FROM forecasts WHERE hierarchy_id = %s OR item_id = ANY(%s)",
+        (h, item_ids),
+    )
+    conn.execute(
+        "DELETE FROM nodes WHERE node_type = 'ForecastDemand' AND location_id = %s",
+        (loc_id,),
+    )
+    conn.execute("DELETE FROM demand_history WHERE item_id = ANY(%s)", (item_ids,))
+    conn.execute("DELETE FROM item_hierarchy WHERE hierarchy_id = %s", (h,))
+    conn.execute("DELETE FROM items WHERE item_id = ANY(%s)", (item_ids,))
+    conn.execute("DELETE FROM locations WHERE location_id = %s", (loc_id,))
+    conn.execute("DELETE FROM hierarchy_node WHERE hierarchy_id = %s", (h,))
+    conn.execute("DELETE FROM hierarchy WHERE hierarchy_id = %s", (h,))
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app / client wiring (mirrors test_pyramide_b1_integration.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app(migrated_db):
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = "integration-test-token"
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+
+    application = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    application.dependency_overrides[get_db] = override_db
+    yield application
+    application.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client(app):
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def auth():
+    return {"Authorization": "Bearer integration-test-token"}
+
+
+def _post_run(client, auth, code: str, **body):
+    payload = {"item_id": code, "location_id": f"DC-{code}", "horizon_days": 7}
+    payload.update(body)
+    return client.post("/v1/forecast/runs", json=payload, headers=auth)
+
+
+# ---------------------------------------------------------------------------
+# 1. Hierarchical auto_route stamps routing on EVERY series
+# ---------------------------------------------------------------------------
+
+
+def test_hierarchical_auto_route_stamps_routing_on_every_series(
+    migrated_db, client, auth
+):
+    """POST /hierarchical-runs auto_route=True -> the router builds a decision
+    for every series of the block and the runner persists it per series, so
+    reading each series' run back through GET /runs/{run_id} yields non-NULL
+    routed_method / routed_level / routing_reason on 100 % of them (the 3
+    aggregate nodes AND the 3 leaves)."""
+    h = "dem1-h-rw-all"
+    with _db_conn(migrated_db) as conn:
+        fam, prd1, prd2, items, loc_id = _seed_block(conn, h, "ALL")
+        try:
+            resp = client.post(
+                "/v1/forecast/hierarchical-runs",
+                json={
+                    "hierarchy_id": h,
+                    "block_code": fam,
+                    "leaf_location_id": "DEM1-ALL-DC",
+                    "horizon_days": 14,
+                    "lookback_days": 90,
+                    "auto_route": True,
+                },
+                headers=auth,
+            )
+            assert resp.status_code == 201, resp.text
+            series = resp.json()["series"]
+            # 3 aggregates (fam + prd1 + prd2) + 3 leaves = 6 series, all routed.
+            assert len(series) == 6
+            assert [s["kind"] for s in series].count("aggregate") == 3
+            assert [s["kind"] for s in series].count("leaf") == 3
+
+            for s in series:
+                run = client.get(
+                    f"/v1/forecast/runs/{s['run_id']}", headers=auth
+                )
+                assert run.status_code == 200, run.text
+                body = run.json()
+                assert body["routed_method"] is not None, (s["kind"], s["key"])
+                assert body["routed_level"] in {"leaf", "aggregate"}, body
+                assert body["routing_reason"], body
+        finally:
+            _cleanup_block(conn, h, items, loc_id)
+
+
+# ---------------------------------------------------------------------------
+# 2. Single-series AUTO_SELECT + auto_route -> routed method executes
+# ---------------------------------------------------------------------------
+
+
+def test_single_series_auto_select_executes_routed_method(
+    migrated_db, client, auth
+):
+    """method=AUTO_SELECT + auto_route=True on an intermittent series: the
+    router recommends CROSTON, that recommendation REPLACES the executed
+    method (pyramide_runs.method == routed_method), and the provenance is
+    traced (a concrete method, not AUTO_SELECT)."""
+    code = f"DEM1RW2-{uuid4().hex[:8].upper()}"
+    with _db_conn(migrated_db) as conn:
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            _seed_intermittent(conn, item_id, code, f"DC-{code}")
+            resp = _post_run(client, auth, code, auto_route=True)
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["routed_method"] == "CROSTON", body
+            assert body["routed_method"] != "AUTO_SELECT"
+            assert body["routed_level"] == "leaf", body
+            assert body["routing_reason"], body
+            # The routed recommendation became the executed method contract.
+            assert body["method"] == body["routed_method"]
+        finally:
+            _cleanup_item(conn, item_id, location_id)
+
+
+# ---------------------------------------------------------------------------
+# 3. Single-series explicit method -> not overwritten, recommendation recorded
+# ---------------------------------------------------------------------------
+
+
+def test_single_series_explicit_method_survives_but_records_routing(
+    migrated_db, client, auth
+):
+    """An EXPLICIT method + auto_route=True: the executed method is NOT
+    overwritten (a caller who asked for MA gets MA), yet the router's
+    recommendation is still recorded as routed provenance (present and != the
+    executed method)."""
+    code = f"DEM1RW3-{uuid4().hex[:8].upper()}"
+    with _db_conn(migrated_db) as conn:
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            _seed_intermittent(conn, item_id, code, f"DC-{code}")
+            resp = _post_run(
+                client, auth, code,
+                auto_route=True, method="MA", method_params={"window": 3},
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            # Explicit method survives untouched.
+            assert body["method"] == "MA", body
+            # The recommendation is still recorded, and it is a different
+            # method (the router would have picked CROSTON for this series).
+            assert body["routed_method"] == "CROSTON", body
+            assert body["routed_method"] != body["method"]
+            assert body["routed_level"] == "leaf", body
+            assert body["routing_reason"], body
+        finally:
+            _cleanup_item(conn, item_id, location_id)
+
+
+# ---------------------------------------------------------------------------
+# 4. auto_route=False (default) -> routed_* NULL (byte-identical kill switch)
+# ---------------------------------------------------------------------------
+
+
+def test_auto_route_off_leaves_routing_columns_null(migrated_db, client, auth):
+    """The opt-in defaults False: without auto_route the run is byte-identical
+    to the historical behaviour — routed_method / routed_level /
+    routing_reason all stay NULL."""
+    code = f"DEM1RW4-{uuid4().hex[:8].upper()}"
+    with _db_conn(migrated_db) as conn:
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            _seed_intermittent(conn, item_id, code, f"DC-{code}")
+            # auto_route omitted entirely (default False).
+            resp = _post_run(client, auth, code)
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["routed_method"] is None, body
+            assert body["routed_level"] is None, body
+            assert body["routing_reason"] is None, body
+        finally:
+            _cleanup_item(conn, item_id, location_id)
+
+
+# ---------------------------------------------------------------------------
+# 5. Cold-start -> conservative route, no crash
+# ---------------------------------------------------------------------------
+
+
+def test_cold_start_routes_conservatively_without_crashing(
+    migrated_db, client, auth
+):
+    """An item with only 3 demand points routes to the conservative cold-start
+    branch (FM_CHRONOS at leaf). auto_route=True on an AUTO_SELECT request
+    therefore hands execution to FM_CHRONOS — which, with the optional FM
+    backend absent and no strict_backend, falls back to a deterministic
+    AUTO_SELECT: the run COMPLETES (201) and carries the cold-start
+    provenance, it never crashes."""
+    code = f"DEM1RW5-{uuid4().hex[:8].upper()}"
+    with _db_conn(migrated_db) as conn:
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            _seed_cold_start(conn, item_id, code, f"DC-{code}")
+            resp = _post_run(client, auth, code, auto_route=True)
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["routed_method"] == "FM_CHRONOS", body
+            assert body["routed_level"] == "leaf", body
+            assert "cold-start" in body["routing_reason"].lower(), body
+            # The FM recommendation is the executed method contract; internally
+            # it fell back to AUTO_SELECT, but that never surfaces as an error.
+            assert body["method"] == "FM_CHRONOS"
+        finally:
+            _cleanup_item(conn, item_id, location_id)
+
+
+# ---------------------------------------------------------------------------
+# 6. A routed method actually runs: the frozen values carry it
+# ---------------------------------------------------------------------------
+
+
+def test_routed_method_is_carried_in_result_values(migrated_db, client, auth):
+    """A series routed to CROSTON (concrete, executable) runs WITH it: the
+    frozen forecast values read back through GET /runs/{run_id}/result all
+    carry method == the routed method — proof the routed recommendation drove
+    execution, not just provenance."""
+    code = f"DEM1RW6-{uuid4().hex[:8].upper()}"
+    with _db_conn(migrated_db) as conn:
+        item_id = _create_item(conn, code)
+        location_id = _create_location(conn, f"DC-{code}")
+        try:
+            _seed_intermittent(conn, item_id, code, f"DC-{code}")
+            resp = _post_run(client, auth, code, auto_route=True)
+            assert resp.status_code == 201, resp.text
+            run_id = resp.json()["run_id"]
+            assert resp.json()["routed_method"] == "CROSTON"
+
+            result = client.get(
+                f"/v1/forecast/runs/{run_id}/result", headers=auth
+            )
+            assert result.status_code == 200, result.text
+            payload = result.json()
+            assert payload["run"]["routed_method"] == "CROSTON"
+            assert payload["run"]["method"] == "CROSTON"
+            values = payload["values"]
+            assert values, "expected at least one frozen forecast value"
+            assert all(v["method"] == "CROSTON" for v in values), values
+            # Sanity: demand forecasts are clamped >= 0.
+            for v in values:
+                assert Decimal(v["quantity"]) >= Decimal("0")
+        finally:
+            _cleanup_item(conn, item_id, location_id)

--- a/tests/test_pyramide_routing_wiring.py
+++ b/tests/test_pyramide_routing_wiring.py
@@ -1,0 +1,436 @@
+"""
+Unit tests for the DEM-1 head/tail routing WIRING (PR-1): the DB-side feature
+builders (build_series_features / build_routing_decisions) and the opt-in
+auto_route plumbing on both Pyramide endpoints.
+
+DB-free by construction: the feature builders are exercised against a tiny fake
+connection that serves canned rows, build_routing_decisions against a
+hand-built summing block, and the endpoints against the no-DB TestClient with
+every repository/runner seam monkeypatched. The routing MATH itself lives in
+tests/test_pyramide_routing.py (routing.py is pure); here we only assert the
+wiring: features arithmetic, series->decision mapping, method-override policy,
+and that provenance reaches persist. Integration (routed_* non-NULL on the
+seeded dataset) is the test-writer's job.
+"""
+from __future__ import annotations
+
+import os
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+os.environ["OOTILS_API_TOKEN"] = "test-token"
+
+from ootils_core.api.app import create_app
+from ootils_core.api.dependencies import get_db
+from ootils_core.api.routers import pyramide as pyramide_router
+from ootils_core.pyramide import repository as repo
+from ootils_core.pyramide.hierarchy import summing as summing_mod
+from ootils_core.pyramide.hierarchy.summing import (
+    AGGREGATE,
+    LEAF,
+    SeriesRef,
+    SummingBlock,
+)
+from ootils_core.pyramide.routing import RoutingDecision, SeriesFeatures
+
+D = Decimal
+AUTH = {"Authorization": "Bearer test-token"}
+
+
+# ---------------------------------------------------------------------------
+# Fake connection for the feature builders
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def fetchall(self):
+        return list(self._rows)
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+
+class _FeatureConn:
+    """Routes execute() to canned rows by inspecting the SQL: demand_history
+    daily series vs item_asp annual value. Records every SQL seen so the
+    site-filter presence can be asserted."""
+
+    def __init__(self, *, daily=(), annual=None):
+        self._daily = list(daily)
+        self._annual = annual
+        self.sql_seen: list[str] = []
+
+    def execute(self, sql, params=None):
+        self.sql_seen.append(sql)
+        if "FROM item_asp" in sql:
+            return _FakeCursor([self._annual] if self._annual is not None else [])
+        if "FROM demand_history" in sql:
+            return _FakeCursor(self._daily)
+        raise AssertionError(f"unexpected query: {sql[:80]}")
+
+
+# ---------------------------------------------------------------------------
+# build_series_features
+# ---------------------------------------------------------------------------
+
+
+def test_build_series_features_zero_ratio_and_span():
+    # 4 booking days over a 10-day span (Jan1..Jan10) -> zero_ratio 6/10.
+    daily = [
+        {"demand_date": date(2025, 1, 1), "total_qty": 5},
+        {"demand_date": date(2025, 1, 3), "total_qty": 2},
+        {"demand_date": date(2025, 1, 7), "total_qty": 1},
+        {"demand_date": date(2025, 1, 10), "total_qty": 4},
+    ]
+    conn = _FeatureConn(daily=daily, annual={"annual_value": D("150000")})
+    feats = repo.build_series_features(conn, uuid4(), None)
+
+    assert feats.history_depth_days == 10
+    assert feats.zero_ratio == D(6) / D(10)
+    assert feats.annual_value == D("150000")
+    assert feats.lifecycle is None
+    assert feats.has_twin is False
+    assert feats.aggregate_signal_ok is False
+
+
+def test_build_series_features_annual_value_fallback_none():
+    daily = [{"demand_date": date(2025, 1, 1), "total_qty": 3}]
+    # No item_asp row at all -> None (documented fallback), never a masked 0.
+    conn_no_row = _FeatureConn(daily=daily, annual=None)
+    assert repo.build_series_features(conn_no_row, uuid4(), None).annual_value is None
+    # Row exists but value_12m NULL -> still None (SUM over NULLs is NULL).
+    conn_null = _FeatureConn(daily=daily, annual={"annual_value": None})
+    assert repo.build_series_features(conn_null, uuid4(), None).annual_value is None
+
+
+def test_build_series_features_empty_history_is_cold_start_shaped():
+    conn = _FeatureConn(daily=[], annual={"annual_value": D("9999")})
+    feats = repo.build_series_features(conn, uuid4(), None)
+
+    assert feats.history_depth_days == 0
+    assert feats.zero_ratio == D(0)
+    assert feats.seasonal_strength is None
+    assert feats.annual_value == D("9999")
+
+
+def test_build_series_features_site_filter_only_with_location():
+    conn_sited = _FeatureConn(daily=[], annual=None)
+    repo.build_series_features(conn_sited, uuid4(), uuid4())
+    dh_sql = next(s for s in conn_sited.sql_seen if "FROM demand_history" in s)
+    # _warehouse_codes_subquery() is embedded (alias-aware) only when a site
+    # filter intervenes.
+    assert "location_aliases" in dh_sql
+
+    conn_all_sites = _FeatureConn(daily=[], annual=None)
+    repo.build_series_features(conn_all_sites, uuid4(), None)
+    dh_sql_all = next(s for s in conn_all_sites.sql_seen if "FROM demand_history" in s)
+    assert "location_aliases" not in dh_sql_all
+
+
+def test_build_series_features_aggregate_signal_ok_passthrough():
+    conn = _FeatureConn(daily=[], annual=None)
+    feats = repo.build_series_features(conn, uuid4(), None, aggregate_signal_ok=True)
+    assert feats.aggregate_signal_ok is True
+
+
+# ---------------------------------------------------------------------------
+# build_routing_decisions
+# ---------------------------------------------------------------------------
+
+
+def _one_block(item_key: str) -> SummingBlock:
+    return SummingBlock(
+        hierarchy_id="H",
+        block_code="ROOT",
+        block_level="family",
+        series=(
+            SeriesRef(kind=AGGREGATE, key="ROOT", level="family"),
+            SeriesRef(kind=LEAF, key=item_key, leaf_code="ROOT"),
+        ),
+        leaves=(item_key,),
+        rows=((0,), (0,)),
+    )
+
+
+def test_build_routing_decisions_maps_every_series(monkeypatch):
+    item_key = str(uuid4())
+    monkeypatch.setattr(
+        summing_mod, "load_summing_blocks", lambda db, **k: [_one_block(item_key)]
+    )
+
+    node_feats = SeriesFeatures(
+        history_depth_days=800,
+        zero_ratio=D("0.1"),
+        abc_class="A",
+        seasonal_strength=D("0.4"),
+    )
+    leaf_call: dict[str, object] = {}
+
+    def fake_node(db, hid, code, *, aggregate_signal_ok=False):
+        return node_feats
+
+    def fake_leaf(db, iid, loc, *, aggregate_signal_ok=False):
+        leaf_call["aggregate_signal_ok"] = aggregate_signal_ok
+        leaf_call["location_id"] = loc
+        return SeriesFeatures(
+            history_depth_days=30,
+            zero_ratio=D("0.1"),
+            abc_class="C",
+            aggregate_signal_ok=aggregate_signal_ok,
+        )
+
+    monkeypatch.setattr(repo, "_build_node_features", fake_node)
+    monkeypatch.setattr(repo, "build_series_features", fake_leaf)
+
+    decisions = repo.build_routing_decisions(
+        _FeatureConn(), hierarchy_id="H", block_code="ROOT"
+    )
+
+    assert set(decisions) == {"ROOT", item_key}
+    for decision in decisions.values():
+        assert isinstance(decision, RoutingDecision)
+        assert decision.method
+        assert decision.reason  # non-empty auditable sentence
+    # Leaves route site-agnostic (location None) with a signal-bearing parent.
+    assert leaf_call["aggregate_signal_ok"] is True
+    assert leaf_call["location_id"] is None
+
+
+def test_build_routing_decisions_block_not_found_raises(monkeypatch):
+    monkeypatch.setattr(summing_mod, "load_summing_blocks", lambda db, **k: [])
+    with pytest.raises(ValueError):
+        repo.build_routing_decisions(
+            _FeatureConn(), hierarchy_id="H", block_code="MISSING"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Endpoint wiring — shared harness
+# ---------------------------------------------------------------------------
+
+
+def _client() -> TestClient:
+    app = create_app()
+
+    def _override_db():
+        yield object()
+
+    app.dependency_overrides[get_db] = _override_db
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _fake_summary(**over) -> SimpleNamespace:
+    base = dict(
+        run_id=uuid4(),
+        snapshot_id=uuid4(),
+        forecast_id=uuid4(),
+        status="generated",
+        item_id=uuid4(),
+        location_id=uuid4(),
+        hierarchy_id=None,
+        level=None,
+        node_code=None,
+        scenario_id=uuid4(),
+        horizon_start=date(2025, 1, 1),
+        horizon_end=date(2025, 3, 31),
+        granularity="daily",
+        method="AUTO_SELECT",
+        model_strategy="stat",
+        recon_method="none",
+        random_seed=0,
+        code_version="local",
+        selected_model="ETS",
+        engine_backend="internal",
+        source_history_count=10,
+        value_count=3,
+        total_quantity=D("30"),
+        deterministic_artifact="forecast_values",
+        created_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        committed_at=None,
+        stale_demand=False,
+        routed_method=None,
+        routed_level=None,
+        routing_reason=None,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+_HEAD_FEATS = SeriesFeatures(
+    history_depth_days=800,
+    zero_ratio=D("0.05"),
+    abc_class="A",
+    seasonal_strength=D("0.4"),
+)  # routes to SEASONAL, leaf
+
+
+def _wire_single_series(monkeypatch) -> dict:
+    """Stub every seam of create_pyramide_run; return capture dict."""
+    captured: dict[str, object] = {"features_called": 0}
+
+    class _FakeRunner:
+        def run(self, config, history):
+            captured["config"] = config
+            return SimpleNamespace()
+
+    def fake_features(db, item_id, location_id, *, aggregate_signal_ok=False):
+        captured["features_called"] = int(captured["features_called"]) + 1
+        return _HEAD_FEATS
+
+    def fake_persist(db, result, *, stale_demand=False, routing=None, history=None):
+        captured["routing"] = routing
+        return SimpleNamespace(
+            run_id=uuid4(), snapshot_id=uuid4(), forecast_id=uuid4()
+        )
+
+    monkeypatch.setattr(pyramide_router, "resolve_item_uuid", lambda db, x: uuid4())
+    monkeypatch.setattr(pyramide_router, "resolve_location_uuid", lambda db, x: uuid4())
+    monkeypatch.setattr(
+        pyramide_router,
+        "get_historical_demand",
+        lambda *, db, item_id, location_id, lookback_days, scenario_id: [D("1")],
+    )
+    monkeypatch.setattr(pyramide_router, "build_series_features", fake_features)
+    monkeypatch.setattr(
+        pyramide_router,
+        "get_demand_freshness",
+        lambda db, item_id: SimpleNamespace(ingest_age_days=1),
+    )
+    monkeypatch.setattr(pyramide_router, "persist_run", fake_persist)
+    monkeypatch.setattr(
+        pyramide_router, "fetch_run_summary", lambda db, run_id: _fake_summary()
+    )
+    monkeypatch.setattr(pyramide_router, "PyramideRunner", _FakeRunner)
+    return captured
+
+
+def _post_run(client: TestClient, **body) -> "TestClient.__class__":
+    payload = {"item_id": "ITEM-1", "location_id": "LOC-1"}
+    payload.update(body)
+    return client.post("/v1/forecast/runs", json=payload, headers=AUTH)
+
+
+# ---------------------------------------------------------------------------
+# Single-series endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_single_series_auto_route_off_is_byte_identical(monkeypatch):
+    captured = _wire_single_series(monkeypatch)
+    resp = _post_run(_client())  # auto_route defaults False
+
+    assert resp.status_code == status.HTTP_201_CREATED
+    assert captured["features_called"] == 0  # router never computes features
+    assert captured["routing"] is None  # nothing handed to persist_run
+    assert captured["config"].method == "AUTO_SELECT"  # method untouched
+
+
+def test_single_series_auto_route_passes_routing_to_persist(monkeypatch):
+    captured = _wire_single_series(monkeypatch)
+    resp = _post_run(_client(), auto_route=True)
+
+    assert resp.status_code == status.HTTP_201_CREATED
+    assert captured["features_called"] == 1
+    routing = captured["routing"]
+    assert isinstance(routing, RoutingDecision)
+    assert routing.level == "leaf"  # single-series is always leaf
+    assert routing.reason
+
+
+def test_single_series_auto_route_overrides_only_auto_select(monkeypatch):
+    captured = _wire_single_series(monkeypatch)
+    resp = _post_run(_client(), auto_route=True)  # method defaults AUTO_SELECT
+
+    assert resp.status_code == status.HTTP_201_CREATED
+    routing = captured["routing"]
+    # An unopinionated AUTO_SELECT request runs the routed method.
+    assert captured["config"].method == routing.method
+    assert routing.method != "AUTO_SELECT"
+
+
+def test_single_series_auto_route_never_overwrites_explicit_method(monkeypatch):
+    captured = _wire_single_series(monkeypatch)
+    resp = _post_run(_client(), auto_route=True, method="ENSEMBLE_STAT")
+
+    assert resp.status_code == status.HTTP_201_CREATED
+    # Explicit method survives; the routed recommendation is still recorded.
+    assert captured["config"].method == "ENSEMBLE_STAT"
+    assert isinstance(captured["routing"], RoutingDecision)
+    assert captured["routing"].method != "ENSEMBLE_STAT"
+
+
+# ---------------------------------------------------------------------------
+# Hierarchical endpoint
+# ---------------------------------------------------------------------------
+
+
+def _wire_hierarchical(monkeypatch, canned) -> dict:
+    captured: dict[str, object] = {"build_calls": 0}
+
+    class _FakeHRunner:
+        def run(self, db, config):
+            captured["config"] = config
+            return SimpleNamespace(
+                hierarchy_id=config.hierarchy_id,
+                block_code=config.block_code,
+                block_level="family",
+                recon_level="family",
+                recon_method="middleout",
+                horizon_start=config.horizon_start,
+                horizon_end=config.horizon_end,
+                granularity=config.granularity,
+                method=config.method,
+                persisted=(),
+                warnings=(),
+            )
+
+    def fake_build(db, *, hierarchy_id, block_code, block_level=None, thresholds=None):
+        captured["build_calls"] = int(captured["build_calls"]) + 1
+        return canned
+
+    monkeypatch.setattr(pyramide_router, "resolve_location_uuid", lambda db, x: uuid4())
+    monkeypatch.setattr(pyramide_router, "build_routing_decisions", fake_build)
+    monkeypatch.setattr(pyramide_router, "HierarchicalRunner", _FakeHRunner)
+    return captured
+
+
+def _post_hier(client: TestClient, **body) -> "TestClient.__class__":
+    payload = {
+        "hierarchy_id": "H",
+        "block_code": "ROOT",
+        "leaf_location_id": "LOC-1",
+    }
+    payload.update(body)
+    return client.post("/v1/forecast/hierarchical-runs", json=payload, headers=AUTH)
+
+
+def test_hierarchical_auto_route_off_injects_empty_decisions(monkeypatch):
+    captured = _wire_hierarchical(monkeypatch, canned={"IGNORED": None})
+    resp = _post_hier(_client())  # auto_route defaults False
+
+    assert resp.status_code == status.HTTP_201_CREATED
+    assert captured["build_calls"] == 0
+    assert dict(captured["config"].routing_decisions) == {}
+
+
+def test_hierarchical_auto_route_injects_built_decisions(monkeypatch):
+    canned = {
+        "ROOT": RoutingDecision(
+            method="SEASONAL", level="aggregate", reason="node head"
+        )
+    }
+    captured = _wire_hierarchical(monkeypatch, canned=canned)
+    resp = _post_hier(_client(), auto_route=True)
+
+    assert resp.status_code == status.HTTP_201_CREATED
+    assert captured["build_calls"] == 1
+    assert dict(captured["config"].routing_decisions) == canned


### PR DESCRIPTION
Le routeur de 577 lignes jamais appelé en production devient vivant — en opt-in strict (auto_route=False = byte-identique, prouvé). Features par agrégats SQL alias-aware, clés du contrat runner matchées par construction, AUTO_SELECT routé / choix explicite jamais écrasé (sémantique 058 : recommandé ≠ exécuté), ZÉRO migration (la 058 attendait ce câblage). 13 unit + 6 intégration aux routages déterministes par construction (re-dérivés en revue). Revue adversariale GO. 2 🎯 consignés (calibration zero_ratio daily, cohérence fenêtre routage/forecast). PR-2 ensuite : watcher FORECAST_DRIFT + migration 072. Réf DEM-1, #433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)