### PR TITLE
feat(interfaces): PR-4a -- noms dates + parts regroupees + fix bom_components morte

### DIFF
--- a/scripts/ingest_file.py
+++ b/scripts/ingest_file.py
@@ -10,6 +10,14 @@ Usage:
     python scripts/ingest_file.py data/inbox/items.tsv
     python scripts/ingest_file.py data/inbox/items.tsv --dry-run
 
+Accepted filenames (see `parse_ingest_filename` for the exact grammar):
+    <entity>.tsv                     canonical (e.g. 'items.tsv')
+    <entity>_<AAAAMMJJ>.tsv          daily drop, date ignored for dispatch
+                                      (e.g. 'on_hand_20260718.tsv')
+    <entity>.partNN.tsv              part file, siblings in the same
+    <entity>.partNN_<AAAAMMJJ>.tsv   directory are grouped into ONE load
+                                      (e.g. 'forecasts.part01.tsv')
+
 Environment:
     DATABASE_URL       (required) PostgreSQL DSN
     OOTILS_API_TOKEN   (required) bearer token for in-process API auth
@@ -36,8 +44,10 @@ import csv
 import json
 import logging
 import os
+import re
 import shutil
 import sys
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -75,6 +85,78 @@ DISPATCH: dict[str, dict[str, str]] = {
     # alongside and emits N POSTs (one per BOM). Special-cased in main().
     "bom_header.tsv":           {"endpoint": "/v1/ingest/bom",              "body_key": "_bom_bundle"},
 }
+
+
+# ─────────────────────────────────────────────────────────────
+# Filename grammar (PR-4a) — pure, no filesystem access
+# ─────────────────────────────────────────────────────────────
+# Beyond the canonical '<entity>.tsv' name (the DISPATCH keys above), two
+# real-world drop conventions are accepted:
+#   - daily drop:  '<entity>_<AAAAMMJJ>.tsv'          e.g. on_hand_20260718.tsv
+#   - part file:   '<entity>.partNN.tsv'              e.g. forecasts.part01.tsv
+#                  '<entity>.partNN_<AAAAMMJJ>.tsv'   e.g. forecasts.part01_20260718.tsv
+# The date suffix is ignored for dispatch (informational only — the entity
+# alone decides the endpoint). Part files sharing the same (entity, date)
+# in the same directory are grouped into ONE logical load — see
+# `find_sibling_parts`/`parse_tsv_parts` below and `handle_part_group` in
+# the main() dispatch section.
+_DATE_SUFFIX_RE = re.compile(r"^(?P<stem>.+)_(?P<date>\d{8})$")
+_PART_SUFFIX_RE = re.compile(r"^(?P<stem>.+)\.part(?P<part>\d{2,})$")
+
+
+@dataclass(frozen=True)
+class ParsedFilename:
+    """Result of `parse_ingest_filename`.
+
+    `entity` is the bare feed-key stem — no '.tsv' extension, no date or
+    part marker (e.g. 'on_hand', 'bom_header', 'forecasts'). This parser has
+    zero knowledge of which entities are actually supported; callers must
+    still check `f"{entity}.tsv"` against DISPATCH.
+    """
+
+    entity: str
+    date: str | None
+    part: int | None
+
+
+def parse_ingest_filename(filename: str) -> ParsedFilename:
+    """Pure parser: basename -> (entity, date, part). No filesystem access.
+
+    Accepted grammars (basename only, no directory component):
+        '<entity>.tsv'                    canonical (e.g. 'items.tsv')
+        '<entity>_<AAAAMMJJ>.tsv'         daily drop (e.g. 'on_hand_20260718.tsv')
+        '<entity>.partNN.tsv'             part file (e.g. 'forecasts.part01.tsv')
+        '<entity>.partNN_<AAAAMMJJ>.tsv'  dated part file
+
+    The date, when present, is returned as its raw 8-digit string (not
+    parsed/validated as a real calendar date — same structural-only
+    tolerance as `_to_date_str` elsewhere in this file) and is otherwise
+    unused: it exists for traceability/grouping, never for dispatch.
+
+    Raises ValueError if `filename` doesn't end in '.tsv', has an empty
+    entity segment once date/part markers are stripped, or a malformed
+    '.part' marker (no digits).
+    """
+    if not filename.endswith(".tsv"):
+        raise ValueError(f"filename must end with '.tsv': '{filename}'")
+    stem = filename[: -len(".tsv")]
+
+    date: str | None = None
+    date_match = _DATE_SUFFIX_RE.match(stem)
+    if date_match:
+        stem = date_match.group("stem")
+        date = date_match.group("date")
+
+    part: int | None = None
+    part_match = _PART_SUFFIX_RE.match(stem)
+    if part_match:
+        stem = part_match.group("stem")
+        part = int(part_match.group("part"))
+
+    if not stem:
+        raise ValueError(f"filename has no entity segment: '{filename}'")
+
+    return ParsedFilename(entity=stem, date=date, part=part)
 
 
 # ─────────────────────────────────────────────────────────────
@@ -156,6 +238,97 @@ def parse_tsv(path: Path) -> tuple[list[str], list[dict[str, str]]]:
         data_rows.append(row)
 
     return headers, data_rows
+
+
+# ─────────────────────────────────────────────────────────────
+# Part-file grouping (PR-4a)
+# ─────────────────────────────────────────────────────────────
+def find_sibling_parts(path: Path) -> list[Path]:
+    """Return every sibling '.partNN' file for the same (entity, date) as
+    `path`, scanned in `path`'s own directory ONLY (never data/processed/
+    or data/rejected/ — grouping is scoped to files currently sitting
+    together in the inbox), sorted by part number ascending. `path` itself
+    is included.
+
+    Raises ValueError if:
+      - `path`'s own filename doesn't parse as a part file (part is None);
+      - two files in the directory collide on the same part number for
+        this (entity, date) group (ambiguous — cannot pick one);
+      - `path` itself is not among the files found in its own directory
+        (typo, or the file was already archived by a prior run — the
+        caller should treat this as a hard error, not silently ingest
+        whatever siblings remain).
+
+    Propagates FileNotFoundError if `path.parent` doesn't exist.
+    """
+    parsed = parse_ingest_filename(path.name)
+    if parsed.part is None:
+        raise ValueError(f"'{path.name}' is not a '.partNN' file")
+
+    by_part: dict[int, Path] = {}
+    for candidate in sorted(path.parent.iterdir()):
+        if not candidate.is_file():
+            continue
+        try:
+            c_parsed = parse_ingest_filename(candidate.name)
+        except ValueError:
+            continue
+        if c_parsed.part is None:
+            continue
+        if c_parsed.entity != parsed.entity or c_parsed.date != parsed.date:
+            continue
+        if c_parsed.part in by_part:
+            raise ValueError(
+                f"duplicate part {c_parsed.part:02d} for entity '{parsed.entity}' "
+                f"(date={parsed.date}): '{by_part[c_parsed.part].name}' "
+                f"and '{candidate.name}'"
+            )
+        by_part[c_parsed.part] = candidate
+
+    siblings = [by_part[k] for k in sorted(by_part)]
+    if not any(p.name == path.name for p in siblings):
+        raise ValueError(
+            f"'{path.name}' was not found in '{path.parent}' "
+            f"(found {len(siblings)} other part(s) for entity '{parsed.entity}'"
+            + (f", date {parsed.date}" if parsed.date else "")
+            + ") — check the path, or whether this part was already archived"
+        )
+    return siblings
+
+
+def parse_tsv_parts(paths: list[Path]) -> tuple[list[str], list[dict[str, str]]]:
+    """Parse and concatenate N sibling part files into one logical
+    (headers, rows), in the given order (expected: ascending by part
+    number, see `find_sibling_parts`).
+
+    Every part is parsed independently via `parse_tsv`; all parts must
+    share byte-identical headers (same column names, same order) — a
+    mismatch raises ValueError naming the offending file. Each row's
+    `__line__` tag is re-prefixed with its source file's name so error
+    messages built from it stay traceable across parts, e.g.
+    "forecasts.part02.tsv:L14".
+    """
+    if not paths:
+        raise ValueError("no part files to parse")
+
+    headers: list[str] | None = None
+    all_rows: list[dict[str, str]] = []
+    for p in paths:
+        p_headers, p_rows = parse_tsv(p)
+        if headers is None:
+            headers = p_headers
+        elif p_headers != headers:
+            raise ValueError(
+                f"part file '{p.name}' header {p_headers} does not match "
+                f"first part's header {headers}"
+            )
+        for row in p_rows:
+            row = dict(row)
+            row["__line__"] = f"{p.name}:L{row.get('__line__', '?')}"
+            all_rows.append(row)
+
+    assert headers is not None  # `paths` non-empty => at least one iteration ran
+    return headers, all_rows
 
 
 # ─────────────────────────────────────────────────────────────
