### PR TITLE
feat(interfaces): PR-2 -- gardes du run quotidien + daily_runs (078, ADR-042)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,11 @@ jobs:
 
       - name: Install pip-audit + project
         run: |
-          pip install --upgrade pip
+          # setuptools >= 83 : PYSEC-2026-3447 (advisory publiee 2026-07,
+          # fix disponible) — on met a niveau l'outil d'environnement plutot
+          # que d'ajouter un ignore, contrairement aux ignores documentes
+          # ci-dessous qui n'ont PAS de fix atteignable.
+          pip install --upgrade pip "setuptools>=83"
           pip install pip-audit
           pip install -e ".[dev]"
 

--- a/src/ootils_core/db/migrations/078_daily_runs.sql
+++ b/src/ootils_core/db/migrations/078_daily_runs.sql
@@ -1,0 +1,207 @@
+-- ============================================================
+-- Migration 078 — daily_runs (guard-evaluation audit trail) + recommendations.exported_at
+-- ============================================================
+-- ADR-042 (docs/ADR-042-interface-doctrine.md) decision 3 step 10 / decision
+-- 4, PR-2 of the pilot-decided delivery order ("la valeur d'abord"), which
+-- absorbs ADR-037's INT-1 PR2 (docs/ADR-037-daily-run-and-governed-ingest.md
+-- §5): "Table daily_runs (+ FK vers feed_contracts) ; évaluation runtime par
+-- flux : fenêtre d'arrivée (cadence + arrival_window_minutes vs l'horodatage
+-- réel d'upload), gardes de volume (volume_guard_min_rows/
+-- volume_guard_max_pct_delta vs le run précédent), lues via
+-- get_active_contract()."
+--
+-- SCOPE OF THIS PR: schema + the pure/persisted guard-evaluation audit
+-- trail only (src/ootils_core/interfaces/guards.py + daily_run.py). NOT in
+-- scope here (see those modules' docstrings for the full boundary):
+--   * the governed auto-approve/escalate DECISION (ADR-037 §0 option (a))
+--     that combines these guard verdicts with a batch's DQ status — PR-3's
+--     engine/ingest/apply.py territory.
+--   * a `daily_run_completed` events.event_type CHECK widening — ADR-042
+--     ties that event to the RUN as a whole (every feed evaluated + the
+--     governed decision taken), a granularity only PR-3's decision engine
+--     can know it has reached. Adding the CHECK value here, unused, would
+--     invite exactly the kind of un-exercised schema drift migration 073's
+--     own header warns against for daily_runs' FK. Deferred to the PR that
+--     actually emits it (same discipline as migration 076's purge_executed,
+--     added in the SAME PR that started emitting it).
+--   * computing row deltas from a real file diff — the TSV-vs-canonical
+--     diffing service does not exist yet in this worktree; row_count/
+--     deleted_count are recorded as OBSERVED inputs the caller supplies.
+--
+-- WHY daily_runs HAS NO scenario_id: a governed daily run evaluates ERP
+-- feed interfaces (on-hand, POs, WOs, customer orders, ...) — it is not
+-- scenario-scoped working state (unlike nodes/edges/shortages). It is
+-- baseline-by-nature, same rationale ADR-030 already established for
+-- inventory_snapshots/recommendation_outcomes: an observed ERP feed
+-- evaluation is a fact, not a fork's simulated state.
+-- tests/test_purge_whitelist_guard.py re-derives scenario-scoped tables by
+-- scanning for a literal scenario_id column — daily_runs correctly does not
+-- appear in that scan, exactly like feed_contracts before it.
+--
+-- APPEND-ONLY AUDIT TRAIL, NOT UPSERTED: no UNIQUE(feed_key, run_date). A
+-- feed's guard verdict can legitimately be (re-)evaluated more than once on
+-- the same run_date (e.g. reported missing at the arrival deadline, then
+-- re-evaluated once the file lands later that day) — each attempt is its
+-- own honest row, same philosophy as calc_runs/maintenance_purge_runs
+-- (076). The "current" verdict for a (feed_key, run_date) is simply the
+-- most recent row by observed_at — see interfaces/daily_run.py's
+-- plan_daily_run_guard_check, which reads the latest PRIOR-DAY row for the
+-- volume-delta baseline.
+--
+-- feed_contract_id FK: ON DELETE RESTRICT. feed_contracts rows are never
+-- hard-deleted (append-only per version, migration 073) — RESTRICT is a
+-- pure safety net, mirroring the FK-to-append-only-audit-table convention
+-- used elsewhere (maintenance_purge_runs -> scenarios, migration 076).
+--
+-- Guard status vocabulary ('ok' | 'failed' | 'not_evaluated') on the four
+-- per-guard columns mirrors interfaces/guards.py's GuardStatus enum exactly
+-- (kept in lockstep — widen one, widen the other). 'not_evaluated' is the
+-- None-honest state: the guard was not configured on the active contract,
+-- or had no baseline to compare against — never a fabricated 'ok'.
+-- overall_status is narrower ('ok' | 'failed' only): FeedGuardEvaluation.
+-- overall_status never returns NOT_EVALUATED (see guards.py) — a run's
+-- overall verdict is always a real ok/failed call.
+--
+-- exported_at on recommendations: bundled into this SAME migration per
+-- ADR-042 decision 4 ("Colonne exported_at sur recommendations (migration
+-- 078, la même migration que daily_runs)"). Schema-only in THIS PR — the
+-- idempotent outbound-export/reconciliation logic that stamps it lands in
+-- PR-5. NULL means "not yet exported"; a stamped row is never re-exported
+-- (a plain `WHERE exported_at IS NULL` is the idempotency check, ADR-042
+-- decision 4).
+--
+-- Idempotence (pattern from migration 063's header, mandatory — the runner
+-- wraps each file in ONE transaction and ABORTS on any error, it does NOT
+-- swallow "already exists", so a fixed migration re-attempted at the next
+-- boot re-runs every statement from scratch):
+--   * CREATE TABLE IF NOT EXISTS   — no-op on re-run.
+--   * CREATE INDEX IF NOT EXISTS   — no-op on re-run.
+--   * ADD COLUMN IF NOT EXISTS     — no-op on re-run.
+--
+-- No JSONB: every column here is typed and business-queryable (guard
+-- verdicts feed the daily report, ADR-042 §5 — not diagnostic-only detail).
+--
+-- ref: ADR-042 (PR-2), ADR-037 (INT-1 PR2, absorbed).
+-- ============================================================
+
+BEGIN;
+
+-- ------------------------------------------------------------
+-- daily_runs — one row per (feed_key, run_date) guard-evaluation attempt
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS daily_runs (
+    daily_run_id           UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- The contract version this evaluation was run against. RESTRICT: see
+    -- header (feed_contracts rows are never hard-deleted).
+    feed_contract_id       UUID        NOT NULL REFERENCES feed_contracts(feed_contract_id) ON DELETE RESTRICT,
+
+    -- Denormalized from feed_contracts for query convenience (same
+    -- denormalization pattern as shortages' item_external_id, migration
+    -- 004) — a feed_key spans many contract versions, so this is NOT
+    -- redundant with a simple join key, it is the stable identifier the
+    -- daily-run runtime actually keys evaluations on.
+    feed_key               TEXT        NOT NULL,
+
+    -- Calendar day this evaluation covers (the daily run's own "today").
+    run_date               DATE        NOT NULL,
+
+    -- When THIS evaluation attempt ran (may be re-evaluated intra-day —
+    -- see header "APPEND-ONLY AUDIT TRAIL").
+    observed_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- When the feed's file actually landed, NULL if it never arrived by
+    -- the time this evaluation ran.
+    file_arrived_at        TIMESTAMPTZ,
+
+    -- Observed row count in the arrived file, NULL if the file never
+    -- arrived (None-honest: distinct from a genuine zero-row file).
+    row_count              INTEGER     CHECK (row_count IS NULL OR row_count >= 0),
+
+    -- The previous evaluation's row_count for this feed_key (the volume-
+    -- delta guard's baseline), denormalized at write time so a daily_runs
+    -- row is a self-contained audit record even if earlier rows are later
+    -- purged/retained differently.
+    previous_row_count     INTEGER     CHECK (previous_row_count IS NULL OR previous_row_count >= 0),
+
+    -- Rows that disappeared vs the previous run's canonical picture (the
+    -- deletion-ratio guard's numerator). NULL until the real file-diff
+    -- service (PR-3/4) supplies it — see module docstring for the current
+    -- caller-supplied-observation boundary.
+    deleted_count          INTEGER     CHECK (deleted_count IS NULL OR deleted_count >= 0),
+
+    -- Denormalized from feed_contracts at evaluation time (a contract's
+    -- criticality could in principle change between versions; this column
+    -- freezes what was actually in effect for THIS evaluation).
+    criticality            TEXT        NOT NULL CHECK (criticality IN ('blocking', 'advisory')),
+
+    -- Per-guard verdicts — kept in lockstep with interfaces/guards.py's
+    -- GuardStatus enum (see header).
+    arrival_status         TEXT        NOT NULL CHECK (arrival_status        IN ('ok', 'failed', 'not_evaluated')),
+    volume_floor_status    TEXT        NOT NULL CHECK (volume_floor_status   IN ('ok', 'failed', 'not_evaluated')),
+    volume_delta_status    TEXT        NOT NULL CHECK (volume_delta_status   IN ('ok', 'failed', 'not_evaluated')),
+    deletion_ratio_status  TEXT        NOT NULL CHECK (deletion_ratio_status IN ('ok', 'failed', 'not_evaluated')),
+
+    -- FAILED iff any of the four guards above is FAILED — never
+    -- NOT_EVALUATED itself (see interfaces/guards.py:FeedGuardEvaluation.overall_status).
+    overall_status         TEXT        NOT NULL CHECK (overall_status IN ('ok', 'failed')),
+
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE daily_runs IS
+    'Guard-evaluation audit trail for the daily-run governed-ingest pipeline '
+    '(ADR-042 PR-2, absorbs ADR-037 INT-1 PR2). One row per (feed_key, '
+    'run_date) evaluation ATTEMPT — append-only, not upserted (a feed can be '
+    'legitimately re-evaluated intra-day). The governed auto-approve/'
+    'escalate decision that CONSUMES these verdicts is PR-3 territory '
+    '(engine/ingest/apply.py), not written here.';
+
+COMMENT ON COLUMN daily_runs.feed_contract_id IS
+    'The feed_contracts version this evaluation ran against. ON DELETE '
+    'RESTRICT: feed_contracts rows are never hard-deleted (append-only per '
+    'version), this is a pure safety net.';
+
+COMMENT ON COLUMN daily_runs.deleted_count IS
+    'Rows that disappeared vs the previous run''s canonical picture — the '
+    'deletion_ratio guard''s numerator. NULL until the real file-diff '
+    'service (PR-3/4) supplies it; interfaces/guards.py treats NULL as '
+    'NOT_EVALUATED, never a fabricated pass.';
+
+COMMENT ON COLUMN daily_runs.overall_status IS
+    'FAILED iff any of the four per-guard columns is failed. Never '
+    '''not_evaluated'' itself — an overall verdict is always a real ok/'
+    'failed call (interfaces/guards.py:FeedGuardEvaluation.overall_status).';
+
+-- Guard-evaluation history for one feed, newest first (the daily report,
+-- ADR-042 §5, and plan_daily_run_guard_check's previous-day lookup both
+-- read this way).
+CREATE INDEX IF NOT EXISTS idx_daily_runs_feed_key_run_date
+    ON daily_runs (feed_key, run_date DESC, observed_at DESC);
+
+-- Cross-feed "what failed today" query (the daily report's headline view).
+CREATE INDEX IF NOT EXISTS idx_daily_runs_run_date_overall_status
+    ON daily_runs (run_date, overall_status);
+
+-- ------------------------------------------------------------
+-- recommendations.exported_at — idempotent-export marker (ADR-042 decision 4)
+-- ------------------------------------------------------------
+-- Schema-only in this PR: nothing stamps this column yet (the outbound
+-- export/reconciliation write-side lands in PR-5). NULL = not yet exported.
+ALTER TABLE recommendations ADD COLUMN IF NOT EXISTS exported_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN recommendations.exported_at IS
+    'When this recommendation was written to the ootils-outbox as a '
+    'po_draft/reschedule_message (ADR-042 decision 4, PR-5). NULL = not yet '
+    'exported. A stamped row is NEVER re-exported: a plain WHERE '
+    'exported_at IS NULL is the idempotency check. Schema-only in PR-2 — '
+    'nothing stamps this column until PR-5.';
+
+-- The pending-export scan ("every APPROVED reco not yet exported") is a
+-- partial index on the common case (most recos, once exported, are never
+-- queried by this predicate again).
+CREATE INDEX IF NOT EXISTS ix_reco_pending_export
+    ON recommendations (status)
+    WHERE exported_at IS NULL;
+
+COMMIT;

--- a/src/ootils_core/interfaces/__init__.py
+++ b/src/ootils_core/interfaces/__init__.py
@@ -1,11 +1,18 @@
 """
-External-interface contracts (INT-1, ADR-037).
+External-interface contracts (INT-1/ADR-037, daily-run guards/ADR-042 PR-2).
 
 ``contracts.py`` is the Python half of the feed-contract registry: strict
 pydantic parsing of ``config/feed-contracts/*.yaml``, a versioned/idempotent
 loader into the ``feed_contracts`` table (migration 073), and the
-``get_active_contract`` reader. PR1 is registry-only — nothing here reads a
-contract at ingest time yet (the daily-run runtime lands in PR2/PR3).
+``get_active_contract`` reader.
+
+``guards.py`` is the pure (DB-free) runtime-guard evaluator ADR-037 §6
+describes (arrival window, volume floor/delta, deletion ratio) — see its
+module docstring. ``daily_run.py`` is the DB-touching persistence layer
+(``daily_runs`` table, migration 078) that gathers a feed's active contract
++ previous run stats and records one guard-evaluation attempt. The governed
+auto-approve/escalate DECISION that consumes these verdicts is PR-3
+territory (``engine/ingest/apply.py``, not yet written).
 """
 from ootils_core.interfaces.contracts import (
     ContractError,
@@ -17,6 +24,26 @@ from ootils_core.interfaces.contracts import (
     parse_contract_file,
     upsert_contract,
 )
+from ootils_core.interfaces.daily_run import (
+    DailyRunGuardError,
+    DailyRunGuardPlan,
+    DailyRunObservation,
+    DailyRunRecord,
+    plan_daily_run_guard_check,
+    record_daily_run,
+)
+from ootils_core.interfaces.guards import (
+    DELETION_RATIO_THRESHOLD,
+    FeedGuardEvaluation,
+    GuardResult,
+    GuardStatus,
+    compute_expected_arrival_deadline,
+    evaluate_arrival_window_guard,
+    evaluate_deletion_ratio_guard,
+    evaluate_feed_guards,
+    evaluate_volume_delta_guard,
+    evaluate_volume_floor_guard,
+)
 
 __all__ = [
     "ContractError",
@@ -27,4 +54,20 @@ __all__ = [
     "load_contract_dir",
     "parse_contract_file",
     "upsert_contract",
+    "DailyRunGuardError",
+    "DailyRunGuardPlan",
+    "DailyRunObservation",
+    "DailyRunRecord",
+    "plan_daily_run_guard_check",
+    "record_daily_run",
+    "DELETION_RATIO_THRESHOLD",
+    "FeedGuardEvaluation",
+    "GuardResult",
+    "GuardStatus",
+    "compute_expected_arrival_deadline",
+    "evaluate_arrival_window_guard",
+    "evaluate_deletion_ratio_guard",
+    "evaluate_feed_guards",
+    "evaluate_volume_delta_guard",
+    "evaluate_volume_floor_guard",
 ]

--- a/src/ootils_core/interfaces/daily_run.py
+++ b/src/ootils_core/interfaces/daily_run.py
@@ -1,0 +1,221 @@
+"""
+daily_run.py — persistence for the daily-run guard evaluations (``daily_runs``
+table, migration 078; ADR-042 decision 3, absorbs ADR-037's INT-1 PR2).
+
+Same DB-boundary split as ``engine/maintenance/purge.py``: a read-only
+``plan_*`` helper gathers the DB-dependent inputs one feed's guard
+evaluation needs (its active contract, via
+``interfaces.contracts.get_active_contract``, and the previous evaluation's
+row count for the day/day comparison), and the sole writer —
+``record_daily_run`` — re-runs that same plan on FRESH data immediately
+before writing (never trusts a stale caller-supplied plan, same defense in
+depth as ``purge.py``'s ``_apply_one``), calls the pure guard evaluator
+(``interfaces.guards.evaluate_feed_guards``), and INSERTs exactly one
+``daily_runs`` row.
+
+SCOPE OF THIS PR (ADR-042's PR-2 / ADR-037's INT-1 PR2): guard evaluation +
+persistence only. Deliberately OUT of scope here — see migration 078's
+header for the full rationale:
+
+  * the auto-approve/escalate DECISION (ADR-037 §0 option (a)) that combines
+    this module's per-feed guard verdicts with a batch's DQ status — PR-3's
+    ``engine/ingest/apply.py`` territory.
+  * emitting a ``daily_run_completed`` stream event — that event's
+    granularity is the RUN AS A WHOLE (every feed evaluated + the governed
+    decision taken, ADR-027 convention), which only PR-3's decision engine
+    can know it has reached. Emitting one per feed, per evaluation attempt,
+    here, would misrepresent "one event per run".
+  * deriving ``deleted_count``/``previous_active_count`` from a real file
+    diff — the TSV-vs-canonical diffing service (``engine/ingest/apply``)
+    does not exist yet in this worktree; ``record_daily_run`` accepts them
+    as caller-supplied observation inputs, ``None`` when not yet knowable
+    (the deletion_ratio guard treats that as NOT_EVALUATED, never a
+    fabricated pass).
+
+Never commits/rolls back — the caller owns the transaction (same
+convention as ``interfaces/contracts.py`` and ``engine/maintenance/purge.py``).
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from uuid import UUID
+
+from psycopg.rows import dict_row
+
+from ootils_core.db.types import DictRowConnection
+from ootils_core.interfaces.contracts import FeedContract, get_active_contract
+from ootils_core.interfaces.guards import FeedGuardEvaluation, evaluate_feed_guards
+
+logger = logging.getLogger(__name__)
+
+
+class DailyRunGuardError(Exception):
+    """Raised when a daily-run guard evaluation cannot proceed: ``feed_key``
+    has no active ``feed_contracts`` row (unregistered or retired). Never
+    bypassed — a feed with no contract has nothing to evaluate against."""
+
+
+@dataclass(frozen=True)
+class DailyRunGuardPlan:
+    """The DB-dependent inputs one feed's guard evaluation needs, gathered
+    read-only. Mirrors ``PurgePlan`` (``engine/maintenance/purge.py``): a
+    pure preview, safe to call from a read-only endpoint, writes nothing."""
+
+    contract: FeedContract
+    previous_row_count: int | None
+
+
+@dataclass(frozen=True)
+class DailyRunObservation:
+    """Caller-supplied raw observation for one feed on one ``run_date`` —
+    the DB-free inputs ``record_daily_run`` cannot derive itself in this
+    PR's scope (see module docstring)."""
+
+    file_arrived_at: datetime | None
+    row_count: int | None
+    deleted_count: int | None = None
+    previous_active_count: int | None = None
+
+
+@dataclass(frozen=True)
+class DailyRunRecord:
+    """The persisted outcome of one ``record_daily_run`` call."""
+
+    daily_run_id: UUID
+    feed_key: str
+    run_date: date
+    evaluation: FeedGuardEvaluation
+
+
+def plan_daily_run_guard_check(
+    conn: DictRowConnection, feed_key: str, run_date: date
+) -> DailyRunGuardPlan:
+    """SELECT-only: the active contract for ``feed_key`` plus the previous
+    evaluation's row count — the most recent ``daily_runs`` row for this
+    feed_key strictly BEFORE ``run_date`` by calendar day (not merely the
+    last-inserted row, so a same-day re-evaluation never becomes its own
+    baseline). Writes nothing.
+
+    Raises ``DailyRunGuardError`` if ``feed_key`` has no active contract.
+    """
+    contract = get_active_contract(conn, feed_key)
+    if contract is None:
+        raise DailyRunGuardError(
+            f"daily_run guard check: feed_key {feed_key!r} has no active "
+            "feed_contracts row — nothing to evaluate against"
+        )
+
+    cur = conn.cursor(row_factory=dict_row)
+    prev = cur.execute(
+        """
+        SELECT row_count FROM daily_runs
+        WHERE feed_key = %s AND run_date < %s
+        ORDER BY run_date DESC, observed_at DESC
+        LIMIT 1
+        """,
+        (feed_key, run_date),
+    ).fetchone()
+    previous_row_count = (
+        int(prev["row_count"])
+        if prev is not None and prev["row_count"] is not None
+        else None
+    )
+
+    return DailyRunGuardPlan(contract=contract, previous_row_count=previous_row_count)
+
+
+def record_daily_run(
+    conn: DictRowConnection,
+    feed_key: str,
+    run_date: date,
+    observation: DailyRunObservation,
+    now: datetime | None = None,
+) -> DailyRunRecord:
+    """The sole writer of the ``daily_runs`` guard-evaluation audit trail.
+
+    Re-gathers ``plan_daily_run_guard_check`` on FRESH data immediately
+    before writing (never trusts a plan built earlier — the active contract
+    or the previous run's row count may have changed since), runs the pure
+    guard evaluator, INSERTs exactly one ``daily_runs`` row, and returns the
+    typed result.
+
+    Multiple evaluation attempts for the same ``(feed_key, run_date)`` are
+    NOT deduplicated at the DB level (no unique constraint) — this is an
+    append-only audit trail (same philosophy as ``calc_runs``/
+    ``maintenance_purge_runs``): a feed reported missing at the arrival
+    deadline and then re-evaluated once the file lands are two honest,
+    distinct rows, not an overwrite.
+
+    Does NOT commit — the caller owns the transaction.
+    """
+    plan = plan_daily_run_guard_check(conn, feed_key, run_date)
+    evaluated_at = now if now is not None else datetime.now(timezone.utc)
+
+    evaluation = evaluate_feed_guards(
+        feed_key=feed_key,
+        criticality=plan.contract.criticality,
+        cadence=plan.contract.cadence,
+        arrival_window_minutes=plan.contract.arrival_window_minutes,
+        volume_guard_min_rows=plan.contract.volume_guard_min_rows,
+        volume_guard_max_pct_delta=plan.contract.volume_guard_max_pct_delta,
+        run_date=run_date,
+        file_arrived_at=observation.file_arrived_at,
+        row_count=observation.row_count,
+        previous_row_count=plan.previous_row_count,
+        deleted_count=observation.deleted_count,
+        previous_active_count=observation.previous_active_count,
+        now=evaluated_at,
+    )
+
+    cur = conn.cursor(row_factory=dict_row)
+    inserted = cur.execute(
+        """
+        INSERT INTO daily_runs (
+            feed_contract_id, feed_key, run_date, observed_at,
+            file_arrived_at, row_count, previous_row_count, deleted_count,
+            criticality, arrival_status, volume_floor_status,
+            volume_delta_status, deletion_ratio_status, overall_status
+        ) VALUES (
+            %(feed_contract_id)s, %(feed_key)s, %(run_date)s, %(observed_at)s,
+            %(file_arrived_at)s, %(row_count)s, %(previous_row_count)s,
+            %(deleted_count)s, %(criticality)s, %(arrival_status)s,
+            %(volume_floor_status)s, %(volume_delta_status)s,
+            %(deletion_ratio_status)s, %(overall_status)s
+        ) RETURNING daily_run_id
+        """,
+        {
+            "feed_contract_id": plan.contract.feed_contract_id,
+            "feed_key": feed_key,
+            "run_date": run_date,
+            "observed_at": evaluated_at,
+            "file_arrived_at": observation.file_arrived_at,
+            "row_count": observation.row_count,
+            "previous_row_count": plan.previous_row_count,
+            "deleted_count": observation.deleted_count,
+            "criticality": plan.contract.criticality,
+            "arrival_status": evaluation.by_name("arrival_window").status.value,
+            "volume_floor_status": evaluation.by_name("volume_floor").status.value,
+            "volume_delta_status": evaluation.by_name("volume_delta").status.value,
+            "deletion_ratio_status": evaluation.by_name("deletion_ratio").status.value,
+            "overall_status": evaluation.overall_status.value,
+        },
+    ).fetchone()
+    if inserted is None:  # INSERT..RETURNING yields exactly one row — fail loudly
+        raise RuntimeError("daily_runs INSERT ... RETURNING yielded no row")
+    raw_id = inserted["daily_run_id"]
+    daily_run_id = raw_id if isinstance(raw_id, UUID) else UUID(str(raw_id))
+
+    logger.info(
+        "daily_run.guard_recorded feed_key=%s run_date=%s daily_run_id=%s "
+        "overall_status=%s",
+        feed_key, run_date, daily_run_id, evaluation.overall_status.value,
+    )
+
+    return DailyRunRecord(
+        daily_run_id=daily_run_id,
+        feed_key=feed_key,
+        run_date=run_date,
+        evaluation=evaluation,
+    )

--- a/src/ootils_core/interfaces/guards.py
+++ b/src/ootils_core/interfaces/guards.py
@@ -1,0 +1,357 @@
+"""
+guards.py — pure runtime guards for the daily-run governed-ingest pipeline
+(ADR-042 decision 3 step 5; absorbs ADR-037's INT-1 PR2, §6).
+
+Every daily run evaluates, PER FEED, the runtime guards a `feed_contracts`
+row (``interfaces/contracts.py``) only DECLARES: has the file arrived within
+its cadence + arrival window, does its row count clear the configured
+volume floor, did the row count swing more than the configured day/day
+tolerance, and did more than the repo-wide deletion-ratio threshold of
+previously-active rows disappear. ADR-037 §6 names these as the guards that
+catch a feed's silent death modes ("extraction partielle silencieuse" and
+"flux totalement absent") before a governed run trusts the feed.
+
+Every function in this module is PURE: no DB, no wall-clock read (``now``
+and every timestamp are always caller-supplied), no I/O, never raises on a
+"bad" observation — a red guard is data (a ``GuardResult``), not an
+exception. The DB-touching counterpart — gathering the active contract and
+the previous run's stats, and persisting the evaluation — lives in
+``daily_run.py``, split the same way ``engine/maintenance/purge.py`` splits
+its pure guard checks (``_verify_purge_guards``) from its DB-touching
+plan/apply functions.
+
+NONE-HONEST BY CONSTRUCTION: a guard whose contract does not configure it
+(e.g. no ``volume_guard_min_rows``), or that has no baseline to compare
+against (no previous run yet, or the file never arrived), returns
+``GuardStatus.NOT_EVALUATED`` — never a fabricated OK, never a false
+FAILED. ``FeedGuardEvaluation.overall_status`` only turns FAILED on an
+ACTUAL guard failure; NOT_EVALUATED guards never block a run on their own.
+
+CADENCE PARSING — V1 LIMITATION: ``compute_expected_arrival_deadline``
+supports ONLY the ``"M H * * *"`` cron shape (a fixed daily UTC time) — the
+only shape the 3 seed contracts (``config/feed-contracts/*.yaml``) actually
+use. Any other field (day-of-month, day-of-week, step/range syntax) raises
+``ValueError`` naming the unsupported cadence, rather than silently
+mis-parsing it. Widening this is a follow-up once the pilot's real feed
+calendars are known (ADR-037 🎯 Pilote).
+
+TIMEZONE CONTRACT: every ``datetime`` this module accepts or returns
+(``file_arrived_at``, ``now``, ``compute_expected_arrival_deadline``'s
+return value) is UTC and timezone-AWARE. Comparing an aware deadline against
+a naive ``file_arrived_at``/``now`` raises ``TypeError`` at the point of
+comparison (Python's own guard) rather than silently miscomputing — callers
+(the persistence layer, tests) must pass ``tzinfo=timezone.utc`` datetimes.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from enum import Enum
+
+
+class GuardStatus(str, Enum):
+    """One guard's verdict. ``NOT_EVALUATED`` is None-honest: the guard was
+    not configured for this feed, or had no baseline to compare against —
+    never treated as evidence of a problem. Values are kept in lockstep
+    with migration 078's ``daily_runs`` per-guard CHECK vocabulary."""
+
+    OK = "ok"
+    FAILED = "failed"
+    NOT_EVALUATED = "not_evaluated"
+
+
+@dataclass(frozen=True)
+class GuardResult:
+    """One guard's verdict for one feed evaluation. ``detail`` is a
+    human-readable, secret-free explanation — it feeds the daily report
+    (ADR-042 §5) and, on a red guard, the L3 escalation payload (ADR-037
+    PR3), so it must always name the precise reason (North Star
+    "Explicable" — never a silent block)."""
+
+    guard_name: str
+    status: GuardStatus
+    detail: str
+
+
+# Relogged from staging/diff.py's DELETION_RATIO_THRESHOLD (ADR-013 D4) — a
+# repo-wide constant, deliberately NOT a per-feed-contract configurable (see
+# ADR-042 decision 2.1: "les deux gardes de valeur sont sauvées ... relogées
+# comme gardes du nouveau pipeline gouverné").
+DELETION_RATIO_THRESHOLD = 0.20
+
+
+def compute_expected_arrival_deadline(
+    cadence: str, arrival_window_minutes: int, run_date: date
+) -> datetime:
+    """The latest UTC instant a feed may arrive on ``run_date`` before the
+    arrival-window guard treats it as missing.
+
+    V1 supports ONLY the ``"M H * * *"`` cron shape (daily at a fixed UTC
+    time) — see module docstring. Raises ``ValueError`` naming the cadence
+    on any other shape (unsupported field, out-of-range minute/hour,
+    non-integer field).
+    """
+    fields = cadence.split()
+    if len(fields) != 5:
+        raise ValueError(
+            f"compute_expected_arrival_deadline: cadence {cadence!r} must "
+            "have 5 cron fields (minute hour day month weekday)"
+        )
+    minute_f, hour_f, day_f, month_f, weekday_f = fields
+    if day_f != "*" or month_f != "*" or weekday_f != "*":
+        raise ValueError(
+            f"compute_expected_arrival_deadline: cadence {cadence!r} is not "
+            "a supported V1 shape — only 'M H * * *' (daily at a fixed UTC "
+            "time) is implemented"
+        )
+    try:
+        minute = int(minute_f)
+        hour = int(hour_f)
+    except ValueError as exc:
+        raise ValueError(
+            f"compute_expected_arrival_deadline: cadence {cadence!r} has a "
+            "non-integer minute/hour field"
+        ) from exc
+    if not (0 <= minute <= 59):
+        raise ValueError(
+            f"compute_expected_arrival_deadline: cadence {cadence!r} minute "
+            "field out of range (0-59)"
+        )
+    if not (0 <= hour <= 23):
+        raise ValueError(
+            f"compute_expected_arrival_deadline: cadence {cadence!r} hour "
+            "field out of range (0-23)"
+        )
+    tick = datetime(
+        run_date.year, run_date.month, run_date.day, hour, minute, tzinfo=timezone.utc
+    )
+    return tick + timedelta(minutes=arrival_window_minutes)
+
+
+def evaluate_arrival_window_guard(
+    *,
+    cadence: str,
+    arrival_window_minutes: int,
+    run_date: date,
+    file_arrived_at: datetime | None,
+    now: datetime,
+) -> GuardResult:
+    """Missing-feed guard (ADR-037 §6, "flux totalement absent"). Evaluated
+    relative to the caller-supplied ``now`` — never reads the wall clock,
+    so it is fully deterministic in tests.
+
+    Returns NOT_EVALUATED when the deadline has not yet elapsed and the
+    file has not arrived — this guard is meant to be evaluated once the
+    window has passed, not mid-window; a run checking early is not evidence
+    the feed is missing.
+    """
+    deadline = compute_expected_arrival_deadline(cadence, arrival_window_minutes, run_date)
+    if file_arrived_at is not None:
+        if file_arrived_at <= deadline:
+            return GuardResult(
+                "arrival_window",
+                GuardStatus.OK,
+                f"arrived at {file_arrived_at.isoformat()}, within the "
+                f"{deadline.isoformat()} deadline",
+            )
+        return GuardResult(
+            "arrival_window",
+            GuardStatus.FAILED,
+            f"arrived at {file_arrived_at.isoformat()}, after the "
+            f"{deadline.isoformat()} deadline",
+        )
+    if now < deadline:
+        return GuardResult(
+            "arrival_window",
+            GuardStatus.NOT_EVALUATED,
+            f"no file yet, deadline {deadline.isoformat()} not yet elapsed "
+            f"(now={now.isoformat()})",
+        )
+    return GuardResult(
+        "arrival_window",
+        GuardStatus.FAILED,
+        f"no file arrived by the {deadline.isoformat()} deadline "
+        f"(now={now.isoformat()})",
+    )
+
+
+def evaluate_volume_floor_guard(
+    min_rows: int | None, observed_row_count: int | None
+) -> GuardResult:
+    """Silent-partial-extraction guard, floor half (ADR-037 §6, "extraction
+    partielle silencieuse")."""
+    if min_rows is None:
+        return GuardResult(
+            "volume_floor",
+            GuardStatus.NOT_EVALUATED,
+            "no volume_guard_min_rows configured on the active contract",
+        )
+    if observed_row_count is None:
+        return GuardResult(
+            "volume_floor",
+            GuardStatus.NOT_EVALUATED,
+            "no row count observed (file missing — see the arrival_window guard)",
+        )
+    if observed_row_count < min_rows:
+        return GuardResult(
+            "volume_floor",
+            GuardStatus.FAILED,
+            f"observed {observed_row_count} rows, below the floor of {min_rows}",
+        )
+    return GuardResult(
+        "volume_floor",
+        GuardStatus.OK,
+        f"observed {observed_row_count} rows, at or above the floor of {min_rows}",
+    )
+
+
+def evaluate_volume_delta_guard(
+    max_pct_delta: Decimal | None,
+    observed_row_count: int | None,
+    previous_row_count: int | None,
+) -> GuardResult:
+    """Silent-partial-extraction guard, day/day swing half (ADR-037 §6).
+
+    ``previous_row_count`` of ``None`` (no prior run yet) or ``0`` (a prior
+    empty day makes any ratio meaningless/undefined) both yield
+    NOT_EVALUATED — neither is an honest baseline to compare against.
+    """
+    if max_pct_delta is None:
+        return GuardResult(
+            "volume_delta",
+            GuardStatus.NOT_EVALUATED,
+            "no volume_guard_max_pct_delta configured on the active contract",
+        )
+    if observed_row_count is None:
+        return GuardResult(
+            "volume_delta",
+            GuardStatus.NOT_EVALUATED,
+            "no row count observed (file missing — see the arrival_window guard)",
+        )
+    if not previous_row_count:
+        return GuardResult(
+            "volume_delta",
+            GuardStatus.NOT_EVALUATED,
+            "no previous run's row count to compare against",
+        )
+    delta_ratio = Decimal(abs(observed_row_count - previous_row_count)) / Decimal(previous_row_count)
+    if delta_ratio > max_pct_delta:
+        return GuardResult(
+            "volume_delta",
+            GuardStatus.FAILED,
+            f"row count swung {float(delta_ratio):.2%} vs the previous run's "
+            f"{previous_row_count} (today {observed_row_count}), exceeding "
+            f"the {float(max_pct_delta):.2%} tolerance",
+        )
+    return GuardResult(
+        "volume_delta",
+        GuardStatus.OK,
+        f"row count swung {float(delta_ratio):.2%} vs the previous run's "
+        f"{previous_row_count} (today {observed_row_count}), within the "
+        f"{float(max_pct_delta):.2%} tolerance",
+    )
+
+
+def evaluate_deletion_ratio_guard(
+    deleted_count: int | None, previous_active_count: int | None
+) -> GuardResult:
+    """Relogged from ``staging/diff.py``'s ``DELETION_RATIO_THRESHOLD``
+    (ADR-013 D4, ADR-042 decision 2.1): more than 20% of what was active in
+    the previous run disappearing from this one is a soft-delete storm, not
+    normal day/day variation."""
+    if previous_active_count is None or previous_active_count <= 0:
+        return GuardResult(
+            "deletion_ratio",
+            GuardStatus.NOT_EVALUATED,
+            "no previous run's active row count to compare against",
+        )
+    if deleted_count is None:
+        return GuardResult(
+            "deletion_ratio",
+            GuardStatus.NOT_EVALUATED,
+            "no deleted-row count observed (file missing — see the "
+            "arrival_window guard)",
+        )
+    ratio = deleted_count / previous_active_count
+    if ratio > DELETION_RATIO_THRESHOLD:
+        return GuardResult(
+            "deletion_ratio",
+            GuardStatus.FAILED,
+            f"{deleted_count} of {previous_active_count} previously-active "
+            f"rows disappeared ({ratio:.2%}), exceeding the "
+            f"{DELETION_RATIO_THRESHOLD:.0%} threshold",
+        )
+    return GuardResult(
+        "deletion_ratio",
+        GuardStatus.OK,
+        f"{deleted_count} of {previous_active_count} previously-active rows "
+        f"disappeared ({ratio:.2%}), within the {DELETION_RATIO_THRESHOLD:.0%} "
+        "threshold",
+    )
+
+
+@dataclass(frozen=True)
+class FeedGuardEvaluation:
+    """The full guard verdict for one feed's one daily-run evaluation
+    attempt."""
+
+    feed_key: str
+    # 'blocking' | 'advisory' — carried through for the caller's DECISION
+    # logic (ADR-037 §0 option (a), PR-3 territory); never interpreted here.
+    criticality: str
+    results: tuple[GuardResult, ...]
+
+    @property
+    def overall_status(self) -> GuardStatus:
+        """FAILED iff ANY guard FAILED. NOT_EVALUATED guards never fail the
+        evaluation on their own — an unconfigured guard or a missing
+        baseline is not evidence of a problem (None-honest). Never returns
+        NOT_EVALUATED itself."""
+        if any(r.status == GuardStatus.FAILED for r in self.results):
+            return GuardStatus.FAILED
+        return GuardStatus.OK
+
+    def by_name(self, guard_name: str) -> GuardResult:
+        for result in self.results:
+            if result.guard_name == guard_name:
+                return result
+        raise KeyError(f"no guard result named {guard_name!r} in this evaluation")
+
+
+def evaluate_feed_guards(
+    *,
+    feed_key: str,
+    criticality: str,
+    cadence: str,
+    arrival_window_minutes: int,
+    volume_guard_min_rows: int | None,
+    volume_guard_max_pct_delta: Decimal | None,
+    run_date: date,
+    file_arrived_at: datetime | None,
+    row_count: int | None,
+    previous_row_count: int | None,
+    deleted_count: int | None,
+    previous_active_count: int | None,
+    now: datetime,
+) -> FeedGuardEvaluation:
+    """Run all four runtime guards for one feed's one daily-run evaluation.
+
+    Pure — no DB, no wall-clock read. The persistence layer
+    (``daily_run.py``) gathers these inputs from the active
+    ``feed_contracts`` row + the previous ``daily_runs`` row and calls this
+    function.
+    """
+    results = (
+        evaluate_arrival_window_guard(
+            cadence=cadence,
+            arrival_window_minutes=arrival_window_minutes,
+            run_date=run_date,
+            file_arrived_at=file_arrived_at,
+            now=now,
+        ),
+        evaluate_volume_floor_guard(volume_guard_min_rows, row_count),
+        evaluate_volume_delta_guard(volume_guard_max_pct_delta, row_count, previous_row_count),
+        evaluate_deletion_ratio_guard(deleted_count, previous_active_count),
+    )
+    return FeedGuardEvaluation(feed_key=feed_key, criticality=criticality, results=results)

--- a/tests/integration/test_daily_runs_integration.py
+++ b/tests/integration/test_daily_runs_integration.py
@@ -1,0 +1,837 @@
+"""
+tests/integration/test_daily_runs_integration.py — daily-run guard evaluations
+(ADR-042 PR-2, absorbing ADR-037's INT-1 PR2) against a real PostgreSQL — no
+mocks (CLAUDE.md). The pure guard logic lives in tests/test_daily_run_guards.py.
+
+Covers the DB half of src/ootils_core/interfaces/daily_run.py + migration 078:
+
+  1. Schema guarantees of migration 078: exact daily_runs column set (zero
+     JSONB, no scenario_id — baseline-by-nature per the migration header),
+     the FK to feed_contracts confirmed ON DELETE RESTRICT and enforced in
+     both directions (unknown contract refused; deleting a referenced
+     contract refused), every CHECK (per-guard status vocabulary, the
+     deliberately narrower overall_status, criticality, non-negative
+     counts), NULL counts accepted (None-honest: a missing file is not a
+     zero-row file), and — the cadrage's tranché — NO UNIQUE(feed_key,
+     run_date): the table is an append-only audit trail (one row per
+     evaluation ATTEMPT, same philosophy as calc_runs). Plus the bundled
+     recommendations.exported_at column + its partial pending-export index
+     (ADR-042 decision 4, schema-only in this PR).
+  2. record_daily_run — the sole writer: persists ONE complete row whose
+     per-guard verdict columns mirror the returned FeedGuardEvaluation
+     exactly; runs against the ACTIVE contract version; never commits
+     (caller owns the transaction).
+  3. The prior-day baseline lookup (plan_daily_run_guard_check): the
+     volume-delta baseline is the latest STRICTLY-PRIOR-day row (a same-day
+     re-evaluation never becomes its own baseline), the latest attempt of
+     that prior day wins (observed_at tiebreak), and a prior day whose file
+     never arrived (row_count NULL) yields a None-honest NOT_EVALUATED
+     delta, never a fabricated comparison.
+  4. Re-run on the same run_date = append-only: a second attempt INSERTs a
+     second row (no unique violation, distinct daily_run_id), and the
+     "current" verdict is simply the most recent row by observed_at — the
+     documented re-evaluated-once-the-file-lands lifecycle.
+  5. A FAILED verdict on a blocking feed reads correctly through the
+     headline "what failed today" query (run_date + overall_status), with
+     criticality frozen at evaluation time on the row itself.
+  6. Migration 078 idempotence: re-executing the file verbatim on an
+     already-migrated DB (rows present) is a clean no-op preserving data and
+     schema; a second OotilsDB() bootstrap likewise (defensive-idempotence
+     contract, canonical pattern of migration 063's header).
+
+ISOLATION (the committed-seed lesson, cf. test_purge_integration.py's
+_cleanup_baseline_seed): the only test that COMMITS is the migration-078
+idempotence rerun (autocommit connection, required so the re-executed SQL
+file sees the rows). Its residue is neutralized by a request.addfinalizer
+registered BEFORE the commit — plain child-first DELETEs on the test's own
+uniquely-named feed_key (daily_runs first, then feed_contracts), which can
+violate nothing (daily_runs has no children); NEVER a delete-cascade. Belt
+and braces: the autouse pre-test TRUNCATE (daily_runs, feed_contracts in ONE
+statement — 078's FK means feed_contracts can no longer be truncated alone)
+sweeps any leftovers, and the module teardown drops all public tables.
+Every other test stays on the rollback-teardown ``conn`` fixture and commits
+nothing.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import psycopg
+import pytest
+from psycopg import errors
+from psycopg.rows import dict_row
+
+from ootils_core.interfaces.contracts import (
+    FeedContract,
+    FeedContractSpec,
+    get_active_contract,
+    upsert_contract,
+)
+from ootils_core.interfaces.daily_run import (
+    DailyRunGuardError,
+    DailyRunObservation,
+    plan_daily_run_guard_check,
+    record_daily_run,
+)
+from ootils_core.interfaces.guards import GuardStatus
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_078 = (
+    _REPO_ROOT / "src" / "ootils_core" / "db" / "migrations" / "078_daily_runs.sql"
+)
+
+# Shared timeline: cadence "0 6 * * *" (daily 06:00 UTC) + a 90-minute window
+# puts the arrival deadline at 07:30 UTC on each run date.
+D1 = date(2026, 7, 13)
+D2 = date(2026, 7, 14)
+
+DAILY_RUNS_COLUMNS = {
+    "daily_run_id", "feed_contract_id", "feed_key", "run_date", "observed_at",
+    "file_arrived_at", "row_count", "previous_row_count", "deleted_count",
+    "criticality", "arrival_status", "volume_floor_status",
+    "volume_delta_status", "deletion_ratio_status", "overall_status",
+    "created_at",
+}
+
+
+def _utc(d: date, hour: int, minute: int = 0) -> datetime:
+    return datetime(d.year, d.month, d.day, hour, minute, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_daily_runs(migrated_db):
+    """Pre-test TRUNCATE on its own autocommit connection. daily_runs
+    references feed_contracts (078's FK), so Postgres refuses to truncate
+    feed_contracts alone even when daily_runs is empty — both go in ONE
+    statement, child listed with its parent. Pre-test only — a post-yield
+    TRUNCATE could block on the function-scoped ``conn`` fixture's still-open
+    transaction; committed leftovers are swept by the NEXT test's pre-clean,
+    the idempotence test's own finalizer, and the module teardown's DROP of
+    all public tables (same convention as the feed-contracts sibling)."""
+    with psycopg.connect(migrated_db, autocommit=True) as c:
+        c.execute("TRUNCATE daily_runs, feed_contracts")
+    yield
+
+
+def _spec(**over) -> FeedContractSpec:
+    base = {
+        "feed_key": "dr-feed",
+        "entity_type": "on_hand",
+        "source_system": "WMS-DR",
+        "format": "tsv",
+        "key_columns": ["item_external_id", "location_external_id"],
+        "mandatory_columns": [
+            "item_external_id", "location_external_id", "quantity",
+        ],
+        "load_mode": "full",
+        "cadence": "0 6 * * *",
+        "arrival_window_minutes": 90,
+        "owner": "dr-ops",
+        "criticality": "blocking",
+        "volume_guard_min_rows": 100,
+        "volume_guard_max_pct_delta": Decimal("0.20"),
+        "depends_on": [],
+    }
+    base.update(over)
+    return FeedContractSpec.model_validate(base)
+
+
+def _register(conn, **over) -> FeedContract:
+    """Register a contract through the REAL loader path (upsert_contract) and
+    return the active row — never a hand-rolled INSERT for the happy paths."""
+    spec = _spec(**over)
+    upsert_contract(conn, spec)
+    active = get_active_contract(conn, spec.feed_key)
+    assert active is not None
+    return active
+
+
+def _daily_rows(conn, feed_key: str) -> list[dict]:
+    return conn.execute(
+        "SELECT * FROM daily_runs WHERE feed_key = %s "
+        "ORDER BY run_date, observed_at",
+        (feed_key,),
+    ).fetchall()
+
+
+def _raw_daily_insert(conn, feed_contract_id: UUID, **over) -> None:
+    """Direct INSERT bypassing the Python layer — used to probe the DB's own
+    CHECK/FK defenses (mirrors the sibling's _raw_insert)."""
+    row = {
+        "feed_contract_id": feed_contract_id,
+        "feed_key": "raw-dr-feed",
+        "run_date": D1,
+        "observed_at": _utc(D1, 8),
+        "file_arrived_at": _utc(D1, 6, 30),
+        "row_count": 150,
+        "previous_row_count": None,
+        "deleted_count": None,
+        "criticality": "blocking",
+        "arrival_status": "ok",
+        "volume_floor_status": "ok",
+        "volume_delta_status": "not_evaluated",
+        "deletion_ratio_status": "not_evaluated",
+        "overall_status": "ok",
+    }
+    row.update(over)
+    conn.execute(
+        """
+        INSERT INTO daily_runs (
+            feed_contract_id, feed_key, run_date, observed_at,
+            file_arrived_at, row_count, previous_row_count, deleted_count,
+            criticality, arrival_status, volume_floor_status,
+            volume_delta_status, deletion_ratio_status, overall_status
+        ) VALUES (
+            %(feed_contract_id)s, %(feed_key)s, %(run_date)s, %(observed_at)s,
+            %(file_arrived_at)s, %(row_count)s, %(previous_row_count)s,
+            %(deleted_count)s, %(criticality)s, %(arrival_status)s,
+            %(volume_floor_status)s, %(volume_delta_status)s,
+            %(deletion_ratio_status)s, %(overall_status)s
+        )
+        """,
+        row,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Migration 078 — schema guarantees
+# ---------------------------------------------------------------------------
+
+
+class TestMigration078Schema:
+    def test_daily_runs_columns_exact_and_zero_jsonb(self, conn):
+        rows = conn.execute(
+            "SELECT column_name, data_type FROM information_schema.columns "
+            "WHERE table_schema = 'public' AND table_name = 'daily_runs'"
+        ).fetchall()
+        columns = {r["column_name"] for r in rows}
+        assert columns == DAILY_RUNS_COLUMNS
+        # Baseline-by-nature (migration header, ADR-030 rationale): an
+        # observed ERP feed evaluation is a fact, never a fork's state.
+        assert "scenario_id" not in columns
+        # Every column typed and business-queryable — the JSONB carve-out
+        # does not apply here.
+        jsonb = [r["column_name"] for r in rows if r["data_type"] == "jsonb"]
+        assert jsonb == []
+
+    def test_indexes_present(self, conn):
+        rows = conn.execute(
+            "SELECT indexname, indexdef FROM pg_indexes "
+            "WHERE schemaname = 'public' AND tablename = 'daily_runs'"
+        ).fetchall()
+        by_name = {r["indexname"]: r["indexdef"] for r in rows}
+        assert "idx_daily_runs_feed_key_run_date" in by_name
+        assert "idx_daily_runs_run_date_overall_status" in by_name
+
+    def test_no_unique_on_feed_key_run_date_append_only(self, conn):
+        """The cadrage's tranché, enforced structurally: NO UNIQUE(feed_key,
+        run_date) — a (feed_key, run_date) can accumulate several evaluation
+        ATTEMPTS (append-only audit trail, migration header). The only
+        unique index on the table is the PK."""
+        unique_defs = [
+            r["indexname"]
+            for r in conn.execute(
+                "SELECT indexname FROM pg_indexes "
+                "WHERE schemaname = 'public' AND tablename = 'daily_runs' "
+                "AND indexdef LIKE '%UNIQUE%'"
+            ).fetchall()
+        ]
+        assert unique_defs == ["daily_runs_pkey"]
+
+    def test_fk_to_feed_contracts_is_on_delete_restrict(self, conn):
+        """EXPLICIT confdeltype='r' (RESTRICT), not the Postgres-default
+        NO ACTION — the FK convention the repo enforces (cf. ADR-030's
+        scenarios-FK rule, same discipline here)."""
+        fks = conn.execute(
+            "SELECT confrelid::regclass::text AS target, confdeltype "
+            "FROM pg_constraint "
+            "WHERE contype = 'f' AND conrelid = 'daily_runs'::regclass"
+        ).fetchall()
+        assert len(fks) == 1
+        assert fks[0]["target"] == "feed_contracts"
+        assert fks[0]["confdeltype"] == "r"
+
+    def test_fk_rejects_unknown_contract(self, conn):
+        with pytest.raises(errors.ForeignKeyViolation):
+            _raw_daily_insert(conn, uuid4())
+        conn.rollback()
+
+    def test_fk_restrict_blocks_referenced_contract_delete(self, conn):
+        """A real contract inserted via the REAL loader, referenced by a
+        daily_runs row, cannot be hard-deleted — the RESTRICT safety net
+        (feed_contracts is append-only per version and never hard-deleted in
+        normal operation; this proves the net actually catches)."""
+        contract = _register(conn, feed_key="dr-restrict")
+        _raw_daily_insert(
+            conn, contract.feed_contract_id, feed_key="dr-restrict"
+        )
+        with pytest.raises(errors.ForeignKeyViolation):
+            conn.execute(
+                "DELETE FROM feed_contracts WHERE feed_contract_id = %s",
+                (contract.feed_contract_id,),
+            )
+        conn.rollback()
+
+    @pytest.mark.parametrize(
+        "column",
+        [
+            "arrival_status", "volume_floor_status",
+            "volume_delta_status", "deletion_ratio_status",
+        ],
+    )
+    def test_per_guard_status_checks_reject_unknown_value(self, conn, column):
+        contract = _register(conn)
+        with pytest.raises(errors.CheckViolation):
+            _raw_daily_insert(
+                conn, contract.feed_contract_id,
+                feed_key="dr-feed", **{column: "weird"},
+            )
+        conn.rollback()
+
+    def test_per_guard_columns_accept_not_evaluated(self, conn):
+        """'not_evaluated' is a legal per-guard verdict (the None-honest
+        state), while overall_status stays a real ok/failed call."""
+        contract = _register(conn)
+        _raw_daily_insert(
+            conn, contract.feed_contract_id, feed_key="dr-feed",
+            file_arrived_at=None, row_count=None,
+            arrival_status="not_evaluated",
+            volume_floor_status="not_evaluated",
+            volume_delta_status="not_evaluated",
+            deletion_ratio_status="not_evaluated",
+            overall_status="ok",
+        )
+        assert len(_daily_rows(conn, "dr-feed")) == 1
+
+    def test_overall_status_check_rejects_not_evaluated(self, conn):
+        """overall_status's CHECK is deliberately NARROWER than the per-guard
+        vocabulary: FeedGuardEvaluation.overall_status never returns
+        NOT_EVALUATED, and the DB refuses it too."""
+        contract = _register(conn)
+        with pytest.raises(errors.CheckViolation):
+            _raw_daily_insert(
+                conn, contract.feed_contract_id,
+                feed_key="dr-feed", overall_status="not_evaluated",
+            )
+        conn.rollback()
+
+    def test_criticality_check_rejects_unknown_value(self, conn):
+        contract = _register(conn)
+        with pytest.raises(errors.CheckViolation):
+            _raw_daily_insert(
+                conn, contract.feed_contract_id,
+                feed_key="dr-feed", criticality="critical",
+            )
+        conn.rollback()
+
+    @pytest.mark.parametrize(
+        "column", ["row_count", "previous_row_count", "deleted_count"]
+    )
+    def test_negative_counts_rejected(self, conn, column):
+        contract = _register(conn)
+        with pytest.raises(errors.CheckViolation):
+            _raw_daily_insert(
+                conn, contract.feed_contract_id,
+                feed_key="dr-feed", **{column: -1},
+            )
+        conn.rollback()
+
+    def test_null_counts_accepted_none_honest(self, conn):
+        """NULL row_count is legal and distinct from 0: a file that never
+        arrived is not an empty file (migration header)."""
+        contract = _register(conn)
+        _raw_daily_insert(
+            conn, contract.feed_contract_id, feed_key="dr-feed",
+            file_arrived_at=None, row_count=None,
+            arrival_status="failed", volume_floor_status="not_evaluated",
+            overall_status="failed",
+        )
+        row = _daily_rows(conn, "dr-feed")[0]
+        assert row["row_count"] is None
+        assert row["file_arrived_at"] is None
+
+    def test_recommendations_exported_at_column_present(self, conn):
+        """ADR-042 decision 4, bundled into 078: nullable TIMESTAMPTZ,
+        schema-only in this PR (nothing stamps it until PR-5)."""
+        row = conn.execute(
+            "SELECT data_type, is_nullable FROM information_schema.columns "
+            "WHERE table_schema = 'public' AND table_name = 'recommendations' "
+            "AND column_name = 'exported_at'"
+        ).fetchone()
+        assert row is not None
+        assert row["data_type"] == "timestamp with time zone"
+        assert row["is_nullable"] == "YES"
+
+    def test_reco_pending_export_index_is_partial_on_null(self, conn):
+        indexdef = conn.execute(
+            "SELECT indexdef FROM pg_indexes "
+            "WHERE schemaname = 'public' AND indexname = 'ix_reco_pending_export'"
+        ).fetchone()
+        assert indexdef is not None
+        assert "WHERE (exported_at IS NULL)" in indexdef["indexdef"]
+
+
+# ---------------------------------------------------------------------------
+# 2. record_daily_run — the sole writer
+# ---------------------------------------------------------------------------
+
+
+class TestRecordDailyRun:
+    def test_green_run_persists_complete_row(self, conn):
+        """First evaluation ever: arrival + floor evaluated (green), delta +
+        deletion honestly NOT_EVALUATED (no baseline yet). The persisted row
+        mirrors the returned FeedGuardEvaluation column for column."""
+        contract = _register(conn)
+        observed_at = _utc(D1, 8)
+        record = record_daily_run(
+            conn, "dr-feed", D1,
+            DailyRunObservation(file_arrived_at=_utc(D1, 6, 30), row_count=150),
+            now=observed_at,
+        )
+
+        assert isinstance(record.daily_run_id, UUID)
+        assert record.feed_key == "dr-feed"
+        assert record.run_date == D1
+        ev = record.evaluation
+        assert ev.criticality == "blocking"
+        assert ev.by_name("arrival_window").status == GuardStatus.OK
+        assert ev.by_name("volume_floor").status == GuardStatus.OK
+        assert ev.by_name("volume_delta").status == GuardStatus.NOT_EVALUATED
+        assert ev.by_name("deletion_ratio").status == GuardStatus.NOT_EVALUATED
+        assert ev.overall_status == GuardStatus.OK
+
+        rows = _daily_rows(conn, "dr-feed")
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["daily_run_id"] == record.daily_run_id
+        assert row["feed_contract_id"] == contract.feed_contract_id
+        assert row["feed_key"] == "dr-feed"
+        assert row["run_date"] == D1
+        assert row["observed_at"] == observed_at
+        assert row["file_arrived_at"] == _utc(D1, 6, 30)
+        assert row["row_count"] == 150
+        assert row["previous_row_count"] is None
+        assert row["deleted_count"] is None
+        assert row["criticality"] == "blocking"
+        assert row["arrival_status"] == "ok"
+        assert row["volume_floor_status"] == "ok"
+        assert row["volume_delta_status"] == "not_evaluated"
+        assert row["deletion_ratio_status"] == "not_evaluated"
+        assert row["overall_status"] == "ok"
+
+    def test_evaluation_runs_against_active_contract_version(self, conn):
+        """v2 supersedes v1 -> the recorded feed_contract_id is v2's (the
+        version actually in effect), never the retired v1's."""
+        v1 = _register(conn)
+        upsert_contract(conn, _spec(arrival_window_minutes=120))
+        v2 = get_active_contract(conn, "dr-feed")
+        assert v2 is not None and v2.version == 2
+
+        record = record_daily_run(
+            conn, "dr-feed", D1,
+            DailyRunObservation(file_arrived_at=_utc(D1, 6, 30), row_count=150),
+            now=_utc(D1, 8),
+        )
+        row = _daily_rows(conn, "dr-feed")[0]
+        assert row["feed_contract_id"] == v2.feed_contract_id
+        assert row["feed_contract_id"] != v1.feed_contract_id
+        assert record.evaluation.overall_status == GuardStatus.OK
+
+    def test_day_two_uses_prior_day_baseline_for_volume_delta(self, conn):
+        """Day 1: 150 rows. Day 2: 100 rows -> a 33% swing over the 20%
+        tolerance: volume_delta FAILED, previous_row_count frozen on the row
+        (self-contained audit record), overall FAILED."""
+        _register(conn)
+        record_daily_run(
+            conn, "dr-feed", D1,
+            DailyRunObservation(file_arrived_at=_utc(D1, 6, 30), row_count=150),
+            now=_utc(D1, 8),
+        )
+        record = record_daily_run(
+            conn, "dr-feed", D2,
+            DailyRunObservation(file_arrived_at=_utc(D2, 6, 30), row_count=100),
+            now=_utc(D2, 8),
+        )
+
+        assert record.evaluation.by_name("volume_delta").status == GuardStatus.FAILED
+        assert record.evaluation.overall_status == GuardStatus.FAILED
+        day2_row = _daily_rows(conn, "dr-feed")[1]
+        assert day2_row["previous_row_count"] == 150
+        assert day2_row["volume_delta_status"] == "failed"
+        assert day2_row["overall_status"] == "failed"
+
+    def test_prior_day_latest_attempt_is_the_baseline(self, conn):
+        """Two attempts on day 1 (100 rows @08:00, then 200 rows @12:00 after
+        a corrected re-drop): day 2's baseline is the LATEST prior-day
+        attempt (ORDER BY run_date DESC, observed_at DESC)."""
+        _register(conn)
+        record_daily_run(
+            conn, "dr-feed", D1,
+            DailyRunObservation(file_arrived_at=_utc(D1, 6, 30), row_count=100),
+            now=_utc(D1, 8),
+        )
+        record_daily_run(
+            conn, "dr-feed", D1,
+            DailyRunObservation(file_arrived_at=_utc(D1, 6, 30), row_count=200),
+            now=_utc(D1, 12),
+        )
+
+        plan = plan_daily_run_guard_check(conn, "dr-feed", D2)
+        assert plan.previous_row_count == 200
+
+        record = record_daily_run(
+            conn, "dr-feed", D2,
+            DailyRunObservation(file_arrived_at=_utc(D2, 6, 30), row_count=200),
+            now=_utc(D2, 8),
+        )
+        # 200 -> 200: 0% swing vs the latest attempt — OK. (Against the
+        # 08:00 attempt's 100 it would be a 100% swing and FAILED.)
+        assert record.evaluation.by_name("volume_delta").status == GuardStatus.OK
+
+    def test_same_day_attempt_never_its_own_baseline(self, conn):
+        """Day 1: 100 rows. Day 2, attempt #1: 500 rows (400% swing, FAILED).
+        Day 2, attempt #2 (same 500 rows): the baseline is STILL day 1's 100
+        — never the same-day attempt #1 (which would make the swing 0% and
+        silently launder the anomaly into an OK)."""
+        _register(conn)
+        record_daily_run(
+            conn, "dr-feed", D1,
+            DailyRunObservation(file_arrived_at=_utc(D1, 6, 30), row_count=100),
+            now=_utc(D1, 8),
+        )
+        first = record_daily_run(
+            conn, "dr-feed", D2,
+            DailyRunObservation(file_arrived_at=_utc(D2, 6, 30), row_count=500),
+            now=_utc(D2, 8),
+        )
+        second = record_daily_run(
+            conn, "dr-feed", D2,
+            DailyRunObservation(file_arrived_at=_utc(D2, 6, 30), row_count=500),
+            now=_utc(D2, 9),
+        )
+
+        assert first.evaluation.by_name("volume_delta").status == GuardStatus.FAILED
+        assert second.evaluation.by_name("volume_delta").status == GuardStatus.FAILED
+        rows = _daily_rows(conn, "dr-feed")
+        assert rows[1]["previous_row_count"] == 100
+        assert rows[2]["previous_row_count"] == 100  # not attempt #1's 500
+
+    def test_prior_day_missing_file_yields_none_honest_delta(self, conn):
+        """Day 1's file never arrived (row_count NULL): day 2 has no honest
+        baseline -> volume_delta NOT_EVALUATED, never a fabricated
+        comparison against NULL-coerced garbage."""
+        _register(conn)
+        d1 = record_daily_run(
+            conn, "dr-feed", D1,
+            DailyRunObservation(file_arrived_at=None, row_count=None),
+            now=_utc(D1, 9),  # past the 07:30 deadline
+        )
+        assert d1.evaluation.by_name("arrival_window").status == GuardStatus.FAILED
+        assert d1.evaluation.overall_status == GuardStatus.FAILED
+
+        d2 = record_daily_run(
+            conn, "dr-feed", D2,
+            DailyRunObservation(file_arrived_at=_utc(D2, 6, 30), row_count=150),
+            now=_utc(D2, 8),
+        )
+        assert d2.evaluation.by_name("volume_delta").status == GuardStatus.NOT_EVALUATED
+        assert _daily_rows(conn, "dr-feed")[1]["previous_row_count"] is None
+
+    def test_deletion_ratio_observation_flows_through(self, conn):
+        """Caller-supplied deletion observation (the file-diff service is
+        PR-3/4): 30 of 100 previously-active rows gone = 30% > the repo-wide
+        20% threshold -> deletion_ratio FAILED. Only the numerator
+        (deleted_count) is persisted — 078 has no previous_active_count
+        column; the denominator lives in the guard's detail message."""
+        _register(conn)
+        record = record_daily_run(
+            conn, "dr-feed", D1,
+            DailyRunObservation(
+                file_arrived_at=_utc(D1, 6, 30), row_count=150,
+                deleted_count=30, previous_active_count=100,
+            ),
+            now=_utc(D1, 8),
+        )
+        assert record.evaluation.by_name("deletion_ratio").status == GuardStatus.FAILED
+        assert record.evaluation.overall_status == GuardStatus.FAILED
+        row = _daily_rows(conn, "dr-feed")[0]
+        assert row["deleted_count"] == 30
+        assert row["deletion_ratio_status"] == "failed"
+
+    def test_unknown_feed_raises_daily_run_guard_error(self, conn):
+        with pytest.raises(DailyRunGuardError, match="never-registered"):
+            plan_daily_run_guard_check(conn, "never-registered", D1)
+        with pytest.raises(DailyRunGuardError, match="never-registered"):
+            record_daily_run(
+                conn, "never-registered", D1,
+                DailyRunObservation(file_arrived_at=None, row_count=None),
+                now=_utc(D1, 8),
+            )
+
+    def test_retired_feed_raises_fresh_data_defense(self, conn):
+        """record_daily_run re-plans on FRESH data: a feed retired AFTER
+        registration (zero active rows) is refused at write time — never
+        evaluated against a stale notion of the contract."""
+        _register(conn)
+        conn.execute(
+            "UPDATE feed_contracts SET active = FALSE, updated_at = now() "
+            "WHERE feed_key = %s AND active",
+            ("dr-feed",),
+        )
+        with pytest.raises(DailyRunGuardError, match="dr-feed"):
+            record_daily_run(
+                conn, "dr-feed", D1,
+                DailyRunObservation(file_arrived_at=_utc(D1, 6, 30), row_count=150),
+                now=_utc(D1, 8),
+            )
+
+    def test_record_never_commits_caller_owns_transaction(self, conn):
+        """Same convention as upsert_contract/ScenarioManager: rollback after
+        an un-committed record leaves nothing behind."""
+        _register(conn)
+        record_daily_run(
+            conn, "dr-feed", D1,
+            DailyRunObservation(file_arrived_at=_utc(D1, 6, 30), row_count=150),
+            now=_utc(D1, 8),
+        )
+        conn.rollback()
+        n = conn.execute("SELECT COUNT(*) AS n FROM daily_runs").fetchone()["n"]
+        assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Re-run on the same run_date — append-only, tranché by the cadrage
+# ---------------------------------------------------------------------------
+
+
+class TestSameDateRerunAppendOnly:
+    def test_rerun_same_date_appends_second_row(self, conn):
+        """The documented lifecycle: checked mid-window (nothing arrived yet,
+        NOT_EVALUATED, overall ok) then re-evaluated once the file lands
+        (arrival ok). TWO honest rows — no unique violation, no overwrite,
+        distinct daily_run_ids — and the 'current' verdict is simply the
+        most recent row by observed_at."""
+        _register(conn)
+        early = record_daily_run(
+            conn, "dr-feed", D1,
+            DailyRunObservation(file_arrived_at=None, row_count=None),
+            now=_utc(D1, 7),  # 07:00 < the 07:30 deadline
+        )
+        late = record_daily_run(
+            conn, "dr-feed", D1,
+            DailyRunObservation(file_arrived_at=_utc(D1, 6, 50), row_count=150),
+            now=_utc(D1, 9),
+        )
+
+        assert early.daily_run_id != late.daily_run_id
+        assert (
+            early.evaluation.by_name("arrival_window").status
+            == GuardStatus.NOT_EVALUATED
+        )
+        assert early.evaluation.overall_status == GuardStatus.OK
+        assert late.evaluation.by_name("arrival_window").status == GuardStatus.OK
+
+        rows = _daily_rows(conn, "dr-feed")
+        assert len(rows) == 2
+        assert all(r["run_date"] == D1 for r in rows)
+
+        current = conn.execute(
+            "SELECT daily_run_id FROM daily_runs "
+            "WHERE feed_key = %s AND run_date = %s "
+            "ORDER BY observed_at DESC LIMIT 1",
+            ("dr-feed", D1),
+        ).fetchone()
+        assert current["daily_run_id"] == late.daily_run_id
+
+    def test_identical_rerun_same_date_also_appends(self, conn):
+        """Even a byte-identical re-evaluation is a new attempt row (attempt
+        semantics, NOT idempotent-upsert semantics — the deliberate contrast
+        with the deterministic-uuid5 recommendation tables)."""
+        _register(conn)
+        obs = DailyRunObservation(file_arrived_at=_utc(D1, 6, 30), row_count=150)
+        a = record_daily_run(conn, "dr-feed", D1, obs, now=_utc(D1, 8))
+        b = record_daily_run(conn, "dr-feed", D1, obs, now=_utc(D1, 8))
+        assert a.daily_run_id != b.daily_run_id
+        assert len(_daily_rows(conn, "dr-feed")) == 2
+        # Same inputs -> same VERDICT (deterministic core), distinct rows.
+        assert a.evaluation == b.evaluation
+
+
+# ---------------------------------------------------------------------------
+# 4. A FAILED verdict on a blocking feed reads correctly
+# ---------------------------------------------------------------------------
+
+
+class TestBlockingFeedFailureReads:
+    def test_blocking_feed_floor_breach_reads_through_headline_query(self, conn):
+        """The 'extraction partielle silencieuse' case on a BLOCKING feed:
+        file on time but 40 rows under the 100-row floor. The headline
+        'what failed today' query (the run_date + overall_status index)
+        surfaces the row with criticality frozen at evaluation time — the
+        exact tuple PR-3's escalate-vs-advisory decision will consume."""
+        _register(conn)  # criticality='blocking'
+        record = record_daily_run(
+            conn, "dr-feed", D1,
+            DailyRunObservation(file_arrived_at=_utc(D1, 6, 30), row_count=40),
+            now=_utc(D1, 8),
+        )
+        assert record.evaluation.by_name("volume_floor").status == GuardStatus.FAILED
+        assert record.evaluation.criticality == "blocking"
+        # The detail names observed value + threshold (exploitable evidence).
+        detail = record.evaluation.by_name("volume_floor").detail
+        assert "40" in detail and "100" in detail
+
+        failed_today = conn.execute(
+            "SELECT feed_key, criticality, arrival_status, volume_floor_status, "
+            "       overall_status "
+            "FROM daily_runs WHERE run_date = %s AND overall_status = 'failed'",
+            (D1,),
+        ).fetchall()
+        assert len(failed_today) == 1
+        row = failed_today[0]
+        assert row["feed_key"] == "dr-feed"
+        assert row["criticality"] == "blocking"
+        assert row["arrival_status"] == "ok"        # arrival was fine
+        assert row["volume_floor_status"] == "failed"  # the actual breach
+        assert row["overall_status"] == "failed"
+
+    def test_advisory_feed_failure_reads_as_advisory(self, conn):
+        """Same failure on an ADVISORY feed: overall_status is just as
+        'failed' (the guard verdict does not soften), but the frozen
+        criticality lets PR-3 route it to the report instead of the L3
+        webhook — both columns must read back exactly."""
+        _register(
+            conn, feed_key="dr-advisory", criticality="advisory",
+            volume_guard_min_rows=100,
+        )
+        record = record_daily_run(
+            conn, "dr-advisory", D1,
+            DailyRunObservation(file_arrived_at=_utc(D1, 6, 30), row_count=40),
+            now=_utc(D1, 8),
+        )
+        assert record.evaluation.overall_status == GuardStatus.FAILED
+        row = _daily_rows(conn, "dr-advisory")[0]
+        assert row["criticality"] == "advisory"
+        assert row["overall_status"] == "failed"
+
+    def test_blocking_feed_missing_file_reads_failed_arrival(self, conn):
+        """The 'flux totalement absent' case: no file by the deadline on a
+        blocking feed — arrival FAILED, volume guards honestly
+        NOT_EVALUATED, overall FAILED, all readable from the row."""
+        _register(conn)
+        record_daily_run(
+            conn, "dr-feed", D1,
+            DailyRunObservation(file_arrived_at=None, row_count=None),
+            now=_utc(D1, 9),
+        )
+        row = _daily_rows(conn, "dr-feed")[0]
+        assert row["arrival_status"] == "failed"
+        assert row["volume_floor_status"] == "not_evaluated"
+        assert row["volume_delta_status"] == "not_evaluated"
+        assert row["deletion_ratio_status"] == "not_evaluated"
+        assert row["overall_status"] == "failed"
+        assert row["criticality"] == "blocking"
+        assert row["file_arrived_at"] is None
+        assert row["row_count"] is None
+
+
+# ---------------------------------------------------------------------------
+# 5. Migration 078 idempotence at re-run
+# ---------------------------------------------------------------------------
+
+
+class TestMigration078Idempotent:
+    def test_reexecuting_078_sql_is_noop_preserving_rows(
+        self, migrated_db, conn, request
+    ):
+        """Defensive-idempotence contract (migration 063 header, runner in
+        db/connection.py does NOT swallow 'already exists'): re-running the
+        file verbatim on an already-migrated DB — twice — must neither raise
+        nor touch existing rows/schema. The file carries its own
+        BEGIN/COMMIT, so it runs on a fresh autocommit connection (mirrors
+        test_reexecuting_073_sql_is_noop).
+
+        This test COMMITS (the re-executed SQL must see the rows), so the
+        residue is neutralized by a finalizer registered BEFORE the commit:
+        child-first DELETEs on this test's own feed_key — safe by
+        construction (daily_runs has no children), never a cascade."""
+
+        def _sweep():
+            with psycopg.connect(migrated_db, autocommit=True) as c:
+                c.execute(
+                    "DELETE FROM daily_runs WHERE feed_key = %s", ("idem-dr",)
+                )
+                c.execute(
+                    "DELETE FROM feed_contracts WHERE feed_key = %s", ("idem-dr",)
+                )
+
+        request.addfinalizer(_sweep)
+
+        with psycopg.connect(
+            migrated_db, autocommit=True, row_factory=dict_row
+        ) as raw:
+            contract = _register(raw, feed_key="idem-dr")
+            _raw_daily_insert(
+                raw, contract.feed_contract_id, feed_key="idem-dr"
+            )
+
+        sql_text = MIGRATION_078.read_text(encoding="utf-8")
+        with psycopg.connect(migrated_db, autocommit=True) as raw:
+            raw.execute(sql_text)  # 2nd application overall
+            raw.execute(sql_text)  # and a 3rd — still a clean no-op
+
+        # Data survived the re-runs.
+        rows = _daily_rows(conn, "idem-dr")
+        assert len(rows) == 1
+        assert rows[0]["overall_status"] == "ok"
+
+        # Schema intact: table, both indexes, the exported_at column + its
+        # partial index.
+        assert conn.execute(
+            "SELECT to_regclass('public.daily_runs') AS t"
+        ).fetchone()["t"] is not None
+        names = {
+            r["indexname"]
+            for r in conn.execute(
+                "SELECT indexname FROM pg_indexes WHERE schemaname='public' "
+                "AND tablename IN ('daily_runs', 'recommendations')"
+            ).fetchall()
+        }
+        assert "idx_daily_runs_feed_key_run_date" in names
+        assert "idx_daily_runs_run_date_overall_status" in names
+        assert "ix_reco_pending_export" in names
+        n_exported_at = conn.execute(
+            "SELECT COUNT(*) AS n FROM information_schema.columns "
+            "WHERE table_schema='public' AND table_name='recommendations' "
+            "AND column_name='exported_at'"
+        ).fetchone()["n"]
+        assert n_exported_at == 1  # ADD COLUMN IF NOT EXISTS did not duplicate
+
+    def test_bootstrap_rerun_is_idempotent(self, migrated_db):
+        """A second OotilsDB() on an already-migrated DB (the exact boot
+        path) is a no-op — 078 is tracked in schema_migrations and skipped."""
+        from ootils_core.db.connection import OotilsDB
+
+        OotilsDB(migrated_db)
+
+        with psycopg.connect(migrated_db, row_factory=dict_row) as c:
+            assert c.execute(
+                "SELECT to_regclass('public.daily_runs') AS t"
+            ).fetchone()["t"] is not None
+            applied = c.execute(
+                "SELECT COUNT(*) AS n FROM schema_migrations "
+                "WHERE version LIKE '078%'"
+            ).fetchone()["n"]
+            assert applied == 1

--- a/tests/integration/test_feed_contracts_integration.py
+++ b/tests/integration/test_feed_contracts_integration.py
@@ -26,10 +26,14 @@ Covers the DB half of src/ootils_core/interfaces/contracts.py + migration 073:
      and schema; a second OotilsDB() bootstrap likewise (defensive-idempotence
      contract, canonical pattern of migration 063's header).
 
-feed_contracts has NO foreign key in either direction — deliberately (no
-daily_runs FK until PR3, no scenarios FK: global ingest-time config, not
-scenario-scoped) — asserted below, so the sibling "FK-ordered cleanup"
-pattern collapses to a single pre-test TRUNCATE.
+feed_contracts has NO OUTBOUND foreign key (no scenarios FK: global
+ingest-time config, not scenario-scoped). Since migration 078 (ADR-042 PR-2,
+which absorbed ADR-037's INT-1 PR2 earlier than the "PR3" this file
+originally predicted) it has exactly ONE inbound FK —
+daily_runs.feed_contract_id, ON DELETE RESTRICT — asserted below. The
+pre-test cleanup therefore truncates daily_runs alongside feed_contracts:
+Postgres refuses to TRUNCATE a referenced table alone, even when the
+referencing table is empty.
 """
 from __future__ import annotations
 
@@ -79,15 +83,17 @@ SEED_KEYS = ["on-hand", "open-purchase-orders", "open-work-orders"]
 
 @pytest.fixture(autouse=True)
 def _clean_feed_contracts(migrated_db):
-    """Pre-test TRUNCATE on its own autocommit connection. feed_contracts has
-    no FK in either direction (asserted by
-    test_no_fk_constraints_in_either_direction) so the FK-ordered cleanup is
-    a single statement. Pre-test only — a post-yield TRUNCATE could block on
-    the function-scoped `conn` fixture's still-open transaction; committed
+    """Pre-test TRUNCATE on its own autocommit connection. daily_runs
+    (migration 078, ADR-042 PR-2) references feed_contracts, and Postgres
+    refuses to truncate a referenced table alone even when the referencing
+    table is empty — both go in ONE statement, child listed with its parent
+    (asserted by test_fk_surface_no_outbound_inbound_daily_runs_only).
+    Pre-test only — a post-yield TRUNCATE could block on the
+    function-scoped `conn` fixture's still-open transaction; committed
     leftovers (the CLI tests commit) are swept by the NEXT test's pre-clean
     and by the module teardown's DROP of all public tables."""
     with psycopg.connect(migrated_db, autocommit=True) as c:
-        c.execute("TRUNCATE feed_contracts")
+        c.execute("TRUNCATE daily_runs, feed_contracts")
     yield
 
 
@@ -204,17 +210,27 @@ class TestMigration073Schema:
         assert "UNIQUE" in active_def
         assert "WHERE active" in active_def
 
-    def test_no_fk_constraints_in_either_direction(self, conn):
-        """No daily_runs FK yet (PR3), no scenarios FK (global ingest-time
-        config) — the registry stands alone in PR1."""
-        n = conn.execute(
+    def test_fk_surface_no_outbound_inbound_daily_runs_only(self, conn):
+        """No OUTBOUND FK (no scenarios FK: global ingest-time config, not
+        scenario-scoped). Exactly ONE inbound FK since migration 078
+        (ADR-042 PR-2, which absorbed the "PR3" this test originally
+        predicted): daily_runs.feed_contract_id, ON DELETE RESTRICT
+        (confdeltype 'r' — the explicit-RESTRICT repo convention, never the
+        Postgres-default NO ACTION)."""
+        outbound = conn.execute(
             "SELECT COUNT(*) AS n FROM pg_constraint "
-            "WHERE contype = 'f' AND ("
-            "    conrelid = 'feed_contracts'::regclass "
-            "    OR confrelid = 'feed_contracts'::regclass"
-            ")"
+            "WHERE contype = 'f' AND conrelid = 'feed_contracts'::regclass"
         ).fetchone()["n"]
-        assert n == 0
+        assert outbound == 0
+        inbound = conn.execute(
+            "SELECT conrelid::regclass::text AS source, confdeltype "
+            "FROM pg_constraint "
+            "WHERE contype = 'f' AND confrelid = 'feed_contracts'::regclass "
+            "ORDER BY conrelid::regclass::text"
+        ).fetchall()
+        assert [(r["source"], r["confdeltype"]) for r in inbound] == [
+            ("daily_runs", "r")
+        ]
 
     def test_feed_key_version_unique(self, conn):
         _raw_insert(conn, feed_key="uq-feed", version=1, active=True)

--- a/tests/test_daily_run_guards.py
+++ b/tests/test_daily_run_guards.py
@@ -1,0 +1,572 @@
+"""
+tests/test_daily_run_guards.py — Pure unit tests for the daily-run runtime
+guards (ADR-042 PR-2, absorbing ADR-037's INT-1 PR2). No database.
+
+Covers src/ootils_core/interfaces/guards.py, which is pure by construction
+(no DB, no wall-clock read, no I/O — every timestamp caller-supplied), so
+everything here runs DB-free:
+
+  1. compute_expected_arrival_deadline — the V1 "M H * * *" cadence parser:
+     happy path (tick + window, UTC-aware), midnight rollover, and the
+     fail-loudly refusals (wrong field count, non-daily shapes, step syntax,
+     non-integer / out-of-range minute & hour) each NAMING the cadence.
+  2. Each of the four guards x the required grid: clear PASS / clear FAIL /
+     the EXACT boundary at the threshold / NOT_EVALUATED when the contract
+     does not configure the threshold or no honest baseline exists
+     (None-honest: never a fabricated OK, never a false FAILED).
+  3. GuardResult is exploitable evidence: guard_name + status + a detail
+     message carrying the observed value AND the threshold (it feeds the
+     daily report and the L3 escalation payload — North Star "Explicable").
+  4. FeedGuardEvaluation composition: overall_status FAILED iff any guard
+     FAILED; NOT_EVALUATED never blocks on its own; never NOT_EVALUATED
+     itself; by_name() lookup; feed_key/criticality carried verbatim.
+  5. Determinism: same inputs -> structurally equal results (frozen
+     dataclasses), across repeated calls.
+  6. Lockstep tripwires: GuardStatus vocabulary vs migration 078's per-guard
+     CHECKs (and overall_status's deliberately narrower CHECK), and
+     DELETION_RATIO_THRESHOLD vs the staging/diff.py constant it was
+     relogged from (ADR-042 decision 2.1).
+  7. The timezone contract: an aware deadline compared against a naive
+     file_arrived_at/now raises TypeError at the comparison point — never a
+     silent miscompute.
+
+DB-touching behaviour (migration 078 schema, record_daily_run persistence,
+the prior-day baseline lookup, append-only re-runs) lives in
+tests/integration/test_daily_runs_integration.py.
+"""
+from __future__ import annotations
+
+import dataclasses
+import re
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from ootils_core.interfaces.guards import (
+    DELETION_RATIO_THRESHOLD,
+    GuardResult,
+    GuardStatus,
+    compute_expected_arrival_deadline,
+    evaluate_arrival_window_guard,
+    evaluate_deletion_ratio_guard,
+    evaluate_feed_guards,
+    evaluate_volume_delta_guard,
+    evaluate_volume_floor_guard,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+MIGRATION_078 = (
+    _REPO_ROOT / "src" / "ootils_core" / "db" / "migrations" / "078_daily_runs.sql"
+)
+
+# Shared timeline: cadence "0 6 * * *" (daily 06:00 UTC) + a 90-minute window
+# puts the arrival deadline at 07:30 UTC on the run date.
+RUN_DATE = date(2026, 7, 13)
+CADENCE = "0 6 * * *"
+WINDOW_MIN = 90
+DEADLINE = datetime(2026, 7, 13, 7, 30, tzinfo=timezone.utc)
+
+
+def _utc(hour: int, minute: int = 0, *, day: int = 13) -> datetime:
+    return datetime(2026, 7, day, hour, minute, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# 1. compute_expected_arrival_deadline — the V1 cadence parser
+# ---------------------------------------------------------------------------
+
+
+class TestComputeExpectedArrivalDeadline:
+    def test_happy_path_tick_plus_window_utc_aware(self):
+        deadline = compute_expected_arrival_deadline(CADENCE, WINDOW_MIN, RUN_DATE)
+        assert deadline == DEADLINE
+        assert deadline.tzinfo == timezone.utc
+
+    def test_window_rolls_past_midnight_into_next_day(self):
+        deadline = compute_expected_arrival_deadline("30 23 * * *", 90, RUN_DATE)
+        assert deadline == datetime(2026, 7, 14, 1, 0, tzinfo=timezone.utc)
+
+    def test_zero_padded_fields_parse(self):
+        # "00 06 * * *" is the same instant as "0 6 * * *" — int() accepts both.
+        assert compute_expected_arrival_deadline(
+            "00 06 * * *", WINDOW_MIN, RUN_DATE
+        ) == DEADLINE
+
+    @pytest.mark.parametrize(
+        "cadence",
+        [
+            "0 6 * *",          # 4 fields
+            "0 6 * * * *",      # 6 fields
+            "0 6",              # 2 fields
+            "",                 # empty
+        ],
+    )
+    def test_wrong_field_count_raises_naming_cadence(self, cadence):
+        with pytest.raises(ValueError, match=re.escape(repr(cadence))):
+            compute_expected_arrival_deadline(cadence, WINDOW_MIN, RUN_DATE)
+
+    @pytest.mark.parametrize(
+        "cadence",
+        [
+            "0 6 1 * *",    # day-of-month pinned
+            "0 6 * 2 *",    # month pinned
+            "0 6 * * 1",    # weekday pinned
+        ],
+    )
+    def test_non_daily_shape_refused_not_misparsed(self, cadence):
+        """V1 limitation is fail-loudly: anything but 'M H * * *' raises,
+        never silently mis-parses (module docstring, ADR-037 🎯 Pilote)."""
+        with pytest.raises(ValueError, match="supported V1 shape"):
+            compute_expected_arrival_deadline(cadence, WINDOW_MIN, RUN_DATE)
+
+    @pytest.mark.parametrize(
+        "cadence",
+        [
+            "*/15 6 * * *",   # step syntax in minute
+            "0 6-8 * * *",    # range syntax in hour
+            "* 6 * * *",      # wildcard minute
+            "0 * * * *",      # wildcard hour (hourly — not a daily shape)
+            "a 6 * * *",      # garbage
+        ],
+    )
+    def test_non_integer_minute_or_hour_raises(self, cadence):
+        with pytest.raises(ValueError, match="non-integer minute/hour"):
+            compute_expected_arrival_deadline(cadence, WINDOW_MIN, RUN_DATE)
+
+    @pytest.mark.parametrize(
+        ("cadence", "fragment"),
+        [
+            ("60 6 * * *", "minute"),
+            ("-1 6 * * *", "minute"),
+            ("0 24 * * *", "hour"),
+            ("0 -1 * * *", "hour"),
+        ],
+    )
+    def test_out_of_range_minute_or_hour_raises(self, cadence, fragment):
+        with pytest.raises(ValueError, match=fragment):
+            compute_expected_arrival_deadline(cadence, WINDOW_MIN, RUN_DATE)
+
+
+# ---------------------------------------------------------------------------
+# 2a. Arrival-window guard — PASS / FAIL / boundary / not-yet-evaluable
+# ---------------------------------------------------------------------------
+
+
+def _arrival(**over) -> GuardResult:
+    kwargs = dict(
+        cadence=CADENCE,
+        arrival_window_minutes=WINDOW_MIN,
+        run_date=RUN_DATE,
+        file_arrived_at=_utc(6, 30),
+        now=_utc(8, 0),
+    )
+    kwargs.update(over)
+    return evaluate_arrival_window_guard(**kwargs)
+
+
+class TestArrivalWindowGuard:
+    def test_pass_arrived_before_deadline(self):
+        result = _arrival(file_arrived_at=_utc(6, 30))
+        assert result.status == GuardStatus.OK
+        assert result.guard_name == "arrival_window"
+
+    def test_boundary_arrived_exactly_at_deadline_is_ok(self):
+        # <= at the deadline: the window is inclusive of its last instant.
+        result = _arrival(file_arrived_at=DEADLINE)
+        assert result.status == GuardStatus.OK
+
+    def test_fail_arrived_one_microsecond_after_deadline(self):
+        result = _arrival(file_arrived_at=DEADLINE + timedelta(microseconds=1))
+        assert result.status == GuardStatus.FAILED
+
+    def test_fail_no_file_after_deadline(self):
+        result = _arrival(file_arrived_at=None, now=_utc(9, 0))
+        assert result.status == GuardStatus.FAILED
+
+    def test_boundary_no_file_now_exactly_at_deadline_is_failed(self):
+        # `now < deadline` is strict: at the deadline instant the window has
+        # elapsed and a still-missing file is a real miss.
+        result = _arrival(file_arrived_at=None, now=DEADLINE)
+        assert result.status == GuardStatus.FAILED
+
+    def test_not_evaluated_no_file_before_deadline(self):
+        """This guard's honest SKIP: cadence + window are NOT NULL on every
+        contract (no unconfigured case exists), so its only NOT_EVALUATED
+        path is 'checked mid-window' — an early check is not evidence the
+        feed is missing."""
+        result = _arrival(
+            file_arrived_at=None, now=DEADLINE - timedelta(microseconds=1)
+        )
+        assert result.status == GuardStatus.NOT_EVALUATED
+        assert "not yet elapsed" in result.detail
+
+    def test_detail_carries_arrival_and_deadline_on_fail(self):
+        late = DEADLINE + timedelta(hours=1)
+        result = _arrival(file_arrived_at=late)
+        assert late.isoformat() in result.detail
+        assert DEADLINE.isoformat() in result.detail
+
+    def test_detail_carries_deadline_and_now_when_missing(self):
+        now = _utc(9, 0)
+        result = _arrival(file_arrived_at=None, now=now)
+        assert DEADLINE.isoformat() in result.detail
+        assert now.isoformat() in result.detail
+
+    def test_naive_file_arrived_at_raises_typeerror(self):
+        """The timezone contract (module docstring): aware-vs-naive raises at
+        the comparison, never a silent miscompute."""
+        with pytest.raises(TypeError):
+            _arrival(file_arrived_at=datetime(2026, 7, 13, 6, 30))
+
+    def test_naive_now_raises_typeerror_when_no_file(self):
+        with pytest.raises(TypeError):
+            _arrival(file_arrived_at=None, now=datetime(2026, 7, 13, 8, 0))
+
+
+# ---------------------------------------------------------------------------
+# 2b. Volume-floor guard — PASS / FAIL / boundary / SKIP
+# ---------------------------------------------------------------------------
+
+
+class TestVolumeFloorGuard:
+    def test_pass_above_floor(self):
+        result = evaluate_volume_floor_guard(100, 150)
+        assert result.status == GuardStatus.OK
+        assert result.guard_name == "volume_floor"
+
+    def test_boundary_exactly_at_floor_is_ok(self):
+        assert evaluate_volume_floor_guard(100, 100).status == GuardStatus.OK
+
+    def test_fail_one_below_floor(self):
+        assert evaluate_volume_floor_guard(100, 99).status == GuardStatus.FAILED
+
+    def test_skip_when_contract_does_not_configure_floor(self):
+        result = evaluate_volume_floor_guard(None, 150)
+        assert result.status == GuardStatus.NOT_EVALUATED
+        assert "volume_guard_min_rows" in result.detail
+
+    def test_skip_when_no_row_count_observed(self):
+        # File missing: no observation is not a floor breach (the
+        # arrival_window guard owns that failure).
+        result = evaluate_volume_floor_guard(100, None)
+        assert result.status == GuardStatus.NOT_EVALUATED
+        assert "arrival_window" in result.detail
+
+    def test_configured_zero_floor_is_evaluated_not_skipped(self):
+        """0 is a real configured threshold, not an absent one (None-honest:
+        the None/0 distinction matters)."""
+        assert evaluate_volume_floor_guard(0, 0).status == GuardStatus.OK
+
+    def test_zero_rows_below_positive_floor_fails(self):
+        # An empty file is an honest observation — and a floor breach.
+        assert evaluate_volume_floor_guard(1, 0).status == GuardStatus.FAILED
+
+    def test_detail_carries_observed_and_threshold(self):
+        result = evaluate_volume_floor_guard(100, 99)
+        assert "99" in result.detail
+        assert "100" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# 2c. Volume-delta guard — PASS / FAIL / boundary / SKIP
+# ---------------------------------------------------------------------------
+
+PCT_20 = Decimal("0.20")
+
+
+class TestVolumeDeltaGuard:
+    def test_pass_within_tolerance(self):
+        result = evaluate_volume_delta_guard(PCT_20, 110, 100)
+        assert result.status == GuardStatus.OK
+        assert result.guard_name == "volume_delta"
+
+    def test_boundary_swing_exactly_at_tolerance_is_ok(self):
+        # 100 -> 120 is exactly 20%: `>` is strict, the boundary passes.
+        # Decimal arithmetic keeps this exact (0.2 == 0.20 as Decimals).
+        assert evaluate_volume_delta_guard(PCT_20, 120, 100).status == GuardStatus.OK
+
+    def test_fail_just_above_tolerance(self):
+        assert (
+            evaluate_volume_delta_guard(PCT_20, 121, 100).status == GuardStatus.FAILED
+        )
+
+    def test_boundary_downward_swing_exactly_at_tolerance_is_ok(self):
+        # The swing is absolute: -20% sits on the same boundary as +20%.
+        assert evaluate_volume_delta_guard(PCT_20, 80, 100).status == GuardStatus.OK
+
+    def test_fail_downward_swing_above_tolerance(self):
+        assert (
+            evaluate_volume_delta_guard(PCT_20, 79, 100).status == GuardStatus.FAILED
+        )
+
+    def test_skip_when_contract_does_not_configure_delta(self):
+        result = evaluate_volume_delta_guard(None, 110, 100)
+        assert result.status == GuardStatus.NOT_EVALUATED
+        assert "volume_guard_max_pct_delta" in result.detail
+
+    def test_skip_when_no_row_count_observed(self):
+        result = evaluate_volume_delta_guard(PCT_20, None, 100)
+        assert result.status == GuardStatus.NOT_EVALUATED
+
+    def test_skip_when_no_previous_run(self):
+        result = evaluate_volume_delta_guard(PCT_20, 110, None)
+        assert result.status == GuardStatus.NOT_EVALUATED
+        assert "previous run" in result.detail
+
+    def test_skip_when_previous_run_was_empty(self):
+        # A zero baseline makes any ratio undefined — NOT_EVALUATED, never a
+        # ZeroDivisionError, never a fabricated verdict.
+        result = evaluate_volume_delta_guard(PCT_20, 110, 0)
+        assert result.status == GuardStatus.NOT_EVALUATED
+
+    def test_detail_carries_both_counts_and_threshold(self):
+        result = evaluate_volume_delta_guard(PCT_20, 121, 100)
+        assert "121" in result.detail
+        assert "100" in result.detail
+        assert "20.00%" in result.detail  # the tolerance, rendered as a percent
+        assert "21.00%" in result.detail  # the observed swing
+
+
+# ---------------------------------------------------------------------------
+# 2d. Deletion-ratio guard — PASS / FAIL / boundary / SKIP
+# ---------------------------------------------------------------------------
+
+
+class TestDeletionRatioGuard:
+    def test_threshold_relogged_from_staging_diff_in_lockstep(self):
+        """ADR-042 decision 2.1: the 20% threshold is RELOGGED from
+        staging/diff.py — the two constants must never drift apart."""
+        from ootils_core.staging.diff import (
+            DELETION_RATIO_THRESHOLD as STAGING_THRESHOLD,
+        )
+
+        assert DELETION_RATIO_THRESHOLD == STAGING_THRESHOLD == 0.20
+
+    def test_pass_below_threshold(self):
+        result = evaluate_deletion_ratio_guard(10, 100)
+        assert result.status == GuardStatus.OK
+        assert result.guard_name == "deletion_ratio"
+
+    def test_pass_zero_deletions(self):
+        assert evaluate_deletion_ratio_guard(0, 100).status == GuardStatus.OK
+
+    def test_boundary_exactly_20_percent_is_ok(self):
+        # 20/100 == the 0.20 threshold exactly: `>` is strict.
+        assert evaluate_deletion_ratio_guard(20, 100).status == GuardStatus.OK
+
+    def test_fail_just_above_threshold(self):
+        assert evaluate_deletion_ratio_guard(21, 100).status == GuardStatus.FAILED
+
+    def test_skip_when_no_previous_active_baseline(self):
+        result = evaluate_deletion_ratio_guard(10, None)
+        assert result.status == GuardStatus.NOT_EVALUATED
+
+    def test_skip_when_previous_active_zero_or_negative(self):
+        assert evaluate_deletion_ratio_guard(10, 0).status == GuardStatus.NOT_EVALUATED
+        assert (
+            evaluate_deletion_ratio_guard(10, -5).status == GuardStatus.NOT_EVALUATED
+        )
+
+    def test_skip_when_no_deleted_count_observed(self):
+        result = evaluate_deletion_ratio_guard(None, 100)
+        assert result.status == GuardStatus.NOT_EVALUATED
+        assert "arrival_window" in result.detail
+
+    def test_detail_carries_counts_ratio_and_threshold(self):
+        result = evaluate_deletion_ratio_guard(30, 100)
+        assert result.status == GuardStatus.FAILED
+        assert "30" in result.detail
+        assert "100" in result.detail
+        assert "30.00%" in result.detail  # the observed ratio
+        assert "20%" in result.detail     # the threshold
+
+
+# ---------------------------------------------------------------------------
+# 3. FeedGuardEvaluation — composition + overall verdict
+# ---------------------------------------------------------------------------
+
+
+def _full_kwargs(**over) -> dict:
+    """A fully green evaluation: file on time, floor cleared, delta within
+    tolerance, deletions below threshold. Override any field."""
+    base = dict(
+        feed_key="unit-feed",
+        criticality="blocking",
+        cadence=CADENCE,
+        arrival_window_minutes=WINDOW_MIN,
+        volume_guard_min_rows=100,
+        volume_guard_max_pct_delta=PCT_20,
+        run_date=RUN_DATE,
+        file_arrived_at=_utc(6, 30),
+        row_count=150,
+        previous_row_count=140,
+        deleted_count=5,
+        previous_active_count=140,
+        now=_utc(8, 0),
+    )
+    base.update(over)
+    return base
+
+
+class TestFeedGuardEvaluation:
+    def test_all_green_overall_ok(self):
+        evaluation = evaluate_feed_guards(**_full_kwargs())
+        assert evaluation.overall_status == GuardStatus.OK
+        assert all(r.status == GuardStatus.OK for r in evaluation.results)
+
+    def test_four_guards_present_by_name(self):
+        evaluation = evaluate_feed_guards(**_full_kwargs())
+        names = [r.guard_name for r in evaluation.results]
+        assert names == [
+            "arrival_window", "volume_floor", "volume_delta", "deletion_ratio",
+        ]
+        for name in names:
+            assert evaluation.by_name(name).guard_name == name
+
+    def test_by_name_unknown_guard_raises_keyerror(self):
+        evaluation = evaluate_feed_guards(**_full_kwargs())
+        with pytest.raises(KeyError, match="no_such_guard"):
+            evaluation.by_name("no_such_guard")
+
+    def test_one_failed_guard_fails_overall(self):
+        evaluation = evaluate_feed_guards(**_full_kwargs(row_count=40))
+        assert evaluation.by_name("volume_floor").status == GuardStatus.FAILED
+        assert evaluation.overall_status == GuardStatus.FAILED
+
+    def test_not_evaluated_guards_never_block_on_their_own(self):
+        """Unconfigured guards + no deletion baseline: 3 of 4 guards
+        NOT_EVALUATED, arrival OK -> overall OK (None-honest: absence of a
+        threshold or a baseline is not evidence of a problem)."""
+        evaluation = evaluate_feed_guards(
+            **_full_kwargs(
+                volume_guard_min_rows=None,
+                volume_guard_max_pct_delta=None,
+                deleted_count=None,
+                previous_active_count=None,
+            )
+        )
+        assert evaluation.by_name("arrival_window").status == GuardStatus.OK
+        assert evaluation.by_name("volume_floor").status == GuardStatus.NOT_EVALUATED
+        assert evaluation.by_name("volume_delta").status == GuardStatus.NOT_EVALUATED
+        assert evaluation.by_name("deletion_ratio").status == GuardStatus.NOT_EVALUATED
+        assert evaluation.overall_status == GuardStatus.OK
+
+    def test_overall_never_not_evaluated_even_if_all_guards_are(self):
+        """The documented degenerate case: mid-window check, nothing arrived
+        yet, no thresholds, no baselines — every guard NOT_EVALUATED, and
+        overall_status is still a real OK (never NOT_EVALUATED, matching
+        migration 078's narrower overall_status CHECK)."""
+        evaluation = evaluate_feed_guards(
+            **_full_kwargs(
+                file_arrived_at=None,
+                now=_utc(7, 0),  # before the 07:30 deadline
+                row_count=None,
+                previous_row_count=None,
+                volume_guard_min_rows=None,
+                volume_guard_max_pct_delta=None,
+                deleted_count=None,
+                previous_active_count=None,
+            )
+        )
+        assert all(
+            r.status == GuardStatus.NOT_EVALUATED for r in evaluation.results
+        )
+        assert evaluation.overall_status == GuardStatus.OK
+
+    def test_feed_key_and_criticality_carried_verbatim(self):
+        evaluation = evaluate_feed_guards(
+            **_full_kwargs(feed_key="my-feed", criticality="advisory")
+        )
+        assert evaluation.feed_key == "my-feed"
+        assert evaluation.criticality == "advisory"
+
+    def test_missing_file_after_deadline_fails_arrival_only(self):
+        """The 'flux totalement absent' scenario (ADR-037 §6): arrival FAILED,
+        the volume/deletion guards honestly NOT_EVALUATED (no observation is
+        not a second failure), overall FAILED."""
+        evaluation = evaluate_feed_guards(
+            **_full_kwargs(
+                file_arrived_at=None, row_count=None,
+                deleted_count=None, previous_active_count=None,
+                now=_utc(9, 0),
+            )
+        )
+        assert evaluation.by_name("arrival_window").status == GuardStatus.FAILED
+        assert evaluation.by_name("volume_floor").status == GuardStatus.NOT_EVALUATED
+        assert evaluation.by_name("volume_delta").status == GuardStatus.NOT_EVALUATED
+        assert evaluation.by_name("deletion_ratio").status == GuardStatus.NOT_EVALUATED
+        assert evaluation.overall_status == GuardStatus.FAILED
+
+    def test_guard_result_is_frozen(self):
+        result = evaluate_volume_floor_guard(100, 150)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            result.status = GuardStatus.FAILED  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# 4. Determinism — same inputs, same result
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_full_evaluation_is_reproducible(self):
+        """No wall-clock read, no randomness: two calls with identical inputs
+        yield structurally EQUAL evaluations (frozen dataclasses compare by
+        value) — the North Star's deterministic-core requirement."""
+        a = evaluate_feed_guards(**_full_kwargs())
+        b = evaluate_feed_guards(**_full_kwargs())
+        assert a == b
+        assert a.results == b.results
+        assert a.overall_status == b.overall_status
+
+    def test_failing_evaluation_is_reproducible_too(self):
+        kwargs = _full_kwargs(row_count=40, file_arrived_at=None, now=_utc(9, 0))
+        assert evaluate_feed_guards(**kwargs) == evaluate_feed_guards(**kwargs)
+
+    def test_single_guard_results_are_reproducible(self):
+        assert evaluate_volume_floor_guard(100, 99) == evaluate_volume_floor_guard(
+            100, 99
+        )
+        assert evaluate_deletion_ratio_guard(21, 100) == evaluate_deletion_ratio_guard(
+            21, 100
+        )
+        assert evaluate_volume_delta_guard(
+            PCT_20, 121, 100
+        ) == evaluate_volume_delta_guard(PCT_20, 121, 100)
+
+
+# ---------------------------------------------------------------------------
+# 5. Lockstep with migration 078's CHECK vocabulary
+# ---------------------------------------------------------------------------
+
+
+def _check_values(sql: str, column: str) -> set[str]:
+    match = re.search(rf"CHECK \({column}\s+IN \(([^)]*)\)\)", sql)
+    assert match is not None, f"no CHECK ... IN (...) found for {column!r}"
+    return set(re.findall(r"'([^']*)'", match.group(1)))
+
+
+class TestMigration078Lockstep:
+    """guards.py's docstring promises GuardStatus is 'kept in lockstep with
+    migration 078's daily_runs per-guard CHECK vocabulary' — this is the
+    tripwire (same pattern as test_feed_contracts.py's enum-lockstep tests)."""
+
+    def test_per_guard_checks_match_guardstatus_exactly(self):
+        sql = MIGRATION_078.read_text(encoding="utf-8")
+        expected = {status.value for status in GuardStatus}
+        for column in (
+            "arrival_status", "volume_floor_status",
+            "volume_delta_status", "deletion_ratio_status",
+        ):
+            assert _check_values(sql, column) == expected, column
+
+    def test_overall_status_check_is_narrower_no_not_evaluated(self):
+        """overall_status never carries 'not_evaluated' — the DB CHECK is
+        deliberately narrower than GuardStatus, mirroring
+        FeedGuardEvaluation.overall_status's contract."""
+        sql = MIGRATION_078.read_text(encoding="utf-8")
+        assert _check_values(sql, "overall_status") == {
+            GuardStatus.OK.value, GuardStatus.FAILED.value,
+        }


### PR DESCRIPTION
## Premier étage du pipeline demi-interfaces (ADR-042)

La « mémoire » du run quotidien : la table qui trace chaque évaluation de flux, et les 4 gardes qui jugent chaque fichier entrant.

- **Migration 078** : `daily_runs` — une ligne par évaluation `(feed_key, run_date)`, append-only assumé (ré-évaluation intra-jour possible ; le baseline du delta lit strictement le jour antérieur — jamais soi-même, testé), verdicts par garde + statut global (CHECKs en lockstep avec les enums), FK `feed_contracts` RESTRICT. **Le registre de contrats (073) prend vie.**
- **4 gardes pures** (`interfaces/guards.py`) : fenêtre d'arrivée, plancher de volume, delta jour-sur-jour (Decimal, frontière exacte au seuil), ratio-suppression adapté au full-reload (sémantique héritée du staging, lockstep testé, dénominateur 0 → NOT_EVALUATED None-honnête). SKIP explicite si le contrat ne définit pas le seuil.
- **Persistance** (`interfaces/daily_run.py`) : ne commit jamais, re-plan sur données fraîches (pattern purge), dict_row épinglé.
- **Tests** : 70 unitaires purs + intégration complète, isolation par finalizer (leçon #461).

Frontière stricte respectée (vérifiée au grep en revue) : pas de décision, pas de chargement, pas d'event, pas de REST — c'est PR-3/PR-4.

Revue adversariale : **GO, zéro bloquant** (ruff/mypy clean, 70+6+62 tests verts localement). GO merge pilote banké — merge automatique à CI verte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)