### PR TITLE
ci(rust): PERF-1 PR-B -- cargo fmt/clippy/test + proto-drift + batterie engine_service en CI

### DIFF
--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -1,29 +1,196 @@
 name: Rust kernel build
 
-# Validates the Rust extension builds cleanly on Linux + Windows and the
-# Python smoke tests pass against the freshly-compiled wheel. Gates the
-# ADR-016 week-1 "foundation" go/no-go.
+# Validates the Rust workspace (ootils_kernel + ootils_engine + ootils_proto):
+# formatting, clippy, `cargo test`, the maturin wheel build (multi-OS smoke),
+# gRPC stub drift, and — informatively — the engine-service integration
+# battery against a live Postgres.
 #
 # Triggered on any PR that touches:
-# - rust/ootils_kernel/** (the crate)
+# - rust/** (all 3 workspace crates)
+# - tests/engine_service/** (the gRPC engine-service battery)
 # - tests/test_rust_kernel_smoke.py
+# - src/ootils_core/_grpc/** (generated gRPC stubs — drift-checked, not hand-edited)
+# - scripts/regenerate_grpc_stubs.py
 # - this workflow file
+#
+# Deliberately NOT path-filtered on plain Python changes elsewhere in
+# src/ootils_core — those are covered by ci.yml.
 
 on:
   push:
     branches: [main]
     paths:
-      - "rust/ootils_kernel/**"
+      - "rust/**"
+      - "tests/engine_service/**"
       - "tests/test_rust_kernel_smoke.py"
+      - "src/ootils_core/_grpc/**"
+      - "scripts/regenerate_grpc_stubs.py"
       - ".github/workflows/rust-build.yml"
   pull_request:
     paths:
-      - "rust/ootils_kernel/**"
+      - "rust/**"
+      - "tests/engine_service/**"
       - "tests/test_rust_kernel_smoke.py"
+      - "src/ootils_core/_grpc/**"
+      - "scripts/regenerate_grpc_stubs.py"
       - ".github/workflows/rust-build.yml"
   workflow_dispatch:  # manual trigger for ad-hoc runs
 
 jobs:
