### PR TITLE
fix(bom): references obsoletes = structure chargee + warning, pas un rejet de toute la BOM

### DIFF
--- a/src/ootils_core/api/routers/bom.py
+++ b/src/ootils_core/api/routers/bom.py
@@ -51,6 +51,9 @@ class IngestBOMResponse(BaseModel):
     parent_item_id: Optional[str] = None
     components_imported: int
     llc_updated: int
+    # Obsolete items referenced by this BOM (parent or components), accepted
+    # but surfaced — structure is history, obsolescence governs planning.
+    warnings: list[dict] = []
 
 
 class BOMComponentOutput(BaseModel):
@@ -101,12 +104,35 @@ class ExplodeResponse(BaseModel):
 # ─────────────────────────────────────────────────────────────
 
 def _resolve_item_id(db: DictRowConnection, external_id: str) -> UUID | None:
-    """Resolve external_id → item_id. Returns None if not found."""
+    """Resolve external_id → item_id. Returns None if not found.
+
+    Excludes obsolete items — the contract of the READ/explosion endpoints.
+    The INGEST path uses `_resolve_item_with_status` instead: a BOM whose
+    parent or component is obsolete is legitimate STRUCTURE (engineering
+    history, phase-out) and must load — obsolescence governs planning, not
+    structure. Rejecting the whole BOM left the parent with NO structure at
+    all, which is the worse silent wrong answer (first real load, 2026-07-18).
+    """
     row = db.execute(
         "SELECT item_id FROM items WHERE external_id = %s AND status != 'obsolete'",
         (external_id,),
     ).fetchone()
     return row["item_id"] if row else None
+
+
+def _resolve_item_with_status(
+    db: DictRowConnection, external_id: str
+) -> tuple[UUID, str] | None:
+    """Resolve external_id → (item_id, status), obsolete included.
+
+    Ingest-path resolver: genuine unknowns stay None (422 at the call site);
+    an obsolete item resolves and the caller surfaces it as a warning.
+    """
+    row = db.execute(
+        "SELECT item_id, status FROM items WHERE external_id = %s",
+        (external_id,),
+    ).fetchone()
+    return (row["item_id"], row["status"]) if row else None
 
 
 def _get_active_bom(db: DictRowConnection, parent_item_id: UUID) -> dict | None:
@@ -324,27 +350,43 @@ def ingest_bom(
 ) -> IngestBOMResponse:
     """Import a complete BOM for a parent item. Upsert with cycle detection."""
 
-    # 1. Resolve parent
-    parent_item_id = _resolve_item_id(db, body.parent_external_id)
-    if parent_item_id is None:
+    warnings: list[dict] = []
+
+    # 1. Resolve parent (obsolete accepted — structure is history; warned)
+    parent_resolved = _resolve_item_with_status(db, body.parent_external_id)
+    if parent_resolved is None:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=[{"field": "parent_external_id", "error": f"Item '{body.parent_external_id}' not found"}],
         )
+    parent_item_id, parent_status = parent_resolved
+    if parent_status == "obsolete":
+        warnings.append({
+            "field": "parent_external_id",
+            "external_id": body.parent_external_id,
+            "warning": "obsolete item — BOM structure loaded, planning governed by item status",
+        })
 
-    # 2. Resolve all components
+    # 2. Resolve all components (obsolete accepted + warned; unknown → 422)
     errors: list[dict] = []
     component_ids: list[UUID] = []
     for i, comp in enumerate(body.components):
-        cid = _resolve_item_id(db, comp.component_external_id)
-        if cid is None:
+        resolved = _resolve_item_with_status(db, comp.component_external_id)
+        if resolved is None:
             errors.append({
                 "row": i,
                 "component_external_id": comp.component_external_id,
                 "error": f"Item '{comp.component_external_id}' not found",
             })
         else:
+            cid, comp_status = resolved
             component_ids.append(cid)