@@ -338,7 +511,7 @@ def build_item_planning_params_payload(rows: list[dict[str, str]], dry_run: bool
     return {"params": params, "dry_run": dry_run}
 
 
-_DATE_RE = __import__("re").compile(r"^\d{4}-\d{2}-\d{2}$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 def _to_date_str(raw: str, *, field: str, line: str) -> str:
@@ -556,6 +729,58 @@ def archive(source: Path, dest_dir: Path, report: dict[str, Any]) -> tuple[Path,
     return target, report_path
 
 
+def archive_group(sources: list[Path], dest_dir: Path, report: dict[str, Any]) -> list[Path]:
+    """Archive N sibling files (a part group) together, one timestamped move
+    each (same naming as `archive()`), sharing ONE `--report.json` next to
+    the FIRST file (caller's ordering — expected ascending part number) and
+    a minimal pointer report next to every other file. Mirrors the existing
+    bom-bundle archiving pattern (`handle_bom_bundle`)."""
+    if not sources:
+        raise ValueError("no source files to archive")
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    primary_name = sources[0].name
+    targets: list[Path] = []
+
+    for i, source in enumerate(sources):
+        stem = source.stem
+        suffix = source.suffix
+        target = dest_dir / f"{stem}_{ts}{suffix}"
+        shutil.move(str(source), str(target))
+        targets.append(target)
+
+        report_path = dest_dir / f"{stem}_{ts}.report.json"
+        body = report if i == 0 else {"bundled_with": primary_name, "see_main_report": True}
+        report_path.write_text(
+            json.dumps(body, indent=2, default=str, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+    return targets
+
+
+def _find_archived(missing_path: Path) -> Path | None:
+    """If `missing_path` no longer exists at its original location, check
+    whether a file matching `archive()`'s naming (`{stem}_{timestamp}{suffix}`)
+    already exists in PROCESSED or REJECTED — i.e. this exact input was
+    already consumed by a prior run. Returns the most recently modified
+    match, or None if nothing matches (a genuine "not found").
+
+    Only meaningful when `missing_path.exists()` is False; callers must
+    check that first.
+    """
+    stem = missing_path.stem
+    suffix = missing_path.suffix
+    candidates: list[Path] = []
+    for d in (PROCESSED, REJECTED):
+        if d.exists():
+            candidates.extend(d.glob(f"{stem}_*{suffix}"))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
 # ─────────────────────────────────────────────────────────────
 # BOM bundle handler — 2 files (header + components) → N API calls (1 per BOM)
 # ─────────────────────────────────────────────────────────────
@@ -643,17 +868,23 @@ def _build_bom_payloads(
     return payloads
 
 
-def handle_bom_bundle(header_path: Path, dry_run: bool, token: str) -> int:
+def handle_bom_bundle(header_path: Path, dry_run: bool, token: str, *, date: str | None = None) -> int:
     """Bundle BOM ingestion: reads header + components from the same dir, emits N API calls.
+
+    `date`, when set (dated-drop convention, e.g. 'bom_header_20260718.tsv'),
+    picks the matching dated companion 'bom_components_<date>.tsv' instead
+    of the canonical 'bom_components.tsv' — same date suffix on both sides
+    of the bundle, ignored for dispatch otherwise. The '.partNN' convention
+    is NOT supported for the BOM bundle (rejected by the caller in main()).
 
     Returns process exit code (0 if all BOMs OK, non-zero on any failure).
     """
-    components_path = header_path.parent / "bom_components.tsv"
+    companion_name = f"bom_components_{date}.tsv" if date else "bom_components.tsv"
+    components_path = header_path.parent / companion_name
     if not components_path.exists():
         logger.error(
-            "bom_components.tsv not found next to bom_header.tsv. "
-            "Both files must be present in the same directory: %s",
-            header_path.parent,
+            "%s not found next to %s. Both files must be present in the same directory: %s",
+            companion_name, header_path.name, header_path.parent,
         )
         return 7
 
@@ -667,7 +898,7 @@ def handle_bom_bundle(header_path: Path, dry_run: bool, token: str) -> int:
     except (FileNotFoundError, ValueError) as e:
         logger.error("parse error: %s", e)
         report = {
-            "files": ["bom_header.tsv", "bom_components.tsv"],
+            "files": [header_path.name, companion_name],
             "started_at": started_at,
             "finished_at": datetime.now(timezone.utc).isoformat(),
             "outcome": "parse_error",
@@ -676,7 +907,7 @@ def handle_bom_bundle(header_path: Path, dry_run: bool, token: str) -> int:
         if not dry_run:
             archive(header_path, REJECTED, report)
             if components_path.exists():
-                archive(components_path, REJECTED, {"bundled_with": "bom_header.tsv", "see_report": "above"})
+                archive(components_path, REJECTED, {"bundled_with": header_path.name, "see_report": "above"})
         else:
             print(json.dumps(report, indent=2, ensure_ascii=False))
         return 4
@@ -687,7 +918,7 @@ def handle_bom_bundle(header_path: Path, dry_run: bool, token: str) -> int:
     except ValueError as e:
         logger.error("bundle validation error: %s", e)
         report = {
-            "files": ["bom_header.tsv", "bom_components.tsv"],
+            "files": [header_path.name, companion_name],
             "started_at": started_at,
             "finished_at": datetime.now(timezone.utc).isoformat(),
             "outcome": "bundle_validation_error",
@@ -698,7 +929,7 @@ def handle_bom_bundle(header_path: Path, dry_run: bool, token: str) -> int:
         if not dry_run:
             archive(header_path, REJECTED, report)
             if components_path.exists():
-                archive(components_path, REJECTED, {"bundled_with": "bom_header.tsv"})
+                archive(components_path, REJECTED, {"bundled_with": header_path.name})
         else:
             print(json.dumps(report, indent=2, ensure_ascii=False))
         return 4
@@ -747,7 +978,7 @@ def handle_bom_bundle(header_path: Path, dry_run: bool, token: str) -> int:
     # ── 4. Archive both files together ─────────────────────────
     outcome = "ok" if all_ok else "partial" if any(r["outcome"] == "ok" for r in bom_results) else "rejected"
     report = {
-        "files": ["bom_header.tsv", "bom_components.tsv"],
+        "files": [header_path.name, companion_name],
         "endpoint": endpoint,
         "started_at": started_at,
         "finished_at": datetime.now(timezone.utc).isoformat(),
@@ -767,7 +998,7 @@ def handle_bom_bundle(header_path: Path, dry_run: bool, token: str) -> int:
     dest = PROCESSED if all_ok else REJECTED
     archive(header_path, dest, report)
     if components_path.exists():
-        archive(components_path, dest, {"bundled_with": "bom_header.tsv", "see_main_report": True})
+        archive(components_path, dest, {"bundled_with": header_path.name, "see_main_report": True})
     logger.info(
         "%s — bundle archived to %s (%d BOMs, %d ok, %d failed)",
         outcome.upper(), dest, len(payloads),
@@ -782,6 +1013,117 @@ def handle_bom_bundle(header_path: Path, dry_run: bool, token: str) -> int:
             file=sys.stderr,
         )
     return 0 if all_ok else 1
+
+
+# ─────────────────────────────────────────────────────────────
+# Part-group handler — N sibling '.partNN' files -> ONE logical load
+# ─────────────────────────────────────────────────────────────
+def handle_part_group(first_part: Path, dry_run: bool, token: str) -> int:
+    """Group `first_part` with all its same-(entity, date) siblings found in
+    its own directory (see `find_sibling_parts`) and ingest them as ONE
+    logical load — one concatenated payload, one POST, archived together.
+
+    Returns process exit code (0 ok, non-zero on any failure), mirroring
+    the single-file flow in main().
+    """
+    parsed = parse_ingest_filename(first_part.name)
+    canonical = f"{parsed.entity}.tsv"
+    cfg = DISPATCH[canonical]
+    builder = PAYLOAD_BUILDERS[canonical]
+
+    try:
+        siblings = find_sibling_parts(first_part)
+    except (FileNotFoundError, ValueError) as e:
+        logger.error("part grouping error for '%s': %s", first_part.name, e)
+        return 3
+
+    started_at = datetime.now(timezone.utc).isoformat()
+    logger.info(
+        "ingesting %s (%d part(s): %s) → %s",
+        canonical, len(siblings), [p.name for p in siblings], cfg["endpoint"],
+    )
+
+    # ── 1. Parse + concatenate parts ───────────────────────
+    try:
+        headers, rows = parse_tsv_parts(siblings)
+    except (FileNotFoundError, ValueError) as e:
+        logger.error("parse error: %s", e)
+        report: dict[str, Any] = {
+            "filename": first_part.name,
+            "source_files": [p.name for p in siblings],
+            "started_at": started_at,
+            "finished_at": datetime.now(timezone.utc).isoformat(),
+            "outcome": "parse_error",
+            "error": str(e),
+        }
+        if not dry_run:
+            archive_group(siblings, REJECTED, report)
+        else:
+            print(json.dumps(report, indent=2, ensure_ascii=False))
+        return 4
+
+    logger.info(
+        "parsed %d rows from %d part(s) (header: %s)",
+        len(rows), len(siblings), headers,
+    )
+
+    # ── 2. Build payload ───────────────────────────────────
+    payload = builder(rows, dry_run)
+
+    # ── 3. Call API ────────────────────────────────────────
+    try:
+        status_code, body = call_api(cfg["endpoint"], payload, token)
+    except Exception as e:  # noqa: BLE001
+        logger.exception("API call crashed")
+        report = {
+            "filename": first_part.name,
+            "source_files": [p.name for p in siblings],
+            "started_at": started_at,
+            "finished_at": datetime.now(timezone.utc).isoformat(),
+            "outcome": "api_crash",
+            "error": str(e),
+            "rows_parsed": len(rows),
+        }
+        if not dry_run:
+            archive_group(siblings, REJECTED, report)
+        else:
+            print(json.dumps(report, indent=2, ensure_ascii=False))
+        return 5
+
+    # ── 4. Outcome + archive ──────────────────────────────
+    accepted = 200 <= status_code < 300
+    outcome = "ok" if accepted else "rejected"
+    summary = body.get("summary", {}) if isinstance(body, dict) else {}
+
+    report = {
+        "filename": first_part.name,
+        "source_files": [p.name for p in siblings],
+        "endpoint": cfg["endpoint"],
+        "started_at": started_at,
+        "finished_at": datetime.now(timezone.utc).isoformat(),
+        "outcome": outcome,
+        "dry_run": dry_run,
+        "http_status": status_code,
+        "rows_parsed": len(rows),
+        "parts_count": len(siblings),
+        "api_summary": summary,
+        "api_response": body,
+    }
+
+    if dry_run:
+        logger.info("DRY-RUN — files not moved. Outcome: %s (HTTP %d)", outcome, status_code)
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+        return 0 if accepted else 1
+
+    dest = PROCESSED if accepted else REJECTED
+    targets = archive_group(siblings, dest, report)
+    logger.info(
+        "%s — %d part(s) archived to %s",
+        outcome.upper(), len(targets), dest,
+    )
+    if not accepted:
+        print(json.dumps(body, indent=2, ensure_ascii=False), file=sys.stderr)
+    return 0 if accepted else 1
 
 
 # ─────────────────────────────────────────────────────────────
@@ -811,27 +1153,63 @@ def main(argv: list[str] | None = None) -> int:
         logger.error("DATABASE_URL not set — refusing to run")
         return 2
 
-    # Pre-flight: filename supported?
-    if filename == "bom_components.tsv":
+    # Pre-flight: filename grammar (canonical / daily drop / part file — PR-4a)
+    try:
+        parsed = parse_ingest_filename(filename)
+    except ValueError as e:
+        logger.error("unsupported filename '%s': %s", filename, e)
+        return 3
+
+    if parsed.entity == "bom_components":
         logger.error(
-            "bom_components.tsv cannot be ingested alone — it has no metadata. "
-            "Use 'bom_header.tsv' as the entry point; the script will auto-load "
-            "bom_components.tsv from the same directory."
+            "'%s' cannot be ingested alone — it has no metadata. Use the "
+            "matching 'bom_header[...].tsv' as the entry point; the script "
+            "will auto-load the companion bom_components file from the "
+            "same directory.",
+            filename,
         )
         return 6
-    if filename not in DISPATCH:
+
+    canonical = f"{parsed.entity}.tsv"
+    if canonical not in DISPATCH:
         logger.error(
-            "unsupported filename '%s'. Supported: %s",
-            filename, sorted(DISPATCH.keys()),
+            "unsupported filename '%s' (resolved entity '%s'). Supported entities: %s",
+            filename, parsed.entity, sorted(k[: -len('.tsv')] for k in DISPATCH),
         )
         return 3
 
-    # ── BOM bundle: special path (2 files → N API calls) ──
-    if filename == "bom_header.tsv":
-        return handle_bom_bundle(src, args.dry_run, token)
+    # Pre-flight: was this exact input already consumed by a prior run? A
+    # stale part re-run is the concrete case (PR-4a) but this generalizes to
+    # any grammar — a clear "already archived" beats a generic parse_error.
+    if not src.exists():
+        prior = _find_archived(src)
+        if prior is not None:
+            logger.error(
+                "'%s' no longer present at %s — already archived to '%s'. "
+                "Nothing to do (re-running an already-consumed file/part is "
+                "a no-op, not a retryable error).",
+                filename, src.parent, prior,
+            )
+            return 8
 
-    cfg = DISPATCH[filename]
-    builder = PAYLOAD_BUILDERS[filename]
+    # ── BOM bundle: special path (2 files → N API calls) ──
+    if parsed.entity == "bom_header":
+        if parsed.part is not None:
+            logger.error(
+                "'%s' — the BOM bundle does not support the '.partNN' "
+                "convention (bom_header/bom_components already pairs as a "
+                "2-file bundle; use one pair per date instead).",
+                filename,
+            )
+            return 3
+        return handle_bom_bundle(src, args.dry_run, token, date=parsed.date)
+
+    # ── Part file: group with siblings, ONE logical load ──
+    if parsed.part is not None:
+        return handle_part_group(src, args.dry_run, token)
+
+    cfg = DISPATCH[canonical]
+    builder = PAYLOAD_BUILDERS[canonical]
 
     started_at = datetime.now(timezone.utc).isoformat()
     logger.info("ingesting %s → %s", src, cfg["endpoint"])

--- a/src/ootils_core/api/routers/bom.py
+++ b/src/ootils_core/api/routers/bom.py
@@ -103,6 +103,13 @@ class ExplodeResponse(BaseModel):
 # Helpers
 # ─────────────────────────────────────────────────────────────
 
+def _log_safe(value: str) -> str:
+    """Neutralize control chars (CR/LF included) in client-supplied values
+    before logging — a forged external_id must not inject log lines
+    (CodeQL py/log-injection)."""
+    return "".join(c if c.isprintable() else "?" for c in str(value))[:200]
+
+
 def _resolve_item_id(db: DictRowConnection, external_id: str) -> UUID | None:
     """Resolve external_id → item_id. Returns None if not found.
 
@@ -480,12 +487,14 @@ def ingest_bom(
 
     logger.info(
         "bom.ingest parent=%s version=%s components=%d llc_updated=%d",
-        body.parent_external_id, body.bom_version, len(body.components), llc_count,
+        _log_safe(body.parent_external_id), _log_safe(body.bom_version),
+        len(body.components), llc_count,
     )
     if warnings:
         logger.warning(
             "bom.ingest parent=%s version=%s: %d obsolete item reference(s) loaded as structure",
-            body.parent_external_id, body.bom_version, len(warnings),
+            _log_safe(body.parent_external_id), _log_safe(body.bom_version),
+            len(warnings),
         )
 
     return IngestBOMResponse(

--- a/src/ootils_core/api/routers/bom.py
+++ b/src/ootils_core/api/routers/bom.py
@@ -104,10 +104,11 @@ class ExplodeResponse(BaseModel):
 # ─────────────────────────────────────────────────────────────
 
 def _log_safe(value: str) -> str:
-    """Neutralize control chars (CR/LF included) in client-supplied values
-    before logging — a forged external_id must not inject log lines
-    (CodeQL py/log-injection)."""
-    return "".join(c if c.isprintable() else "?" for c in str(value))[:200]
+    """Neutralize CR/LF in client-supplied values before logging — a forged
+    external_id must not inject log lines (CodeQL py/log-injection; the
+    explicit replace() chain is the sanitizer shape CodeQL's taint tracking
+    recognizes — keep it that way)."""
+    return str(value).replace("\r", "?").replace("\n", "?")[:200]
 
 
 def _resolve_item_id(db: DictRowConnection, external_id: str) -> UUID | None:

--- a/src/ootils_core/engine/dq/agent/impact_scorer.py
+++ b/src/ootils_core/engine/dq/agent/impact_scorer.py
@@ -133,22 +133,23 @@ def _get_finished_goods_via_bom(
     queue: list[UUID] = list(component_ids)
     finished_goods: set[str] = set()
 
-    # BOM is stored as edges: from=component → to=parent or from=parent → to=component
-    # The 'bom_component' edge type connects parent to child: parent -[bom_component]-> child
-    # So to go UP, we need edges where to_node_id = item_node_id
-    # GraphStore stores items as nodes via node_type='Item'
-    # We'll use the bom table directly if available
+    # BOM is stored as bom_headers (one row per parent item + version) joined
+    # to bom_lines (one row per component); only active headers/lines count
+    # (migrations 008, 013). To go UP from a component to its finished-good
+    # parent(s), join component_item_id -> bom_id -> parent_item_id.
     while queue:
         batch_component_ids = queue[:50]
         queue = queue[50:]
 
-        # Try bom table first (from migration 008)
         bom_rows = db.execute(
             """
-            SELECT DISTINCT b.parent_item_id, i.external_id
-            FROM bom_components b
-            JOIN items i ON i.item_id = b.parent_item_id
-            WHERE b.component_item_id = ANY(%s)
+            SELECT DISTINCT bh.parent_item_id, i.external_id
+            FROM bom_headers bh
+            JOIN bom_lines bl ON bl.bom_id = bh.bom_id
+            JOIN items i ON i.item_id = bh.parent_item_id
+            WHERE bh.status = 'active'
+              AND bl.active = TRUE
+              AND bl.component_item_id = ANY(%s)
             """,
             (list(batch_component_ids),),
         ).fetchall()

--- a/tests/integration/test_impact_scorer_bom_integration.py
+++ b/tests/integration/test_impact_scorer_bom_integration.py
@@ -1,0 +1,259 @@
+"""
+tests/integration/test_impact_scorer_bom_integration.py — la remontée BOM de
+l'impact scorer DQ contre le VRAI schéma (fix PR-4a).
+
+Avant ce fix, `_get_finished_goods_via_bom` (engine/dq/agent/impact_scorer.py)
+interrogeait une table `bom_components` qui n'existe dans AUCUNE migration —
+chaque appel levait psycopg.errors.UndefinedTable, avalé plus haut ou pas
+selon le chemin : la catégorie 4 (impact supply chain) ne remontait JAMAIS
+la BOM. Le fix réécrit la requête sur le schéma réel (migrations 008/013) :
+bom_headers (parent + version, status='active') JOIN bom_lines
+(component_item_id, active=TRUE).
+
+Ces tests appellent la fonction corrigée directement avec une connexion
+dict_row réelle, sur une mini-BOM semée via l'API (pattern
+test_bom_obsolete_integration.py) :
+  - composant → produit fini résolu via bom_lines, sans UndefinedTable ;
+  - dédup : 2 composants du même parent → UN SEUL produit fini ;
+  - filtres du fix : bh.status='active' ET bl.active=TRUE excluent bien ;
+  - transitivité : la boucle remonte niveau par niveau (comp → sub → top).
+
+Isolation : seeds sous PREFIX unique via l'API réelle, neutralisés par
+DÉSACTIVATION (items obsoleted, bom_headers status='inactive') — jamais de
+DELETE cascade (leçon #461).
+"""
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+TOKEN = "integration-test-token"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+PREFIX = f"IMPS-{uuid4().hex[:8]}"
+
+
+@pytest.fixture(scope="module")
+def api_client(migrated_db):
+    """Module-scoped FastAPI TestClient bound to the real test DB
+    (same pattern as test_bom_obsolete_integration.py)."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = TOKEN
+
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+    from fastapi.testclient import TestClient
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+def _ext(base: str) -> str:
+    return f"{PREFIX}-{base}"
+
+
+def _bom_payload(parent: str, components: list[str], version: str = "1.0") -> dict:
+    return {
+        "parent_external_id": parent,
+        "bom_version": version,
+        "effective_from": "2026-01-01",
+        "components": [
+            {"component_external_id": c, "quantity_per": 2.0, "uom": "EA"}
+            for c in components
+        ],
+    }
+
+
+@pytest.fixture(scope="module")
+def seed(api_client, request, migrated_db):
+    """Mini-BOM via l'API :
+      - PARENT (produit fini) ← COMP-A + COMP-B          (le cas nominal)
+      - TOP ← SUB ← COMP-ML                              (transitivité)
+      - PARENT2 ← COMP-C                                 (filtres actif/inactif)
+    Neutralisation par désactivation, jamais de delete-cascade."""
+    items = [
+        {"external_id": _ext("PARENT"), "name": "Impact scorer parent",
+         "item_type": "finished_good", "uom": "EA", "status": "active"},
+        {"external_id": _ext("COMP-A"), "name": "Composant A",
+         "item_type": "component", "uom": "EA", "status": "active"},
+        {"external_id": _ext("COMP-B"), "name": "Composant B",
+         "item_type": "component", "uom": "EA", "status": "active"},
+        {"external_id": _ext("TOP"), "name": "Produit fini multi-niveau",
+         "item_type": "finished_good", "uom": "EA", "status": "active"},
+        {"external_id": _ext("SUB"), "name": "Sous-ensemble",
+         "item_type": "semi_finished", "uom": "EA", "status": "active"},
+        {"external_id": _ext("COMP-ML"), "name": "Composant feuille multi-niveau",
+         "item_type": "component", "uom": "EA", "status": "active"},
+        {"external_id": _ext("PARENT2"), "name": "Parent pour filtres",
+         "item_type": "finished_good", "uom": "EA", "status": "active"},
+        {"external_id": _ext("COMP-C"), "name": "Composant filtres",
+         "item_type": "component", "uom": "EA", "status": "active"},
+    ]
+    resp = api_client.post("/v1/ingest/items", json={"items": items}, headers=AUTH)
+    assert resp.status_code == 200, resp.text
+
+    for parent, comps in [
+        (_ext("PARENT"), [_ext("COMP-A"), _ext("COMP-B")]),
+        (_ext("SUB"), [_ext("COMP-ML")]),
+        (_ext("TOP"), [_ext("SUB")]),
+        (_ext("PARENT2"), [_ext("COMP-C")]),
+    ]:
+        resp = api_client.post(
+            "/v1/ingest/bom", json=_bom_payload(parent, comps), headers=AUTH
+        )
+        assert resp.status_code == 200, resp.text
+
+    def _neutralize():
+        import psycopg
+        with psycopg.connect(migrated_db, autocommit=True) as conn:
+            conn.execute(
+                """
+                UPDATE bom_headers SET status = 'inactive'
+                WHERE parent_item_id IN (
+                    SELECT item_id FROM items WHERE external_id LIKE %s
+                )
+                """,
+                (PREFIX + "%",),
+            )
+            conn.execute(
+                "UPDATE items SET status = 'obsolete' WHERE external_id LIKE %s",
+                (PREFIX + "%",),
+            )
+
+    request.addfinalizer(_neutralize)
+    return {
+        "parent": _ext("PARENT"),
+        "comp_a": _ext("COMP-A"),
+        "comp_b": _ext("COMP-B"),
+        "top": _ext("TOP"),
+        "sub": _ext("SUB"),
+        "comp_ml": _ext("COMP-ML"),
+        "parent2": _ext("PARENT2"),
+        "comp_c": _ext("COMP-C"),
+    }
+
+
+@pytest.fixture()
+def db_conn(migrated_db):
+    """Connexion dict_row réelle — le type que score_issues reçoit en prod
+    (DictRowConnection). La fonction testée est read-only ; rollback par
+    sécurité en sortie."""
+    import psycopg
+    from psycopg.rows import dict_row
+
+    with psycopg.connect(migrated_db, row_factory=dict_row) as conn:
+        yield conn
+        conn.rollback()
+
+
+class TestImpactScorerBomTraversal:
+    def test_component_resolves_finished_good_without_undefined_table(
+        self, seed, db_conn
+    ):
+        """LE test de régression : la requête vit sur bom_headers/bom_lines,
+        plus sur la table fantôme bom_components."""
+        import psycopg
+        from ootils_core.engine.dq.agent.impact_scorer import (
+            _get_finished_goods_via_bom,
+        )
+
+        try:
+            fgs = _get_finished_goods_via_bom(db_conn, [seed["comp_a"]])
+        except psycopg.errors.UndefinedTable as e:  # pragma: no cover — regression guard
+            pytest.fail(f"la requête bom_components morte est revenue : {e}")
+
+        assert fgs == [seed["parent"]]
+
+    def test_two_components_same_parent_dedup(self, seed, db_conn):
+        """DISTINCT + set : 2 composants du même parent → UN produit fini."""
+        from ootils_core.engine.dq.agent.impact_scorer import (
+            _get_finished_goods_via_bom,
+        )
+
+        fgs = _get_finished_goods_via_bom(db_conn, [seed["comp_a"], seed["comp_b"]])
+        assert fgs == [seed["parent"]]
+
+    def test_unknown_external_id_returns_empty(self, seed, db_conn):
+        from ootils_core.engine.dq.agent.impact_scorer import (
+            _get_finished_goods_via_bom,
+        )
+
+        assert _get_finished_goods_via_bom(db_conn, [_ext("NEVER-EXISTED")]) == []
+        assert _get_finished_goods_via_bom(db_conn, []) == []
+
+    def test_multilevel_traversal_climbs_to_top(self, seed, db_conn):
+        """La boucle remonte niveau par niveau : COMP-ML → SUB → TOP.
+        Les intermédiaires (semi_finished) sont inclus — le contrat est
+        « tout l'amont », pas seulement les feuilles finies."""
+        from ootils_core.engine.dq.agent.impact_scorer import (
+            _get_finished_goods_via_bom,
+        )
+
+        fgs = _get_finished_goods_via_bom(db_conn, [seed["comp_ml"]])
+        assert set(fgs) == {seed["sub"], seed["top"]}
+
+    def test_inactive_line_and_header_filters(self, seed, db_conn, migrated_db):
+        """Les deux filtres du fix, sur une BOM dédiée (PARENT2 ← COMP-C) :
+        bl.active=FALSE puis bh.status='inactive' excluent chacun la
+        remontée. Désactivations locales au test (même mécanisme que le
+        finalizer) — jamais de delete."""
+        import psycopg
+        from ootils_core.engine.dq.agent.impact_scorer import (
+            _get_finished_goods_via_bom,
+        )
+
+        # État initial : COMP-C remonte vers PARENT2.
+        assert _get_finished_goods_via_bom(db_conn, [seed["comp_c"]]) == [
+            seed["parent2"]
+        ]
+
+        with psycopg.connect(migrated_db, autocommit=True) as admin:
+            # 1. Ligne désactivée → plus de remontée.
+            admin.execute(
+                """
+                UPDATE bom_lines SET active = FALSE
+                WHERE component_item_id = (
+                    SELECT item_id FROM items WHERE external_id = %s
+                )
+                """,
+                (seed["comp_c"],),
+            )
+        assert _get_finished_goods_via_bom(db_conn, [seed["comp_c"]]) == []
+
+        with psycopg.connect(migrated_db, autocommit=True) as admin:
+            # 2. Ligne restaurée mais header inactif → toujours rien.
+            admin.execute(
+                """
+                UPDATE bom_lines SET active = TRUE
+                WHERE component_item_id = (
+                    SELECT item_id FROM items WHERE external_id = %s
+                )
+                """,
+                (seed["comp_c"],),
+            )
+            admin.execute(
+                """
+                UPDATE bom_headers SET status = 'inactive'
+                WHERE parent_item_id = (
+                    SELECT item_id FROM items WHERE external_id = %s
+                )
+                """,
+                (seed["parent2"],),
+            )
+        assert _get_finished_goods_via_bom(db_conn, [seed["comp_c"]]) == []

--- a/tests/integration/test_impact_scorer_bom_integration.py
+++ b/tests/integration/test_impact_scorer_bom_integration.py
@@ -173,6 +173,7 @@ class TestImpactScorerBomTraversal:
             _get_finished_goods_via_bom,
         )
 
+        fgs: list = []
         try:
             fgs = _get_finished_goods_via_bom(db_conn, [seed["comp_a"]])
         except psycopg.errors.UndefinedTable as e:  # pragma: no cover — regression guard

--- a/tests/test_dq_impact_scorer.py
+++ b/tests/test_dq_impact_scorer.py
@@ -226,7 +226,7 @@ class TestGetFinishedGoodsViaBom:
             sql_lower = sql.strip().lower()
             if "from items where external_id" in sql_lower:
                 return _make_cursor([{"item_id": str(comp_id), "external_id": "COMP-1"}])
-            if "from bom_components" in sql_lower:
+            if "from bom_headers" in sql_lower:
                 if call_count["n"] == 2:
                     # First BOM query: component -> parent
                     return _make_cursor([{
@@ -259,7 +259,7 @@ class TestGetFinishedGoodsViaBom:
             sql_lower = sql.strip().lower()
             if "from items where external_id" in sql_lower:
                 return _make_cursor(items_rows)
-            if "from bom_components" in sql_lower:
+            if "from bom_headers" in sql_lower:
                 return _make_cursor([])
             return _make_cursor([])
 
@@ -322,7 +322,7 @@ class TestScoreIssues:
                 ])
             if "from items where external_id" in sql_lower:
                 return _make_cursor([])  # no BOM items
-            if "from bom_components" in sql_lower:
+            if "from bom_headers" in sql_lower:
                 return _make_cursor([])
             return _make_cursor([])
 
@@ -366,7 +366,7 @@ class TestScoreIssues:
                 return _make_cursor([
                     {"item_id": str(comp_id), "external_id": "COMP-1"}
                 ])
-            if "from bom_components" in sql_lower:
+            if "from bom_headers" in sql_lower:
                 if call_count["n"] <= 5:
                     return _make_cursor([{
                         "parent_item_id": str(parent_id),

--- a/tests/test_ingest_file_naming.py
+++ b/tests/test_ingest_file_naming.py
@@ -1,0 +1,392 @@
+"""
+tests/test_ingest_file_naming.py — Pure unit tests (no DB) for the PR-4a
+filename grammar and part-file grouping in scripts/ingest_file.py.
+
+Three axes:
+
+1. `parse_ingest_filename` — the pure basename parser. Canonical
+   '<entity>.tsv', daily drop '<entity>_<AAAAMMJJ>.tsv', part file
+   '<entity>.partNN.tsv', dated part '<entity>.partNN_<AAAAMMJJ>.tsv',
+   plus the refusals (.tsv extension mandatory and case-sensitive, empty
+   entity) and the deliberate tolerances (date is structural-only, a
+   '.part' marker without >=2 digits is NOT a part marker — it stays in
+   the entity and gets refused later at DISPATCH lookup, not by the
+   parser).
+
+2. `find_sibling_parts` — grouping of same-(entity, date) '.partNN'
+   siblings in ONE directory: numeric part ordering (part02 < part003 <
+   part10 — lexical order would differ), (entity, date) partitioning,
+   noise immunity, duplicate-part-number refusal, and the hard error when
+   the NAMED part is absent from its own directory (typo or already
+   archived by a prior run).
+
+3. `parse_tsv_parts` — concatenation of N parts into ONE logical load:
+   single header (each part's own header line is consumed, never
+   re-emitted as a data row), byte-identical header requirement (names
+   AND order), `__line__` re-prefixed with the source file name for
+   cross-part traceability.
+
+No DB required — this file must stay collectible and green without
+DATABASE_URL.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# scripts/ are not a package — same import pattern as tests/test_ingest_status_lifecycle.py.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import ingest_file  # noqa: E402
+from ingest_file import (  # noqa: E402
+    DISPATCH,
+    ParsedFilename,
+    _find_archived,
+    find_sibling_parts,
+    parse_ingest_filename,
+    parse_tsv_parts,
+)
+
+
+# ─────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────
+_HEADER = "item_external_id\tqty"
+
+
+def _write_tsv(path: Path, rows: list[str], header: str = _HEADER) -> Path:
+    """Write a minimal TSV file (header + data rows, tab-separated)."""
+    path.write_text("\n".join([header, *rows]) + "\n", encoding="utf-8")
+    return path
+
+
+# ─────────────────────────────────────────────────────────────
+# 1. parse_ingest_filename — canonical names
+# ─────────────────────────────────────────────────────────────
+class TestParseCanonical:
+    def test_items_tsv(self) -> None:
+        assert parse_ingest_filename("items.tsv") == ParsedFilename(
+            entity="items", date=None, part=None
+        )
+
+    @pytest.mark.parametrize("canonical", sorted(DISPATCH))
+    def test_every_dispatch_key_round_trips(self, canonical: str) -> None:
+        """Each supported canonical name parses to a bare entity whose
+        '<entity>.tsv' re-derivation is exactly the DISPATCH key — the
+        invariant main() relies on for dispatch."""
+        parsed = parse_ingest_filename(canonical)
+        assert f"{parsed.entity}.tsv" == canonical
+        assert parsed.date is None
+        assert parsed.part is None
+
+    def test_entity_with_underscore_is_not_a_date(self) -> None:
+        # 'supplier_items' has an underscore but no 8-digit suffix.
+        parsed = parse_ingest_filename("supplier_items.tsv")
+        assert parsed == ParsedFilename(entity="supplier_items", date=None, part=None)
+
+
+# ─────────────────────────────────────────────────────────────
+# 1b. parse_ingest_filename — daily-drop date suffix
+# ─────────────────────────────────────────────────────────────
+class TestParseDate:
+    def test_dated_drop(self) -> None:
+        parsed = parse_ingest_filename("on_hand_20260718.tsv")
+        assert parsed == ParsedFilename(entity="on_hand", date="20260718", part=None)
+
+    def test_entity_own_underscore_survives_date_stripping(self) -> None:
+        parsed = parse_ingest_filename("supplier_items_20260718.tsv")
+        assert parsed == ParsedFilename(
+            entity="supplier_items", date="20260718", part=None
+        )
+
+    def test_short_digit_suffix_is_not_a_date(self) -> None:
+        # 4 digits != AAAAMMJJ — the whole stem is the entity.
+        parsed = parse_ingest_filename("items_2026.tsv")
+        assert parsed == ParsedFilename(entity="items_2026", date=None, part=None)
+
+    def test_date_is_structural_only_no_calendar_validation(self) -> None:
+        # Same structural-only tolerance as `_to_date_str` (docstring pin):
+        # 8 digits suffice, '00000000' is accepted as-is.
+        parsed = parse_ingest_filename("items_00000000.tsv")
+        assert parsed == ParsedFilename(entity="items", date="00000000", part=None)
+
+    def test_only_last_8_digit_suffix_is_the_date(self) -> None:
+        # Greedy stem: a prior 8-digit run stays in the entity.
+        parsed = parse_ingest_filename("items_20260717_20260718.tsv")
+        assert parsed == ParsedFilename(
+            entity="items_20260717", date="20260718", part=None
+        )
+
+
+# ─────────────────────────────────────────────────────────────
+# 1c. parse_ingest_filename — part marker
+# ─────────────────────────────────────────────────────────────
+class TestParsePart:
+    def test_part_file(self) -> None:
+        parsed = parse_ingest_filename("forecasts.part01.tsv")
+        assert parsed == ParsedFilename(entity="forecasts", date=None, part=1)
+
+    def test_two_digit_part(self) -> None:
+        assert parse_ingest_filename("forecasts.part12.tsv").part == 12
+
+    def test_more_than_two_digits_accepted(self) -> None:
+        # NN means "at least two digits" — 'part007' is part 7.
+        parsed = parse_ingest_filename("forecasts.part007.tsv")
+        assert parsed == ParsedFilename(entity="forecasts", date=None, part=7)
+
+    def test_dated_part(self) -> None:
+        parsed = parse_ingest_filename("forecasts.part01_20260718.tsv")
+        assert parsed == ParsedFilename(entity="forecasts", date="20260718", part=1)
+
+    def test_single_digit_is_not_a_part_marker(self) -> None:
+        # The grammar is '.partNN' (>=2 digits). 'part1' is NOT a part
+        # marker: it stays inside the entity and is refused downstream at
+        # DISPATCH lookup ('forecasts.part1.tsv' is not a known entity),
+        # not by the parser.
+        parsed = parse_ingest_filename("forecasts.part1.tsv")
+        assert parsed == ParsedFilename(entity="forecasts.part1", date=None, part=None)
+        assert f"{parsed.entity}.tsv" not in DISPATCH
+
+    def test_digitless_part_is_not_a_part_marker(self) -> None:
+        # Same logic: '.part' without digits is inert — the parser does
+        # not raise; the unknown entity is refused at DISPATCH lookup.
+        parsed = parse_ingest_filename("forecasts.part.tsv")
+        assert parsed == ParsedFilename(entity="forecasts.part", date=None, part=None)
+        assert f"{parsed.entity}.tsv" not in DISPATCH
+
+    def test_reversed_date_part_ordering_not_recognized(self) -> None:
+        # Only '<entity>.partNN_<date>.tsv' is a dated part. The reversed
+        # '<entity>_<date>.partNN.tsv' leaves the date inside the entity
+        # (and thus out of DISPATCH) — pin so the grammar can't silently
+        # widen.
+        parsed = parse_ingest_filename("forecasts_20260718.part01.tsv")
+        assert parsed == ParsedFilename(entity="forecasts_20260718", date=None, part=1)
+
+
+# ─────────────────────────────────────────────────────────────
+# 1d. parse_ingest_filename — refusals & case sensitivity
+# ─────────────────────────────────────────────────────────────
+class TestParseRefusals:
+    @pytest.mark.parametrize(
+        "bad",
+        ["items.csv", "items.tsv.gz", "items", "", "items.TSV", "items.Tsv"],
+    )
+    def test_non_tsv_extension_refused(self, bad: str) -> None:
+        with pytest.raises(ValueError, match=r"\.tsv"):
+            parse_ingest_filename(bad)
+
+    def test_bare_extension_refused(self) -> None:
+        with pytest.raises(ValueError, match="no entity segment"):
+            parse_ingest_filename(".tsv")
+
+    def test_entity_case_is_preserved_not_folded(self) -> None:
+        # The parser is case-preserving; DISPATCH keys are lowercase, so
+        # 'ITEMS.tsv' resolves to an unknown entity downstream.
+        parsed = parse_ingest_filename("ITEMS.tsv")
+        assert parsed.entity == "ITEMS"
+        assert f"{parsed.entity}.tsv" not in DISPATCH
+
+
+# ─────────────────────────────────────────────────────────────
+# 2. find_sibling_parts — grouping
+# ─────────────────────────────────────────────────────────────
+class TestFindSiblingParts:
+    def test_groups_all_parts_ascending_ignoring_noise(self, tmp_path: Path) -> None:
+        p1 = _write_tsv(tmp_path / "forecasts.part01.tsv", ["A\t1"])
+        p2 = _write_tsv(tmp_path / "forecasts.part02.tsv", ["B\t2"])
+        p3 = _write_tsv(tmp_path / "forecasts.part03.tsv", ["C\t3"])
+        # Noise: canonical file, other entity's part, dated part (other
+        # group), non-TSV, and a DIRECTORY named like a part.
+        _write_tsv(tmp_path / "forecasts.tsv", ["Z\t9"])
+        _write_tsv(tmp_path / "items.part01.tsv", ["Y\t8"])
+        _write_tsv(tmp_path / "forecasts.part01_20260718.tsv", ["X\t7"])
+        (tmp_path / "notes.txt").write_text("nope", encoding="utf-8")
+        (tmp_path / "forecasts.part09.tsv").mkdir()
+
+        assert find_sibling_parts(p1) == [p1, p2, p3]
+
+    def test_numeric_ordering_not_lexical(self, tmp_path: Path) -> None:
+        # Lexically 'part003' < 'part02' < 'part10'; numerically 2 < 3 < 10.
+        p10 = _write_tsv(tmp_path / "forecasts.part10.tsv", ["C\t3"])
+        p3 = _write_tsv(tmp_path / "forecasts.part003.tsv", ["B\t2"])
+        p2 = _write_tsv(tmp_path / "forecasts.part02.tsv", ["A\t1"])
+
+        assert find_sibling_parts(p2) == [p2, p3, p10]
+
+    def test_entry_via_any_member_returns_full_group(self, tmp_path: Path) -> None:
+        p1 = _write_tsv(tmp_path / "forecasts.part01.tsv", ["A\t1"])
+        p2 = _write_tsv(tmp_path / "forecasts.part02.tsv", ["B\t2"])
+
+        assert find_sibling_parts(p2) == [p1, p2]
+
+    def test_date_partitions_groups(self, tmp_path: Path) -> None:
+        d1 = _write_tsv(tmp_path / "forecasts.part01_20260718.tsv", ["A\t1"])
+        d2 = _write_tsv(tmp_path / "forecasts.part02_20260718.tsv", ["B\t2"])
+        _write_tsv(tmp_path / "forecasts.part01.tsv", ["C\t3"])
+        _write_tsv(tmp_path / "forecasts.part01_20260719.tsv", ["D\t4"])
+
+        assert find_sibling_parts(d1) == [d1, d2]
+
+    def test_gap_in_part_numbers_is_tolerated(self, tmp_path: Path) -> None:
+        # The filename encodes no total part count, so a gap is NOT
+        # detectable — grouping takes what is present. Pin the actual
+        # semantics so a future gap-check is a deliberate change.
+        p1 = _write_tsv(tmp_path / "forecasts.part01.tsv", ["A\t1"])
+        p3 = _write_tsv(tmp_path / "forecasts.part03.tsv", ["C\t3"])
+
+        assert find_sibling_parts(p1) == [p1, p3]
+
+    def test_duplicate_part_number_refused(self, tmp_path: Path) -> None:
+        # 'part01' and 'part001' both parse to part=1 — ambiguous.
+        p1 = _write_tsv(tmp_path / "forecasts.part01.tsv", ["A\t1"])
+        _write_tsv(tmp_path / "forecasts.part001.tsv", ["B\t2"])
+
+        with pytest.raises(ValueError, match="duplicate part"):
+            find_sibling_parts(p1)
+
+    def test_named_part_absent_from_directory_is_hard_error(self, tmp_path: Path) -> None:
+        # e.g. part01 was already archived by a prior run and only part02
+        # remains: silently ingesting the leftovers would be wrong.
+        _write_tsv(tmp_path / "forecasts.part02.tsv", ["B\t2"])
+        missing = tmp_path / "forecasts.part01.tsv"  # never created
+
+        with pytest.raises(ValueError, match="already archived"):
+            find_sibling_parts(missing)
+
+    def test_non_part_entry_point_refused(self, tmp_path: Path) -> None:
+        p = _write_tsv(tmp_path / "forecasts.tsv", ["A\t1"])
+        with pytest.raises(ValueError, match="not a '.partNN' file"):
+            find_sibling_parts(p)
+
+    def test_missing_directory_propagates(self, tmp_path: Path) -> None:
+        ghost = tmp_path / "nope" / "forecasts.part01.tsv"
+        with pytest.raises(FileNotFoundError):
+            find_sibling_parts(ghost)
+
+
+# ─────────────────────────────────────────────────────────────
+# 3. parse_tsv_parts — concatenation into one logical load
+# ─────────────────────────────────────────────────────────────
+class TestParseTsvParts:
+    def test_concatenates_with_single_header(self, tmp_path: Path) -> None:
+        p1 = _write_tsv(tmp_path / "forecasts.part01.tsv", ["A\t1", "B\t2"])
+        p2 = _write_tsv(tmp_path / "forecasts.part02.tsv", ["C\t3"])
+
+        headers, rows = parse_tsv_parts([p1, p2])
+
+        assert headers == ["item_external_id", "qty"]
+        # Header dedup: part02's own header line is consumed, never
+        # re-emitted as a data row.
+        assert len(rows) == 3
+        assert [r["item_external_id"] for r in rows] == ["A", "B", "C"]
+        assert all(r["item_external_id"] != "item_external_id" for r in rows)
+
+    def test_rows_keep_part_order(self, tmp_path: Path) -> None:
+        # parse_tsv_parts trusts the caller's ordering (find_sibling_parts
+        # hands it ascending) — rows come out part01 first, partNN last.
+        p1 = _write_tsv(tmp_path / "forecasts.part01.tsv", ["A\t1"])
+        p2 = _write_tsv(tmp_path / "forecasts.part02.tsv", ["B\t2"])
+        p3 = _write_tsv(tmp_path / "forecasts.part03.tsv", ["C\t3"])
+
+        _, rows = parse_tsv_parts([p1, p2, p3])
+        assert [r["item_external_id"] for r in rows] == ["A", "B", "C"]
+
+    def test_line_tags_are_prefixed_with_source_file(self, tmp_path: Path) -> None:
+        p1 = _write_tsv(tmp_path / "forecasts.part01.tsv", ["A\t1", "B\t2"])
+        p2 = _write_tsv(tmp_path / "forecasts.part02.tsv", ["C\t3"])
+
+        _, rows = parse_tsv_parts([p1, p2])
+
+        # Line numbers restart per file (header = line 1 in each part).
+        assert rows[0]["__line__"] == "forecasts.part01.tsv:L2"
+        assert rows[1]["__line__"] == "forecasts.part01.tsv:L3"
+        assert rows[2]["__line__"] == "forecasts.part02.tsv:L2"
+
+    def test_header_name_mismatch_refused_naming_offender(self, tmp_path: Path) -> None:
+        p1 = _write_tsv(tmp_path / "forecasts.part01.tsv", ["A\t1"])
+        p2 = _write_tsv(
+            tmp_path / "forecasts.part02.tsv", ["B\t2"],
+            header="item_external_id\tquantity",
+        )
+
+        with pytest.raises(ValueError, match="forecasts.part02.tsv"):
+            parse_tsv_parts([p1, p2])
+
+    def test_header_order_mismatch_refused(self, tmp_path: Path) -> None:
+        # Byte-identical means same order too, not just same column set.
+        p1 = _write_tsv(tmp_path / "forecasts.part01.tsv", ["A\t1"])
+        p2 = _write_tsv(
+            tmp_path / "forecasts.part02.tsv", ["2\tB"],
+            header="qty\titem_external_id",
+        )
+
+        with pytest.raises(ValueError, match="does not match"):
+            parse_tsv_parts([p1, p2])
+
+    def test_empty_part_list_refused(self) -> None:
+        with pytest.raises(ValueError, match="no part files"):
+            parse_tsv_parts([])
+
+    def test_empty_part_file_refused(self, tmp_path: Path) -> None:
+        p1 = _write_tsv(tmp_path / "forecasts.part01.tsv", ["A\t1"])
+        p2 = tmp_path / "forecasts.part02.tsv"
+        p2.write_text("", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="empty"):
+            parse_tsv_parts([p1, p2])
+
+    def test_end_to_end_group_then_parse(self, tmp_path: Path) -> None:
+        # The real pipeline: find_sibling_parts orders, parse_tsv_parts
+        # concatenates — numeric part order decides row order.
+        _write_tsv(tmp_path / "forecasts.part10.tsv", ["LAST\t3"])
+        _write_tsv(tmp_path / "forecasts.part02.tsv", ["FIRST\t1"])
+        p3 = _write_tsv(tmp_path / "forecasts.part003.tsv", ["MID\t2"])
+
+        siblings = find_sibling_parts(p3)
+        headers, rows = parse_tsv_parts(siblings)
+
+        assert headers == ["item_external_id", "qty"]
+        assert [r["item_external_id"] for r in rows] == ["FIRST", "MID", "LAST"]
+
+
+# ─────────────────────────────────────────────────────────────
+# 4. _find_archived — "already consumed" detection
+# ─────────────────────────────────────────────────────────────
+class TestFindArchived:
+    @pytest.fixture()
+    def archive_dirs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        processed = tmp_path / "processed"
+        rejected = tmp_path / "rejected"
+        processed.mkdir()
+        rejected.mkdir()
+        monkeypatch.setattr(ingest_file, "PROCESSED", processed)
+        monkeypatch.setattr(ingest_file, "REJECTED", rejected)
+        return processed, rejected
+
+    def test_finds_archived_copy_in_processed(self, tmp_path: Path, archive_dirs) -> None:
+        processed, _ = archive_dirs
+        # archive() naming: '{stem}_{timestamp}{suffix}'.
+        archived = processed / "forecasts.part01_20260718_120000.tsv"
+        archived.write_text("x", encoding="utf-8")
+
+        missing = tmp_path / "inbox" / "forecasts.part01.tsv"
+        assert _find_archived(missing) == archived
+
+    def test_nothing_matching_returns_none(self, tmp_path: Path, archive_dirs) -> None:
+        missing = tmp_path / "inbox" / "forecasts.part01.tsv"
+        assert _find_archived(missing) is None
+
+    def test_most_recent_match_wins(self, tmp_path: Path, archive_dirs) -> None:
+        processed, rejected = archive_dirs
+        older = processed / "items_20260717_080000.tsv"
+        newer = rejected / "items_20260718_080000.tsv"
+        older.write_text("old", encoding="utf-8")
+        newer.write_text("new", encoding="utf-8")
+        os.utime(older, (1_000_000_000, 1_000_000_000))
+        os.utime(newer, (2_000_000_000, 2_000_000_000))
+
+        missing = tmp_path / "inbox" / "items.tsv"
+        assert _find_archived(missing) == newer


### PR DESCRIPTION
Premier etage de PR-4 (plan architecte — dettes du 1er chargement reel) :

1. **Grammaire des noms d'ingest** : `<feed_key>_<AAAAMMJJ>.tsv` (convention de depot quotidienne de notre spec) + `<flux>.partNN.tsv` (gros fichiers en parts — les 3 parts de forecasts de l'ERP) regroupees en UN chargement logique. Parse pur testable, retro-compat stricte du canonique, re-run d'une part archivee = erreur claire.
2. **Fix requete morte** : `bom_components` n'a jamais existe — le scorer d'impact DQ interroge desormais `bom_headers`×`bom_lines` (UndefinedTable logue a chaque ingest d'items, elimine).

58 tests nouveaux + 2 mocks migres. 3227 unitaires verts, ruff, mypy.
Suite : PR-4b (orchestrateur inbound) puis PR-4c (compte-rendu quotidien → Dropbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)