+  cargo-checks:
+    name: cargo fmt / clippy / test
+    runs-on: ubuntu-latest
+    # Blocking by convention (not yet added to branch-protection required
+    # checks — see the RUNBOOK note on promotion after 2 green runs).
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain (rustfmt + clippy)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust -> target
+
+      - name: cargo fmt --check
+        working-directory: rust
+        run: cargo fmt --check
+
+      - name: cargo clippy (deny warnings)
+        working-directory: rust
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: cargo test --workspace
+        working-directory: rust
+        # 29 #[cfg(test)] across ootils_kernel/ootils_engine — WAL replay,
+        # write-behind dedupe, kernel bucket math. Pure Rust, no Postgres.
+        run: cargo test --workspace
+
+  proto-drift:
+    name: gRPC stub drift
+    runs-on: ubuntu-latest
+    # Regenerates the Python gRPC bindings from rust/ootils_proto/proto/
+    # engine.proto and fails if the committed stubs under
+    # src/ootils_core/_grpc/ don't match byte-for-byte. protoc itself is
+    # vendored by grpcio-tools (no separate apt-get protoc install needed
+    # — same as the Rust side, which vendors protoc via
+    # protoc-bin-vendored in ootils_proto's build.rs).
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install grpcio-tools
+        # Pinned to the same train as the runtime `grpcio ~= 1.71` pin in
+        # pyproject.toml — keeps the codegen output format stable across
+        # runs instead of drifting with an unrelated grpcio-tools bump.
+        run: |
+          pip install --upgrade pip
+          pip install "grpcio-tools ~= 1.71"
+
+      - name: Regenerate gRPC stubs
+        run: python scripts/regenerate_grpc_stubs.py
+
+      - name: Fail if regenerated stubs differ from committed ones
+        run: git diff --exit-code src/ootils_core/_grpc
+
+  engine-service-it:
+    name: engine-service integration battery
+    runs-on: ubuntu-latest
+    # Informative for now (F-* engine-service battery never ran in CI
+    # before this PR — tests/engine_service/conftest.py:41-59 silently
+    # skipped for lack of a built binary). Promote to a required check
+    # after 2 consecutive green runs — see the RUNBOOK note.
+    continue-on-error: true
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: ootils
+          POSTGRES_PASSWORD: ootils
+          POSTGRES_DB: ootils_test_engine_service
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U ootils -d ootils_test_engine_service"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://ootils:ootils@localhost:5432/ootils_test_engine_service
+      OOTILS_DSN: postgresql://ootils:ootils@localhost:5432/ootils_test_engine_service
+      OOTILS_API_TOKEN: ci-token
+      OOTILS_ENABLE_STARTUP_RECOVERY: "0"
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust -> target
+
+      - name: Build the ootils-engine binary (release)
+        # conftest.py's `engine_binary` fixture looks for
+        # rust/target/release/ootils-engine(.exe) — the workspace target
+        # dir, matching Dockerfile.engine's build.
+        working-directory: rust
+        run: cargo build --release -p ootils_engine
+
+      - name: Install maturin + project (dev extras)
+        run: |
+          pip install --upgrade pip maturin
+          pip install -e ".[dev]"
+
+      - name: Build the ootils_kernel wheel
+        # Built fresh in this job rather than reusing the wheel job's
+        # artifact (that job stays untouched, multi-OS, no upload step).
+        working-directory: rust/ootils_kernel
+        run: maturin build --release --out dist
+
+      - name: Install the built kernel wheel
+        shell: bash
+        run: pip install --force-reinstall rust/ootils_kernel/dist/*.whl
+
+      - name: Apply migrations
+        run: python -c "from ootils_core.db.connection import OotilsDB; OotilsDB()"
+
+      - name: Seed demo data
+        # tests/engine_service relies on the seeded baseline (e.g.
+        # conftest.py's pick_pi_node fixture queries seeded PI nodes;
+        # test_correctness.py's propagate smoke test expects the
+        # seeded 90-bucket series). Without this, tests silently
+        # pytest.skip instead of exercising the engine.
+        run: python scripts/seed_demo_data.py
+
+      - name: Run engine-service integration battery
+        run: python -m pytest tests/engine_service -q
+
+      - name: MRP Rust-vs-SQL parity guard (conditional — PR-C sibling)
+        # test_rust_parity_integration.py lands in a sibling PR; guarding
+        # on file presence makes merge order between the two PRs
+        # irrelevant instead of one blocking the other.
+        run: |
+          if [ -f tests/integration/test_rust_parity_integration.py ]; then
+            python -m pytest tests/integration/test_rust_parity_integration.py -q
+          fi
+
   build-and-test:
     name: ${{ matrix.os }} / Python ${{ matrix.python }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -65,8 +65,9 @@ jobs:
 
       - name: cargo test --workspace
         working-directory: rust
-        # 29 #[cfg(test)] across ootils_kernel/ootils_engine — WAL replay,
-        # write-behind dedupe, kernel bucket math. Pure Rust, no Postgres.
+        # 26 #[test] functions (19 ootils_engine + 7 ootils_kernel) — WAL
+        # replay, write-behind dedupe, kernel bucket math. Pure Rust, no
+        # Postgres.
         run: cargo test --workspace
 
   proto-drift:
@@ -87,12 +88,19 @@ jobs:
           python-version: "3.11"
 
       - name: Install grpcio-tools
-        # Pinned to the same train as the runtime `grpcio ~= 1.71` pin in
-        # pyproject.toml — keeps the codegen output format stable across
-        # runs instead of drifting with an unrelated grpcio-tools bump.
+        # EXACT pins, deliberately stricter than the runtime `grpcio ~= 1.71`
+        # in pyproject.toml: byte-for-byte drift checking only works if the
+        # generator matches the one that produced the committed stubs.
+        # 1.80.0 = the GRPC_GENERATED_VERSION stamped in engine_pb2_grpc.py;
+        # 6.31.1 = the "Protobuf Python Version" stamped in engine_pb2.py.
+        # A compatible-release pin here would let an unrelated grpcio-tools
+        # release change the output format and turn this gate red on a
+        # perfectly good PR. Doctrine: to bump the codegen version, regenerate
+        # the stubs AND bump these pins in the SAME commit (the runtime pin in
+        # pyproject.toml is a separate concern — leave it alone).
         run: |
           pip install --upgrade pip
-          pip install "grpcio-tools ~= 1.71"
+          pip install "grpcio-tools==1.80.0" "protobuf==6.31.1"
 
       - name: Regenerate gRPC stubs
         run: python scripts/regenerate_grpc_stubs.py

--- a/docs/RUNBOOK-rust-engine-service.md
+++ b/docs/RUNBOOK-rust-engine-service.md
@@ -274,3 +274,27 @@ at the cost of more frequent Postgres writes.
 - **Per-scenario propagation** not yet exposed. Propagate always
   targets the baseline. Fork-then-propagate-on-fork is a phase-9
   task.
+
+## CI (PERF-1 PR-B, rust-build.yml)
+
+The `tests/engine_service/` battery (15 files — health/metrics/GetNode,
+propagate correctness, concurrency, backpressure, PG failure/outage
+durability, recovery, per-scenario propagation, performance regression)
+now runs in CI via the `engine-service-it` job in
+`.github/workflows/rust-build.yml`: it builds `ootils-engine` in release
+mode, starts a Postgres 16 service container, applies migrations, seeds
+the demo dataset, and runs the battery against the real binary + a real
+DB. The same workflow also gates `cargo fmt --check` / `cargo clippy
+--workspace --all-targets -D warnings` / `cargo test --workspace`
+(`cargo-checks`) and gRPC stub drift (`proto-drift` — regenerates
+`src/ootils_core/_grpc/` from `engine.proto` and fails on any diff).
+
+`engine-service-it` starts **informative** (`continue-on-error: true`):
+the battery never ran in CI before this PR (it silently skipped for
+lack of a built binary — `tests/engine_service/conftest.py`'s
+`engine_binary` fixture calls `pytest.skip` when the release binary
+isn't found), so its baseline flakiness under GitHub Actions runners is
+still unproven. **Promote it to a required check after 2 consecutive
+green runs** (drop `continue-on-error`, then add it to branch
+protection — `cargo-checks` and `proto-drift` are blocking by
+convention from day one, not gated behind this same probation).

--- a/rust/ootils_engine/src/kernel.rs
+++ b/rust/ootils_engine/src/kernel.rs
@@ -44,11 +44,7 @@ pub struct DemandContrib<'a> {
 /// Sum supplies whose `time_ref` falls in `[bucket_start, bucket_end)`.
 /// Mirrors the `point_in_bucket` contribution rule.
 #[inline]
-pub fn sum_inflows<'a, I>(
-    supplies: I,
-    bucket_start: NaiveDate,
-    bucket_end: NaiveDate,
-) -> Decimal
+pub fn sum_inflows<'a, I>(supplies: I, bucket_start: NaiveDate, bucket_end: NaiveDate) -> Decimal
 where
     I: IntoIterator<Item = SupplyContrib<'a>>,
 {
@@ -66,13 +62,10 @@ where
 ///    the day-overlap between the demand span and the bucket.
 ///  - Point demands (CustomerOrderDemand): full quantity if date in
 ///    bucket.
+///
 /// The CASE / numeric(50,28) cast preserves parity with Python kernel.
 #[inline]
-pub fn sum_outflows<'a, I>(
-    demands: I,
-    bucket_start: NaiveDate,
-    bucket_end: NaiveDate,
-) -> Decimal
+pub fn sum_outflows<'a, I>(demands: I, bucket_start: NaiveDate, bucket_end: NaiveDate) -> Decimal
 where
     I: IntoIterator<Item = DemandContrib<'a>>,
 {
@@ -94,8 +87,8 @@ where
                         // precision — divide-first here could drift
                         // > TOLERANCE (1e-18) under high-quantity /
                         // long-span demands.
-                        let frac = d.quantity * Decimal::from(overlap_days)
-                            / Decimal::from(span_days);
+                        let frac =
+                            d.quantity * Decimal::from(overlap_days) / Decimal::from(span_days);
                         total += frac;
                     }
                 }
@@ -130,7 +123,11 @@ where
     let outflows = sum_outflows(demands, bucket_start, bucket_end);
     let closing_stock = opening_stock + inflows - outflows;
     let has_shortage = closing_stock < Decimal::ZERO;
-    let shortage_qty = if has_shortage { -closing_stock } else { Decimal::ZERO };
+    let shortage_qty = if has_shortage {
+        -closing_stock
+    } else {
+        Decimal::ZERO
+    };
     PiResult {
         opening_stock,
         inflows,

--- a/rust/ootils_engine/src/loader.rs
+++ b/rust/ootils_engine/src/loader.rs
@@ -24,18 +24,26 @@ use uuid::Uuid;
 
 /// Hardcoded baseline scenario UUID — same constant the rest of the
 /// system uses. Phase 4 will replace this with per-scenario loaders.
-pub const BASELINE_SCENARIO_ID: Uuid =
-    Uuid::from_u128(0x00000000_0000_0000_0000_000000000001);
+pub const BASELINE_SCENARIO_ID: Uuid = Uuid::from_u128(0x00000000_0000_0000_0000_000000000001);
 
 pub struct LoadStats {
     pub n_nodes: usize,
+    // n_pi/n_supplies/n_demands/n_unknown are computed and logged at
+    // boot (see the `info!` call in `load_baseline`) from their own
+    // local variables; the struct fields below are the reusable form
+    // for a future caller (e.g. a `/metrics` gauge) that doesn't
+    // exist yet — no caller reads `LoadStats` past construction today.
+    #[allow(dead_code)]
     pub n_pi: usize,
+    #[allow(dead_code)]
     pub n_supplies: usize,
+    #[allow(dead_code)]
     pub n_demands: usize,
     /// F-025: nodes the engine doesn't model (e.g. Resource, Ghost,
     /// future types). They're loaded into the graph but ignored by
     /// the propagator. Surfaced here + as a Prometheus counter so a
     /// new node type doesn't silently miscompute totals.
+    #[allow(dead_code)]
     pub n_unknown: usize,
     pub n_edges: usize,
     pub elapsed_ms: u64,
@@ -48,10 +56,7 @@ pub struct LoadStats {
 /// loader bails if the baseline has 0 nodes or 0 PIs (wrong DSN
 /// pointing at an empty DB). Set to true for CI / test fixtures
 /// that intentionally start from an empty schema.
-pub async fn load_baseline(
-    dsn: &str,
-    allow_empty: bool,
-) -> anyhow::Result<(Graph, LoadStats)> {
+pub async fn load_baseline(dsn: &str, allow_empty: bool) -> anyhow::Result<(Graph, LoadStats)> {
     let t0 = Instant::now();
 
     let (client, connection) = tokio_postgres::connect(dsn, NoTls).await?;
@@ -69,8 +74,16 @@ pub async fn load_baseline(
         .iter()
         .filter(|n| n.node_type == NodeType::ProjectedInventory)
         .count();
-    let n_supplies = graph.nodes.iter().filter(|n| n.node_type.is_supply()).count();
-    let n_demands = graph.nodes.iter().filter(|n| n.node_type.is_demand()).count();
+    let n_supplies = graph
+        .nodes
+        .iter()
+        .filter(|n| n.node_type.is_supply())
+        .count();
+    let n_demands = graph
+        .nodes
+        .iter()
+        .filter(|n| n.node_type.is_demand())
+        .count();
     let n_unknown = graph
         .nodes
         .iter()
@@ -102,8 +115,7 @@ pub async fn load_baseline(
         if allow_empty {
             warn!(
                 n_nodes,
-                n_pi,
-                "baseline is empty but --allow-empty-baseline was set — booting anyway"
+                n_pi, "baseline is empty but --allow-empty-baseline was set — booting anyway"
             );
         } else {
             anyhow::bail!(
@@ -132,7 +144,10 @@ pub async fn load_baseline(
                  upgrade the engine doesn't know about yet."
             );
         } else {
-            info!(n_unknown, "loaded nodes with unknown node_type (ignored by propagator)");
+            info!(
+                n_unknown,
+                "loaded nodes with unknown node_type (ignored by propagator)"
+            );
         }
     }
 
@@ -306,10 +321,10 @@ async fn build_graph(client: &Client) -> anyhow::Result<Graph> {
         };
 
         let edge_type = EdgeType::from_db(edge_type_str);
-        edges_in
-            .entry(to_idx)
-            .or_default()
-            .push(EdgeRef { from: from_idx, edge_type });
+        edges_in.entry(to_idx).or_default().push(EdgeRef {
+            from: from_idx,
+            edge_type,
+        });
     }
     if n_skipped > 0 {
         warn!(

--- a/rust/ootils_engine/src/main.rs
+++ b/rust/ootils_engine/src/main.rs
@@ -143,20 +143,19 @@ async fn main() -> anyhow::Result<()> {
     // a 5-second baseline load. (The actual server is spawned later;
     // this is just early validation of the parsed addr.)
     let metrics_addr_str = cli.metrics_listen.trim().to_string();
-    let metrics_addr: Option<SocketAddr> = if metrics_addr_str.is_empty()
-        || metrics_addr_str.eq_ignore_ascii_case("off")
-    {
-        None
-    } else {
-        Some(metrics_addr_str.parse::<SocketAddr>().map_err(|e| {
-            anyhow::anyhow!(
-                "OOTILS_METRICS_LISTEN={:?} is not a valid host:port: {} \
+    let metrics_addr: Option<SocketAddr> =
+        if metrics_addr_str.is_empty() || metrics_addr_str.eq_ignore_ascii_case("off") {
+            None
+        } else {
+            Some(metrics_addr_str.parse::<SocketAddr>().map_err(|e| {
+                anyhow::anyhow!(
+                    "OOTILS_METRICS_LISTEN={:?} is not a valid host:port: {} \
                  (use \"off\" to disable the metrics server)",
-                metrics_addr_str,
-                e
-            )
-        })?)
-    };
+                    metrics_addr_str,
+                    e
+                )
+            })?)
+        };
 
     verify_postgres(&cli.dsn).await?;
 
@@ -260,8 +259,7 @@ async fn main() -> anyhow::Result<()> {
     // (F-007 fail-fast).
     let metrics_registry = Arc::new(metrics::Metrics::new());
     if let Some(addr) = metrics_addr {
-        let _metrics_handle =
-            metrics::spawn_metrics_server(metrics_registry.clone(), addr);
+        let _metrics_handle = metrics::spawn_metrics_server(metrics_registry.clone(), addr);
     } else {
         info!("metrics endpoint explicitly disabled");
     }
@@ -273,9 +271,10 @@ async fn main() -> anyhow::Result<()> {
     ));
     // Publish the configured caps as gauges so operators can see them
     // from /metrics (vs having to dig through engine logs).
-    metrics_registry
-        .queue_max_depth
-        .store(cli.queue_max_depth as i64, std::sync::atomic::Ordering::Relaxed);
+    metrics_registry.queue_max_depth.store(
+        cli.queue_max_depth as i64,
+        std::sync::atomic::Ordering::Relaxed,
+    );
     metrics_registry
         .wal_max_bytes
         .store(cli.wal_max_bytes, std::sync::atomic::Ordering::Relaxed);
@@ -287,11 +286,8 @@ async fn main() -> anyhow::Result<()> {
     // long-lived and worth aborting cleanly to avoid leaving a
     // half-flushed batch in tokio's runtime when main exits.
     let dsn_for_flusher = cli.dsn.clone();
-    let flusher_handle = write_behind::spawn_flusher(
-        queue.clone(),
-        dsn_for_flusher,
-        cli.flush_interval_ms,
-    );
+    let flusher_handle =
+        write_behind::spawn_flusher(queue.clone(), dsn_for_flusher, cli.flush_interval_ms);
 
     // If we recovered from WAL, also re-enqueue those deltas for
     // Postgres flush. Each delta carries the seq of the record it
@@ -324,11 +320,11 @@ async fn main() -> anyhow::Result<()> {
         let scan_interval_sec = (ttl / 4).max(30);
         info!(
             scenario_ttl_sec = ttl,
-            scan_interval_sec,
-            "scenario TTL eviction task spawned (P2.1.d)"
+            scan_interval_sec, "scenario TTL eviction task spawned (P2.1.d)"
         );
         Some(tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(std::time::Duration::from_secs(scan_interval_sec));
+            let mut ticker =
+                tokio::time::interval(std::time::Duration::from_secs(scan_interval_sec));
             // Skip first immediate fire — give the engine a moment to settle.
             ticker.tick().await;
             loop {
@@ -420,9 +416,7 @@ fn run_bench(graph_lock: &Arc<ArcSwap<state::Graph>>) {
     let mark_ms = t_mark.elapsed().as_millis();
     info!(
         n_dirty = dirty.len(),
-        clone_ms,
-        mark_ms,
-        "marked all active PIs dirty (post-CoW)"
+        clone_ms, mark_ms, "marked all active PIs dirty (post-CoW)"
     );
 
     let t_prop = Instant::now();
@@ -471,13 +465,6 @@ fn run_bench_fork(graph_lock: &Arc<ArcSwap<state::Graph>>, n: usize) {
     }
     let total_us: u64 = timings_us.iter().sum();
     let timings_ms: Vec<u64> = timings_us.iter().map(|&us| us / 1000).collect();
-    let total: u64 = timings_ms.iter().sum();
-    let avg = total as f64 / n as f64;
-    let mut sorted = timings_ms.clone();
-    sorted.sort_unstable();
-    let p50 = sorted[sorted.len() / 2];
-    let p95 = sorted[((sorted.len() as f64) * 0.95) as usize];
-    let max = *sorted.last().unwrap();
     // Also report µs versions because ms is too coarse with ArcSwap.
     let mut sorted_us = timings_us.clone();
     sorted_us.sort_unstable();
@@ -486,10 +473,7 @@ fn run_bench_fork(graph_lock: &Arc<ArcSwap<state::Graph>>, n: usize) {
     let max_us = *sorted_us.last().unwrap();
     info!(
         total_us,
-        p50_us,
-        p95_us,
-        max_us,
-        "BENCH (µs precision — P2.1.a ArcSwap)"
+        p50_us, p95_us, max_us, "BENCH (µs precision — P2.1.a ArcSwap)"
     );
     let total: u64 = timings_ms.iter().sum();
     let avg = total as f64 / n as f64;
@@ -564,21 +548,14 @@ pub fn redact_dsn(dsn: &str) -> String {
                 Some(colon) => format!("{}:****", &userinfo[..colon]),
                 None => userinfo.to_string(),
             };
-            return format!(
-                "{}://{}{}",
-                &dsn[..scheme_end],
-                redacted_userinfo,
-                after_at
-            );
+            return format!("{}://{}{}", &dsn[..scheme_end], redacted_userinfo, after_at);
         }
     }
     // Key-value form: ... password=... ...
     let mut out = String::with_capacity(dsn.len());
     let mut chars = dsn.chars().peekable();
     while let Some(c) = chars.next() {
-        if c == 'p'
-            && dsn[out.len()..].starts_with("password=")
-        {
+        if c == 'p' && dsn[out.len()..].starts_with("password=") {
             // Emit "password=****" and skip to next whitespace.
             out.push_str("password=****");
             // Skip past the original "password=value".

--- a/rust/ootils_engine/src/propagator.rs
+++ b/rust/ootils_engine/src/propagator.rs
@@ -40,6 +40,12 @@ pub struct PropagationStats {
 /// graph under a brief write lock. Carries the dirty-PI count so the
 /// caller can still report `n_dirty` accurately.
 pub struct ComputedResults {
+    // `apply`/`apply_scenario` callers derive their own dirty count
+    // from the `&HashSet<NodeIndex>` they already hold (see
+    // `PropagationStats.n_dirty`, populated from `dirty.len()`), so
+    // this field is never read back out of `ComputedResults`. Kept on
+    // the struct as the natural place to carry it if that changes.
+    #[allow(dead_code)]
     pub n_dirty: usize,
     pub results: Vec<(NodeIndex, PiResult)>,
     pub compute_us: u64,
@@ -89,8 +95,8 @@ pub fn plan_compute(graph: &Graph, dirty: &HashSet<NodeIndex>) -> ComputedResult
     // This parallelization is what lets us hit sub-100ms on profile L.
     // Empirically (8 logical cores): 106ms → ~40ms.
     let series_batches: Vec<Vec<NodeIndex>> = by_series
-        .into_iter()
-        .map(|(_, mut buckets)| {
+        .into_values()
+        .map(|mut buckets| {
             buckets.sort_by_key(|&idx| graph.nodes[idx as usize].bucket_sequence);
             buckets
         })
@@ -334,7 +340,13 @@ fn compute_one_bucket(
         })
     });
 
-    Some(compute_pi_bucket(opening_stock, supplies, demands, bucket_start, bucket_end))
+    Some(compute_pi_bucket(
+        opening_stock,
+        supplies,
+        demands,
+        bucket_start,
+        bucket_end,
+    ))
 }
 
 // ============================================================
@@ -370,10 +382,7 @@ use crate::scenario::Scenario;
 /// Scenario equivalent of `plan_compute`. Same rayon parallelism,
 /// same per-series catch_unwind boundary, same output shape — but
 /// all node reads route through the overlay-aware view.
-pub fn plan_compute_scenario(
-    scenario: &Scenario,
-    dirty: &HashSet<NodeIndex>,
-) -> ComputedResults {
+pub fn plan_compute_scenario(scenario: &Scenario, dirty: &HashSet<NodeIndex>) -> ComputedResults {
     let t0 = std::time::Instant::now();
     let snapshot = &scenario.baseline_snapshot;
 
@@ -387,9 +396,7 @@ pub fn plan_compute_scenario(
         if n_snap.node_type != NodeType::ProjectedInventory {
             continue;
         }
-        let sid_opt = scenario
-            .get_node_cloned(idx)
-            .and_then(|n| n.series_id);
+        let sid_opt = scenario.get_node_cloned(idx).and_then(|n| n.series_id);
         if let Some(sid) = sid_opt {
             by_series.entry(sid).or_default().push(idx);
         }
@@ -398,8 +405,8 @@ pub fn plan_compute_scenario(
     // Sort each series' buckets by bucket_sequence. Read from snapshot
     // (bucket_sequence is set at boot, immutable in practice).
     let series_batches: Vec<Vec<NodeIndex>> = by_series
-        .into_iter()
-        .map(|(_, mut buckets)| {
+        .into_values()
+        .map(|mut buckets| {
             buckets.sort_by_key(|&idx| snapshot.nodes[idx as usize].bucket_sequence);
             buckets
         })
@@ -527,10 +534,7 @@ fn compute_one_series_scenario(
 /// Scenario equivalent of `compute_seed_opening_from_sorted`.
 /// PI[0] seed = sum of OnHand supplies (overlay-aware).
 /// PI[N>0] seed = previous bucket's closing_stock (overlay-aware).
-fn compute_seed_opening_scenario(
-    scenario: &Scenario,
-    sorted_dirty: &[NodeIndex],
-) -> Decimal {
+fn compute_seed_opening_scenario(scenario: &Scenario, sorted_dirty: &[NodeIndex]) -> Decimal {
     let &seed_idx = match sorted_dirty.first() {
         Some(x) => x,
         None => return Decimal::ZERO,
@@ -567,9 +571,9 @@ fn compute_seed_opening_scenario(
     if let Some(sid) = seed_node.series_id {
         if let Some(buckets) = snapshot.by_series.get(&sid) {
             let target = seed_seq - 1;
-            if let Ok(pos) = buckets.binary_search_by_key(&target, |&idx| {
-                snapshot.nodes[idx as usize].bucket_sequence
-            }) {
+            if let Ok(pos) = buckets
+                .binary_search_by_key(&target, |&idx| snapshot.nodes[idx as usize].bucket_sequence)
+            {
                 let prev_idx = buckets[pos];
                 if let Some(prev_node) = scenario.get_node_cloned(prev_idx) {
                     return prev_node.closing_stock;

--- a/rust/ootils_engine/src/scenario.rs
+++ b/rust/ootils_engine/src/scenario.rs
@@ -39,6 +39,11 @@ pub struct Scenario {
     pub baseline_snapshot: Arc<Graph>,
     /// Modified nodes — diff from the snapshot.
     pub overlay: DashMap<NodeIndex, Node, RandomState>,
+    // Monotonic counterpart to `created_at_system` below — kept for a
+    // future age/uptime computation; nothing reads it today (gRPC
+    // responses serialize `created_at_system` via `Timestamp::from`,
+    // and TTL eviction uses `last_accessed_at`, not this field).
+    #[allow(dead_code)]
     pub created_at_instant: Instant,
     pub created_at_system: SystemTime,
     /// P2.1.c: per-scenario propagation serializer. Two propagations
@@ -58,8 +63,20 @@ pub struct Scenario {
 }
 
 impl Scenario {
+    // Convenience constructor for the per-scenario propagation module
+    // sketched in `propagator_scenario.rs.skeleton` (not yet wired
+    // into `mod` — see main.rs). Every live call site goes through
+    // `with_options` directly (fork_from_baseline_with_ttl,
+    // fork_from_scenario).
+    #[allow(dead_code)]
     pub fn new(name: String, parent_id: Option<Uuid>, baseline: Arc<Graph>) -> Self {
-        Self::with_options(name, parent_id, baseline, DashMap::with_hasher(RandomState::new()), 0)
+        Self::with_options(
+            name,
+            parent_id,
+            baseline,
+            DashMap::with_hasher(RandomState::new()),
+            0,
+        )
     }
 
     /// Full constructor used by fork paths that may inherit a parent's
@@ -103,24 +120,23 @@ impl Scenario {
         if let Some(entry) = self.overlay.get(&idx) {
             return Some(entry.value().clone());
         }
-        self.baseline_snapshot
-            .nodes
-            .get(idx as usize)
-            .cloned()
+        self.baseline_snapshot.nodes.get(idx as usize).cloned()
     }
 
     /// Same as `get_node_cloned` but returns the node by reference from
     /// the snapshot if not in overlay. Caller must NOT mutate.
+    // Prepared for `propagator_scenario.rs.skeleton` (unwired draft
+    // module); `get_node_cloned` is what current callers use instead.
+    #[allow(dead_code)]
     pub fn read_node<R>(&self, idx: NodeIndex, f: impl FnOnce(&Node) -> R) -> Option<R> {
         if let Some(entry) = self.overlay.get(&idx) {
             return Some(f(entry.value()));
         }
-        self.baseline_snapshot
-            .nodes
-            .get(idx as usize)
-            .map(f)
+        self.baseline_snapshot.nodes.get(idx as usize).map(f)
     }
 
+    // Same skeleton-module note as `read_node` above.
+    #[allow(dead_code)]
     pub fn write_node(&self, idx: NodeIndex, node: Node) {
         self.overlay.insert(idx, node);
     }

--- a/rust/ootils_engine/src/service.rs
+++ b/rust/ootils_engine/src/service.rs
@@ -10,6 +10,17 @@
 //! still return `Unimplemented` and reference the phase that will fill
 //! them in.
 
+// `tonic::Status` is ~176 bytes, well over clippy's `result_large_err`
+// threshold — every RPC handler in this file returns
+// `Result<_, Status>` by the tonic contract, so this fires at every
+// handler boundary. The clippy-suggested fix (`Box<Status>`) is a
+// real signature change across the whole gRPC surface (handlers,
+// callers, the `?`-propagation chains below) — out of scope for a CI
+// hardening pass. Allowed module-wide rather than four near-identical
+// per-site allows; revisit if `Status` size becomes an actual
+// (measured) hot-path cost.
+#![allow(clippy::result_large_err)]
+
 use arc_swap::ArcSwap;
 use prost_types::Timestamp;
 use std::collections::HashSet;
@@ -94,16 +105,13 @@ fn date_to_iso(d: chrono::NaiveDate) -> String {
 
 #[tonic::async_trait]
 impl Engine for EngineSvc {
-    type QueryShortagesStream =
-        tokio_stream::wrappers::ReceiverStream<Result<Shortage, Status>>;
-    type StreamChangesStream =
-        tokio_stream::wrappers::ReceiverStream<Result<ChangeEvent, Status>>;
+    type QueryShortagesStream = tokio_stream::wrappers::ReceiverStream<Result<Shortage, Status>>;
+    type StreamChangesStream = tokio_stream::wrappers::ReceiverStream<Result<ChangeEvent, Status>>;
 
     async fn health(&self, _req: Request<()>) -> Result<Response<HealthStatus>, Status> {
         // F-039: explicit cast — saturating semantics on the unlikely
         // overflow (uptime > 292 billion years).
-        let uptime = i64::try_from(self.boot_time.elapsed().as_secs())
-            .unwrap_or(i64::MAX);
+        let uptime = i64::try_from(self.boot_time.elapsed().as_secs()).unwrap_or(i64::MAX);
         let g = self.baseline.load_full();
         // F-040 fix: user-facing detail — no internal "phase N"
         // nomenclature (ADR-017 implementation jargon).
@@ -115,7 +123,7 @@ impl Engine for EngineSvc {
         Ok(Response::new(HealthStatus {
             status: HealthEnum::Serving as i32,
             detail,
-            boot_time: Some(self.boot_timestamp.clone()),
+            boot_time: Some(self.boot_timestamp),
             uptime_seconds: uptime,
         }))
     }
@@ -137,7 +145,10 @@ impl Engine for EngineSvc {
             .sum();
         let events_total = self.metrics.events_total.load(Ordering::Relaxed) as i64;
         let nodes_processed = self.metrics.nodes_processed_total.load(Ordering::Relaxed) as i64;
-        let shortages = self.metrics.shortages_detected_total.load(Ordering::Relaxed) as i64;
+        let shortages = self
+            .metrics
+            .shortages_detected_total
+            .load(Ordering::Relaxed) as i64;
         // p50/p95/p99 require a histogram, which the hand-rolled
         // metrics registry doesn't keep (it accumulates sum-only).
         // Report mean as p50 — Prometheus consumers should use the
@@ -145,13 +156,15 @@ impl Engine for EngineSvc {
         // p95/p99 stay zero until a histogram lands (deferred — not
         // urgent enough to pull in prometheus-client).
         let mean_compute_us = if events_total > 0 {
-            self.metrics.propagate_compute_us_sum.load(Ordering::Relaxed) as f64 / events_total as f64
+            self.metrics
+                .propagate_compute_us_sum
+                .load(Ordering::Relaxed) as f64
+                / events_total as f64
         } else {
             0.0
         };
         let wal_size = self.metrics.wal_size_bytes.load(Ordering::Relaxed) as i64;
-        let queue_depth =
-            self.metrics.writeback_queue_depth.load(Ordering::Relaxed) as i32;
+        let queue_depth = self.metrics.writeback_queue_depth.load(Ordering::Relaxed) as i32;
 
         Ok(Response::new(EngineMetrics {
             baseline_graph_bytes: baseline_bytes,
@@ -169,10 +182,7 @@ impl Engine for EngineSvc {
         }))
     }
 
-    async fn list_scenarios(
-        &self,
-        _req: Request<()>,
-    ) -> Result<Response<ScenarioList>, Status> {
+    async fn list_scenarios(&self, _req: Request<()>) -> Result<Response<ScenarioList>, Status> {
         // Always surface the baseline + every active fork.
         let mut out: Vec<ScenarioInfo> = Vec::new();
         {
@@ -181,7 +191,7 @@ impl Engine for EngineSvc {
                 id: "00000000-0000-0000-0000-000000000001".into(),
                 name: "baseline".into(),
                 parent_id: String::new(),
-                created_at: Some(self.boot_timestamp.clone()),
+                created_at: Some(self.boot_timestamp),
                 overlay_size: 0,
                 memory_bytes: g.memory_bytes() as i64,
             });
@@ -190,14 +200,11 @@ impl Engine for EngineSvc {
             out.push(ScenarioInfo {
                 id: s.id.to_string(),
                 name: s.name.clone(),
-                parent_id: s
-                    .parent_id
-                    .map(|u| u.to_string())
-                    .unwrap_or_default(),
+                parent_id: s.parent_id.map(|u| u.to_string()).unwrap_or_default(),
                 created_at: Some(Timestamp::from(s.created_at_system)),
                 overlay_size: s.overlay_size() as i32,
-                memory_bytes: (s.baseline_snapshot.memory_bytes()
-                    + s.overlay_memory_bytes()) as i64,
+                memory_bytes: (s.baseline_snapshot.memory_bytes() + s.overlay_memory_bytes())
+                    as i64,
             });
         }
         Ok(Response::new(ScenarioList { scenarios: out }))
@@ -219,13 +226,14 @@ impl Engine for EngineSvc {
         //   any other UUID → fork from named scenario (P3.5 MCTS)
         let ttl = q.ttl_seconds as u64;
         let (scenario, stats) = if q.parent_scenario_id.is_empty() {
-            self.scenarios.fork_from_baseline_with_ttl(name.clone(), &self.baseline, ttl)
+            self.scenarios
+                .fork_from_baseline_with_ttl(name.clone(), &self.baseline, ttl)
         } else {
-            let parent_uuid = Uuid::from_str(&q.parent_scenario_id).map_err(|e| {
-                Status::invalid_argument(format!("bad parent_scenario_id: {e}"))
-            })?;
+            let parent_uuid = Uuid::from_str(&q.parent_scenario_id)
+                .map_err(|e| Status::invalid_argument(format!("bad parent_scenario_id: {e}")))?;
             if parent_uuid == crate::loader::BASELINE_SCENARIO_ID {
-                self.scenarios.fork_from_baseline_with_ttl(name.clone(), &self.baseline, ttl)
+                self.scenarios
+                    .fork_from_baseline_with_ttl(name.clone(), &self.baseline, ttl)
             } else {
                 self.scenarios
                     .fork_from_scenario(name.clone(), parent_uuid, ttl)
@@ -235,9 +243,10 @@ impl Engine for EngineSvc {
             }
         };
         self.metrics.record_fork();
-        self.metrics
-            .active_scenarios
-            .store(self.scenarios.len() as i64, std::sync::atomic::Ordering::Relaxed);
+        self.metrics.active_scenarios.store(
+            self.scenarios.len() as i64,
+            std::sync::atomic::Ordering::Relaxed,
+        );
         info!(
             scenario_id = %scenario.id,
             name = %scenario.name,
@@ -276,9 +285,10 @@ impl Engine for EngineSvc {
             .remove(&sid)
             .ok_or_else(|| Status::not_found(format!("scenario {sid} not found")))?;
         let overlay_entries = scenario.overlay_size() as i32;
-        self.metrics
-            .active_scenarios
-            .store(self.scenarios.len() as i64, std::sync::atomic::Ordering::Relaxed);
+        self.metrics.active_scenarios.store(
+            self.scenarios.len() as i64,
+            std::sync::atomic::Ordering::Relaxed,
+        );
         info!(scenario_id = %sid, overlay_entries, "scenario deleted (F-038)");
         Ok(Response::new(DeleteResult {
             overlay_entries_freed: overlay_entries,
@@ -344,9 +354,10 @@ impl Engine for EngineSvc {
         // Drop the scenario from the manager — merged is consumed.
         self.scenarios.remove(&sid);
         self.metrics.record_merge();
-        self.metrics
-            .active_scenarios
-            .store(self.scenarios.len() as i64, std::sync::atomic::Ordering::Relaxed);
+        self.metrics.active_scenarios.store(
+            self.scenarios.len() as i64,
+            std::sync::atomic::Ordering::Relaxed,
+        );
 
         let new_gen = {
             let g = self.baseline.load_full();
@@ -366,10 +377,7 @@ impl Engine for EngineSvc {
         }))
     }
 
-    async fn get_node(
-        &self,
-        req: Request<NodeQuery>,
-    ) -> Result<Response<NodeState>, Status> {
+    async fn get_node(&self, req: Request<NodeQuery>) -> Result<Response<NodeState>, Status> {
         // P3.1 (agent-first): GetNode is now overlay-aware. If
         // scenario_id refers to a forked scenario, read first from
         // its overlay (post-propagation values) and fall back to the
@@ -381,21 +389,20 @@ impl Engine for EngineSvc {
             .map_err(|e| Status::invalid_argument(format!("bad node_id: {e}")))?;
 
         // Resolve target scenario (baseline if empty / canonical UUID).
-        let scenario_opt: Option<Arc<crate::scenario::Scenario>> = if q.scenario_id.is_empty() {
-            None
-        } else {
-            let req_sid = Uuid::from_str(&q.scenario_id)
-                .map_err(|e| Status::invalid_argument(format!("bad scenario_id: {e}")))?;
-            if req_sid == crate::loader::BASELINE_SCENARIO_ID {
+        let scenario_opt: Option<Arc<crate::scenario::Scenario>> =
+            if q.scenario_id.is_empty() {
                 None
             } else {
-                Some(
-                    self.scenarios.get(&req_sid).ok_or_else(|| {
+                let req_sid = Uuid::from_str(&q.scenario_id)
+                    .map_err(|e| Status::invalid_argument(format!("bad scenario_id: {e}")))?;
+                if req_sid == crate::loader::BASELINE_SCENARIO_ID {
+                    None
+                } else {
+                    Some(self.scenarios.get(&req_sid).ok_or_else(|| {
                         Status::not_found(format!("scenario {req_sid} not found"))
-                    })?,
-                )
-            }
-        };
+                    })?)
+                }
+            };
 
         // Fetch the node — overlay-aware if we have a scenario.
         let node = match &scenario_opt {
@@ -542,7 +549,6 @@ impl Engine for EngineSvc {
         //   overlay write only — no WAL/PG. Per-scenario propagation
         //   lock so parallel propags on DIFFERENT scenarios don't
         //   serialize against each other.
-        let metrics = self.metrics.clone();
         let blocking_outcome = if let Some(scenario) = target_scenario.clone() {
             // ---- Scenario propagation path ----
             tokio::task::spawn_blocking(
@@ -700,8 +706,8 @@ impl Engine for EngineSvc {
         let events = q.events;
         let scenario_id_str = q.scenario_id.clone();
 
-        let batch_outcome = tokio::task::spawn_blocking(
-            move || -> (Vec<PropagateResponse>, i32, String) {
+        let batch_outcome =
+            tokio::task::spawn_blocking(move || -> (Vec<PropagateResponse>, i32, String) {
                 let mut results = Vec::with_capacity(events.len());
                 // Single lock acquisition for the whole batch.
                 let n = events.len();
@@ -715,7 +721,13 @@ impl Engine for EngineSvc {
                                 return (
                                     results,
                                     i as i32,
-                                    format!("event #{} of {}: {}: {}", i, n, status.code(), status.message()),
+                                    format!(
+                                        "event #{} of {}: {}: {}",
+                                        i,
+                                        n,
+                                        status.code(),
+                                        status.message()
+                                    ),
                                 );
                             }
                         }
@@ -729,20 +741,24 @@ impl Engine for EngineSvc {
                                 return (
                                     results,
                                     i as i32,
-                                    format!("event #{} of {}: {}: {}", i, n, status.code(), status.message()),
+                                    format!(
+                                        "event #{} of {}: {}: {}",
+                                        i,
+                                        n,
+                                        status.code(),
+                                        status.message()
+                                    ),
                                 );
                             }
                         }
                     }
                 }
                 (results, -1, String::new())
-            },
-        )
-        .await;
+            })
+            .await;
 
-        let (results, failed_at, detail) = batch_outcome.map_err(|e| {
-            Status::internal(format!("propagate_batch worker failed: {e}"))
-        })?;
+        let (results, failed_at, detail) = batch_outcome
+            .map_err(|e| Status::internal(format!("propagate_batch worker failed: {e}")))?;
 
         Ok(Response::new(PropagateBatchResponse {
             results,
@@ -910,7 +926,11 @@ fn apply_one_baseline(
     let mut wal_fsync_us = 0.0;
     if !stats.deltas.is_empty() {
         let t_wal = Instant::now();
-        let record = make_record(cr_uuid, crate::loader::BASELINE_SCENARIO_ID, stats.deltas.clone());
+        let record = make_record(
+            cr_uuid,
+            crate::loader::BASELINE_SCENARIO_ID,
+            stats.deltas.clone(),
+        );
         let assigned_seq = match writeback.wal().append(&record) {
             Ok(s) => s,
             Err(e) => {

--- a/rust/ootils_engine/src/state.rs
+++ b/rust/ootils_engine/src/state.rs
@@ -134,6 +134,11 @@ impl Node {
     pub const FLAG_SHORTAGE: u8 = 0x02;
     pub const FLAG_ACTIVE: u8 = 0x04;
 
+    // Companion accessor to `has_shortage`/`is_active` below (same
+    // flag-bit pattern); no current caller inspects FLAG_DIRTY through
+    // the accessor — callers check dirtiness via the `HashSet<NodeIndex>`
+    // dirty-set instead (propagator.rs), not the per-node flag.
+    #[allow(dead_code)]
     pub fn is_dirty(&self) -> bool {
         self.flags & Self::FLAG_DIRTY != 0
     }
@@ -230,6 +235,9 @@ impl Graph {
         self.nodes.len()
     }
 
+    // Companion to `len()` above; no current caller needs it (empty
+    // baseline is checked via `LoadStats.n_nodes` in loader.rs).
+    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.nodes.is_empty()
     }
@@ -250,18 +258,18 @@ impl Graph {
             + self.by_node_id.capacity() * (size_of::<Uuid>() + size_of::<NodeIndex>())
             + self
                 .by_item_location
-                .iter()
-                .map(|(_, v)| v.capacity() * size_of::<NodeIndex>())
+                .values()
+                .map(|v| v.capacity() * size_of::<NodeIndex>())
                 .sum::<usize>()
             + self
                 .by_series
-                .iter()
-                .map(|(_, v)| v.capacity() * size_of::<NodeIndex>())
+                .values()
+                .map(|v| v.capacity() * size_of::<NodeIndex>())
                 .sum::<usize>()
             + self
                 .edges_in
-                .iter()
-                .map(|(_, v)| v.capacity() * size_of::<EdgeRef>())
+                .values()
+                .map(|v| v.capacity() * size_of::<EdgeRef>())
                 .sum::<usize>()
     }
 }

--- a/rust/ootils_engine/src/wal.rs
+++ b/rust/ootils_engine/src/wal.rs
@@ -186,6 +186,10 @@ pub struct WalWriter {
 impl WalWriter {
     /// Open (or create) the WAL at `path` using default rotation +
     /// size caps. Refuses v1 files with a clear error.
+    // Production boots via `open_with_caps` directly (main.rs, custom
+    // caps from CLI args) — this default-caps wrapper is exercised
+    // only by the unit tests below.
+    #[allow(dead_code)]
     pub fn open(path: impl AsRef<Path>) -> anyhow::Result<Self> {
         Self::open_with_caps(
             path,
@@ -195,6 +199,7 @@ impl WalWriter {
     }
 
     /// Backward-compat shim for tests that only care about rotation.
+    #[allow(dead_code)]
     pub fn open_with_threshold(
         path: impl AsRef<Path>,
         rotation_threshold_bytes: u64,
@@ -222,10 +227,14 @@ impl WalWriter {
         }
 
         let exists = path.exists();
+        // Durability-critical: NEVER truncate. If the WAL already
+        // exists we resume from it (read_header below); truncating
+        // on every restart would silently destroy unflushed deltas.
         let mut file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
+            .truncate(false)
             .open(&path)?;
 
         let (applied_pg_seq, _hdr_version) = if !exists {
@@ -315,11 +324,14 @@ impl WalWriter {
         // Durability barrier — caller will not see success until disk has it.
         f.sync_data()?;
 
-        self.current_size
-            .fetch_add(record_bytes, Ordering::Relaxed);
+        self.current_size.fetch_add(record_bytes, Ordering::Relaxed);
         Ok(seq)
     }
 
+    // No current caller (the RUNBOOK documents checking WAL size via
+    // `stat` on the file directly); kept as the natural accessor for a
+    // future health/metrics endpoint.
+    #[allow(dead_code)]
     pub fn max_bytes(&self) -> u64 {
         self.max_bytes
     }
@@ -340,6 +352,9 @@ impl WalWriter {
         self.applied_pg_seq.load(Ordering::Acquire)
     }
 
+    // Test-only peek (assertions in the unit tests below); production
+    // code never reads `next_seq` back out.
+    #[allow(dead_code)]
     pub fn next_seq_peek(&self) -> u64 {
         self.next_seq.load(Ordering::Acquire)
     }
@@ -374,7 +389,10 @@ impl WalWriter {
             }
             let len = u32::from_be_bytes(len_buf) as usize;
             if len > MAX_RECORD_PAYLOAD {
-                warn!(len, "WAL: record length overflow, treating as truncated, stopping");
+                warn!(
+                    len,
+                    "WAL: record length overflow, treating as truncated, stopping"
+                );
                 break;
             }
             if f.read_exact(&mut seq_buf).is_err() {
@@ -548,10 +566,7 @@ impl WalWriter {
         // Reopen the rotated file and swap it into the MutexGuard's
         // slot WITHOUT releasing the lock. Any append() that was
         // waiting on the lock now sees the new file handle.
-        let mut reopened = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(&self.path)?;
+        let mut reopened = OpenOptions::new().read(true).write(true).open(&self.path)?;
         reopened.seek(SeekFrom::End(0))?;
         *live = reopened;
         self.current_size.store(new_size, Ordering::Relaxed);
@@ -566,6 +581,9 @@ impl WalWriter {
         Ok(reclaimed)
     }
 
+    // No current caller; kept as the natural accessor for a future
+    // health/metrics endpoint (same rationale as `max_bytes` above).
+    #[allow(dead_code)]
     pub fn path(&self) -> &Path {
         &self.path
     }
@@ -595,9 +613,8 @@ fn write_header(file: &mut File, applied_pg_seq: u64) -> anyhow::Result<()> {
 fn read_header(file: &mut File, path: &Path) -> anyhow::Result<(u64, u32)> {
     file.seek(SeekFrom::Start(0))?;
     let mut magic = [0u8; 4];
-    file.read_exact(&mut magic).map_err(|e| {
-        anyhow::anyhow!("WAL file {} unreadable: {}", path.display(), e)
-    })?;
+    file.read_exact(&mut magic)
+        .map_err(|e| anyhow::anyhow!("WAL file {} unreadable: {}", path.display(), e))?;
     if magic == MAGIC_V1 {
         anyhow::bail!(
             "WAL file {} is v1 format (magic WAL\\0). v2 (WAL2) is required. \
@@ -640,11 +657,7 @@ fn read_header(file: &mut File, path: &Path) -> anyhow::Result<(u64, u32)> {
 }
 
 /// Helper to build a `WalRecord` with timestamp filled in.
-pub fn make_record(
-    calc_run_id: Uuid,
-    scenario_id: Uuid,
-    deltas: Vec<NodeDelta>,
-) -> WalRecord {
+pub fn make_record(calc_run_id: Uuid, scenario_id: Uuid, deltas: Vec<NodeDelta>) -> WalRecord {
     WalRecord {
         timestamp_ms: Utc::now().timestamp_millis(),
         calc_run_id,
@@ -732,7 +745,10 @@ mod tests {
         let w2 = WalWriter::open(&path).unwrap();
         let recovered = w2.replay().unwrap();
         assert_eq!(recovered.len(), 5);
-        assert_eq!(recovered.iter().map(|r| r.seq).collect::<Vec<_>>(), vec![1, 2, 3, 4, 5]);
+        assert_eq!(
+            recovered.iter().map(|r| r.seq).collect::<Vec<_>>(),
+            vec![1, 2, 3, 4, 5]
+        );
     }
 
     #[test]
@@ -983,7 +999,10 @@ mod tests {
                 }
             }
         }
-        assert!(tripped, "expected WalFull within 10 appends past the 256B cap");
+        assert!(
+            tripped,
+            "expected WalFull within 10 appends past the 256B cap"
+        );
         // File on disk has NOT grown past the cap.
         let on_disk = std::fs::metadata(&path).unwrap().len();
         assert!(

--- a/rust/ootils_engine/src/write_behind.rs
+++ b/rust/ootils_engine/src/write_behind.rs
@@ -14,7 +14,7 @@
 //!   2. apply to Graph (in RAM)
 //!   3. WAL.append() + fsync     -- assigns + returns a sequence number
 //!   4. WriteBehindQueue.push(PendingDelta { seq, ... })  -- non-blocking
-//!   ----- caller-visible latency stops here -----
+//!      ----- caller-visible latency stops here -----
 //!   5. background task flushes batch to Postgres
 //!   6. on flush success: WAL.set_applied_pg_seq(max_seq_in_batch)
 //!      (NOT a truncate — see wal.rs for the v2 marker contract)
@@ -135,6 +135,10 @@ pub struct WriteBehindQueue {
 }
 
 impl WriteBehindQueue {
+    // Production boots via `with_caps` directly (main.rs, explicit
+    // depth cap from CLI args); this default-depth wrapper has no
+    // current caller.
+    #[allow(dead_code)]
     pub fn new(wal: Arc<WalWriter>, metrics: Arc<crate::metrics::Metrics>) -> Self {
         Self::with_caps(wal, metrics, 1_000_000)
     }
@@ -153,6 +157,9 @@ impl WriteBehindQueue {
         }
     }
 
+    // No current caller; kept as the natural accessor for a future
+    // health/metrics endpoint (same rationale as WalWriter's).
+    #[allow(dead_code)]
     pub fn max_depth(&self) -> usize {
         self.max_depth
     }
@@ -220,6 +227,10 @@ impl WriteBehindQueue {
         (out, max_seq)
     }
 
+    // Exercised by the unit tests below (queue-depth assertions);
+    // production code reads depth via `metrics.writeback_queue_depth`
+    // instead.
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.pending.lock().len()
     }
@@ -240,7 +251,8 @@ impl WriteBehindQueue {
         // Build a map of all known node_id → highest-seq delta, scanning
         // both the current queue (which has new deltas appended during
         // the failed flush) and the failed batch.
-        let mut latest: HashMap<Uuid, PendingDelta> = HashMap::with_capacity(q.len() + failed_batch.len());
+        let mut latest: HashMap<Uuid, PendingDelta> =
+            HashMap::with_capacity(q.len() + failed_batch.len());
         for d in q.drain(..) {
             keep_latest(&mut latest, d);
         }
@@ -311,7 +323,10 @@ impl PgFlushClient {
             ))
             .await?;
         let stmt = client.prepare(FLUSH_UPDATE_SQL).await?;
-        info!(timeout_ms = PG_STATEMENT_TIMEOUT_MS, "PG flush client connected + statement prepared");
+        info!(
+            timeout_ms = PG_STATEMENT_TIMEOUT_MS,
+            "PG flush client connected + statement prepared"
+        );
         self.state = Some((client, stmt));
         Ok(())
     }
@@ -378,7 +393,10 @@ impl PgFlushClient {
             )
             .await?;
             tx.commit().await?;
-            debug!(n, "wrote batch to Postgres (REPEATABLE READ tx, cached client)");
+            debug!(
+                n,
+                "wrote batch to Postgres (REPEATABLE READ tx, cached client)"
+            );
             Ok(())
         }
         .await;
@@ -453,8 +471,7 @@ pub fn spawn_flusher(
                     } else {
                         debug!(
                             n,
-                            max_seq,
-                            "WriteBehindQueue: batch flushed + WAL marker advanced"
+                            max_seq, "WriteBehindQueue: batch flushed + WAL marker advanced"
                         );
                     }
                     // After a successful flush is a good moment to attempt
@@ -463,10 +480,7 @@ pub fn spawn_flusher(
                         warn!(error = %e, "WAL rotation failed (will retry)");
                     }
                     if consecutive_failures > 0 {
-                        info!(
-                            consecutive_failures,
-                            "flusher recovered, resetting backoff"
-                        );
+                        info!(consecutive_failures, "flusher recovered, resetting backoff");
                         consecutive_failures = 0;
                         current_interval = baseline_interval;
                     }
@@ -563,15 +577,12 @@ mod tests {
         // bounds memory.
         let (_d, q) = fresh_queue(1000);
         // Pre-existing pending: node 1 at seq=5, node 2 at seq=6.
-        q.try_push(vec![dummy_delta(5, 1), dummy_delta(6, 2)]).unwrap();
+        q.try_push(vec![dummy_delta(5, 1), dummy_delta(6, 2)])
+            .unwrap();
 
         // Failed batch coming back from PG: node 1 at seq=2 (older),
         // node 3 at seq=3 (new), node 2 at seq=8 (newer than current).
-        let failed = vec![
-            dummy_delta(2, 1),
-            dummy_delta(3, 3),
-            dummy_delta(8, 2),
-        ];
+        let failed = vec![dummy_delta(2, 1), dummy_delta(3, 3), dummy_delta(8, 2)];
         q.reenqueue_with_dedupe(failed);
 
         // After dedupe: 3 unique nodes, with their respective highest seqs:
@@ -581,10 +592,8 @@ mod tests {
         let (drained, max_seq) = q.drain_batch();
         assert_eq!(drained.len(), 3);
         assert_eq!(max_seq, 8);
-        let by_node: std::collections::HashMap<Uuid, u64> = drained
-            .iter()
-            .map(|d| (d.node_id, d.seq))
-            .collect();
+        let by_node: std::collections::HashMap<Uuid, u64> =
+            drained.iter().map(|d| (d.node_id, d.seq)).collect();
         assert_eq!(by_node[&Uuid::from_u128(1)], 5);
         assert_eq!(by_node[&Uuid::from_u128(2)], 8);
         assert_eq!(by_node[&Uuid::from_u128(3)], 3);

--- a/rust/ootils_kernel/src/io.rs
+++ b/rust/ootils_kernel/src/io.rs
@@ -101,14 +101,14 @@ impl Loader {
 ///
 /// Per-kind semantics:
 ///   - kind='pi'     : uuid_a=node_id, uuid_b=projection_series_id,
-///                     int_a=bucket_sequence, date_a=time_span_start,
-///                     date_b=time_span_end
+///     int_a=bucket_sequence, date_a=time_span_start,
+///     date_b=time_span_end
 ///   - kind='supply' : uuid_a=pi_node_id, qty=quantity, date_a=time_ref
 ///   - kind='demand' : uuid_a=pi_node_id, qty=quantity,
-///                     date_a=time_span_start, date_b=time_span_end,
-///                     date_c=time_ref
+///     date_a=time_span_start, date_b=time_span_end,
+///     date_c=time_ref
 ///   - kind='seed'   : uuid_a=projection_series_id, int_a=seed_seq,
-///                     qty=seed_opening
+///     qty=seed_opening
 const COMBINED_LOAD_SQL: &str = "\
 WITH dirty AS ( \
     SELECT pi.node_id, pi.projection_series_id, pi.bucket_sequence, \

--- a/rust/ootils_kernel/src/kernel.rs
+++ b/rust/ootils_kernel/src/kernel.rs
@@ -65,9 +65,8 @@ pub fn sum_outflows(demands: &[Demand], bucket_start: NaiveDate, bucket_end: Nai
                     let overlap_days = (overlap_end - overlap_start).num_days().max(0);
                     if overlap_days > 0 {
                         // qty / span_days * overlap_days, preserving Decimal precision
-                        let frac = d.quantity
-                            / Decimal::from(span_days)
-                            * Decimal::from(overlap_days);
+                        let frac =
+                            d.quantity / Decimal::from(span_days) * Decimal::from(overlap_days);
                         total += frac;
                     }
                 }
@@ -149,7 +148,13 @@ mod tests {
             quantity: dec("50"),
             time_ref: date("2026-01-04"),
         }];
-        let r = compute_pi_bucket(dec("10"), &supplies, &[], date("2026-01-01"), date("2026-01-08"));
+        let r = compute_pi_bucket(
+            dec("10"),
+            &supplies,
+            &[],
+            date("2026-01-01"),
+            date("2026-01-08"),
+        );
         assert_eq!(r.inflows, dec("50"));
         assert_eq!(r.closing_stock, dec("60"));
     }
@@ -161,7 +166,13 @@ mod tests {
             quantity: dec("50"),
             time_ref: date("2026-01-08"),
         }];
-        let r = compute_pi_bucket(dec("10"), &supplies, &[], date("2026-01-01"), date("2026-01-08"));
+        let r = compute_pi_bucket(
+            dec("10"),
+            &supplies,
+            &[],
+            date("2026-01-01"),
+            date("2026-01-08"),
+        );
         assert_eq!(r.inflows, Decimal::ZERO);
     }
 
@@ -173,7 +184,13 @@ mod tests {
             time_span_end: Some(date("2026-01-08")),
             time_ref: None,
         }];
-        let r = compute_pi_bucket(dec("100"), &[], &demands, date("2026-01-01"), date("2026-01-08"));
+        let r = compute_pi_bucket(
+            dec("100"),
+            &[],
+            &demands,
+            date("2026-01-01"),
+            date("2026-01-08"),
+        );
         // Full 7-day span = 7 days overlap, so 100% of the 30 -> 30.
         assert_eq!(r.outflows, dec("30"));
     }
@@ -187,7 +204,13 @@ mod tests {
             time_span_end: Some(date("2026-01-31")),
             time_ref: None,
         }];
-        let r = compute_pi_bucket(dec("100"), &[], &demands, date("2026-01-01"), date("2026-01-02"));
+        let r = compute_pi_bucket(
+            dec("100"),
+            &[],
+            &demands,
+            date("2026-01-01"),
+            date("2026-01-02"),
+        );
         assert_eq!(r.outflows, dec("1"));
     }
 
@@ -199,7 +222,13 @@ mod tests {
             time_span_end: None,
             time_ref: Some(date("2026-01-05")),
         }];
-        let r = compute_pi_bucket(dec("100"), &[], &demands, date("2026-01-01"), date("2026-01-08"));
+        let r = compute_pi_bucket(
+            dec("100"),
+            &[],
+            &demands,
+            date("2026-01-01"),
+            date("2026-01-08"),
+        );
         assert_eq!(r.outflows, dec("20"));
     }
 
@@ -211,7 +240,13 @@ mod tests {
             time_span_end: None,
             time_ref: Some(date("2026-01-04")),
         }];
-        let r = compute_pi_bucket(dec("100"), &[], &demands, date("2026-01-01"), date("2026-01-08"));
+        let r = compute_pi_bucket(
+            dec("100"),
+            &[],
+            &demands,
+            date("2026-01-01"),
+            date("2026-01-08"),
+        );
         assert_eq!(r.closing_stock, dec("-50"));
         assert!(r.has_shortage);
         assert_eq!(r.shortage_qty, dec("50"));

--- a/rust/ootils_kernel/src/lib.rs
+++ b/rust/ootils_kernel/src/lib.rs
@@ -22,6 +22,18 @@
 //! arithmetic — and keep one wheel compatible across Python 3.11/3.12/
 //! 3.13+ without rebuild.
 
+// pyo3 0.22's `#[pyfunction]` macro wraps every function body in a
+// generic `.into()` conversion to normalize the error type to
+// `PyErr` — a no-op when the function already returns
+// `PyResult<T>` (i.e. `Err = PyErr`), but clippy 1.95's
+// `useless_conversion` lint flags that macro-generated identity
+// conversion on the function signature span. It fires on every
+// `#[pyfunction]` in this crate (not our code — the offending
+// `.into()` lives inside pyo3's macro expansion), so a crate-level
+// allow is the targeted fix rather than six near-identical
+// per-function ones. Revisit when pyo3 is upgraded past this.
+#![allow(clippy::useless_conversion)]
+
 mod io;
 mod kernel;
 mod pool;
@@ -110,9 +122,11 @@ fn load_subgraph_stats<'py>(
     let mut loader = io::Loader::connect(dsn).map_err(|e| {
         pyo3::exceptions::PyRuntimeError::new_err(format!("postgres connect failed: {e}"))
     })?;
-    let sg = loader.load_subgraph(calc_run_id, scenario_id).map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("load_subgraph failed: {e}"))
-    })?;
+    let sg = loader
+        .load_subgraph(calc_run_id, scenario_id)
+        .map_err(|e| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!("load_subgraph failed: {e}"))
+        })?;
     let elapsed_ms = t0.elapsed().as_secs_f64() * 1000.0;
 
     let d = pyo3::types::PyDict::new_bound(py);
@@ -145,7 +159,10 @@ fn project_subgraph<'py>(
     dsn: &str,
     calc_run_id_str: &str,
     scenario_id_str: &str,
-) -> PyResult<(Vec<Bound<'py, pyo3::types::PyDict>>, Bound<'py, pyo3::types::PyDict>)> {
+) -> PyResult<(
+    Vec<Bound<'py, pyo3::types::PyDict>>,
+    Bound<'py, pyo3::types::PyDict>,
+)> {
     let calc_run_id = parse_uuid(calc_run_id_str)?;
     let scenario_id = parse_uuid(scenario_id_str)?;
 
@@ -155,7 +172,9 @@ fn project_subgraph<'py>(
     })?;
     let sg = loader
         .load_subgraph(calc_run_id, scenario_id)
-        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("load_subgraph failed: {e}")))?;
+        .map_err(|e| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!("load_subgraph failed: {e}"))
+        })?;
     let load_ms = t_load_start.elapsed().as_secs_f64() * 1000.0;
 
     let t_compute_start = std::time::Instant::now();
@@ -213,8 +232,9 @@ fn propagate_and_write<'py>(
     let calc_run_id = parse_uuid(calc_run_id_str)?;
     let scenario_id = parse_uuid(scenario_id_str)?;
 
-    let stats = writeback::propagate_and_write(dsn, calc_run_id, scenario_id)
-        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("propagate_and_write failed: {e}")))?;
+    let stats = writeback::propagate_and_write(dsn, calc_run_id, scenario_id).map_err(|e| {
+        pyo3::exceptions::PyRuntimeError::new_err(format!("propagate_and_write failed: {e}"))
+    })?;
 
     let d = pyo3::types::PyDict::new_bound(py);
     d.set_item("n_dirty_pis", stats.n_dirty_pis)?;

--- a/rust/ootils_kernel/src/propagator.rs
+++ b/rust/ootils_kernel/src/propagator.rs
@@ -56,7 +56,10 @@ pub fn project(sg: &Subgraph) -> Projection {
     // happy because sg outlives this function call.
     let mut by_series: HashMap<Uuid, Vec<&crate::io::DirtyPi>> = HashMap::new();
     for pi in &sg.dirty_pis {
-        by_series.entry(pi.projection_series_id).or_default().push(pi);
+        by_series
+            .entry(pi.projection_series_id)
+            .or_default()
+            .push(pi);
     }
 
     for (series_id, mut buckets) in by_series {
@@ -76,8 +79,16 @@ pub fn project(sg: &Subgraph) -> Projection {
         // Walk forward.
         let mut prev_closing = seed_opening;
         for pi in buckets {
-            let supplies = sg.supplies_by_pi.get(&pi.node_id).map(|v| v.as_slice()).unwrap_or(&[]);
-            let demands = sg.demands_by_pi.get(&pi.node_id).map(|v| v.as_slice()).unwrap_or(&[]);
+            let supplies = sg
+                .supplies_by_pi
+                .get(&pi.node_id)
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]);
+            let demands = sg
+                .demands_by_pi
+                .get(&pi.node_id)
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]);
             let r = compute_pi_bucket(
                 prev_closing,
                 supplies,

--- a/rust/ootils_kernel/src/writeback.rs
+++ b/rust/ootils_kernel/src/writeback.rs
@@ -35,6 +35,12 @@ const COPY_THRESHOLD: usize = 5000;
 ///
 /// MUST be kept in sync with `src/ootils_core/engine/orchestration/
 /// propagator_sql.py::SHORTAGES_SQL`.
+// Not wired yet: `propagate_and_write` still leaves shortage detection
+// to Python's SHORTAGES_SQL (see the doc comment on `propagate_and_write`
+// in lib.rs) — this copy is prepared for the day the Rust side runs
+// detection in-transaction too. Tracked as follow-up, not dead code to
+// delete: removing it would lose the "kept in sync" contract above.
+#[allow(dead_code)]
 const SHORTAGES_SQL: &str = "\
 WITH pi_with_ss AS ( \
     SELECT \
@@ -113,6 +119,10 @@ ON CONFLICT (pi_node_id, calc_run_id) DO UPDATE SET \
 /// Stats returned after one writeback pass (used by the diagnostic dict
 /// surfaced to Python).
 pub struct WriteStats {
+    // Computed at both call sites but not yet threaded through
+    // `FullStats`/the Python diagnostic dict (lib.rs). Whether to
+    // surface it is a call-signature decision, not made here.
+    #[allow(dead_code)]
     pub n_rows_written: usize,
     pub n_shortages_detected: usize,
     pub path: &'static str,

--- a/rust/ootils_proto/build.rs
+++ b/rust/ootils_proto/build.rs
@@ -15,9 +15,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build_server(true)
         .build_client(true)
         // Keep proto source path explicit so cargo re-runs on .proto edits.
-        .compile_protos(
-            &["proto/engine.proto"],
-            &["proto"],
-        )?;
+        .compile_protos(&["proto/engine.proto"], &["proto"])?;
     Ok(())
 }


### PR DESCRIPTION
## Contexte

Le code Rust (2 crates, ~5 200 lignes) n'était protégé par presque rien : `rust-build.yml` path-filtré sur `ootils_kernel/**` seul, `cargo test` jamais exécuté en CI (26 tests), pas de clippy/fmt, et la batterie `tests/engine_service/` (15 fichiers : durabilité, PG outage, recovery, concurrence) s'auto-skippe depuis toujours faute de binaire compilé. Un PR touchant `ootils_engine/**` ou `ootils_proto/**` ne déclenchait RIEN.

## Contenu (réécriture de rust-build.yml, pas de nouveau workflow)

- **paths élargis** : `rust/**`, `tests/engine_service/**`, stubs `src/ootils_core/_grpc/**`, régénérateur. Jamais déclenché sur un PR Python pur.
- **Job `cargo-checks`** : `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (26 tests), cache Swatinem/rust-cache.
- **Job `proto-drift`** : régénération des stubs gRPC + `git diff --exit-code` — un stub désynchronisé du proto = rouge. Validé localement bout-en-bout (zéro dérive, reproduction byte-for-byte).
- **Job `engine-service-it`** (`continue-on-error: true` au départ — informatif, promotion en required après 2 runs verts, documenté dans le RUNBOOK) : build release `ootils_engine` + service Postgres 16 + batterie `tests/engine_service` + exécution **conditionnelle** du test de parité PyO3 (guard shell — le fichier arrive dans la PR sœur, ordre de merge indifférent).
- **Fixes strictement mécaniques** pour faire naître la CI verte : `cargo fmt` (12 fichiers, whitespace), clippy `iter_kv_map`/`clone_on_copy`/doc-comments, et `.truncate(false)` explicite sur les OpenOptions du WAL (no-op confirmé — le défaut Rust ne tronque pas — rendu explicite car durability-critical).

## Vérifications locales

fmt/clippy/test verts (3 passes), YAML parse (4 jobs), build release OK, proto-drift reproduit zéro dérive.

## Note branch-protection

`cargo-checks`/`proto-drift` sont bloquants **par convention** (croix rouge visible), volontairement PAS cochés required en branch-protection — un check required non déclenché (PR Python pur) resterait « pending » et bloquerait le merge.

Chantier PERF-1 — PRs sœurs : migration 075, industrialisation PyO3. Revue adversariale : GO, zéro bloquant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)