+            if comp_status == "obsolete":
+                warnings.append({
+                    "row": i,
+                    "component_external_id": comp.component_external_id,
+                    "warning": "obsolete item — BOM line loaded, planning governed by item status",
+                })
 
     if errors:
         raise HTTPException(
@@ -365,6 +407,7 @@ def ingest_bom(
             status="dry_run",
             components_imported=len(body.components),
             llc_updated=0,
+            warnings=warnings,
         )
 
     # 5. Upsert bom_headers
@@ -439,6 +482,11 @@ def ingest_bom(
         "bom.ingest parent=%s version=%s components=%d llc_updated=%d",
         body.parent_external_id, body.bom_version, len(body.components), llc_count,
     )
+    if warnings:
+        logger.warning(
+            "bom.ingest parent=%s version=%s: %d obsolete item reference(s) loaded as structure",
+            body.parent_external_id, body.bom_version, len(warnings),
+        )
 
     return IngestBOMResponse(
         status="ok",
@@ -446,6 +494,7 @@ def ingest_bom(
         parent_item_id=str(parent_item_id),
         components_imported=len(body.components),
         llc_updated=llc_count,
+        warnings=warnings,
     )
 
 

--- a/src/ootils_core/api/routers/bom.py
+++ b/src/ootils_core/api/routers/bom.py
@@ -364,7 +364,7 @@ def ingest_bom(
         warnings.append({
             "field": "parent_external_id",
             "external_id": body.parent_external_id,
-            "warning": "obsolete item — BOM structure loaded, planning governed by item status",
+            "warning": "obsolete item — BOM structure loaded as history; planning is NOT auto-gated by item status yet (recommendations stay governed drafts — review them)",
         })
 
     # 2. Resolve all components (obsolete accepted + warned; unknown → 422)
@@ -385,7 +385,7 @@ def ingest_bom(
                 warnings.append({
                     "row": i,
                     "component_external_id": comp.component_external_id,
-                    "warning": "obsolete item — BOM line loaded, planning governed by item status",
+                    "warning": "obsolete item — BOM line loaded as history; planning is NOT auto-gated by item status yet (recommendations stay governed drafts — review them)",
                 })
 
     if errors:

--- a/tests/integration/test_bom_obsolete_integration.py
+++ b/tests/integration/test_bom_obsolete_integration.py
@@ -1,0 +1,183 @@
+"""
+tests/integration/test_bom_obsolete_integration.py — BOM et items obsolètes
+(découvert au premier chargement réel, 2026-07-18).
+
+Avant ce fix, `_resolve_item_id` (filtre `status != 'obsolete'`) s'appliquait
+aussi au chemin d'INGESTION : toute nomenclature dont le parent OU un seul
+composant était obsolète partait en 422 « not found » (message trompeur —
+l'item existe) et le parent restait SANS AUCUNE structure — l'explosion MRP
+ne voyait plus rien du tout, le pire des silences. Les données ERP réelles
+référencent légitimement des composants obsolètes (historique d'ingénierie,
+phase-out) et le bundle incluait ces items exprès pour que les références se
+résolvent.
+
+Nouveau contrat d'ingestion :
+  (a) composant obsolète → BOM ACCEPTÉE, ligne chargée, warning explicite
+      dans la réponse (« planning governed by item status ») ;
+  (b) parent obsolète → BOM ACCEPTÉE, warning symétrique ;
+  (c) item réellement inconnu → 422 inchangé (le vrai « not found ») ;
+  (d) les endpoints de LECTURE/explosion gardent leur filtre (hors scope).
+
+Isolation : seeds sous PREFIX unique via l'API réelle, neutralisés par
+DÉSACTIVATION (items obsoleted, bom_headers status='inactive') — jamais de
+DELETE cascade (leçon #461).
+"""
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+TOKEN = "integration-test-token"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+PREFIX = f"BOMO-{uuid4().hex[:8]}"
+
+
+@pytest.fixture(scope="module")
+def api_client(migrated_db):
+    """Module-scoped FastAPI TestClient bound to the real test DB
+    (same pattern as test_ingest_retraction_integration.py)."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = TOKEN
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+    from fastapi.testclient import TestClient
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+def _ext(base: str) -> str:
+    return f"{PREFIX}-{base}"
+
+
+@pytest.fixture(scope="module")
+def seed(api_client, request, migrated_db):
+    """3 items : parent actif, composant actif, composant OBSOLÈTE + un
+    parent obsolète pour le cas (b). Neutralisation par désactivation."""
+    items = [
+        {"external_id": _ext("PARENT"), "name": "BOM obsolete parent actif",
+         "item_type": "finished_good", "uom": "EA", "status": "active"},
+        {"external_id": _ext("COMP-OK"), "name": "Composant actif",
+         "item_type": "component", "uom": "EA", "status": "active"},
+        {"external_id": _ext("COMP-OBS"), "name": "Composant obsolete",
+         "item_type": "component", "uom": "EA", "status": "obsolete"},
+        {"external_id": _ext("PARENT-OBS"), "name": "Parent obsolete",
+         "item_type": "finished_good", "uom": "EA", "status": "obsolete"},
+    ]
+    resp = api_client.post("/v1/ingest/items", json={"items": items}, headers=AUTH)
+    assert resp.status_code == 200, resp.text
+
+    def _neutralize():
+        import psycopg
+        with psycopg.connect(migrated_db, autocommit=True) as conn:
+            conn.execute(
+                """
+                UPDATE bom_headers SET status = 'inactive'
+                WHERE parent_item_id IN (
+                    SELECT item_id FROM items WHERE external_id LIKE %s
+                )
+                """,
+                (PREFIX + "%",),
+            )
+            conn.execute(
+                "UPDATE items SET status = 'obsolete' WHERE external_id LIKE %s",
+                (PREFIX + "%",),
+            )
+
+    request.addfinalizer(_neutralize)
+    return {
+        "parent": _ext("PARENT"),
+        "comp_ok": _ext("COMP-OK"),
+        "comp_obs": _ext("COMP-OBS"),
+        "parent_obs": _ext("PARENT-OBS"),
+    }
+
+
+def _bom_payload(parent: str, components: list[str], version: str = "1.0") -> dict:
+    return {
+        "parent_external_id": parent,
+        "bom_version": version,
+        "effective_from": "2026-01-01",
+        "components": [
+            {"component_external_id": c, "quantity_per": 2.0, "uom": "EA"}
+            for c in components
+        ],
+    }
+
+
+class TestBomObsoleteReferences:
+    def test_obsolete_component_loads_with_warning(self, api_client, seed, migrated_db):
+        """(a) LE cas du premier chargement : composant obsolète → BOM chargée."""
+        resp = api_client.post(
+            "/v1/ingest/bom",
+            json=_bom_payload(seed["parent"], [seed["comp_ok"], seed["comp_obs"]]),
+            headers=AUTH,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "ok"
+        assert body["components_imported"] == 2
+        warned = [w for w in body["warnings"]
+                  if w.get("component_external_id") == seed["comp_obs"]]
+        assert len(warned) == 1
+        assert "obsolete" in warned[0]["warning"]
+
+        # La STRUCTURE est bien en base : 2 lignes actives, obsolète incluse.
+        import psycopg
+        from psycopg.rows import dict_row
+        with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+            n = conn.execute(
+                """
+                SELECT COUNT(*) AS n
+                FROM bom_lines bl
+                JOIN bom_headers bh ON bh.bom_id = bl.bom_id
+                JOIN items p ON p.item_id = bh.parent_item_id
+                WHERE p.external_id = %s AND bl.active
+                """,
+                (seed["parent"],),
+            ).fetchone()["n"]
+        assert n == 2
+
+    def test_obsolete_parent_loads_with_warning(self, api_client, seed):
+        """(b) parent obsolète → structure historique chargée, warning."""
+        resp = api_client.post(
+            "/v1/ingest/bom",
+            json=_bom_payload(seed["parent_obs"], [seed["comp_ok"]]),
+            headers=AUTH,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        warned = [w for w in body["warnings"]
+                  if w.get("external_id") == seed["parent_obs"]]
+        assert len(warned) == 1
+
+    def test_truly_unknown_component_still_422(self, api_client, seed):
+        """(c) le vrai « not found » reste un refus net."""
+        resp = api_client.post(
+            "/v1/ingest/bom",
+            json=_bom_payload(seed["parent"],
+                              [seed["comp_ok"], _ext("NEVER-EXISTED")],
+                              version="2.0"),
+            headers=AUTH,
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert any(_ext("NEVER-EXISTED") in str(d) for d in detail)


### PR DESCRIPTION
Découvert au premier chargement réel : le filtre `status != 'obsolete'` du resolveur s'appliquait aussi à l'INGESTION → toute BOM avec un parent/composant obsolète partait en 422 « not found » (l'item existe !) et le parent restait sans AUCUNE structure — l'explosion MRP aveugle, le pire silence. L'ERP référence légitimement des composants obsolètes et le bundle inclut ces items exprès (MANIFEST : zéro orphelin, contre-vérifié).

- Ingestion : obsolète → chargé + `warnings[]` explicite ; inconnu réel → 422 inchangé. Lecture/explosion : filtre conservé (hors scope).
- Tests intégration (3) + 14/14 unitaires inchangés.

Bloque la complétude du premier chargement (~centaines de BOMs sur 3 766).

🤖 Generated with [Claude Code](https://claude.com/claude-code)