### PR TITLE
docs(perf): re-bench VM post-#455 -- SQL 272x + SQL ≈ Rust, recadrage SCALE-2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,8 @@ HTTP request → Bearer-token auth (`api/auth.py`) → router in `api/routers/<d
 ### Propagation model (ADR-003)
 Event-driven, incremental, deterministic. An event marks a subgraph dirty; compute happens in topo order; unchanged nodes stop the cascade (they do not propagate further). Every change is attributable. Determinism is a hard constraint — **no randomness in the core engine**.
 
+**Planner-stats invariant (#455):** any bulk INSERT into a table the planner reads back *within the same request* must be followed by an explicit `ANALYZE`. Canonical site: `DirtyFlagManager.flush_to_postgres` (`engine/kernel/graph/dirty.py`) runs `ANALYZE dirty_nodes` after the batch INSERT — without it, `PROPAGATE_SQL`/`SHORTAGES_SQL` see stale `rows=1` stats, the planner picks a per-row nested loop, and full propagation collapses to O(N²) (measured 272× slower: 1 099 s vs 4 s on 47 520 PI). All propagation flavors (sql/python/rust in-process) go through this site; rust-svc computes in RAM and is out of scope. Perf note (`docs/PERF-BASELINE.md` § re-bench 2026-07-11): once stats are fresh, **SQL and in-process Rust are within ±4%** end-to-end — the "Rust wins at every scale" framing was an artifact of the stale-stats bug; Rust's real leverage is the in-RAM rust-svc architecture (SCALE-2), not per-node compute.
+
 ## Conventions that aren't obvious from the code
 
 - **Tests run against real Postgres, no mocks.** Point `DATABASE_URL` at a throwaway DB. Pure-Python helper functions (and Pydantic-validation 422 boundary tests) live in `tests/test_*.py` and don't need a DB. DB-touching tests live in `tests/integration/test_*_integration.py` and use the `conn` / `seeded_db` fixtures.

--- a/docs/PERF-BASELINE.md
+++ b/docs/PERF-BASELINE.md
@@ -333,4 +333,73 @@ DATABASE_URL="postgresql://ootils:ootils@<host>:5432/ootils_bench_m" \
     python scripts/bench_incremental.py --n 20 --warmup 5 --engine sql
 ```
 
+---
+
+## Re-bench 2026-07-11 — VM engine-direct, moteur SQL assaini (#455) + saveur `rust` (PyO3 0.2.0)
+
+Premier re-bench après (a) l'industrialisation de la wheel PyO3 (#454, wheel
+`ootils_kernel` 0.2.0 buildée via `docker build --build-arg WITH_RUST=1` sur la
+VM) et (b) le fix de la régression O(N²) du moteur SQL (#455, `ANALYZE
+dirty_nodes` dans `flush_to_postgres`). Bases `ootils_bench_{s,m,l}` sur la VM
+pilote (`docker-compose.override.yml` : 8 GB shared_buffers, 4 workers,
+`shm_size=1g`), débit comparé sur `dirty_node_count` (non biaisé entre moteurs,
+cf. `CalcRun` docstring). Harness `scripts/bench_engine_comparison.py`.
+
+### Propagation complète (temps du graphe entier)
+
+| Profil | PI actifs | Python | **SQL avant #455 (bug stats)** | **SQL après #455** | Rust (PyO3) |
+|---|---|---|---|---|---|
+| S | 47 520 | 16,6 s (2 861 nps) | **1 099 s (43 nps)** | **4,04 s (11 768 nps)** | 3,95 s (12 035 nps) |
+| M | 111 240 | 30,9 s (3 602 nps) | pathologique | 6,48 s (17 159 nps) | 6,23 s (17 845 nps) |
+| L | 226 800 | 67,5 s (3 362 nps) | pathologique | 16,3 s (13 909 nps) | 16,8 s (13 473 nps) |
+
+**Le vrai gain = le fix #455 : profil S de 1 099 s → 4,04 s (272×)** — le moteur
+par défaut retrouve (et dépasse légèrement, grâce au tuning PG du 09/07) son
+niveau sain de mai (5,6 s sur S). La régression était non-déterministe : le
+`bench_engine_comparison` de mai était rapide par accident de fraîcheur de
+stats.
+
+**SQL ≈ Rust à ±4 % end-to-end** sur les 3 profils (SQL gagne même sur L :
+16,3 vs 16,8 s). L'ancien claim « Rust gagne partout / full-L 9,5 s vs SQL
+36,8 s » (ex-commentaire `propagator_rust.py`) était mesuré contre le SQL
+**cassé** (stats périmées) ; une fois les stats fraîches, l'avantage in-process
+s'évapore, parce que le wall de propagation est dominé par l'orchestration
+Python/SQL autour du kernel (persistance shortages, calc_run, resolve_stale),
+pas par le compute par nœud — cohérent avec le profiling Tier-3 (« compute =
+7,5 % du wall »). Le kernel Rust pur reste rapide (0,80 s pour 111 k PIs en
+direct, cf. parité ci-dessous), mais ce n'est que ~7,5 % du travail total.
+
+### Incrémental (latence événement réel, `bench_incremental.py --n 30`)
+
+| Profil | Moteur | p50 | p95 | débit |
+|---|---|---|---|---|
+| M (111 k) | SQL | ~38 ms | ~80 ms | 971 nps |
+| M (111 k) | Rust | ~48 ms | **341 ms** | 671 nps |
+| L (227 k) | SQL | ~66 ms | ~100 ms | 583 nps |
+| L (227 k) | Rust | ~69 ms | ~103 ms | 586 nps |
+
+Sur le chemin chaud incrémental (ce que font réellement les agents), **SQL ≥
+Rust** : à parité sur L, et SQL meilleur sur M avec une queue p95 bien plus
+basse (le Rust in-process paie une connexion PG dédiée + handshake par appel).
+
+### Parité 3-way (`parity_3way.py`, profil M)
+
+`0 mismatch` SQL vs Python **et** Rust vs Python sur 111 240 PIs communs —
+déterminisme intact entre les trois moteurs. Temps engine-direct : Python
+30,7 s / SQL 5,5 s / **Rust 0,80 s** (load 570 ms + compute 55 ms) — le 0,80 s
+Rust est le kernel PUR, sans l'orchestration Python qui domine le end-to-end de
+6,2 s ci-dessus.
+
+### Conséquence pour SCALE-2
+
+Le dossier pour faire de **Rust-in-process (PyO3) le défaut** est faible : aucun
+gain de vitesse mesurable sur un SQL sain, plus le coût de packaging/build. La
+vraie valeur de Rust est ailleurs — l'architecture **rust-svc in-RAM** (fork
+O(1), zéro round-trip PG), qui est un pari différent avec ses blockers connus
+(ADR-017, cf. `docs/RUNBOOK-rust-engine-service.md`). Ce re-bench recentre donc
+l'arbitrage : Rust ≠ « moteur plus rapide », Rust = « architecture de scénarios
+en mémoire ».
+
+---
+
 À mettre à jour à chaque modification du propagator ou de la couche SQL.

--- a/docs/SCALABILITY.md
+++ b/docs/SCALABILITY.md
@@ -194,6 +194,15 @@ Two structural lessons, both now measured rather than estimated:
   (475 nps vs ~4 000 nps) — HTTP stack + remote-LAN DB round-trips dominate.
   The 7.7-minute synchronous HTTP request is issue #193 (async calc workers)
   demonstrating itself.
+  **⚠ Correction (2026-07-11, #455):** this "~8× is all HTTP/LAN" reading was
+  partly wrong. The 2026-07 VM re-bench uncovered a latent O(N²) plan
+  regression in the SQL engine — stale `dirty_nodes` stats made the planner
+  pick a per-row nested loop (43 nps vs the expected ~8 400). The pilot's
+  464 s run went through that pathology, so an unknown (likely large) share
+  of it was the stats bug, **not** HTTP/LAN. Fixed by `ANALYZE dirty_nodes`
+  in `flush_to_postgres` (#455). The SCALE-1 API-path re-profiling must
+  re-decompose the 464 s **after** this fix ships to the pilot before
+  attributing the remainder to the transport layer.
 - **The deep-copy fork is O(N) in STORAGE as well as time**: each pilot fork
   duplicates the full node/edge set (211 K → the fork carried 431 K rows after
   bootstrap). Five concurrent forks of a bootstrapped pilot base would add

--- a/src/ootils_core/engine/orchestration/propagator_rust.py
+++ b/src/ootils_core/engine/orchestration/propagator_rust.py
@@ -56,15 +56,24 @@ logger = logging.getLogger(__name__)
 
 
 # Crossover point: below this many dirty PIs, fall back to the SQL
-# inline path. Measured on profile L after the week-5 perf optims
-# (connection pool + UNNEST writeback + combined UNION ALL load):
-#   -    91 PIs : SQL 95ms vs Rust ~40ms (warm pool)  → Rust 2.4× FASTER
-#   -  5000 PIs : Rust still wins
-#   - 50000+ PIs: Rust wins decisively (full prop L: 9.5s vs 36.8s)
+# inline path.
 #
-# Default 0 = always use Rust (post-week-5 optims made it win at every
-# scale we've measured). Set OOTILS_RUST_MIN_DIRTY > 0 to force the
-# SQL fallback below a threshold if regressions show up.
+# HISTORY / CAUTION: an earlier version of this comment claimed "Rust
+# wins at every scale (full prop L: 9.5s vs 36.8s)". The 36.8s SQL
+# figure was measured against a SQL engine with STALE dirty_nodes stats
+# — the O(N²) nested-loop pathology fixed in #455 (ANALYZE dirty_nodes
+# in flush_to_postgres). The 2026-07-11 VM re-bench with the fix live
+# shows SQL and Rust are within ±4% end-to-end on profiles S/M/L (SQL
+# even wins on L: 16.3s vs 16.8s), because propagation wall time is
+# dominated by the Python/SQL orchestration around the kernel (shortage
+# persistence, calc_run, resolve_stale), not the per-node compute — the
+# Rust kernel itself is fast (0.8s for 111k PIs engine-direct) but that
+# is ~7.5% of the wall. See docs/PERF-BASELINE.md (§ re-bench 2026-07-11).
+# In-process Rust is therefore NOT a decisive speedup over healthy SQL;
+# the real Rust lever is the rust-svc in-RAM architecture (SCALE-2).
+#
+# Default 0 = use Rust whenever OOTILS_ENGINE=rust is opted into. Set
+# OOTILS_RUST_MIN_DIRTY > 0 to force the SQL fallback below a threshold.
 RUST_DISPATCH_THRESHOLD = int(os.environ.get("OOTILS_RUST_MIN_DIRTY", "0"))
 
 


### PR DESCRIPTION
## Les chiffres définitifs du chantier perf

Re-bench engine-direct sur la VM (profils S/M/L), **après** le fix `ANALYZE` (#455) et la wheel PyO3 0.2.0 (#454). Il répond, mesures en main, à « est-ce plus rapide ? » — et le résultat recadre la stratégie Rust.

### Propagation complète (débit dirty-node)
| Profil | PI | Python | **SQL avant #455** | **SQL après** | Rust |
|---|---|---|---|---|---|
| S | 47 520 | 16,6 s | **1 099 s (43 nps)** | **4,04 s (11 768 nps)** | 3,95 s |
| M | 111 240 | 30,9 s | pathologique | 6,48 s | 6,23 s |
| L | 226 800 | 67,5 s | pathologique | 16,3 s | 16,8 s |

### Trois enseignements
1. **Le vrai gain est le fix #455, pas Rust : S de 1 099 s → 4,04 s (272×)**, retour au-dessus du niveau sain de mai. La régression était non-déterministe (stats périmées).
2. **SQL ≈ Rust à ±4 %** end-to-end (SQL gagne même sur L). Le claim historique « Rust gagne partout » était mesuré contre le SQL cassé ; stats fraîches, l'avantage in-process disparaît — le wall est dominé par l'orchestration Python/SQL, pas le compute (Tier-3 : 7,5 %). En incrémental, SQL ≥ Rust (queue p95 rust pire).
3. **Parité 3-way : 0 mismatch** sur 111 240 PIs — déterminisme intact.

### Conséquence SCALE-2
Le dossier pour faire de **Rust-in-process le défaut est faible** (aucun gain vs SQL sain + coût packaging). La vraie valeur Rust = l'architecture **rust-svc in-RAM** (fork O(1), zéro round-trip PG). Ce re-bench recentre l'arbitrage : Rust ≠ moteur plus rapide, Rust = architecture de scénarios en mémoire.

## Fichiers
- `PERF-BASELINE.md` : section chiffrée complète + conséquence SCALE-2.
- `SCALABILITY.md` : **correction de l'inférence #414** (les 464 s attribués au HTTP/LAN incluaient la pathologie de stats — à re-décomposer post-fix par SCALE-1).
- `CLAUDE.md` : invariant planner-stats (bulk INSERT lu dans la même requête → `ANALYZE`).
- `propagator_rust.py` : **commentaire uniquement** — l'ancien seuil affirmait « Rust gagne partout / full-L 9,5 s vs 36,8 s », qui était le SQL à stats périmées ; corrigé pour refléter la mesure. Aucun changement de comportement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)