### PR TITLE
fix(ingest): retractation statuts terminaux + dedup edges + QUOTE_NONE + defaults DB -- prealable au 1er chargement

### DIFF
--- a/scripts/bulk_ingest.py
+++ b/scripts/bulk_ingest.py
@@ -89,9 +89,14 @@ def _copy_tsv_to_temp(
 
 
 def _read_tsv_header(tsv_path: Path) -> list[str]:
-    """Read the header row of a TSV file."""
+    """Read the header row of a TSV file.
+
+    quoting=csv.QUOTE_NONE — same rationale as scripts/ingest_file.py's
+    parse_tsv: TSV-FILES-SPEC.md §1.1 mandates no quoting, and a header
+    name containing a literal `"` must not be silently mangled.
+    """
     with tsv_path.open("r", encoding="utf-8-sig", newline="") as f:
-        reader = csv.reader(f, delimiter="\t")
+        reader = csv.reader(f, delimiter="\t", quoting=csv.QUOTE_NONE)
         return [h.strip() for h in next(reader)]
 
 

--- a/scripts/ingest_file.py
+++ b/scripts/ingest_file.py
@@ -117,6 +117,12 @@ def parse_tsv(path: Path) -> tuple[list[str], list[dict[str, str]]]:
     """Parse a UTF-8 TSV file into (headers, rows-as-dicts).
 
     - Tabulation separator (no escape — values must not contain raw tabs).
+    - No quoting whatsoever (TSV-FILES-SPEC.md §1.1: "aucun guillemet"): a
+      literal `"` in a cell (e.g. an inch-mark item description like
+      `"U" BOLT 1/4"`) must be preserved verbatim, never treated as a CSV
+      quote character. `quoting=csv.QUOTE_NONE` is required here — the
+      default QUOTE_MINIMAL silently swallows a leading `"` and everything
+      up to the next `"`, corrupting the value.
     - First non-empty line is the header.
     - Empty lines are skipped.
     - BOM (UTF-8 signature) is tolerated and stripped.
@@ -128,7 +134,7 @@ def parse_tsv(path: Path) -> tuple[list[str], list[dict[str, str]]]:
         raise ValueError(f"input file is empty: {path}")
 
     with path.open("r", encoding="utf-8-sig", newline="") as f:
-        reader = csv.reader(f, delimiter="\t")
+        reader = csv.reader(f, delimiter="\t", quoting=csv.QUOTE_NONE)
         rows = [r for r in reader if any(cell.strip() for cell in r)]
 
     if not rows:

--- a/src/ootils_core/api/routers/ingest.py
+++ b/src/ootils_core/api/routers/ingest.py
@@ -344,7 +344,24 @@ def _wire_node_to_pi(
 ) -> int:
     """
     Connect a supply/demand node to the matching PI bucket via an edge.
-    Returns number of edges created.
+
+    Idempotent per (node_id, edge_type, scenario_id): a supply/demand node
+    is wired to at most ONE PI bucket at a time (single item/location/
+    time_ref triple). Re-wiring on a re-ingest (status/date/qty update)
+    retargets the existing edge instead of INSERTing a parallel one —
+    `edges` carries no unique constraint (only the `edge_id` PK, which is
+    always a fresh uuid4() here), so `ON CONFLICT DO NOTHING` never fired
+    and every UPDATE silently accumulated a duplicate 'replenishes'/
+    'consumes' edge to the same PI bucket. `inflows_agg`/`outflows_agg`
+    (propagator_sql.py) SUM(s.quantity) once PER MATCHING EDGE — N stale
+    duplicates meant N x the real quantity for any item/location that was
+    re-ingested more than once at an unchanged date (e.g. a PO stepping
+    draft -> confirmed -> in_transit with the same expected_delivery_date).
+    Fixed 2026-07-16 (ingest lifecycle retraction fix). Also opportunistically
+    cleans up any duplicates left over from before this fix.
+
+    Returns the number of edges created or retargeted (0 if no PI bucket
+    was found for time_ref, or the existing edge already points at it).
     """
     if node_type in ("PurchaseOrderSupply", "WorkOrderSupply", "PlannedSupply", "TransferSupply", "OnHandSupply"):
         edge_type = "replenishes"
@@ -377,23 +394,56 @@ def _wire_node_to_pi(
         return 0
 
     pi_node_id = pi_row["node_id"]
-    edge_id = uuid4()
-    from_id, to_id = node_id, pi_node_id
 
-    db.execute(
+    existing_edges = db.execute(
         """
-        INSERT INTO edges (edge_id, edge_type, from_node_id, to_node_id, scenario_id, active, created_at)
-        VALUES (%s, %s, %s, %s, %s, TRUE, now())
-        ON CONFLICT DO NOTHING
+        SELECT edge_id, to_node_id FROM edges
+        WHERE from_node_id = %s AND edge_type = %s AND scenario_id = %s
+        ORDER BY created_at ASC
         """,
-        (edge_id, edge_type, from_id, to_id, scenario_id),
+        (node_id, edge_type, scenario_id),
+    ).fetchall()
+
+    keep_id: UUID | None = next(
+        (e["edge_id"] for e in existing_edges if e["to_node_id"] == pi_node_id),
+        None,
     )
+
+    if keep_id is not None:
+        wired = 0  # already correctly wired — nothing to create or retarget
+    elif existing_edges:
+        # Retarget the oldest existing edge instead of leaving it stale
+        # and inserting a parallel one.
+        keep_id = existing_edges[0]["edge_id"]
+        db.execute(
+            "UPDATE edges SET to_node_id = %s, active = TRUE WHERE edge_id = %s",
+            (pi_node_id, keep_id),
+        )
+        wired = 1
+    else:
+        keep_id = uuid4()
+        db.execute(
+            """
+            INSERT INTO edges (edge_id, edge_type, from_node_id, to_node_id, scenario_id, active, created_at)
+            VALUES (%s, %s, %s, %s, %s, TRUE, now())
+            """,
+            (keep_id, edge_type, node_id, pi_node_id, scenario_id),
+        )
+        wired = 1
+
+    stale_ids = [e["edge_id"] for e in existing_edges if e["edge_id"] != keep_id]
+    if stale_ids:
+        db.execute("DELETE FROM edges WHERE edge_id = ANY(%s)", (stale_ids,))
+        logger.info(
+            "_wire_node_to_pi: removed %d duplicate %s edge(s) from node=%s",
+            len(stale_ids), edge_type, node_id,
+        )
 
     logger.debug(
         "_wire_node_to_pi: wired node=%s (%s) → PI=%s via %s",
         node_id, node_type, pi_node_id, edge_type,
     )
-    return 1
+    return wired
 
 
 def _emit_ingestion_event(db: DictRowConnection, scenario_id: UUID, node_id: UUID) -> None:
@@ -1320,6 +1370,14 @@ def ingest_on_hand(
 
 VALID_PO_STATUSES = {"draft", "confirmed", "in_transit", "received", "cancelled"}
 
+# Impact table per docs/contracts/TSV-FILES-SPEC.md §2.7 — this is the
+# single source of truth for "does this status still count as active
+# supply in the projection". `draft` does not count (not yet committed),
+# `received` does not count (already folded into on_hand), `cancelled`
+# does not count. Only `confirmed`/`in_transit` are active expected
+# receipts. Keep in lockstep with the doc table if it changes.
+_PO_ACTIVE_STATUSES = {"confirmed", "in_transit"}
+
 
 class PurchaseOrderRow(BaseModel):
     external_id: str = Field(..., description="ERP PO number. Upsert key.")
@@ -1336,6 +1394,13 @@ class PurchaseOrderRow(BaseModel):
     def non_empty(cls, v: str) -> str:
         if not v or not v.strip():
             raise ValueError("must not be empty")
+        return v
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str) -> str:
+        if v not in VALID_PO_STATUSES:
+            raise ValueError(f"status must be one of {VALID_PO_STATUSES}")
         return v
 
 
@@ -1416,7 +1481,7 @@ def ingest_purchase_orders(
     for po in body.purchase_orders:
         item_id = item_map[po.item_external_id]
         location_id = loc_map[po.location_external_id]
-        active = po.status != "cancelled"
+        active = po.status in _PO_ACTIVE_STATUSES
 
         # Ensure PI series exists for this (item, location)
         _ensure_projection_series(db, item_id, location_id, BASELINE_SCENARIO_ID)
@@ -1989,6 +2054,12 @@ def ingest_work_orders(
 
 VALID_CUSTOMER_ORDER_STATUSES = {"open", "confirmed", "shipped", "delivered", "cancelled"}
 
+# Impact table per docs/contracts/TSV-FILES-SPEC.md §2.8 — the ERP source
+# system never emits `delivered` in practice, only `shipped` (the shipment
+# already left, demand is gone from the projection's perspective). `open`
+# and `confirmed` are the only statuses still counted as future demand.
+_CO_ACTIVE_STATUSES = {"open", "confirmed"}
+
 
 class CustomerOrderRow(BaseModel):
     external_id: str = Field(..., description="ERP sales order number. Upsert key.")
@@ -2081,7 +2152,7 @@ def ingest_customer_orders(
     for co in body.customer_orders:
         item_id = item_map[co.item_external_id]
         location_id = loc_map[co.location_external_id]
-        active = co.status not in ("delivered", "cancelled")
+        active = co.status in _CO_ACTIVE_STATUSES
 
         _ensure_projection_series(db, item_id, location_id, BASELINE_SCENARIO_ID)
 
@@ -2142,6 +2213,15 @@ def ingest_customer_orders(
 # ─────────────────────────────────────────────────────────────
 
 VALID_TRANSFER_STATUSES = {"planned", "in_transit", "delivered", "cancelled"}
+
+# Impact table per docs/contracts/transfers/format-transfers-tsv.md §4 —
+# `planned`/`in_transit` still count as an expected receipt at the
+# destination PI; `delivered` no longer counts (already folded into the
+# destination's on_hand) and `cancelled` is ignored. Verified against the
+# PO/CO terminal-status bug family (docs/contracts/TSV-FILES-SPEC.md
+# §2.7/§2.8) — transfers were already correct, kept here for parity/audit
+# clarity rather than as a behaviour change.
+_TRANSFER_ACTIVE_STATUSES = {"planned", "in_transit"}
 
 
 class TransferRow(BaseModel):
@@ -2243,7 +2323,7 @@ def ingest_transfers(
     for t in body.transfers:
         item_id = item_map[t.item_external_id]
         to_location_id = loc_map[t.to_location_external_id]
-        active = t.status not in ("delivered", "cancelled")
+        active = t.status in _TRANSFER_ACTIVE_STATUSES
 
         # Wire to destination PI (to_location is the receiving side)
         _ensure_projection_series(db, item_id, to_location_id, BASELINE_SCENARIO_ID)
@@ -2637,16 +2717,27 @@ def ingest_planning_params(
             )
 
         # Build the new row from active values (carry-over) overridden by incoming fields.
-        # If no active row (CREATED), start from None values; if active exists (ROTATED),
-        # carry over the active values for unspecified fields.
+        # If active exists (ROTATED), carry over the active values for unspecified
+        # fields — SCD2 partial-push semantics (ADR-014 D3): an empty cell means
+        # "do not touch", never "clear the value". This branch is untouched by
+        # the fix below.
+        #
+        # If there is no active row (CREATED — first-ever push for this item ×
+        # location) and the client did not send a field, the key is simply
+        # OMITTED from new_row_values below instead of being set to None. A
+        # dict key present with value None still ends up in the INSERT's
+        # column list as an explicit `NULL`, which short-circuits the column's
+        # DB DEFAULT (migrations 007/021 — e.g. consumption_window_days -> 7,
+        # forecast_consumption_strategy -> 'max_only'). Omitting the column
+        # entirely lets Postgres apply that DEFAULT instead. Bug fixed
+        # 2026-07-16 — see docs/contracts/TSV-FILES-SPEC.md §2.5.
         new_row_values: dict = {}
         for k in _PLANNING_PARAMS_TRACKED_FIELDS:
             if k in incoming:
                 new_row_values[k] = incoming[k]
             elif active is not None:
                 new_row_values[k] = active.get(k)
-            else:
-                new_row_values[k] = None
+            # else: CREATED + field not sent -> key omitted, DB DEFAULT applies.
 
         # lot_size_rule cannot be NULL in DB (DEFAULT 'LOTFORLOT'); enforce
         if new_row_values.get("lot_size_rule") is None:

--- a/src/ootils_core/api/routers/ingest.py
+++ b/src/ootils_core/api/routers/ingest.py
@@ -263,6 +263,21 @@ def _ensure_projection_series(
     """
     Ensure a ProjectionSeries + PI bucket nodes exist for (item, location, scenario).
     Creates them if missing. Returns True if created, False if already existed.
+
+    Also chains the 90 buckets with 'feeds_forward' edges (bucket[i] -> bucket[i+1],
+    weight_ratio=1.0), mirroring migration 019's backfill. Without this chain,
+    GraphTraversal.expand_dirty_subgraph's downstream BFS (traversal.py) has no
+    edge to walk past the single PI bucket a supply/demand node is wired to, so
+    incremental propagation (POST /v1/events) only ever recomputes that one
+    bucket and never cascades the closing_stock change to the rest of the
+    horizon — silently stale projections outside a full recompute (found via
+    the 2026-07-17 ingest lifecycle retraction test, which is the first test
+    to drive the incremental path in isolation; every other caller in this
+    file's test suite masks the gap with a full recompute, which recomputes
+    every PI node directly and never needs the edges). This bug predates and
+    is independent of the retraction fix: it affects every ProjectionSeries
+    created through this ingest path (never through the demo seed, which
+    migration 019 already backfilled).
     """
     from datetime import date, timedelta
 
@@ -297,9 +312,14 @@ def _ensure_projection_series(
     ).fetchone()
     actual_series_id = UUID(str(row["series_id"])) if row else series_id
 
+    bucket_node_ids: list[UUID] = []
+    bucket_spans: list[tuple[date, date]] = []
     for i in range(90):
         day_start = today + timedelta(days=i)
         day_end = day_start + timedelta(days=1)
+        node_id = uuid4()
+        bucket_node_ids.append(node_id)
+        bucket_spans.append((day_start, day_end))
         db.execute(
             """
             INSERT INTO nodes (
@@ -320,14 +340,39 @@ def _ensure_projection_series(
             ON CONFLICT DO NOTHING
             """,
             (
-                uuid4(), scenario_id, item_id, location_id,
+                node_id, scenario_id, item_id, location_id,
                 day_start, day_end, day_start,
                 actual_series_id, i,
             ),
         )
 
+    # Chain consecutive buckets: PI[i].closing_stock -> PI[i+1].opening_stock
+    # (same contract as migration 019's backfill INSERT).
+    for i in range(len(bucket_node_ids) - 1):
+        from_id = bucket_node_ids[i]
+        to_id = bucket_node_ids[i + 1]
+        # Mirrors migration 019's backfill exactly: effective_start =
+        # n1.time_span_start, effective_end = n2.time_span_end.
+        effective_start, _ = bucket_spans[i]
+        _, effective_end = bucket_spans[i + 1]
+        db.execute(
+            """
+            INSERT INTO edges (
+                edge_id, edge_type, from_node_id, to_node_id, scenario_id,
+                priority, weight_ratio, effective_start, effective_end,
+                active, created_at
+            ) VALUES (
+                %s, 'feeds_forward', %s, %s, %s,
+                0, 1.0, %s, %s,
+                TRUE, now()
+            )
+            ON CONFLICT DO NOTHING
+            """,
+            (uuid4(), from_id, to_id, scenario_id, effective_start, effective_end),
+        )
+
     logger.info(
-        "_ensure_projection_series: created series + 90 PI buckets for item=%s loc=%s",
+        "_ensure_projection_series: created series + 90 PI buckets + 89 feeds_forward edges for item=%s loc=%s",
         item_id, location_id,
     )
     return True

--- a/src/ootils_core/db/migrations/080_backfill_feeds_forward_edges.sql
+++ b/src/ootils_core/db/migrations/080_backfill_feeds_forward_edges.sql
@@ -1,0 +1,80 @@
+-- ============================================================
+-- Migration 080 — backfill missing feeds_forward edges
+-- (2026-07-17 ingest lifecycle incremental-propagation fix)
+-- ============================================================
+-- Root cause: migration 019 chained every ProjectedInventory series that
+-- existed AT THAT TIME with 'feeds_forward' edges (PI[N].closing_stock ->
+-- PI[N+1].opening_stock) — the edge GraphTraversal.expand_dirty_subgraph
+-- (engine/kernel/graph/traversal.py) walks to cascade an incremental
+-- propagation (POST /v1/events) forward through a projection series.
+--
+-- `_ensure_projection_series` (api/routers/ingest.py) — the function that
+-- creates a ProjectionSeries + its 90 daily PI buckets for every real
+-- ingest of a NEW (item, location) pair — was added without ever creating
+-- this chain, so every series created through the real ingest API (as
+-- opposed to the demo seed migration 019 backfilled) has ZERO
+-- feeds_forward edges. Incremental propagation still "works" in the sense
+-- that it recomputes the ONE PI bucket directly wired to the triggering
+-- supply/demand node, but the closing_stock change never cascades to the
+-- rest of the horizon: every later bucket keeps its STALE closing_stock
+-- until the next full recompute silently papers over it (full recompute
+-- marks every PI node dirty directly — see POST /v1/calc/run
+-- {"full_recompute": true} in api/routers/calc.py — bypassing edges
+-- entirely, which is why this was invisible until a test drove the
+-- incremental path in isolation). This is the exact failure mode
+-- migration 019's own header describes ("all what-if simulations ...
+-- incorrect projections"), re-introduced by a later ingest-path addition
+-- that never got the same treatment.
+--
+-- `_ensure_projection_series` itself is fixed in the same change (it now
+-- creates the 89 feeds_forward edges alongside the 90 buckets), so no NEW
+-- gap opens after this migration runs; this migration only backfills
+-- whatever series already exist in this database without the chain.
+--
+-- Idempotent by construction (same NOT EXISTS guard as migration 019): a
+-- from/to pair that already has an active feeds_forward edge is skipped,
+-- so a migration re-attempt after a partial failure — or simply running
+-- this against a database where every series already has its chain — is
+-- a clean no-op.
+-- ============================================================
+
+INSERT INTO edges (
+    edge_id,
+    edge_type,
+    from_node_id,
+    to_node_id,
+    scenario_id,
+    priority,
+    weight_ratio,
+    effective_start,
+    effective_end,
+    active,
+    created_at
+)
+SELECT
+    gen_random_uuid(),
+    'feeds_forward',
+    n1.node_id,
+    n2.node_id,
+    n1.scenario_id,
+    0,
+    1.0,
+    n1.time_span_start,
+    n2.time_span_end,
+    TRUE,
+    now()
+FROM nodes n1
+JOIN nodes n2
+    ON  n2.projection_series_id = n1.projection_series_id
+    AND n2.bucket_sequence      = n1.bucket_sequence + 1
+    AND n2.active               = TRUE
+WHERE n1.node_type = 'ProjectedInventory'
+  AND n1.active    = TRUE
+  -- Skip pairs that already have a feeds_forward edge (idempotent)
+  AND NOT EXISTS (
+      SELECT 1 FROM edges e
+      WHERE e.from_node_id = n1.node_id
+        AND e.to_node_id   = n2.node_id
+        AND e.edge_type    = 'feeds_forward'
+        AND e.active       = TRUE
+  );

--- a/src/ootils_core/engine/kernel/graph/store.py
+++ b/src/ootils_core/engine/kernel/graph/store.py
@@ -45,6 +45,7 @@ class GraphStore:
         node_id: UUID,
         scenario_id: UUID,
         for_update: bool = False,
+        include_inactive: bool = False,
     ) -> Optional[Node]:
         """Fetch a single node by ID and scenario. Returns None if not found.
 
@@ -53,12 +54,23 @@ class GraphStore:
                 current transaction commits. Use this during allocation to
                 prevent concurrent runners from reading stale closing_stock
                 and double-deducting supply (#154).
+            include_inactive: If True, drops the `active = TRUE` filter.
+                Reserved for the propagation trigger-resolution path
+                (ingest lifecycle retraction fix, 2026-07-17): a PO/CO/
+                transfer node can be deactivated by the SAME write that
+                raises the event (status -> received/shipped/delivered/
+                cancelled), and the propagator still needs to resolve that
+                node to seed the dirty-subgraph expansion — otherwise the
+                retraction is invisible to incremental propagation (only a
+                full recompute would notice it). Every other caller keeps
+                the active-only contract; do not flip this default.
         """
         lock_clause = " FOR UPDATE" if for_update else ""
+        active_clause = "" if include_inactive else " AND active = TRUE"
         row = self._conn.execute(
             f"""
             SELECT * FROM nodes
-            WHERE node_id = %s AND scenario_id = %s AND active = TRUE
+            WHERE node_id = %s AND scenario_id = %s{active_clause}
             {lock_clause}
             """,
             (node_id, scenario_id),

--- a/src/ootils_core/engine/kernel/graph/traversal.py
+++ b/src/ootils_core/engine/kernel/graph/traversal.py
@@ -91,8 +91,20 @@ class GraphTraversal:
             if current_id in affected:
                 continue
 
-            # Load the node to check its time_span
-            node = self._store.get_node(current_id, scenario_id)
+            # Load the node to check its time_span. The trigger node is
+            # resolved WITHOUT the active filter: it may have just been
+            # deactivated by the same write that raised this event (PO ->
+            # received, CO -> shipped, etc. — ingest lifecycle retraction
+            # fix, 2026-07-17). Chosen over dirtying the item/location PI
+            # window blindly (option b) because it stays inside the
+            # existing edge-driven cascade (the retracted node's
+            # 'replenishes'/'consumes' edges are untouched by deactivation)
+            # instead of duplicating that expansion logic. Every other node
+            # visited by this BFS keeps the active-only contract — an
+            # inactive node genuinely stops the cascade there.
+            node = self._store.get_node(
+                current_id, scenario_id, include_inactive=(current_id == trigger_node_id),
+            )
             if node is None:
                 continue
 

--- a/src/ootils_core/engine/orchestration/propagator.py
+++ b/src/ootils_core/engine/orchestration/propagator.py
@@ -138,7 +138,13 @@ class PropagationEngine:
             # rewired from an old bucket to a new bucket before propagation,
             # so the old bucket is no longer reachable from the trigger node
             # via current outbound edges.
-            trigger_node = self._store.get_node(trigger_node_id, scenario_id)
+            # include_inactive=True: same rationale as expand_dirty_subgraph
+            # (ingest lifecycle retraction fix, 2026-07-17) — this lookup only
+            # reads item_id/location_id to widen the dirty PI window, so a
+            # trigger node deactivated by the same write must still resolve.
+            trigger_node = self._store.get_node(
+                trigger_node_id, scenario_id, include_inactive=True,
+            )
             if (
                 isinstance(trigger_node, Node)
                 and trigger_node.item_id is not None

--- a/src/ootils_core/staging/parser.py
+++ b/src/ootils_core/staging/parser.py
@@ -147,7 +147,7 @@ def parse(
     # TSV / CSV
     text, enc = _decode_text(data)
     delim = opts.delimiter or _sniff_delimiter(text, fmt)
-    rows, headers = _parse_delimited(text, delim, opts.max_rows)
+    rows, headers = _parse_delimited(text, delim, opts.max_rows, fmt=fmt)
     return ParseResult(
         rows=rows, headers=headers, format=fmt,
         encoding=enc, delimiter=delim, sha256=sha,
@@ -258,15 +258,27 @@ def _sniff_delimiter(text: str, fmt: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _parse_delimited(text: str, delimiter: str, max_rows: int | None) -> tuple[list[dict[str, str]], list[str]]:
+def _parse_delimited(
+    text: str, delimiter: str, max_rows: int | None, fmt: str = "csv"
+) -> tuple[list[dict[str, str]], list[str]]:
     """Parse a delimited text blob into (rows, headers).
 
     The first non-empty line is the header. Trailing whitespace on each
     cell is stripped. Empty cells become "" (not None) — typing happens
     in the DQ pipeline, not here.
+
+    Quoting: CSV keeps standard `"`-quoting (module docstring, §CSV) since
+    a comma-delimited value legitimately needs it. TSV disables quoting
+    entirely (`csv.QUOTE_NONE`) — same rationale as `scripts/ingest_file.py`
+    and TSV-FILES-SPEC.md §1.1 ("aucun guillemet"): a literal `"` in a cell
+    (e.g. an inch-mark item description) must be preserved verbatim, never
+    interpreted as a CSV quote character.
     """
     buf = io.StringIO(text)
-    reader = csv.reader(buf, delimiter=delimiter, quotechar='"')
+    if fmt == "tsv":
+        reader = csv.reader(buf, delimiter=delimiter, quoting=csv.QUOTE_NONE)
+    else:
+        reader = csv.reader(buf, delimiter=delimiter, quotechar='"')
 
     headers: list[str] = []
     rows: list[dict[str, str]] = []

--- a/tests/integration/test_ingest_retraction_integration.py
+++ b/tests/integration/test_ingest_retraction_integration.py
@@ -1,0 +1,632 @@
+"""
+tests/integration/test_ingest_retraction_integration.py — End-to-end proof of
+the 2026-07-16 ingest lifecycle fix, against real Postgres.
+
+The bug family: terminal statuses were only half-honoured. A PO re-ingested as
+'received' (or a CO as 'shipped') kept counting in the projection because the
+old blacklists (`status != 'cancelled'` / `not in ('delivered','cancelled')`)
+never retracted it, and `_wire_node_to_pi` accumulated a duplicate edge on
+every re-ingest (double-counting the quantity via inflows_agg/outflows_agg).
+
+Proof cycles here (each on its own item so projections never interfere):
+
+  (a)+(b) PO confirmed → projection counts the inflow; re-ingest the SAME
+          external_id as 'received' → node inactive AND the projection has
+          FORGOTTEN the quantity (closing stock back to the no-PO state).
+  (c)     CO open → outflow counted; re-ingest 'shipped' → demand gone.
+  (d)     PO confirmed → in_transit (non-terminal): stays active, quantity
+          counted EXACTLY once (the duplicate-edge regression proof), one
+          single replenishes edge.
+  (e)     planning params: CREATED with omitted cells → DB DEFAULTs applied
+          (forecast_consumption_strategy='max_only', consumption_window_days=7);
+          SCD2 rotation with an omitted cell → previous value preserved.
+
+Propagation is driven through the REAL production path after a TSV load:
+POST /v1/calc/run {"full_recompute": true} (all active PI buckets re-derived;
+inflows_agg/outflows_agg filter on node+edge active — the retraction axis).
+
+test_incremental_event_sees_retraction proves the INCREMENTAL path too
+(POST /v1/events with trigger_node_id, no full recompute): until 2026-07-17,
+GraphStore.get_node filtered active=TRUE unconditionally, so
+expand_dirty_subgraph (and process_event's item/location window fallback)
+returned an empty dirty set for a trigger node deactivated by the same write
+that raised the event — the retraction was invisible outside a full
+recompute. Fixed via GraphStore.get_node(include_inactive=True), scoped to
+the trigger-resolution call sites only (traversal.py, propagator.py).
+
+Isolation lesson applied: every committed seed is neutralized by a SAFE
+module finalizer — deactivation only (nodes/edges active=FALSE, events
+processed=TRUE, items obsoleted), never a DELETE cascade.
+"""
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+from uuid import UUID, uuid4
+
+import psycopg
+import pytest
+from psycopg.rows import dict_row
+
+from ootils_core.constants import BASELINE_SCENARIO_ID
+
+from .conftest import requires_db, TEST_DB_URL
+
+pytestmark = requires_db
+
+TOKEN = "integration-test-token"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+# Unique prefix per test run — seeds never collide across runs.
+PREFIX = f"RETR-{uuid4().hex[:8]}"
+
+TODAY = date.today()
+
+
+# ─────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def api_client(migrated_db):
+    """Module-scoped FastAPI TestClient bound to the real test DB
+    (same pattern as test_ingest_planning_params_integration.py)."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = TOKEN
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+    from fastapi.testclient import TestClient
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+def _ext(base: str) -> str:
+    return f"{PREFIX}-{base}"
+
+
+@pytest.fixture(scope="module")
+def seed(api_client):
+    """Seed master data through the real ingest API, then NEUTRALIZE (never
+    delete) everything committed under this module's PREFIX."""
+    items = [
+        {"external_id": _ext("ITEM-PO"), "name": "Retraction PO item",
+         "item_type": "component", "uom": "EA", "status": "active"},
+        {"external_id": _ext("ITEM-CO"), "name": "Retraction CO item",
+         "item_type": "finished_good", "uom": "EA", "status": "active"},
+        {"external_id": _ext("ITEM-NOREG"), "name": "Non-terminal PO item",
+         "item_type": "component", "uom": "EA", "status": "active"},
+        {"external_id": _ext("ITEM-INCR"), "name": "Incremental-event retraction item",
+         "item_type": "component", "uom": "EA", "status": "active"},
+        {"external_id": _ext("ITEM-PP1"), "name": "Planning params item 1",
+         "item_type": "component", "uom": "EA", "status": "active"},
+        {"external_id": _ext("ITEM-PP2"), "name": "Planning params item 2",
+         "item_type": "component", "uom": "EA", "status": "active"},
+    ]
+    resp = api_client.post("/v1/ingest/items", json={"items": items}, headers=AUTH)
+    assert resp.status_code == 200, resp.text
+
+    resp = api_client.post(
+        "/v1/ingest/locations",
+        json={"locations": [{"external_id": _ext("LOC"), "name": "Retraction test DC",
+                             "location_type": "dc"}]},
+        headers=AUTH,
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = api_client.post(
+        "/v1/ingest/suppliers",
+        json={"suppliers": [{"external_id": _ext("SUP"), "name": "Retraction supplier"}]},
+        headers=AUTH,
+    )
+    assert resp.status_code == 200, resp.text
+
+    yield {
+        "item_po": _ext("ITEM-PO"),
+        "item_co": _ext("ITEM-CO"),
+        "item_noreg": _ext("ITEM-NOREG"),
+        "item_incr": _ext("ITEM-INCR"),
+        "item_pp1": _ext("ITEM-PP1"),
+        "item_pp2": _ext("ITEM-PP2"),
+        "loc": _ext("LOC"),
+        "sup": _ext("SUP"),
+    }
+
+    # ── Safe neutralizing finalizer (isolation lesson): deactivate, never
+    # DELETE — no cascade can take innocent rows with it. The module-scoped
+    # migrated_db teardown drops the schema afterwards anyway; this keeps the
+    # DB coherent for any test that still runs in between.
+    like = PREFIX + "%"
+    try:
+        with psycopg.connect(TEST_DB_URL, autocommit=True) as c:
+            c.execute(
+                """
+                UPDATE edges SET active = FALSE
+                WHERE scenario_id = %s AND from_node_id IN (
+                    SELECT n.node_id FROM nodes n
+                    JOIN items i ON i.item_id = n.item_id
+                    WHERE i.external_id LIKE %s)
+                """,
+                (BASELINE_SCENARIO_ID, like),
+            )
+            c.execute(
+                """
+                UPDATE events SET processed = TRUE
+                WHERE processed = FALSE AND trigger_node_id IN (
+                    SELECT n.node_id FROM nodes n
+                    JOIN items i ON i.item_id = n.item_id
+                    WHERE i.external_id LIKE %s)
+                """,
+                (like,),
+            )
+            c.execute(
+                """
+                UPDATE nodes SET active = FALSE, is_dirty = FALSE
+                WHERE scenario_id = %s AND item_id IN (
+                    SELECT item_id FROM items WHERE external_id LIKE %s)
+                """,
+                (BASELINE_SCENARIO_ID, like),
+            )
+            c.execute(
+                "UPDATE items SET status = 'obsolete' WHERE external_id LIKE %s",
+                (like,),
+            )
+    except Exception:
+        pass  # best-effort — migrated_db teardown is the backstop
+
+
+# ─────────────────────────────────────────────────────────────
+# DB read helpers (fresh connection: only committed state is asserted)
+# ─────────────────────────────────────────────────────────────
+
+
+def _fetchone(sql: str, params: tuple):
+    with psycopg.connect(TEST_DB_URL, row_factory=dict_row) as c:
+        return c.execute(sql, params).fetchone()
+
+
+def _fetchall(sql: str, params: tuple):
+    with psycopg.connect(TEST_DB_URL, row_factory=dict_row) as c:
+        return c.execute(sql, params).fetchall()
+
+
+def _node_for(entity_type: str, external_id: str) -> dict:
+    row = _fetchone(
+        """
+        SELECT n.node_id, n.active, n.quantity, n.time_ref
+        FROM external_references er
+        JOIN nodes n ON n.node_id = er.internal_id
+        WHERE er.entity_type = %s AND er.external_id = %s
+        """,
+        (entity_type, external_id),
+    )
+    assert row is not None, f"no node for {entity_type} '{external_id}'"
+    return row
+
+
+def _pi_bucket(item_ext: str, loc_ext: str, day: date) -> dict:
+    row = _fetchone(
+        """
+        SELECT n.node_id, n.inflows, n.outflows, n.closing_stock
+        FROM nodes n
+        JOIN items i ON i.item_id = n.item_id
+        JOIN locations l ON l.location_id = n.location_id
+        WHERE i.external_id = %s AND l.external_id = %s
+          AND n.node_type = 'ProjectedInventory'
+          AND n.scenario_id = %s AND n.active = TRUE
+          AND n.time_span_start <= %s AND n.time_span_end > %s
+        """,
+        (item_ext, loc_ext, BASELINE_SCENARIO_ID, day, day),
+    )
+    assert row is not None, f"no PI bucket for {item_ext}@{loc_ext} on {day}"
+    return row
+
+
+def _last_pi_closing(item_ext: str, loc_ext: str):
+    row = _fetchone(
+        """
+        SELECT n.closing_stock
+        FROM nodes n
+        JOIN items i ON i.item_id = n.item_id
+        JOIN locations l ON l.location_id = n.location_id
+        WHERE i.external_id = %s AND l.external_id = %s
+          AND n.node_type = 'ProjectedInventory'
+          AND n.scenario_id = %s AND n.active = TRUE
+        ORDER BY n.bucket_sequence DESC
+        LIMIT 1
+        """,
+        (item_ext, loc_ext, BASELINE_SCENARIO_ID),
+    )
+    assert row is not None
+    return row["closing_stock"]
+
+
+def _edges_from(node_id) -> list[dict]:
+    return _fetchall(
+        """
+        SELECT edge_id, to_node_id, active FROM edges
+        WHERE from_node_id = %s AND scenario_id = %s
+        """,
+        (node_id, BASELINE_SCENARIO_ID),
+    )
+
+
+def _recalc(api_client) -> None:
+    """Full recompute through the real production path (all PI re-derived)."""
+    resp = api_client.post(
+        "/v1/calc/run", json={"full_recompute": True}, headers=AUTH,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "completed", body  # 'locked' would mean a stuck run
+
+
+# ─────────────────────────────────────────────────────────────
+# (a) + (b) — PO confirmed counts, PO received is FORGOTTEN
+# ─────────────────────────────────────────────────────────────
+
+
+def test_po_received_retracts_supply_from_projection(api_client, seed):
+    po_ext = _ext("PO-1")
+    delivery = TODAY + timedelta(days=5)
+    qty = 40
+
+    def po_payload(status: str) -> dict:
+        return {
+            "purchase_orders": [{
+                "external_id": po_ext,
+                "item_external_id": seed["item_po"],
+                "location_external_id": seed["loc"],
+                "supplier_external_id": seed["sup"],
+                "quantity": qty,
+                "uom": "EA",
+                "expected_delivery_date": delivery.isoformat(),
+                "status": status,
+            }]
+        }
+
+    # (a) confirmed → the projection must count the inflow
+    resp = api_client.post("/v1/ingest/purchase-orders", json=po_payload("confirmed"), headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["results"][0]["action"] == "inserted"
+
+    node = _node_for("purchase_order", po_ext)
+    assert node["active"] is True
+
+    _recalc(api_client)
+    bucket = _pi_bucket(seed["item_po"], seed["loc"], delivery)
+    assert bucket["inflows"] == qty
+    assert _last_pi_closing(seed["item_po"], seed["loc"]) == qty
+
+    # (b) SAME external_id re-ingested as 'received' → retraction
+    resp = api_client.post("/v1/ingest/purchase-orders", json=po_payload("received"), headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["results"][0]["action"] == "updated"
+
+    node = _node_for("purchase_order", po_ext)
+    assert node["active"] is False, (
+        "terminal status 'received' must deactivate the supply node "
+        "(whitelist applied on the UPDATE arm of the upsert)"
+    )
+
+    _recalc(api_client)
+    bucket = _pi_bucket(seed["item_po"], seed["loc"], delivery)
+    assert bucket["inflows"] == 0, "projection still counts a received PO"
+    assert _last_pi_closing(seed["item_po"], seed["loc"]) == 0, (
+        "closing stock must return to the no-PO state after retraction"
+    )
+
+    # The edge is kept (single, still active) — retraction rides the NODE
+    # active flag; inflows_agg filters s.active = TRUE.
+    edges = _edges_from(node["node_id"])
+    assert len(edges) == 1
+
+
+# ─────────────────────────────────────────────────────────────
+# (b') — the INCREMENTAL path (POST /v1/events, no full recompute) must
+# see the retraction too — GraphStore.get_node(include_inactive=True) fix
+# ─────────────────────────────────────────────────────────────
+
+
+def test_incremental_event_sees_retraction(api_client, seed):
+    """Before the 2026-07-17 fix this failed: expand_dirty_subgraph resolved
+    the trigger node through GraphStore.get_node, which unconditionally
+    filtered active=TRUE. A PO re-ingested as 'received' deactivates its
+    own node in the SAME write that raises the 'ingestion_complete' event,
+    so the very next lookup of that node — done to seed the dirty-subgraph
+    BFS — returned None, the dirty set came back empty, and POST /v1/events
+    recomputed nothing: the projection kept the retracted PO's quantity
+    forever, until someone ran a full recompute. This test drives ONLY the
+    incremental path (no /v1/calc/run after the retraction) and asserts the
+    projection has forgotten the quantity anyway.
+    """
+    po_ext = _ext("PO-INCR")
+    delivery = TODAY + timedelta(days=6)
+    qty = 15
+
+    def po_payload(status: str) -> dict:
+        return {
+            "purchase_orders": [{
+                "external_id": po_ext,
+                "item_external_id": seed["item_incr"],
+                "location_external_id": seed["loc"],
+                "supplier_external_id": seed["sup"],
+                "quantity": qty,
+                "uom": "EA",
+                "expected_delivery_date": delivery.isoformat(),
+                "status": status,
+            }]
+        }
+
+    # Seed: confirmed PO, established via a full recompute (unrelated to
+    # the axis under test — just gets the baseline projection in place).
+    resp = api_client.post("/v1/ingest/purchase-orders", json=po_payload("confirmed"), headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    _recalc(api_client)
+    bucket = _pi_bucket(seed["item_incr"], seed["loc"], delivery)
+    assert bucket["inflows"] == qty
+    assert _last_pi_closing(seed["item_incr"], seed["loc"]) == qty
+
+    # Retract: same external_id, terminal status. The node is deactivated
+    # synchronously by this write; propagation is NOT run yet.
+    resp = api_client.post("/v1/ingest/purchase-orders", json=po_payload("received"), headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["results"][0]["action"] == "updated"
+
+    node = _node_for("purchase_order", po_ext)
+    assert node["active"] is False
+
+    # The incremental path, driven directly — no /v1/calc/run anywhere
+    # from here on. trigger_node_id is the now-INACTIVE PO node.
+    resp = api_client.post(
+        "/v1/events",
+        json={
+            "event_type": "ingestion_complete",
+            "trigger_node_id": str(node["node_id"]),
+        },
+        headers=AUTH,
+    )
+    assert resp.status_code == 202, resp.text
+    assert resp.json()["affected_nodes_estimate"] > 0, (
+        "incremental propagation recomputed nothing — the dirty subgraph "
+        "expansion did not see the retracted trigger node"
+    )
+
+    bucket = _pi_bucket(seed["item_incr"], seed["loc"], delivery)
+    assert bucket["inflows"] == 0, (
+        "incremental propagation still counts a received PO — the "
+        "retraction is invisible outside a full recompute"
+    )
+    assert _last_pi_closing(seed["item_incr"], seed["loc"]) == 0, (
+        "closing stock must return to the no-PO state via the incremental "
+        "path alone"
+    )
+
+
+# ─────────────────────────────────────────────────────────────
+# (c) — CO open counts as demand, CO shipped disappears
+# ─────────────────────────────────────────────────────────────
+
+
+def test_co_shipped_retracts_demand_from_projection(api_client, seed):
+    co_ext = _ext("CO-1")
+    req_date = TODAY + timedelta(days=10)
+    qty = 7
+
+    def co_payload(status: str) -> dict:
+        return {
+            "customer_orders": [{
+                "external_id": co_ext,
+                "item_external_id": seed["item_co"],
+                "location_external_id": seed["loc"],
+                "quantity": qty,
+                "requested_delivery_date": req_date.isoformat(),
+                "status": status,
+            }]
+        }
+
+    resp = api_client.post("/v1/ingest/customer-orders", json=co_payload("open"), headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    assert _node_for("customer_order", co_ext)["active"] is True
+
+    _recalc(api_client)
+    bucket = _pi_bucket(seed["item_co"], seed["loc"], req_date)
+    assert bucket["outflows"] == qty
+    # No supply on this item — the demand drives the projection negative.
+    assert _last_pi_closing(seed["item_co"], seed["loc"]) == -qty
+
+    # shipped → the outflow already happened; future demand must vanish
+    resp = api_client.post("/v1/ingest/customer-orders", json=co_payload("shipped"), headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["results"][0]["action"] == "updated"
+    assert _node_for("customer_order", co_ext)["active"] is False
+
+    _recalc(api_client)
+    bucket = _pi_bucket(seed["item_co"], seed["loc"], req_date)
+    assert bucket["outflows"] == 0, "projection still counts a shipped CO as demand"
+    assert _last_pi_closing(seed["item_co"], seed["loc"]) == 0
+
+
+# ─────────────────────────────────────────────────────────────
+# (d) — non-terminal transition stays active, counted exactly ONCE
+# ─────────────────────────────────────────────────────────────
+
+
+def test_po_confirmed_to_in_transit_stays_active_no_double_count(api_client, seed):
+    po_ext = _ext("PO-2")
+    delivery = TODAY + timedelta(days=7)
+    qty = 25
+
+    def po_payload(status: str) -> dict:
+        return {
+            "purchase_orders": [{
+                "external_id": po_ext,
+                "item_external_id": seed["item_noreg"],
+                "location_external_id": seed["loc"],
+                "supplier_external_id": seed["sup"],
+                "quantity": qty,
+                "uom": "EA",
+                "expected_delivery_date": delivery.isoformat(),
+                "status": status,
+            }]
+        }
+
+    resp = api_client.post("/v1/ingest/purchase-orders", json=po_payload("confirmed"), headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    _recalc(api_client)
+    assert _pi_bucket(seed["item_noreg"], seed["loc"], delivery)["inflows"] == qty
+
+    # confirmed → in_transit: same date, same qty — must stay active.
+    resp = api_client.post("/v1/ingest/purchase-orders", json=po_payload("in_transit"), headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["results"][0]["action"] == "updated"
+
+    node = _node_for("purchase_order", po_ext)
+    assert node["active"] is True, "non-terminal in_transit must NOT retract the PO"
+
+    _recalc(api_client)
+    bucket = _pi_bucket(seed["item_noreg"], seed["loc"], delivery)
+    # THE duplicate-edge regression proof: before the _wire_node_to_pi fix,
+    # each re-ingest at an unchanged date INSERTed a parallel replenishes
+    # edge and inflows_agg summed the quantity once PER EDGE (2 × qty here).
+    assert bucket["inflows"] == qty, (
+        f"expected inflows == {qty} exactly once; a duplicated edge would "
+        f"double-count (got {bucket['inflows']})"
+    )
+    assert _last_pi_closing(seed["item_noreg"], seed["loc"]) == qty
+
+    edges = _edges_from(node["node_id"])
+    assert len(edges) == 1, (
+        f"exactly ONE replenishes edge expected after re-ingest, got {len(edges)}"
+    )
+    assert edges[0]["active"] is True
+
+
+# ─────────────────────────────────────────────────────────────
+# (e) — planning params: DB DEFAULTs at CREATED, carry-over at ROTATED
+# ─────────────────────────────────────────────────────────────
+
+
+def _active_pp_row(item_ext: str, loc_ext: str) -> dict:
+    row = _fetchone(
+        """
+        SELECT p.*
+        FROM item_planning_params p
+        JOIN items i ON i.item_id = p.item_id
+        JOIN locations l ON l.location_id = p.location_id
+        WHERE i.external_id = %s AND l.external_id = %s
+          AND p.effective_to IS NULL
+        ORDER BY p.effective_from DESC
+        LIMIT 1
+        """,
+        (item_ext, loc_ext),
+    )
+    assert row is not None, f"no active planning-params row for {item_ext}"
+    return row
+
+
+def test_planning_params_created_with_empty_cells_gets_db_defaults(api_client, seed):
+    """CREATED with omitted fields: the INSERT must OMIT the columns so the
+    DB DEFAULTs apply (migrations 007/021) — the old code pushed explicit
+    NULLs that short-circuited them."""
+    resp = api_client.post(
+        "/v1/ingest/planning-params",
+        json={"params": [{
+            "item_external_id": seed["item_pp1"],
+            "location_external_id": seed["loc"],
+            "safety_stock_qty": 50,
+        }]},
+        headers=AUTH,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["results"][0]["action"] == "created"
+
+    row = _active_pp_row(seed["item_pp1"], seed["loc"])
+    # The explicitly pushed value:
+    assert row["safety_stock_qty"] == 50
+    # DB DEFAULTs that the old explicit-NULL INSERT used to wipe out:
+    assert row["forecast_consumption_strategy"] == "max_only"
+    assert row["consumption_window_days"] == 7
+    # Python-side floor defaults (NOT NULL columns), unchanged by the fix:
+    assert row["lot_size_rule"] == "LOTFORLOT"
+    assert row["planning_horizon_days"] == 90
+    assert row["is_make"] is False
+    # Nullable columns with no DEFAULT stay honestly NULL:
+    assert row["lead_time_sourcing_days"] is None
+    assert row["safety_stock_days"] is None
+
+
+def test_planning_params_rotation_empty_cell_keeps_previous_value(api_client, seed):
+    """SCD2 rotation: an omitted cell means 'do not touch' — the previous
+    value (including one that came from a DB DEFAULT) is carried over."""
+    # First push: two explicit values; the rest take DB DEFAULTs.
+    resp = api_client.post(
+        "/v1/ingest/planning-params",
+        json={"params": [{
+            "item_external_id": seed["item_pp2"],
+            "location_external_id": seed["loc"],
+            "safety_stock_qty": 50,
+            "lead_time_sourcing_days": 5,
+        }]},
+        headers=AUTH,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["results"][0]["action"] == "created"
+    param_id = UUID(resp.json()["results"][0]["param_id"])
+
+    # Backdate the active row so the next differing push ROTATES instead of
+    # updating in place (decide_action: same-day change = UPDATED_INPLACE).
+    with psycopg.connect(TEST_DB_URL, autocommit=True) as c:
+        c.execute(
+            "UPDATE item_planning_params SET effective_from = %s WHERE param_id = %s",
+            (TODAY - timedelta(days=5), param_id),
+        )
+
+    # Rotation push: ONLY lead_time_sourcing_days; safety_stock_qty omitted
+    # (the empty TSV cell) → must be preserved from the previous version.
+    resp = api_client.post(
+        "/v1/ingest/planning-params",
+        json={"params": [{
+            "item_external_id": seed["item_pp2"],
+            "location_external_id": seed["loc"],
+            "lead_time_sourcing_days": 9,
+        }]},
+        headers=AUTH,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["results"][0]["action"] == "rotated"
+
+    row = _active_pp_row(seed["item_pp2"], seed["loc"])
+    assert row["lead_time_sourcing_days"] == 9          # the pushed change
+    assert row["safety_stock_qty"] == 50                # empty cell → untouched
+    assert row["consumption_window_days"] == 7          # DB DEFAULT carried over
+    assert row["forecast_consumption_strategy"] == "max_only"
+
+    # The previous version was closed at today (half-open interval), never lost.
+    old = _fetchone(
+        "SELECT effective_to FROM item_planning_params WHERE param_id = %s",
+        (param_id,),
+    )
+    assert old["effective_to"] == TODAY
+
+    history = _fetchall(
+        """
+        SELECT p.param_id FROM item_planning_params p
+        JOIN items i ON i.item_id = p.item_id
+        WHERE i.external_id = %s
+        """,
+        (seed["item_pp2"],),
+    )
+    assert len(history) == 2

--- a/tests/integration/test_ingest_retraction_integration.py
+++ b/tests/integration/test_ingest_retraction_integration.py
@@ -20,6 +20,15 @@ Proof cycles here (each on its own item so projections never interfere):
   (e)     planning params: CREATED with omitted cells → DB DEFAULTs applied
           (forecast_consumption_strategy='max_only', consumption_window_days=7);
           SCD2 rotation with an omitted cell → previous value preserved.
+  (f)     feeds_forward chain SHAPE: a series created through the real ingest
+          path carries exactly N-1 edges strictly chaining consecutive
+          bucket_sequence values (no loop, no skip, no duplicate), all
+          active, weight_ratio=1.0 — the 2026-07-17 `_ensure_projection_series`
+          fix (before it, ingest-created series had ZERO feeds_forward edges
+          and incremental propagation never cascaded past the first bucket).
+  (g)     migration 080 backfill: a pre-fix series (PI nodes, no edges —
+          INSERTed directly) gets its exact N-1 chain from the migration SQL,
+          and a re-execution adds nothing (NOT EXISTS guard, idempotent).
 
 Propagation is driven through the REAL production path after a TSV load:
 POST /v1/calc/run {"full_recompute": true} (all active PI buckets re-derived;
@@ -42,6 +51,7 @@ from __future__ import annotations
 
 import os
 from datetime import date, timedelta
+from pathlib import Path
 from uuid import UUID, uuid4
 
 import psycopg
@@ -114,6 +124,8 @@ def seed(api_client):
          "item_type": "component", "uom": "EA", "status": "active"},
         {"external_id": _ext("ITEM-PP2"), "name": "Planning params item 2",
          "item_type": "component", "uom": "EA", "status": "active"},
+        {"external_id": _ext("ITEM-CHAIN"), "name": "Feeds-forward chain item",
+         "item_type": "component", "uom": "EA", "status": "active"},
     ]
     resp = api_client.post("/v1/ingest/items", json={"items": items}, headers=AUTH)
     assert resp.status_code == 200, resp.text
@@ -140,6 +152,7 @@ def seed(api_client):
         "item_incr": _ext("ITEM-INCR"),
         "item_pp1": _ext("ITEM-PP1"),
         "item_pp2": _ext("ITEM-PP2"),
+        "item_chain": _ext("ITEM-CHAIN"),
         "loc": _ext("LOC"),
         "sup": _ext("SUP"),
     }
@@ -630,3 +643,258 @@ def test_planning_params_rotation_empty_cell_keeps_previous_value(api_client, se
         (seed["item_pp2"],),
     )
     assert len(history) == 2
+
+
+# ─────────────────────────────────────────────────────────────
+# (f) — feeds_forward chain SHAPE on a series created by the real ingest path
+# ─────────────────────────────────────────────────────────────
+
+
+def _series_id_for(item_ext: str, loc_ext: str) -> UUID:
+    row = _fetchone(
+        """
+        SELECT ps.series_id
+        FROM projection_series ps
+        JOIN items i ON i.item_id = ps.item_id
+        JOIN locations l ON l.location_id = ps.location_id
+        WHERE i.external_id = %s AND l.external_id = %s AND ps.scenario_id = %s
+        """,
+        (item_ext, loc_ext, BASELINE_SCENARIO_ID),
+    )
+    assert row is not None, f"no projection_series for {item_ext}@{loc_ext}"
+    return UUID(str(row["series_id"]))
+
+
+def test_new_series_feeds_forward_chain_shape(api_client, seed):
+    """Structural proof of the `_ensure_projection_series` fix: an ingest that
+    creates a NEW series must chain its N buckets with exactly N-1
+    feeds_forward edges — from=seq i → to=seq i+1, strictly consecutive, no
+    self-loop, no skip, no duplicate, never leaving the series — all active,
+    weight_ratio=1.0 (migration 019's contract). Before the fix this SELECT
+    returned ZERO rows for every ingest-created series."""
+    po_ext = _ext("PO-CHAIN")
+    resp = api_client.post(
+        "/v1/ingest/purchase-orders",
+        json={"purchase_orders": [{
+            "external_id": po_ext,
+            "item_external_id": seed["item_chain"],
+            "location_external_id": seed["loc"],
+            "supplier_external_id": seed["sup"],
+            "quantity": 10,
+            "uom": "EA",
+            "expected_delivery_date": (TODAY + timedelta(days=3)).isoformat(),
+            "status": "confirmed",
+        }]},
+        headers=AUTH,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["results"][0]["action"] == "inserted"
+
+    series_id = _series_id_for(seed["item_chain"], seed["loc"])
+
+    n_buckets = _fetchone(
+        """
+        SELECT COUNT(*) AS n FROM nodes
+        WHERE projection_series_id = %s
+          AND node_type = 'ProjectedInventory' AND active = TRUE
+        """,
+        (series_id,),
+    )["n"]
+    assert n_buckets == 90, f"expected the 90 daily PI buckets, got {n_buckets}"
+
+    # Every feeds_forward edge LEAVING a node of the series, with both ends'
+    # coordinates — the raw material for every structural assertion below.
+    rows = _fetchall(
+        """
+        SELECT n1.bucket_sequence AS from_seq,
+               n2.bucket_sequence AS to_seq,
+               n2.projection_series_id AS to_series,
+               e.active AS edge_active,
+               e.weight_ratio,
+               e.scenario_id
+        FROM edges e
+        JOIN nodes n1 ON n1.node_id = e.from_node_id
+        JOIN nodes n2 ON n2.node_id = e.to_node_id
+        WHERE e.edge_type = 'feeds_forward'
+          AND n1.projection_series_id = %s
+        ORDER BY n1.bucket_sequence
+        """,
+        (series_id,),
+    )
+
+    # Exactly N-1 edges for N buckets.
+    assert len(rows) == n_buckets - 1, (
+        f"expected {n_buckets - 1} feeds_forward edges for {n_buckets} "
+        f"buckets, got {len(rows)}"
+    )
+
+    # Strict consecutive chaining: the ordered (from, to) list IS the ideal
+    # chain — one comparison rules out loops (i,i), skips (i,i+2), backward
+    # edges, and duplicates all at once.
+    pairs = [(r["from_seq"], r["to_seq"]) for r in rows]
+    assert pairs == [(i, i + 1) for i in range(n_buckets - 1)], (
+        f"chain is not strictly consecutive: {pairs[:5]}... "
+    )
+
+    for r in rows:
+        # An edge must never jump to another series' bucket.
+        assert UUID(str(r["to_series"])) == series_id
+        assert r["edge_active"] is True
+        assert r["weight_ratio"] == 1
+        assert UUID(str(r["scenario_id"])) == BASELINE_SCENARIO_ID
+
+    # And nothing feeds INTO the series from outside it (no foreign edge
+    # masquerading as part of the chain).
+    inbound_foreign = _fetchone(
+        """
+        SELECT COUNT(*) AS n
+        FROM edges e
+        JOIN nodes n2 ON n2.node_id = e.to_node_id
+        JOIN nodes n1 ON n1.node_id = e.from_node_id
+        WHERE e.edge_type = 'feeds_forward'
+          AND n2.projection_series_id = %s
+          AND (n1.projection_series_id IS DISTINCT FROM %s)
+        """,
+        (series_id, series_id),
+    )["n"]
+    assert inbound_foreign == 0
+
+
+# ─────────────────────────────────────────────────────────────
+# (g) — migration 080: exact backfill of a pre-fix series + idempotence
+# ─────────────────────────────────────────────────────────────
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_080 = (
+    _REPO_ROOT / "src" / "ootils_core" / "db" / "migrations"
+    / "080_backfill_feeds_forward_edges.sql"
+)
+
+
+class TestMigration080Backfill:
+    def test_backfill_exact_then_reexecution_is_noop(self, migrated_db, conn):
+        """Backfill + defensive-idempotence contract of migration 080 (same
+        NOT EXISTS guard as 019). Triple execution overall, mirroring
+        test_reexecuting_078_sql_is_noop — with ONE adaptation: unlike 078,
+        the 080 file carries NO internal BEGIN/COMMIT (a single INSERT ...
+        SELECT), so it runs INSIDE this test's transaction on the `conn`
+        fixture and everything — seed included — rolls back at teardown.
+        Execution #1 was the migrated_db boot (fresh DB, zero series: no-op);
+        #2 backfills the pre-fix series seeded below; #3 must add nothing.
+
+        Isolation lesson: nothing here ever COMMITs, so no finalizer is
+        needed — the rollback IS the cleanup (strictly safer than the
+        neutralizing finalizer used for the module's committed seeds)."""
+        today = date.today()
+        n_buckets = 5
+
+        # ── Seed the PRE-FIX state: item + location + series + N active PI
+        # buckets, and deliberately ZERO feeds_forward edges (what every
+        # ingest-created series looked like before `_ensure_projection_series`
+        # learned to chain them).
+        item_id, location_id, series_id = uuid4(), uuid4(), uuid4()
+        conn.execute(
+            """
+            INSERT INTO items (item_id, name, item_type, uom, status, external_id)
+            VALUES (%s, 'Mig080 backfill item', 'component', 'EA', 'active', %s)
+            """,
+            (item_id, _ext("MIG080-ITEM")),
+        )
+        conn.execute(
+            """
+            INSERT INTO locations (location_id, name, location_type, external_id)
+            VALUES (%s, 'Mig080 backfill DC', 'dc', %s)
+            """,
+            (location_id, _ext("MIG080-LOC")),
+        )
+        conn.execute(
+            """
+            INSERT INTO projection_series
+                (series_id, item_id, location_id, scenario_id,
+                 horizon_start, horizon_end)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            """,
+            (series_id, item_id, location_id, BASELINE_SCENARIO_ID,
+             today, today + timedelta(days=n_buckets)),
+        )
+        for i in range(n_buckets):
+            day_start = today + timedelta(days=i)
+            conn.execute(
+                """
+                INSERT INTO nodes (
+                    node_id, node_type, scenario_id, item_id, location_id,
+                    time_grain, time_span_start, time_span_end, time_ref,
+                    projection_series_id, bucket_sequence,
+                    opening_stock, inflows, outflows, closing_stock,
+                    is_dirty, active
+                ) VALUES (
+                    %s, 'ProjectedInventory', %s, %s, %s,
+                    'day', %s, %s, %s,
+                    %s, %s,
+                    0, 0, 0, 0,
+                    FALSE, TRUE
+                )
+                """,
+                (uuid4(), BASELINE_SCENARIO_ID, item_id, location_id,
+                 day_start, day_start + timedelta(days=1), day_start,
+                 series_id, i),
+            )
+
+        def _series_pairs() -> list[tuple[int, int]]:
+            return [
+                (r["from_seq"], r["to_seq"])
+                for r in conn.execute(
+                    """
+                    SELECT n1.bucket_sequence AS from_seq,
+                           n2.bucket_sequence AS to_seq
+                    FROM edges e
+                    JOIN nodes n1 ON n1.node_id = e.from_node_id
+                    JOIN nodes n2 ON n2.node_id = e.to_node_id
+                    WHERE e.edge_type = 'feeds_forward'
+                      AND n1.projection_series_id = %s
+                    ORDER BY n1.bucket_sequence
+                    """,
+                    (series_id,),
+                ).fetchall()
+            ]
+
+        def _global_ff_count() -> int:
+            return conn.execute(
+                "SELECT COUNT(*) AS n FROM edges WHERE edge_type = 'feeds_forward'"
+            ).fetchone()["n"]
+
+        assert _series_pairs() == [], "seed must start with ZERO edges (pre-fix state)"
+        n_global_before = _global_ff_count()
+
+        sql_text = MIGRATION_080.read_text(encoding="utf-8")
+
+        # ── Execution #2 (the backfill): exactly N-1 edges, strictly chained.
+        conn.execute(sql_text)
+        assert _series_pairs() == [(i, i + 1) for i in range(n_buckets - 1)]
+        # ... and it touched NOTHING else: every other series in this DB was
+        # created by the FIXED ingest path, already chained, skipped by the
+        # NOT EXISTS guard.
+        assert _global_ff_count() == n_global_before + (n_buckets - 1)
+
+        # The backfilled edges honour migration 019's contract.
+        edge_rows = conn.execute(
+            """
+            SELECT e.active, e.weight_ratio, e.scenario_id
+            FROM edges e
+            JOIN nodes n1 ON n1.node_id = e.from_node_id
+            WHERE e.edge_type = 'feeds_forward'
+              AND n1.projection_series_id = %s
+            """,
+            (series_id,),
+        ).fetchall()
+        for r in edge_rows:
+            assert r["active"] is True
+            assert r["weight_ratio"] == 1
+            assert UUID(str(r["scenario_id"])) == BASELINE_SCENARIO_ID
+
+        # ── Execution #3: a clean no-op — not one duplicated edge, anywhere.
+        conn.execute(sql_text)
+        assert _series_pairs() == [(i, i + 1) for i in range(n_buckets - 1)], (
+            "re-executing migration 080 duplicated or altered chain edges"
+        )
+        assert _global_ff_count() == n_global_before + (n_buckets - 1)

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -930,7 +930,7 @@ class TestTraversalGaps:
         nodes = {trigger: node_trigger, b: node_b, c: node_c, d: node_d, e: None}
 
         store = MagicMock()
-        store.get_node.side_effect = lambda nid, sid: nodes.get(nid)
+        store.get_node.side_effect = lambda nid, sid, **_: nodes.get(nid)
         store.get_edges_from.side_effect = lambda nid, sid: edges_from.get(nid, [])
 
         traversal = GraphTraversal(store)

--- a/tests/test_graph_traversal.py
+++ b/tests/test_graph_traversal.py
@@ -133,7 +133,7 @@ class TestExpandDirtySubgraph:
         node_b = make_node(b, node_type="OnHandSupply", scenario_id=scenario)
         edge_ab = make_edge(a, b, scenario)
         store = MagicMock()
-        store.get_node.side_effect = lambda nid, sid: node_a if nid == a else node_b
+        store.get_node.side_effect = lambda nid, sid, **_: node_a if nid == a else node_b
         store.get_edges_from.side_effect = lambda nid, sid: [edge_ab] if nid == a else []
         traversal = GraphTraversal(store)
         result = traversal.expand_dirty_subgraph(a, scenario, (date(2025, 1, 1), date(2025, 12, 31)))
@@ -153,7 +153,7 @@ class TestExpandDirtySubgraph:
         )
         edge_ab = make_edge(a, b, scenario)
         store = MagicMock()
-        store.get_node.side_effect = lambda nid, sid: node_a if nid == a else node_b
+        store.get_node.side_effect = lambda nid, sid, **_: node_a if nid == a else node_b
         store.get_edges_from.side_effect = lambda nid, sid: [edge_ab] if nid == a else []
         traversal = GraphTraversal(store)
         result = traversal.expand_dirty_subgraph(a, scenario, (date(2025, 1, 1), date(2025, 12, 31)))
@@ -173,7 +173,7 @@ class TestExpandDirtySubgraph:
         )
         edge_ab = make_edge(a, b, scenario)
         store = MagicMock()
-        store.get_node.side_effect = lambda nid, sid: node_a if nid == a else node_b
+        store.get_node.side_effect = lambda nid, sid, **_: node_a if nid == a else node_b
         store.get_edges_from.side_effect = lambda nid, sid: [edge_ab] if nid == a else []
         traversal = GraphTraversal(store)
         result = traversal.expand_dirty_subgraph(a, scenario, (date(2025, 1, 1), date(2025, 12, 31)))
@@ -190,7 +190,7 @@ class TestExpandDirtySubgraph:
         edge_ab = make_edge(a, b, scenario)
         edge_ba = make_edge(b, a, scenario)
         store = MagicMock()
-        store.get_node.side_effect = lambda nid, sid: node_a if nid == a else node_b
+        store.get_node.side_effect = lambda nid, sid, **_: node_a if nid == a else node_b
         store.get_edges_from.side_effect = lambda nid, sid: [edge_ab] if nid == a else [edge_ba]
         traversal = GraphTraversal(store)
         # Should terminate (not loop forever) and include both nodes

--- a/tests/test_ingest_status_lifecycle.py
+++ b/tests/test_ingest_status_lifecycle.py
@@ -1,0 +1,286 @@
+"""
+tests/test_ingest_status_lifecycle.py — Pure unit tests (no DB) for the
+2026-07-16 ingest lifecycle fix.
+
+Two axes:
+
+1. Status → active mapping (terminal-status retraction). The whitelists
+   `_PO_ACTIVE_STATUSES` / `_CO_ACTIVE_STATUSES` / `_TRANSFER_ACTIVE_STATUSES`
+   in api/routers/ingest.py are the single source of "does this status still
+   count in the projection". The expected impact tables below are transcribed
+   from the CONTRACT docs (docs/contracts/TSV-FILES-SPEC.md §2.7 for POs,
+   §2.8 for COs; docs/contracts/transfers/format-transfers-tsv.md for
+   transfers — §2.10 of the spec carries no impact table) and pinned
+   EXHAUSTIVELY against each entity's status enum: if either the enum or the
+   whitelist drifts, a test here fails before the projection silently
+   over/under-counts supply or demand again.
+
+2. TSV quoting (QUOTE_NONE). TSV-FILES-SPEC.md §1.1 mandates "no quoting":
+   a literal `"` in a cell (inch-mark item descriptions like
+   `"U" BOLT 1/4-20 X 1-3/4`) must survive parsing verbatim. The three fixed
+   parsers are exercised through their REAL public functions:
+   scripts/ingest_file.py:parse_tsv, scripts/bulk_ingest.py:_read_tsv_header,
+   and ootils_core.staging.parser.parse (TSV branch; the CSV branch keeps
+   standard quoting — pinned too, it is a deliberate carve-out).
+
+No DB required — this file must stay collectible and green without
+DATABASE_URL.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+# auth.py validates OOTILS_API_TOKEN at IMPORT time — set it before importing
+# anything that pulls in api.auth (same pattern as tests/test_auth_principal.py).
+os.environ.setdefault("OOTILS_API_TOKEN", "test-token")
+
+# scripts/ are not a package — same import pattern as tests/test_mrp_shim_compat.py.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import bulk_ingest  # noqa: E402
+import ingest_file  # noqa: E402
+
+from ootils_core.api.routers.ingest import (  # noqa: E402
+    _CO_ACTIVE_STATUSES,
+    _PO_ACTIVE_STATUSES,
+    _TRANSFER_ACTIVE_STATUSES,
+    VALID_CUSTOMER_ORDER_STATUSES,
+    VALID_PO_STATUSES,
+    VALID_TRANSFER_STATUSES,
+    CustomerOrderRow,
+    PurchaseOrderRow,
+    TransferRow,
+)
+from ootils_core.staging.parser import parse as staging_parse  # noqa: E402
+
+
+# ─────────────────────────────────────────────────────────────
+# 1. Status → active impact tables (from the contract docs)
+# ─────────────────────────────────────────────────────────────
+
+# docs/contracts/TSV-FILES-SPEC.md §2.7 "Impact projection par statut"
+PO_IMPACT: dict[str, bool] = {
+    "draft": False,        # not yet committed supply
+    "confirmed": True,     # expected receipt
+    "in_transit": True,    # expected receipt
+    "received": False,     # already folded into on_hand
+    "cancelled": False,
+}
+
+# docs/contracts/TSV-FILES-SPEC.md §2.8 "Impact projection par statut"
+CO_IMPACT: dict[str, bool] = {
+    "open": True,          # soft demand
+    "confirmed": True,     # firm demand
+    "shipped": False,      # outflow already happened
+    "delivered": False,
+    "cancelled": False,
+}
+
+# docs/contracts/transfers/format-transfers-tsv.md (destination-PI receipt)
+TRANSFER_IMPACT: dict[str, bool] = {
+    "planned": True,       # expected receipt at destination
+    "in_transit": True,    # expected receipt at destination
+    "delivered": False,    # already folded into destination on_hand
+    "cancelled": False,
+}
+
+
+class TestImpactTablesAreExhaustive:
+    """The expected tables must cover each contract enum EXACTLY — a status
+    added to (or removed from) the enum without a deliberate impact decision
+    fails here."""
+
+    def test_po_impact_table_covers_the_full_enum(self):
+        assert set(PO_IMPACT) == VALID_PO_STATUSES
+
+    def test_co_impact_table_covers_the_full_enum(self):
+        assert set(CO_IMPACT) == VALID_CUSTOMER_ORDER_STATUSES
+
+    def test_transfer_impact_table_covers_the_full_enum(self):
+        assert set(TRANSFER_IMPACT) == VALID_TRANSFER_STATUSES
+
+
+class TestStatusToActiveMapping:
+    """The whitelist membership test IS the production mapping
+    (`active = status in _X_ACTIVE_STATUSES` in each ingest endpoint) —
+    assert it status by status against the contract impact tables."""
+
+    @pytest.mark.parametrize("status", sorted(PO_IMPACT))
+    def test_po_status_maps_to_contract_impact(self, status):
+        assert (status in _PO_ACTIVE_STATUSES) == PO_IMPACT[status], (
+            f"PO status '{status}': whitelist says active="
+            f"{status in _PO_ACTIVE_STATUSES}, contract §2.7 says {PO_IMPACT[status]}"
+        )
+
+    @pytest.mark.parametrize("status", sorted(CO_IMPACT))
+    def test_co_status_maps_to_contract_impact(self, status):
+        assert (status in _CO_ACTIVE_STATUSES) == CO_IMPACT[status], (
+            f"CO status '{status}': whitelist says active="
+            f"{status in _CO_ACTIVE_STATUSES}, contract §2.8 says {CO_IMPACT[status]}"
+        )
+
+    @pytest.mark.parametrize("status", sorted(TRANSFER_IMPACT))
+    def test_transfer_status_maps_to_contract_impact(self, status):
+        assert (status in _TRANSFER_ACTIVE_STATUSES) == TRANSFER_IMPACT[status], (
+            f"Transfer status '{status}': whitelist says active="
+            f"{status in _TRANSFER_ACTIVE_STATUSES}, contract says "
+            f"{TRANSFER_IMPACT[status]}"
+        )
+
+    def test_whitelists_are_subsets_of_their_enums(self):
+        assert _PO_ACTIVE_STATUSES <= VALID_PO_STATUSES
+        assert _CO_ACTIVE_STATUSES <= VALID_CUSTOMER_ORDER_STATUSES
+        assert _TRANSFER_ACTIVE_STATUSES <= VALID_TRANSFER_STATUSES
+
+
+class TestUnknownStatusIsInactiveByDefault:
+    """A whitelist (vs the old `status != 'cancelled'` blacklist) makes the
+    unknown case FAIL SAFE: anything outside the whitelist — typo, case
+    variant, brand-new ERP status — counts as INACTIVE, never as phantom
+    supply/demand in the projection."""
+
+    WEIRD = ["", " ", "Confirmed", "CONFIRMED", "recieved", "in transit",
+             "IN_TRANSIT", "open ", "Planned", "some_future_status"]
+
+    @pytest.mark.parametrize("status", WEIRD)
+    def test_unknown_status_is_inactive_for_all_three_entities(self, status):
+        assert status not in _PO_ACTIVE_STATUSES
+        assert status not in _CO_ACTIVE_STATUSES
+        assert status not in _TRANSFER_ACTIVE_STATUSES
+
+
+class TestModelBoundary:
+    """Pin WHERE the invalid-status rejection happens per entity. CO,
+    transfer AND purchase-order rows all carry a Pydantic validator (422 at
+    the API edge) — a typo'd/out-of-enum status never reaches the whitelist
+    silently. (Until 2026-07-17, PurchaseOrderRow deliberately had no
+    validator and the whitelist's inactive-by-default was the only net;
+    the DQ pipeline's L3_INVALID_PO_STATUS rule still runs independently
+    as defense-in-depth for non-API ingestion paths, e.g. bulk COPY.)"""
+
+    def test_customer_order_row_rejects_out_of_enum_status(self):
+        with pytest.raises(ValidationError):
+            CustomerOrderRow(
+                external_id="CO-X", item_external_id="I", location_external_id="L",
+                quantity=1, requested_delivery_date="2026-08-01", status="fulfilled",
+            )
+
+    def test_transfer_row_rejects_out_of_enum_status(self):
+        with pytest.raises(ValidationError):
+            TransferRow(
+                external_id="TR-X", item_external_id="I",
+                from_location_external_id="A", to_location_external_id="B",
+                quantity=1, expected_delivery_date="2026-08-01", status="received",
+            )
+
+    def test_purchase_order_row_rejects_out_of_enum_status(self):
+        with pytest.raises(ValidationError):
+            PurchaseOrderRow(
+                external_id="PO-X", item_external_id="I", location_external_id="L",
+                supplier_external_id="S", quantity=1,
+                expected_delivery_date="2026-08-01", status="not_a_status",
+            )
+
+    @pytest.mark.parametrize("status", sorted(VALID_PO_STATUSES))
+    def test_purchase_order_row_accepts_every_enum_status(self, status):
+        po = PurchaseOrderRow(
+            external_id="PO-X", item_external_id="I", location_external_id="L",
+            supplier_external_id="S", quantity=1,
+            expected_delivery_date="2026-08-01", status=status,
+        )
+        assert po.status == status
+
+
+# ─────────────────────────────────────────────────────────────
+# 2. TSV quoting — literal `"` preserved verbatim (QUOTE_NONE)
+# ─────────────────────────────────────────────────────────────
+
+# The real pilot case: inch-mark item descriptions. With the csv module's
+# default QUOTE_MINIMAL, the leading `"` used to open a quoted section and
+# the parsers silently returned 'U BOLT 1/4-20 X 1-3/4'.
+UBOLT = '"U" BOLT 1/4-20 X 1-3/4'
+MIDQUOTE = 'PLAT 1/4" X 2"'
+
+
+class TestIngestFileParseTsv:
+    """scripts/ingest_file.py:parse_tsv — the API-path file loader."""
+
+    def test_leading_and_mid_cell_quotes_preserved(self, tmp_path):
+        p = tmp_path / "items.tsv"
+        p.write_text(
+            "external_id\tname\tuom\n"
+            f"SKU-1\t{UBOLT}\tEA\n"
+            f"SKU-2\t{MIDQUOTE}\tEA\n",
+            encoding="utf-8",
+        )
+        headers, rows = ingest_file.parse_tsv(p)
+        assert headers == ["external_id", "name", "uom"]
+        assert rows[0]["name"] == UBOLT
+        assert rows[1]["name"] == MIDQUOTE
+
+    def test_quoted_cell_does_not_swallow_tab_separator(self, tmp_path):
+        # Regression shape of the original bug: under QUOTE_MINIMAL a cell
+        # opening with `"` kept consuming across the next `"` — here the two
+        # columns must stay two columns, each verbatim.
+        p = tmp_path / "items.tsv"
+        p.write_text(
+            'external_id\tname\n'
+            'SKU-3\t"U" BOLT\n',
+            encoding="utf-8",
+        )
+        headers, rows = ingest_file.parse_tsv(p)
+        assert rows[0]["external_id"] == "SKU-3"
+        assert rows[0]["name"] == '"U" BOLT'
+
+
+class TestBulkIngestReadTsvHeader:
+    """scripts/bulk_ingest.py:_read_tsv_header — the COPY-path header reader.
+    (The data path already neutralized quoting via COPY ... QUOTE E'\\x01';
+    the header reader was the remaining QUOTE_MINIMAL site.)"""
+
+    def test_header_cell_with_literal_quotes_preserved(self, tmp_path):
+        p = tmp_path / "weird.tsv"
+        p.write_text(
+            f'external_id\t{UBOLT}\tuom\n'
+            "SKU-1\tx\tEA\n",
+            encoding="utf-8",
+        )
+        headers = bulk_ingest._read_tsv_header(p)
+        assert headers == ["external_id", UBOLT, "uom"]
+
+    def test_plain_header_unchanged(self, tmp_path):
+        p = tmp_path / "items.tsv"
+        p.write_text("external_id\tname\tuom\nSKU-1\tPump\tEA\n", encoding="utf-8")
+        assert bulk_ingest._read_tsv_header(p) == ["external_id", "name", "uom"]
+
+
+class TestStagingParser:
+    """ootils_core.staging.parser.parse — TSV branch loses quoting, CSV
+    branch KEEPS standard `"`-quoting (deliberate carve-out: a comma-
+    delimited value legitimately needs quotes)."""
+
+    def test_tsv_preserves_literal_quotes(self):
+        data = (
+            "external_id\tname\tuom\n"
+            f"SKU-1\t{UBOLT}\tEA\n"
+        ).encode("utf-8")
+        result = staging_parse(data, filename="items.tsv", format_hint="tsv")
+        assert result.format == "tsv"
+        assert result.rows[0]["name"] == UBOLT
+
+    def test_tsv_mid_cell_quote_preserved(self):
+        data = ("external_id\tname\n" f"SKU-2\t{MIDQUOTE}\n").encode("utf-8")
+        result = staging_parse(data, format_hint="tsv")
+        assert result.rows[0]["name"] == MIDQUOTE
+
+    def test_csv_branch_still_honours_standard_quoting(self):
+        # CSV carve-out: a quoted cell containing the delimiter must still
+        # be parsed as ONE cell with the quotes consumed — untouched by the fix.
+        data = b'external_id,name\nSKU-1,"BOLT, U-SHAPE"\n'
+        result = staging_parse(data, filename="items.csv", format_hint="csv")
+        assert result.format == "csv"
+        assert result.rows[0]["name"] == "BOLT, U-SHAPE"

--- a/tests/test_router_ingest.py
+++ b/tests/test_router_ingest.py
@@ -258,8 +258,10 @@ def test_ensure_projection_series_creates_when_missing():
     db = FakeDB(handler=handler)
     created = _ensure_projection_series(db, uuid4(), uuid4(), BASELINE_SCENARIO_ID)
     assert created is True
-    # 2 selects + 1 insert series + 90 bucket inserts = 93 calls
-    assert len(db.calls) == 93
+    # 2 selects + 1 insert series + 90 bucket inserts + 89 feeds_forward
+    # edge inserts (chaining consecutive buckets, 2026-07-17 incremental
+    # propagation fix) = 182 calls.
+    assert len(db.calls) == 182
 
 
 def test_ensure_projection_series_falls_back_to_local_uuid_when_select_returns_none():


### PR DESCRIPTION
## Le préalable au premier chargement du bundle ERP réel

La validation du bundle (17/07) a révélé que le mécanisme de rétractation de l'ERP était inopérant côté Ootils. Quatre vrais bugs corrigés :

1. **Statuts terminaux honorés** (listes blanches conformes aux tables d'impact, INSERT et UPDATE) : sans ce fix, 2 061 PO `received` (4,2 M unités déjà dans le stock) et **18 521 CO `shipped` (57 % du fichier réel)** seraient restés supply/demande actives. Statut inconnu = inactif (défaut sûr) + validateur 422 PO (symétrie).
2. **Propagation incrémentale aveugle aux rétractations** : un événement sur un nœud fraîchement désactivé produisait un dirty set **vide** — la projection gardait la quantité périmée. `include_inactive` trigger-only (les 6 autres appelants inchangés, cascade intacte, 3 saveurs couvertes).
3. **Edges dupliquées au re-ingest** (bug latent attrapé par les tests) : chaque re-push insérait une edge parallèle → quantités ×2. Déduplication tous types supply/demand.
4. Parseurs TSV `QUOTE_NONE` (guillemets de tête préservés) + DEFAULT DB des planning params à la création (rotation SCD2 prouvée intacte).

**Preuves** : rétractation bout-en-bout testée en full recompute **et** en incrémental (`POST /v1/events` sans full recompute → la projection oublie la quantité — le test qui échouait avant le colmatage). 43 unitaires + 6 intégration ; suite complète 3 113 pass ; ruff/mypy clean. Revue adversariale : **GO zéro bloquant**.

GO merge banké — merge auto à CI verte. La PR modélisation (netting + proration + is_stocking) se lance dessus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)