### PR TITLE
feat(interfaces): PR-4b -- orchestrateur du run quotidien gouverne

### DIFF
--- a/scripts/ingest_file.py
+++ b/scripts/ingest_file.py
@@ -25,35 +25,59 @@ Environment:
 Currently supported entities (V1):
     items.tsv                 → POST /v1/ingest/items
     locations.tsv             → POST /v1/ingest/locations
-    suppliers.tsv             → POST /v1/ingest/suppliers
+    suppliers.tsv              → POST /v1/ingest/suppliers
     supplier_items.tsv        → POST /v1/ingest/supplier-items
     item_planning_params.tsv  → POST /v1/ingest/planning-params (SCD2 transparent)
-    on_hand.tsv               → POST /v1/ingest/on-hand
-    purchase_orders.tsv       → POST /v1/ingest/purchase-orders
-    customer_orders.tsv       → POST /v1/ingest/customer-orders
-    forecasts.tsv             → POST /v1/ingest/forecast-demand
-    transfers.tsv             → POST /v1/ingest/transfers
-    bom_header.tsv            → POST /v1/ingest/bom  (bundle mode — merges with bom_components.tsv, N calls)
+    on_hand.tsv                → POST /v1/ingest/on-hand
+    purchase_orders.tsv        → POST /v1/ingest/purchase-orders
+    customer_orders.tsv        → POST /v1/ingest/customer-orders
+    forecasts.tsv              → POST /v1/ingest/forecast-demand
+    transfers.tsv               → POST /v1/ingest/transfers
+    bom_header.tsv             → POST /v1/ingest/bom  (bundle mode — merges with bom_components.tsv, N calls)
 
 See docs/contracts/<entity>/format-<entity>-tsv.md for each format spec.
+
+ARCHITECTURE NOTE (ADR-042 PR-4b): the filename grammar, payload builders,
+`call_api`, and `archive`/`archive_group` used below are NOT defined in this
+file anymore — they live in the importable
+`ootils_core.interfaces.ingest_exec` module (the canonical implementation,
+shared with `engine/ingest/daily_orchestrator.py`'s governed daily run) and
+are re-exported here so this script's CLI behaviour, and every object the
+PR-4a test suite (`tests/test_ingest_file_naming.py`) imports/monkeypatches,
+stay unchanged. This file keeps ONLY what is genuinely CLI-shaped:
+`PROCESSED`/`REJECTED`/`INBOX` (repo-relative archive directories),
+`_find_archived` (reads those same globals — kept local so the test suite's
+`monkeypatch.setattr(ingest_file, "PROCESSED", ...)` still works),
+`handle_bom_bundle`/`handle_part_group` (dry-run JSON printing + process
+exit codes), and `main()`.
 """
 from __future__ import annotations
 
 import argparse
-import csv
 import json
 import logging
 import os
-import re
-import shutil
 import sys
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "src"))
+
+from ootils_core.interfaces.ingest_exec import (  # noqa: E402
+    DISPATCH,
+    PAYLOAD_BUILDERS,
+    ParsedFilename,
+    archive,
+    archive_group,
+    build_bom_payloads,
+    call_api,
+    find_sibling_parts,
+    parse_ingest_filename,
+    parse_tsv,
+    parse_tsv_parts,
+)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -65,699 +89,22 @@ INBOX = ROOT / "data" / "inbox"
 PROCESSED = ROOT / "data" / "processed"
 REJECTED = ROOT / "data" / "rejected"
 
-# ─────────────────────────────────────────────────────────────
-# Dispatch table — filename → endpoint + payload body_key
-# ─────────────────────────────────────────────────────────────
-# Aligned with data-input-canonique-v1/endpoint_mapping.json.
-# Extend here when adding a new supported entity.
-DISPATCH: dict[str, dict[str, str]] = {
-    "items.tsv":                {"endpoint": "/v1/ingest/items",            "body_key": "items"},
-    "locations.tsv":            {"endpoint": "/v1/ingest/locations",        "body_key": "locations"},
-    "suppliers.tsv":            {"endpoint": "/v1/ingest/suppliers",        "body_key": "suppliers"},
-    "supplier_items.tsv":       {"endpoint": "/v1/ingest/supplier-items",   "body_key": "supplier_items"},
-    "item_planning_params.tsv": {"endpoint": "/v1/ingest/planning-params",  "body_key": "params"},
-    "on_hand.tsv":              {"endpoint": "/v1/ingest/on-hand",          "body_key": "on_hand"},
-    "purchase_orders.tsv":      {"endpoint": "/v1/ingest/purchase-orders",  "body_key": "purchase_orders"},
-    "customer_orders.tsv":      {"endpoint": "/v1/ingest/customer-orders",  "body_key": "customer_orders"},
-    "forecasts.tsv":            {"endpoint": "/v1/ingest/forecast-demand",  "body_key": "forecasts"},
-    "transfers.tsv":            {"endpoint": "/v1/ingest/transfers",        "body_key": "transfers"},
-    # BOM bundle: entry point is bom_header.tsv, which auto-loads bom_components.tsv
-    # alongside and emits N POSTs (one per BOM). Special-cased in main().
-    "bom_header.tsv":           {"endpoint": "/v1/ingest/bom",              "body_key": "_bom_bundle"},
-}
-
-
-# ─────────────────────────────────────────────────────────────
-# Filename grammar (PR-4a) — pure, no filesystem access
-# ─────────────────────────────────────────────────────────────
-# Beyond the canonical '<entity>.tsv' name (the DISPATCH keys above), two
-# real-world drop conventions are accepted:
-#   - daily drop:  '<entity>_<AAAAMMJJ>.tsv'          e.g. on_hand_20260718.tsv
-#   - part file:   '<entity>.partNN.tsv'              e.g. forecasts.part01.tsv
-#                  '<entity>.partNN_<AAAAMMJJ>.tsv'   e.g. forecasts.part01_20260718.tsv
-# The date suffix is ignored for dispatch (informational only — the entity
-# alone decides the endpoint). Part files sharing the same (entity, date)
-# in the same directory are grouped into ONE logical load — see
-# `find_sibling_parts`/`parse_tsv_parts` below and `handle_part_group` in
-# the main() dispatch section.
-_DATE_SUFFIX_RE = re.compile(r"^(?P<stem>.+)_(?P<date>\d{8})$")
-_PART_SUFFIX_RE = re.compile(r"^(?P<stem>.+)\.part(?P<part>\d{2,})$")
-
-
-@dataclass(frozen=True)
-class ParsedFilename:
-    """Result of `parse_ingest_filename`.
-
-    `entity` is the bare feed-key stem — no '.tsv' extension, no date or
-    part marker (e.g. 'on_hand', 'bom_header', 'forecasts'). This parser has
-    zero knowledge of which entities are actually supported; callers must
-    still check `f"{entity}.tsv"` against DISPATCH.
-    """
-
-    entity: str
-    date: str | None
-    part: int | None
-
-
-def parse_ingest_filename(filename: str) -> ParsedFilename:
-    """Pure parser: basename -> (entity, date, part). No filesystem access.
-
-    Accepted grammars (basename only, no directory component):
-        '<entity>.tsv'                    canonical (e.g. 'items.tsv')
-        '<entity>_<AAAAMMJJ>.tsv'         daily drop (e.g. 'on_hand_20260718.tsv')
-        '<entity>.partNN.tsv'             part file (e.g. 'forecasts.part01.tsv')
-        '<entity>.partNN_<AAAAMMJJ>.tsv'  dated part file
-
-    The date, when present, is returned as its raw 8-digit string (not
-    parsed/validated as a real calendar date — same structural-only
-    tolerance as `_to_date_str` elsewhere in this file) and is otherwise
-    unused: it exists for traceability/grouping, never for dispatch.
-
-    Raises ValueError if `filename` doesn't end in '.tsv', has an empty
-    entity segment once date/part markers are stripped, or a malformed
-    '.part' marker (no digits).
-    """
-    if not filename.endswith(".tsv"):
-        raise ValueError(f"filename must end with '.tsv': '{filename}'")
-    stem = filename[: -len(".tsv")]
-
-    date: str | None = None
-    date_match = _DATE_SUFFIX_RE.match(stem)
-    if date_match:
-        stem = date_match.group("stem")
-        date = date_match.group("date")
-
-    part: int | None = None
-    part_match = _PART_SUFFIX_RE.match(stem)
-    if part_match:
-        stem = part_match.group("stem")
-        part = int(part_match.group("part"))
-
-    if not stem:
-        raise ValueError(f"filename has no entity segment: '{filename}'")
-
-    return ParsedFilename(entity=stem, date=date, part=part)
-
-
-# ─────────────────────────────────────────────────────────────
-# Type coercion helpers
-# ─────────────────────────────────────────────────────────────
-_TRUE_VALUES = {"true", "1", "yes", "y", "t"}
-_FALSE_VALUES = {"false", "0", "no", "n", "f", ""}
-
-
-def _to_bool(raw: str, *, field: str, line: str) -> bool:
-    v = raw.strip().lower()
-    if v in _TRUE_VALUES:
-        return True
-    if v in _FALSE_VALUES:
-        return False
-    raise ValueError(
-        f"line {line}: {field} '{raw}' is not a valid boolean "
-        f"(accepted: true/false/1/0/yes/no/y/n/t/f)"
-    )
-
-
-def _to_int(raw: str, *, field: str, line: str) -> int:
-    try:
-        return int(raw)
-    except ValueError as e:
-        raise ValueError(f"line {line}: {field} '{raw}' is not a valid integer") from e
-
-
-def _to_float(raw: str, *, field: str, line: str) -> float:
-    try:
-        return float(raw)
-    except ValueError as e:
-        raise ValueError(f"line {line}: {field} '{raw}' is not a valid number") from e
-
-
-# ─────────────────────────────────────────────────────────────
-# TSV parsing
-# ─────────────────────────────────────────────────────────────
-def parse_tsv(path: Path) -> tuple[list[str], list[dict[str, str]]]:
-    """Parse a UTF-8 TSV file into (headers, rows-as-dicts).
-
-    - Tabulation separator (no escape — values must not contain raw tabs).
-    - No quoting whatsoever (TSV-FILES-SPEC.md §1.1: "aucun guillemet"): a
-      literal `"` in a cell (e.g. an inch-mark item description like
-      `"U" BOLT 1/4"`) must be preserved verbatim, never treated as a CSV
-      quote character. `quoting=csv.QUOTE_NONE` is required here — the
-      default QUOTE_MINIMAL silently swallows a leading `"` and everything
-      up to the next `"`, corrupting the value.
-    - First non-empty line is the header.
-    - Empty lines are skipped.
-    - BOM (UTF-8 signature) is tolerated and stripped.
-    - Returns dicts using header names as keys.
-    """
-    if not path.exists():
-        raise FileNotFoundError(f"input file not found: {path}")
-    if path.stat().st_size == 0:
-        raise ValueError(f"input file is empty: {path}")
-
-    with path.open("r", encoding="utf-8-sig", newline="") as f:
-        reader = csv.reader(f, delimiter="\t", quoting=csv.QUOTE_NONE)
-        rows = [r for r in reader if any(cell.strip() for cell in r)]
-
-    if not rows:
-        raise ValueError(f"input file contains no non-empty lines: {path}")
-
-    headers = [h.strip() for h in rows[0]]
-    if not all(headers):
-        raise ValueError(f"header row contains empty column name: {headers}")
-
-    data_rows: list[dict[str, str]] = []
-    for i, raw in enumerate(rows[1:], start=2):  # line numbers 1-based, header is line 1
-        if len(raw) != len(headers):
-            raise ValueError(
-                f"line {i}: column count {len(raw)} != header count {len(headers)}"
-            )
-        row = {headers[j]: raw[j].strip() for j in range(len(headers))}
-        # Tag with the original line number for error reporting
-        row["__line__"] = str(i)
-        data_rows.append(row)
-
-    return headers, data_rows
-
-
-# ─────────────────────────────────────────────────────────────
-# Part-file grouping (PR-4a)
-# ─────────────────────────────────────────────────────────────
-def find_sibling_parts(path: Path) -> list[Path]:
-    """Return every sibling '.partNN' file for the same (entity, date) as
-    `path`, scanned in `path`'s own directory ONLY (never data/processed/
-    or data/rejected/ — grouping is scoped to files currently sitting
-    together in the inbox), sorted by part number ascending. `path` itself
-    is included.
-
-    Raises ValueError if:
-      - `path`'s own filename doesn't parse as a part file (part is None);
-      - two files in the directory collide on the same part number for
-        this (entity, date) group (ambiguous — cannot pick one);
-      - `path` itself is not among the files found in its own directory
-        (typo, or the file was already archived by a prior run — the
-        caller should treat this as a hard error, not silently ingest
-        whatever siblings remain).
-
-    Propagates FileNotFoundError if `path.parent` doesn't exist.
-    """
-    parsed = parse_ingest_filename(path.name)
-    if parsed.part is None:
-        raise ValueError(f"'{path.name}' is not a '.partNN' file")
-
-    by_part: dict[int, Path] = {}
-    for candidate in sorted(path.parent.iterdir()):
-        if not candidate.is_file():
-            continue
-        try:
-            c_parsed = parse_ingest_filename(candidate.name)
-        except ValueError:
-            continue
-        if c_parsed.part is None:
-            continue
-        if c_parsed.entity != parsed.entity or c_parsed.date != parsed.date:
-            continue
-        if c_parsed.part in by_part:
-            raise ValueError(
-                f"duplicate part {c_parsed.part:02d} for entity '{parsed.entity}' "
-                f"(date={parsed.date}): '{by_part[c_parsed.part].name}' "
-                f"and '{candidate.name}'"
-            )
-        by_part[c_parsed.part] = candidate
-
-    siblings = [by_part[k] for k in sorted(by_part)]
-    if not any(p.name == path.name for p in siblings):
-        raise ValueError(
-            f"'{path.name}' was not found in '{path.parent}' "
-            f"(found {len(siblings)} other part(s) for entity '{parsed.entity}'"
-            + (f", date {parsed.date}" if parsed.date else "")
-            + ") — check the path, or whether this part was already archived"
-        )
-    return siblings
-
-
-def parse_tsv_parts(paths: list[Path]) -> tuple[list[str], list[dict[str, str]]]:
-    """Parse and concatenate N sibling part files into one logical
-    (headers, rows), in the given order (expected: ascending by part
-    number, see `find_sibling_parts`).
-
-    Every part is parsed independently via `parse_tsv`; all parts must
-    share byte-identical headers (same column names, same order) — a
-    mismatch raises ValueError naming the offending file. Each row's
-    `__line__` tag is re-prefixed with its source file's name so error
-    messages built from it stay traceable across parts, e.g.
-    "forecasts.part02.tsv:L14".
-    """
-    if not paths:
-        raise ValueError("no part files to parse")
-
-    headers: list[str] | None = None
-    all_rows: list[dict[str, str]] = []
-    for p in paths:
-        p_headers, p_rows = parse_tsv(p)
-        if headers is None:
-            headers = p_headers
-        elif p_headers != headers:
-            raise ValueError(
-                f"part file '{p.name}' header {p_headers} does not match "
-                f"first part's header {headers}"
-            )
-        for row in p_rows:
-            row = dict(row)
-            row["__line__"] = f"{p.name}:L{row.get('__line__', '?')}"
-            all_rows.append(row)
-
-    assert headers is not None  # `paths` non-empty => at least one iteration ran
-    return headers, all_rows
-
-
-# ─────────────────────────────────────────────────────────────
-# Payload construction
-# ─────────────────────────────────────────────────────────────
-def build_items_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
-    """Build the JSON body for POST /v1/ingest/items.
-
-    Applies defaults for optional fields when blank: item_type, uom, status.
-    All-or-nothing validation happens server-side; we just pass values through.
-    """
-    items: list[dict[str, Any]] = []
-    for row in rows:
-        item = {
-            "external_id": row.get("external_id", ""),
-            "name": row.get("name", ""),
-        }
-        # Optional fields — only include if the column exists AND the cell is non-empty,
-        # so the server applies its Pydantic defaults otherwise.
-        if row.get("item_type"):
-            item["item_type"] = row["item_type"]
-        if row.get("uom"):
-            item["uom"] = row["uom"]
-        if row.get("status"):
-            item["status"] = row["status"]
-        items.append(item)
-    return {"items": items, "dry_run": dry_run}
-
-
-def build_locations_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
-    """Build the JSON body for POST /v1/ingest/locations.
-
-    Sends only non-empty optional fields so the server applies Pydantic defaults
-    (e.g. location_type → 'dc'). The API itself validates `parent_external_id`
-    refs against the payload + the existing DB.
-    """
-    locations: list[dict[str, Any]] = []
-    for row in rows:
-        loc = {
-            "external_id": row.get("external_id", ""),
-            "name": row.get("name", ""),
-        }
-        if row.get("location_type"):
-            loc["location_type"] = row["location_type"]
-        if row.get("country"):
-            loc["country"] = row["country"]
-        if row.get("timezone"):
-            loc["timezone"] = row["timezone"]
-        if row.get("parent_external_id"):
-            loc["parent_external_id"] = row["parent_external_id"]
-        locations.append(loc)
-    return {"locations": locations, "dry_run": dry_run}
-
-
-def build_suppliers_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
-    """Build the JSON body for POST /v1/ingest/suppliers."""
-    suppliers: list[dict[str, Any]] = []
-    for row in rows:
-        line = row.get("__line__", "?")
-        sup: dict[str, Any] = {
-            "external_id": row.get("external_id", ""),
-            "name": row.get("name", ""),
-        }
-        if row.get("country"):
-            sup["country"] = row["country"]
-        if row.get("status"):
-            sup["status"] = row["status"]
-        if row.get("lead_time_days"):
-            sup["lead_time_days"] = _to_int(row["lead_time_days"], field="lead_time_days", line=line)
-        if row.get("reliability_score"):
-            sup["reliability_score"] = _to_float(row["reliability_score"], field="reliability_score", line=line)
-        suppliers.append(sup)
-    return {"suppliers": suppliers, "dry_run": dry_run}
-
-
-def build_supplier_items_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
-    """Build the JSON body for POST /v1/ingest/supplier-items.
-
-    Required: supplier_external_id, item_external_id, lead_time_days.
-    Optional with defaults: currency='EUR', is_preferred=false.
-    Optional nullable: moq, unit_cost.
-    """
-    pairs: list[dict[str, Any]] = []
-    for row in rows:
-        line = row.get("__line__", "?")
-        si: dict[str, Any] = {
-            "supplier_external_id": row.get("supplier_external_id", ""),
-            "item_external_id": row.get("item_external_id", ""),
-        }
-        # lead_time_days is REQUIRED by the API (gt=0). Empty → fail explicitly here.
-        if not row.get("lead_time_days"):
-            raise ValueError(
-                f"line {line}: lead_time_days is required and cannot be empty"
-            )
-        si["lead_time_days"] = _to_int(row["lead_time_days"], field="lead_time_days", line=line)
-
-        if row.get("currency"):
-            si["currency"] = row["currency"]
-        if row.get("moq"):
-            si["moq"] = _to_float(row["moq"], field="moq", line=line)
-        if row.get("unit_cost"):
-            si["unit_cost"] = _to_float(row["unit_cost"], field="unit_cost", line=line)
-        # is_preferred: column may exist but be blank (treated as False).
-        # Only normalize if the column is present in headers — but we already
-        # received it through row dict via parse_tsv, so test for presence.
-        if "is_preferred" in row:
-            si["is_preferred"] = _to_bool(row["is_preferred"], field="is_preferred", line=line)
-        pairs.append(si)
-    return {"supplier_items": pairs, "dry_run": dry_run}
-
-
-# Field-type map for item_planning_params columns.
-# Server applies SCD2 partial-push: any column ABSENT from payload = "keep current value".
-# So we must include a key in the payload ONLY when its TSV cell is non-empty,
-# and we must coerce it to the right type.
-_IPP_INT_FIELDS = {
-    "lead_time_sourcing_days",
-    "lead_time_manufacturing_days",
-    "lead_time_transit_days",
-    "planning_horizon_days",
-    "lot_size_poq_periods",
-    "frozen_time_fence_days",
-    "slashed_time_fence_days",
-    "consumption_window_days",
-}
-_IPP_FLOAT_FIELDS = {
-    "safety_stock_qty",
-    "safety_stock_days",
-    "reorder_point_qty",
-    "min_order_qty",
-    "max_order_qty",
-    "order_multiple",
-    "economic_order_qty",
-    "order_multiple_qty",
-}
-_IPP_BOOL_FIELDS = {"is_make"}
-_IPP_STRING_FIELDS = {
-    "lot_size_rule",
-    "preferred_supplier_external_id",
-    "forecast_consumption_strategy",
-}
-
-
-def build_item_planning_params_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
-    """Build the JSON body for POST /v1/ingest/planning-params.
-
-    SCD2 partial-push semantics:
-      - empty cell → key is OMITTED from the payload → server keeps current value
-      - non-empty cell → key included, value coerced to the right type
-
-    Required: item_external_id, location_external_id.
-    All other columns optional. The server resolves FKs (items, locations,
-    suppliers for preferred_supplier_external_id) before any write.
-    """
-    params: list[dict[str, Any]] = []
-    for row in rows:
-        line = row.get("__line__", "?")
-        p: dict[str, Any] = {
-            "item_external_id": row.get("item_external_id", ""),
-            "location_external_id": row.get("location_external_id", ""),
-        }
-        for col, raw in row.items():
-            if col in ("item_external_id", "location_external_id", "__line__"):
-                continue
-            if not raw:  # empty cell → omit → server keeps current value
-                continue
-            if col in _IPP_INT_FIELDS:
-                p[col] = _to_int(raw, field=col, line=line)
-            elif col in _IPP_FLOAT_FIELDS:
-                p[col] = _to_float(raw, field=col, line=line)
-            elif col in _IPP_BOOL_FIELDS:
-                p[col] = _to_bool(raw, field=col, line=line)
-            elif col in _IPP_STRING_FIELDS:
-                p[col] = raw
-            else:
-                # Unknown column → pass through as string; server may reject as 422 or ignore.
-                # Better to let the API decide than to silently drop.
-                p[col] = raw
-        params.append(p)
-    return {"params": params, "dry_run": dry_run}
-
-
-_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
-
-
-def _to_date_str(raw: str, *, field: str, line: str) -> str:
-    """Validate ISO date format YYYY-MM-DD. API expects a string here, not a date object."""
-    v = raw.strip()
-    if not _DATE_RE.match(v):
-        raise ValueError(f"line {line}: {field} '{raw}' must be ISO date YYYY-MM-DD")
-    return v
-
-
-def build_on_hand_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
-    """Build the JSON body for POST /v1/ingest/on-hand.
-
-    Required: item_external_id, location_external_id, quantity, as_of_date.
-    Optional: uom (default 'EA').
-
-    Note: `lot_number` is part of the canonical V1 TSV template but the API
-    Pydantic model does NOT consume it (V1.0). We drop it silently here to
-    avoid sending unknown fields and confusing the user with rejections.
-    """
-    on_hand: list[dict[str, Any]] = []
-    for row in rows:
-        line = row.get("__line__", "?")
-        if not row.get("quantity"):
-            raise ValueError(f"line {line}: quantity is required and cannot be empty")
-        if not row.get("as_of_date"):
-            raise ValueError(f"line {line}: as_of_date is required and cannot be empty")
-        rec: dict[str, Any] = {
-            "item_external_id": row.get("item_external_id", ""),
-            "location_external_id": row.get("location_external_id", ""),
-            "quantity": _to_float(row["quantity"], field="quantity", line=line),
-            "as_of_date": _to_date_str(row["as_of_date"], field="as_of_date", line=line),
-        }
-        if row.get("uom"):
-            rec["uom"] = row["uom"]
-        # lot_number intentionally dropped (V1.0 API doesn't consume it).
-        on_hand.append(rec)
-    return {"on_hand": on_hand, "dry_run": dry_run}
-
-
-def build_purchase_orders_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
-    """Build the JSON body for POST /v1/ingest/purchase-orders.
-
-    Required: external_id, item_external_id, location_external_id,
-              supplier_external_id, quantity, expected_delivery_date.
-    Optional: uom (default 'EA'), status (default 'confirmed').
-    """
-    pos: list[dict[str, Any]] = []
-    for row in rows:
-        line = row.get("__line__", "?")
-        # Required fields — explicit blank checks before building
-        for required in ("quantity", "expected_delivery_date"):
-            if not row.get(required):
-                raise ValueError(f"line {line}: {required} is required and cannot be empty")
-        po: dict[str, Any] = {
-            "external_id": row.get("external_id", ""),
-            "item_external_id": row.get("item_external_id", ""),
-            "location_external_id": row.get("location_external_id", ""),
-            "supplier_external_id": row.get("supplier_external_id", ""),
-            "quantity": _to_float(row["quantity"], field="quantity", line=line),
-            "expected_delivery_date": _to_date_str(row["expected_delivery_date"], field="expected_delivery_date", line=line),
-        }
-        if row.get("uom"):
-            po["uom"] = row["uom"]
-        if row.get("status"):
-            po["status"] = row["status"]
-        pos.append(po)
-    return {"purchase_orders": pos, "dry_run": dry_run}
-
-
-def build_customer_orders_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
-    """Build the JSON body for POST /v1/ingest/customer-orders.
-
-    Required: external_id, item_external_id, location_external_id,
-              quantity, requested_delivery_date.
-    Optional: status (default 'open').
-    """
-    cos: list[dict[str, Any]] = []
-    for row in rows:
-        line = row.get("__line__", "?")
-        for required in ("quantity", "requested_delivery_date"):
-            if not row.get(required):
-                raise ValueError(f"line {line}: {required} is required and cannot be empty")
-        co: dict[str, Any] = {
-            "external_id": row.get("external_id", ""),
-            "item_external_id": row.get("item_external_id", ""),
-            "location_external_id": row.get("location_external_id", ""),
-            "quantity": _to_float(row["quantity"], field="quantity", line=line),
-            "requested_delivery_date": _to_date_str(row["requested_delivery_date"], field="requested_delivery_date", line=line),
-        }
-        if row.get("status"):
-            co["status"] = row["status"]
-        cos.append(co)
-    return {"customer_orders": cos, "dry_run": dry_run}
-
-
-def build_forecasts_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
-    """Build the JSON body for POST /v1/ingest/forecast-demand.
-
-    Required: item_external_id, location_external_id, quantity, bucket_date.
-    Optional: time_grain (default 'week'), source (default 'statistical').
-    quantity may be 0 (explicit "no forecast" for this bucket) — only blocks if blank.
-    """
-    forecasts: list[dict[str, Any]] = []
-    for row in rows:
-        line = row.get("__line__", "?")
-        # quantity can be 0 but must be present
-        q_raw = row.get("quantity", "")
-        if q_raw == "":
-            raise ValueError(f"line {line}: quantity is required and cannot be empty")
-        if not row.get("bucket_date"):
-            raise ValueError(f"line {line}: bucket_date is required and cannot be empty")
-        rec: dict[str, Any] = {
-            "item_external_id": row.get("item_external_id", ""),
-            "location_external_id": row.get("location_external_id", ""),
-            "quantity": _to_float(q_raw, field="quantity", line=line),
-            "bucket_date": _to_date_str(row["bucket_date"], field="bucket_date", line=line),
-        }
-        if row.get("time_grain"):
-            rec["time_grain"] = row["time_grain"]
-        if row.get("source"):
-            rec["source"] = row["source"]
-        forecasts.append(rec)
-    return {"forecasts": forecasts, "dry_run": dry_run}
-
-
-def build_transfers_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
-    """Build the JSON body for POST /v1/ingest/transfers.
-
-    Required: external_id, item_external_id, from_location_external_id,
-              to_location_external_id, quantity, expected_delivery_date.
-    Optional: status (default 'planned').
-    Local extra check: from != to (also enforced server-side but caught earlier here).
-    """
-    transfers: list[dict[str, Any]] = []
-    for row in rows:
-        line = row.get("__line__", "?")
-        for required in ("quantity", "expected_delivery_date"):
-            if not row.get(required):
-                raise ValueError(f"line {line}: {required} is required and cannot be empty")
-        f_loc = row.get("from_location_external_id", "")
-        t_loc = row.get("to_location_external_id", "")
-        if f_loc and t_loc and f_loc == t_loc:
-            raise ValueError(
-                f"line {line}: from_location_external_id and to_location_external_id "
-                f"must differ (both = '{f_loc}')"
-            )
-        tr: dict[str, Any] = {
-            "external_id": row.get("external_id", ""),
-            "item_external_id": row.get("item_external_id", ""),
-            "from_location_external_id": f_loc,
-            "to_location_external_id": t_loc,
-            "quantity": _to_float(row["quantity"], field="quantity", line=line),
-            "expected_delivery_date": _to_date_str(row["expected_delivery_date"], field="expected_delivery_date", line=line),
-        }
-        if row.get("status"):
-            tr["status"] = row["status"]
-        transfers.append(tr)
-    return {"transfers": transfers, "dry_run": dry_run}
-
-
-PAYLOAD_BUILDERS = {
-    "items.tsv":                build_items_payload,
-    "locations.tsv":            build_locations_payload,
-    "suppliers.tsv":            build_suppliers_payload,
-    "supplier_items.tsv":       build_supplier_items_payload,
-    "item_planning_params.tsv": build_item_planning_params_payload,
-    "on_hand.tsv":              build_on_hand_payload,
-    "purchase_orders.tsv":      build_purchase_orders_payload,
-    "customer_orders.tsv":      build_customer_orders_payload,
-    "forecasts.tsv":            build_forecasts_payload,
-    "transfers.tsv":            build_transfers_payload,
-}
-
-
-# ─────────────────────────────────────────────────────────────
-# API call (in-process via TestClient)
-# ─────────────────────────────────────────────────────────────
-def call_api(endpoint: str, payload: dict[str, Any], token: str) -> tuple[int, dict]:
-    """Call the FastAPI app in-process via TestClient. No HTTP server needed."""
-    from fastapi.testclient import TestClient
-    from ootils_core.api.app import app
-
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json",
-    }
-    with TestClient(app) as client:
-        resp = client.post(endpoint, json=payload, headers=headers)
-    try:
-        body = resp.json()
-    except Exception:
-        body = {"raw_body": resp.text}
-    return resp.status_code, body
-
-
-# ─────────────────────────────────────────────────────────────
-# Archiving
-# ─────────────────────────────────────────────────────────────
-def archive(source: Path, dest_dir: Path, report: dict[str, Any]) -> tuple[Path, Path]:
-    """Move source file to dest_dir with a timestamp-suffixed name + drop report next to it."""
-    dest_dir.mkdir(parents=True, exist_ok=True)
-    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-    stem = source.stem
-    suffix = source.suffix
-    new_name = f"{stem}_{ts}{suffix}"
-    target = dest_dir / new_name
-    shutil.move(str(source), str(target))
-
-    report_path = dest_dir / f"{stem}_{ts}.report.json"
-    report_path.write_text(
-        json.dumps(report, indent=2, default=str, ensure_ascii=False),
-        encoding="utf-8",
-    )
-    return target, report_path
-
-
-def archive_group(sources: list[Path], dest_dir: Path, report: dict[str, Any]) -> list[Path]:
-    """Archive N sibling files (a part group) together, one timestamped move
-    each (same naming as `archive()`), sharing ONE `--report.json` next to
-    the FIRST file (caller's ordering — expected ascending part number) and
-    a minimal pointer report next to every other file. Mirrors the existing
-    bom-bundle archiving pattern (`handle_bom_bundle`)."""
-    if not sources:
-        raise ValueError("no source files to archive")
-
-    dest_dir.mkdir(parents=True, exist_ok=True)
-    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-    primary_name = sources[0].name
-    targets: list[Path] = []
-
-    for i, source in enumerate(sources):
-        stem = source.stem
-        suffix = source.suffix
-        target = dest_dir / f"{stem}_{ts}{suffix}"
-        shutil.move(str(source), str(target))
-        targets.append(target)
-
-        report_path = dest_dir / f"{stem}_{ts}.report.json"
-        body = report if i == 0 else {"bundled_with": primary_name, "see_main_report": True}
-        report_path.write_text(
-            json.dumps(body, indent=2, default=str, ensure_ascii=False),
-            encoding="utf-8",
-        )
-
-    return targets
+__all__ = [
+    "DISPATCH",
+    "PAYLOAD_BUILDERS",
+    "ParsedFilename",
+    "archive",
+    "archive_group",
+    "build_bom_payloads",
+    "call_api",
+    "find_sibling_parts",
+    "parse_ingest_filename",
+    "parse_tsv",
+    "parse_tsv_parts",
+    "handle_bom_bundle",
+    "handle_part_group",
+    "main",
+]
 
 
 def _find_archived(missing_path: Path) -> Path | None:
@@ -784,90 +131,6 @@ def _find_archived(missing_path: Path) -> Path | None:
 # ─────────────────────────────────────────────────────────────
 # BOM bundle handler — 2 files (header + components) → N API calls (1 per BOM)
 # ─────────────────────────────────────────────────────────────
-def _build_bom_payloads(
-    header_rows: list[dict[str, str]],
-    component_rows: list[dict[str, str]],
-) -> list[dict[str, Any]]:
-    """Group components by (parent_external_id, bom_version) and merge with
-    header metadata. Returns one payload dict per BOM, ready to POST.
-
-    Raises ValueError if a component references a (parent, version) absent
-    from the header, or if a header has zero components.
-    """
-    # Index headers by (parent, version)
-    header_index: dict[tuple[str, str], dict[str, str]] = {}
-    for hr in header_rows:
-        line = hr.get("__line__", "?")
-        parent = hr.get("parent_external_id", "").strip()
-        version = hr.get("bom_version", "").strip() or "1.0"
-        if not parent:
-            raise ValueError(f"bom_header.tsv line {line}: parent_external_id is required")
-        key = (parent, version)
-        if key in header_index:
-            raise ValueError(
-                f"bom_header.tsv line {line}: duplicate (parent={parent}, version={version})"
-            )
-        header_index[key] = hr
-
-    # Group components by (parent, version)
-    components_by_key: dict[tuple[str, str], list[dict[str, Any]]] = {}
-    for cr in component_rows:
-        line = cr.get("__line__", "?")
-        parent = cr.get("parent_external_id", "").strip()
-        version = cr.get("bom_version", "").strip()
-        if not parent or not version:
-            raise ValueError(
-                f"bom_components.tsv line {line}: parent_external_id and bom_version are required"
-            )
-        key = (parent, version)
-        if key not in header_index:
-            raise ValueError(
-                f"bom_components.tsv line {line}: (parent={parent}, version={version}) "
-                f"has no matching row in bom_header.tsv"
-            )
-        comp_ext = cr.get("component_external_id", "").strip()
-        if not comp_ext:
-            raise ValueError(
-                f"bom_components.tsv line {line}: component_external_id is required"
-            )
-        if not cr.get("quantity_per"):
-            raise ValueError(
-                f"bom_components.tsv line {line}: quantity_per is required"
-            )
-        comp: dict[str, Any] = {
-            "component_external_id": comp_ext,
-            "quantity_per": _to_float(cr["quantity_per"], field="quantity_per", line=line),
-        }
-        if cr.get("uom"):
-            comp["uom"] = cr["uom"]
-        if cr.get("scrap_factor"):
-            comp["scrap_factor"] = _to_float(cr["scrap_factor"], field="scrap_factor", line=line)
-        components_by_key.setdefault(key, []).append(comp)
-
-    # Build one payload per BOM (every header must have at least 1 component)
-    payloads: list[dict[str, Any]] = []
-    for (parent, version), hr in header_index.items():
-        comps = components_by_key.get((parent, version))
-        if not comps:
-            raise ValueError(
-                f"bom_header.tsv: BOM (parent={parent}, version={version}) "
-                f"has no components in bom_components.tsv"
-            )
-        line = hr.get("__line__", "?")
-        payload: dict[str, Any] = {
-            "parent_external_id": parent,
-            "bom_version": version,
-            "components": comps,
-        }
-        if hr.get("effective_from"):
-            payload["effective_from"] = _to_date_str(
-                hr["effective_from"], field="effective_from", line=line
-            )
-        payloads.append(payload)
-
-    return payloads
-
-
 def handle_bom_bundle(header_path: Path, dry_run: bool, token: str, *, date: str | None = None) -> int:
     """Bundle BOM ingestion: reads header + components from the same dir, emits N API calls.
 
@@ -914,7 +177,7 @@ def handle_bom_bundle(header_path: Path, dry_run: bool, token: str, *, date: str
 
     # ── 2. Cross-file merge & validation ───────────────────────
     try:
-        payloads = _build_bom_payloads(header_rows, component_rows)
+        payloads = build_bom_payloads(header_rows, component_rows)
     except ValueError as e:
         logger.error("bundle validation error: %s", e)
         report = {

--- a/scripts/run_daily_ingest.py
+++ b/scripts/run_daily_ingest.py
@@ -1,0 +1,221 @@
+"""
+run_daily_ingest.py — the daily governed-run CLI (ADR-042 decision 3, PR-4b).
+
+Runs ``engine.ingest.daily_orchestrator`` end to end for one ``run_date``:
+scan the inbox for today's dated TSV drops, resolve each feed_key's active
+contract, evaluate PR-2's runtime guards, compute PR-3's governed decision,
+and — gated all-or-nothing on that decision — load every feed whose OWN
+guard is green, reusing the exact same parse/build/call/archive primitives
+``scripts/ingest_file.py`` uses for a manual single-file drop.
+
+DRY-RUN BY DEFAULT: without ``--apply`` this only calls ``plan_daily_run``
+(SELECT-only preview — zero ``daily_runs`` INSERTs, zero
+``daily_run_completed`` event, zero L3 webhook call) and reports the scan,
+each feed's guard verdict, and the decision that WOULD be taken — nothing is
+loaded, nothing moves in the inbox. ``--apply`` is additionally gated by the
+``OOTILS_DAILY_RUN_ENABLED`` kill switch (must be exactly one of
+'1'/'true'/'yes'/'on'; unset or any other value refuses ``--apply`` before a
+DB connection is even opened) — the same double-guard shape as
+``scripts/purge_maintenance.py``'s ``OOTILS_PURGE_ENABLED``.
+
+NO AUTOMATIC RECOMPUTE (deliberate, V1 scope). Loading the green feeds is
+this script's entire job. Propagation / shortage detection is a SEPARATE,
+deliberate call an operator (or a future PR) makes afterwards, e.g.:
+    OOTILS_API_TOKEN=... DATABASE_URL=... python scripts/... (calc:run path)
+Coupling the load and the recompute here would silently widen this PR's
+blast radius (the API endpoints this script calls already trigger their own
+per-entity DQ/graph writes — see ``engine.ingest.daily_orchestrator``'s
+module docstring — but nothing here re-runs propagation across the whole
+graph). A future PR may wire this explicitly; today it is a conscious
+omission, not an oversight.
+
+AUTH: reads ``OOTILS_API_TOKEN`` from the environment, exactly like
+``scripts/ingest_file.py`` — the SAME in-process bearer token, passed
+through to every ``/v1/ingest/<entity>`` call the load phase makes (scope
+``ingest``, per ``api/routers/ingest.py``'s ``require_scope("ingest")`` on
+every route this script can reach). Not read/required in dry-run mode (the
+preview never calls the API). Automatic recompute is explicitly OUT of
+scope (see above) so a ``calc:run``-scoped token is never needed here.
+
+Usage:
+    DATABASE_URL=postgresql://... OOTILS_API_TOKEN=... \\
+    OOTILS_DAILY_RUN_ENABLED=1 python scripts/run_daily_ingest.py \\
+        [--inbox /home/debian/inbox] [--date 2026-07-18] [--apply] [--allow-dev]
+
+Exit codes: 0 the orchestrator ran to completion (including an ESCALATED
+run that loaded nothing by design — check the printed decision / logs, the
+L3 webhook is the real escalation channel, not this exit code); 1 --apply
+refused by the kill switch or a missing OOTILS_API_TOKEN; 2 missing
+DATABASE_URL, a bad --date, a bad --inbox path (does not exist), or bad
+CLI args.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import psycopg
+from psycopg.rows import dict_row
+
+import mrp_core as core
+
+from ootils_core.engine.ingest.apply import RunDecisionStatus
+from ootils_core.engine.ingest.daily_orchestrator import (
+    DailyRunEvaluation,
+    FeedLoadOutcome,
+    apply_daily_run,
+    load_eligible_feeds,
+    plan_daily_run,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+logger = logging.getLogger("run_daily_ingest")
+
+_DEFAULT_INBOX = "/home/debian/inbox"
+
+
+def _daily_run_enabled() -> bool:
+    """Kill switch, default OFF — same truthy-set + double-guard shape as
+    ``purge_maintenance.py``'s ``OOTILS_PURGE_ENABLED``."""
+    return os.environ.get("OOTILS_DAILY_RUN_ENABLED", "0").strip().lower() in {
+        "1", "true", "yes", "on",
+    }
+
+
+def _report_evaluation(evaluation: DailyRunEvaluation) -> None:
+    scan = evaluation.scan
+    logger.info(
+        "SCAN inbox feeds_found=%d issues=%d ignored=%d",
+        len(scan.feeds), len(scan.issues), len(scan.ignored),
+    )
+    for feed_key, scanned in sorted(scan.feeds.items()):
+        logger.info(
+            "  feed_key=%-24s rows=%-6d parts=%d arrived_at=%s",
+            feed_key, scanned.row_count, len(scanned.paths), scanned.file_arrived_at.isoformat(),
+        )
+    for feed_key, issue in sorted(scan.issues.items()):
+        logger.warning("  feed_key=%-24s SCAN ISSUE: %s", feed_key, issue.error)
+
+    if evaluation.ungoverned_feed_keys:
+        logger.warning(
+            "UNGOVERNED feed_keys present in inbox (no active feed_contracts row): %s",
+            ", ".join(evaluation.ungoverned_feed_keys),
+        )
+
+    logger.info("GUARD VERDICTS (%d governed feed(s))", len(evaluation.feed_evaluations))
+    for fe in evaluation.feed_evaluations:
+        logger.info(
+            "  feed_key=%-24s criticality=%-9s overall_status=%s",
+            fe.feed_key, fe.contract.criticality, fe.evaluation.overall_status.value,
+        )
+        for result in fe.evaluation.results:
+            if result.status.value != "ok":
+                logger.info("    %-16s %-13s %s", result.guard_name, result.status.value, result.detail)
+
+    if evaluation.decision is None:
+        logger.error("DECISION: none computable (no active feed_contracts row evaluated)")
+    else:
+        logger.info(
+            "DECISION status=%s feeds=%d",
+            evaluation.decision.status.value, len(evaluation.decision.feeds),
+        )
+        for reason in evaluation.decision.reasons:
+            logger.info("  %s", reason)
+
+
+def _report_load_outcomes(outcomes: tuple[FeedLoadOutcome, ...]) -> None:
+    by_status: dict[str, int] = {}
+    for o in outcomes:
+        by_status[o.status.value] = by_status.get(o.status.value, 0) + 1
+    logger.info("LOAD OUTCOMES total=%d %s", len(outcomes), by_status)
+    for o in outcomes:
+        logger.info(
+            "  feed_key=%-24s canonical=%-28s status=%-18s %s",
+            o.feed_key, o.canonical or "-", o.status.value, o.detail,
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Daily governed-run orchestrator (ADR-042 PR-4b) — scans "
+        "an inbox, evaluates PR-2 guards + PR-3 decision, loads the green "
+        "feeds. Dry-run by default."
+    )
+    p.add_argument("--dsn", default=os.environ.get("DATABASE_URL"))
+    p.add_argument("--inbox", default=_DEFAULT_INBOX, help=f"inbox directory (default: {_DEFAULT_INBOX})")
+    p.add_argument("--date", default=None, help="run_date as YYYY-MM-DD (default: today UTC)")
+    p.add_argument("--apply", action="store_true", help="actually persist + load (default: dry-run / preview only)")
+    p.add_argument("--allow-dev", action="store_true")
+    args = p.parse_args(argv)
+
+    if not args.dsn:
+        logger.error("DATABASE_URL not set")
+        return 2
+
+    if args.date is None:
+        run_date = datetime.now(timezone.utc).date()
+    else:
+        try:
+            run_date = date.fromisoformat(args.date)
+        except ValueError:
+            logger.error("--date %r is not a valid YYYY-MM-DD date", args.date)
+            return 2
+
+    inbox_dir = Path(args.inbox)
+
+    if args.apply and not _daily_run_enabled():
+        logger.error(
+            "REFUSED: --apply requires OOTILS_DAILY_RUN_ENABLED=1 (got %r)",
+            os.environ.get("OOTILS_DAILY_RUN_ENABLED"),
+        )
+        return 1
+
+    token: str | None = None
+    if args.apply:
+        token = os.environ.get("OOTILS_API_TOKEN")
+        if not token:
+            logger.error("REFUSED: --apply requires OOTILS_API_TOKEN to be set")
+            return 1
+
+    db = core.guard_db(args.dsn, args.allow_dev)
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    logger.info(
+        "Daily Ingest Orchestrator (ADR-042 PR-4b) running on DB=%s inbox=%s run_date=%s mode=%s",
+        db, inbox_dir, run_date, mode,
+    )
+
+    try:
+        with psycopg.connect(args.dsn, row_factory=dict_row) as conn:
+            if not args.apply:
+                evaluation = plan_daily_run(conn, inbox_dir, run_date)
+                _report_evaluation(evaluation)
+                logger.info("DRY-RUN — nothing persisted, nothing loaded.")
+                return 0
+
+            evaluation = apply_daily_run(conn, inbox_dir, run_date)
+            conn.commit()
+            _report_evaluation(evaluation)
+
+            assert token is not None  # guarded above
+            outcomes = load_eligible_feeds(evaluation, token=token, inbox_dir=inbox_dir)
+            _report_load_outcomes(outcomes)
+    except FileNotFoundError as exc:
+        logger.error("REFUSED: %s", exc)
+        return 2
+
+    if evaluation.decision is not None and evaluation.decision.status == RunDecisionStatus.ESCALATED:
+        logger.error(
+            "RUN ESCALATED for run_date=%s — nothing loaded, L3 webhook already notified.", run_date,
+        )
+    logger.info("=" * 92)
+    logger.info("DAILY INGEST ORCHESTRATOR — COMPLETED (mode=%s, run_date=%s)", mode, run_date)
+    logger.info("=" * 92)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ootils_core/engine/ingest/__init__.py
+++ b/src/ootils_core/engine/ingest/__init__.py
@@ -1,6 +1,6 @@
 """
-Governed daily-run decision engine (ADR-042 PR-3, absorbs ADR-037's INT-1
-PR3, migration 079).
+Governed daily-run pipeline (ADR-042 decisions 3/PR-3/PR-4b, absorbs
+ADR-037's INT-1 PR3, migrations 078/079).
 
 ``apply.py`` combines the per-feed guard verdicts persisted by PR-2
 (``interfaces.daily_run``/``interfaces.guards``, ``daily_runs`` table,
@@ -14,6 +14,14 @@ multi-entity upsert/writer from ``api/routers/ingest.py``, that stays PR-1
 of ADR-042's plan; and how a feed's DQ status is supplied, since no
 DB wiring from a ``daily_runs`` row to an ``ingest_batches`` row exists
 yet).
+
+``daily_orchestrator.py`` (PR-4b) is the conductor that actually RUNS a
+daily cycle: scans an inbox for today's dated TSV drops, resolves each
+feed_key's active contract, feeds PR-2's guards + PR-3's decision, and —
+gated all-or-nothing on the decision — loads every feed whose OWN guard
+verdict is green via ``interfaces.ingest_exec``'s canonical primitives. See
+its module docstring for the full scope (the feed_key/entity_type mismatch,
+BOM being out of scope in V1, no automatic recompute, baseline-only).
 """
 from ootils_core.engine.ingest.apply import (
     DailyRunDecision,
@@ -26,6 +34,20 @@ from ootils_core.engine.ingest.apply import (
     plan_daily_run_decision,
     record_daily_run_decision,
 )
+from ootils_core.engine.ingest.daily_orchestrator import (
+    LOAD_ORDER,
+    DailyRunEvaluation,
+    FeedLoadOutcome,
+    FeedLoadStatus,
+    FeedRunEvaluation,
+    InboxScan,
+    ScanIssue,
+    ScannedFeedFile,
+    apply_daily_run,
+    load_eligible_feeds,
+    plan_daily_run,
+    scan_inbox,
+)
 
 __all__ = [
     "DailyRunDecision",
@@ -37,4 +59,16 @@ __all__ = [
     "decide_daily_run",
     "plan_daily_run_decision",
     "record_daily_run_decision",
+    "LOAD_ORDER",
+    "DailyRunEvaluation",
+    "FeedLoadOutcome",
+    "FeedLoadStatus",
+    "FeedRunEvaluation",
+    "InboxScan",
+    "ScanIssue",
+    "ScannedFeedFile",
+    "apply_daily_run",
+    "load_eligible_feeds",
+    "plan_daily_run",
+    "scan_inbox",
 ]

--- a/src/ootils_core/engine/ingest/daily_orchestrator.py
+++ b/src/ootils_core/engine/ingest/daily_orchestrator.py
@@ -1,0 +1,855 @@
+"""
+daily_orchestrator.py — the daily-run conductor (ADR-042 decision 3, "la
+séquence entrante d'un run quotidien"; PR-4b of the doctrine's plan).
+
+Wires together, end to end, everything PR-2/PR-3 already built:
+
+  1. **Scan** an inbox directory for TODAY's dated TSV drops
+     (``<feed_key>_<AAAAMMJJ>.tsv``, plus grouped ``.partNN`` siblings —
+     ``interfaces.ingest_exec.parse_ingest_filename``/``find_sibling_parts``/
+     ``parse_tsv_parts``, PR-4a's filename grammar).
+  2. **Resolve** each scanned feed_key's active contract
+     (``interfaces.contracts.list_active_contracts``/``get_active_contract``)
+     — see "THE feed_key / entity_type MISMATCH" below.
+  3. **Observe**: file arrival time (mtime) + row count feed the runtime
+     guards (``interfaces.daily_run.record_daily_run``, PR-2).
+  4. **Decide**: combine every feed's guard verdict into ONE governed
+     run-level decision (``engine.ingest.apply.record_daily_run_decision``,
+     PR-3) — with ``dq_status_by_feed`` deliberately EMPTY (see "DQ STATUS —
+     V1 IS HONEST, NOT WIRED" below).
+  5. **Gate, then load**: an ESCALATED run loads NOTHING (the L3 webhook is
+     already fired by step 4's own call into
+     ``notifications.l3_webhook.notify_daily_run_escalation`` — this module
+     never emits a second escalation or a second ``daily_run_completed``
+     event, ADR-027's one-event-per-run convention); otherwise, every feed
+     whose OWN guard evaluation is green gets loaded, in FK-dependency
+     order, by re-using — never duplicating — ``interfaces.ingest_exec``'s
+     canonical parse/build/call/archive primitives (the same ones
+     ``scripts/ingest_file.py`` uses for a manual single-file drop).
+
+THE feed_key / entity_type MISMATCH (read before touching ``_canonical_
+dispatch_name``). A governed feed's inbox filename is named after its
+``feed_contracts`` row's ``feed_key`` — kebab-case by the registry's own
+convention (``config/feed-contracts/on-hand.yaml``: ``feed_key: on-hand``,
+so the file is ``on-hand_20260718.tsv``). ``interfaces.ingest_exec.DISPATCH``
+(inherited from PR-4a) is keyed by ``entity_type`` in snake_case
+(``on_hand.tsv``) — the two vocabularies do NOT coincide. The active
+contract's own ``entity_type`` column is the ONLY authority for this
+translation (config/feed-contracts/*.yaml wins, never a guess derived from
+the filename) — ``_canonical_dispatch_name`` performs exactly this lookup.
+A feed_key with NO active contract (a referential/on-demand entity that was
+never given a ``feed_contracts`` row by design — ADR-042 decision 1's table
+marks items/locations/suppliers/supplier_items/item_planning_params/BOM
+"jamais dans le run bloquant quotidien") has no ``entity_type`` to translate
+through; its raw feed_key is used AS the canonical stem directly, which is
+already correct for every entity in that referential set (none of them was
+ever given a kebab alias distinct from its DISPATCH key).
+
+A DEACTIVATED CONTRACT IS NOT AN UNGOVERNED FEED. A feed_key that HAS a
+``feed_contracts`` row but no currently ACTIVE version (an operator retired
+it — ``interfaces.contracts``' "ACTIVE SEMANTICS") must never fall through
+to the ungoverned "loaded without governance" path, which is reserved for
+feed_keys the registry has genuinely never heard of.
+``interfaces.contracts.list_known_feed_keys`` (every feed_key ever
+registered, active or not) lets ``_quarantine_deactivated_contracts`` catch
+this case explicitly: any file scanned for such a feed_key becomes a
+``ScanIssue`` ("contract deactivated — refusing feed") before resolution
+even runs, so it is rejected by the SAME scan-issue machinery that already
+handles a malformed TSV, never loaded, and never counted in
+``ungoverned_feed_keys``.
+
+DQ STATUS — V1 IS HONEST, NOT WIRED. ``engine.ingest.apply.
+record_daily_run_decision`` accepts a caller-supplied ``dq_status_by_feed``
+mapping; this orchestrator always passes ``None`` (empty). Per that module's
+own None-honest vocabulary, an absent DQ status is NOT_EVALUATED — which
+means the run-level decision can reach ``AUTO_APPROVED`` for exactly zero
+real V1 runs (NOT_EVALUATED is never silently promoted to green) and will
+sit at best on ``DEGRADED`` (or ``ESCALATED`` on an actual blocking-feed
+guard failure). This is a DELIBERATE, ACCEPTED consequence, not a bug to
+route around — see ``engine.ingest.apply``'s own docstring, "DQ STATUS HAS
+NO DB WIRING YET". Crucially, the per-feed LOAD gate below does NOT use this
+combined (guard+DQ) status — it uses the feed's raw GUARD verdict
+(``FeedGuardEvaluation.overall_status``, PR-2, "only ever OK or FAILED,
+never NOT_EVALUATED at that column"). This is what makes DEGRADED (the
+permanent V1 steady state) still a productive outcome: a run that is
+DEGRADED because DQ is unwired still loads every feed whose OWN runtime
+guard passed; DEGRADED only means "a human should not treat this run's
+confidence as fully proven", never "nothing loaded".
+
+BOM IS OUT OF SCOPE IN V1. ``bom_header.tsv``/``bom_components.tsv`` have no
+entry in ``interfaces.ingest_exec.PAYLOAD_BUILDERS`` (only in ``DISPATCH``,
+as a sentinel — the 2-file, N-payload bundle needs
+``scripts.ingest_file.handle_bom_bundle``'s bespoke orchestration). Since
+BOM is referential/on-demand by ADR-042 doctrine ("à la demande, jamais dans
+le run bloquant quotidien"), a scanned ``bom_header`` feed is reported as
+``FeedLoadStatus.UNSUPPORTED_ENTITY`` and archived to ``rejected/`` with a
+clear reason — load it manually via ``scripts/ingest_file.py`` instead. The
+same applies to any other entity with no registered builder (e.g.
+``work_orders`` — ``open-work-orders.yaml`` declares the contract, but
+``ingest_exec.PAYLOAD_BUILDERS`` has no ``work_orders.tsv`` entry yet,
+despite ``POST /v1/ingest/work-orders`` existing — a capability gap this
+module surfaces loudly, never bypasses).
+
+DEPENDS_ON IS NOT TOPO-SORTED IN V1. Load ordering follows ``LOAD_ORDER``
+only (the FK-respecting order mirrored from ``scripts/bulk_ingest.py``'s
+``ORDERED_FILES`` — the "MANIFEST V1"), NOT each contract's own
+``depends_on`` field. All 3 seed contracts declare an empty ``depends_on``,
+so this is a no-op today; a contract that later declares a real dependency
+needs a topological sort added here (not yet written).
+
+SCOPE — WHAT THIS MODULE DOES NOT DO. No automatic recompute: loading data
+is this module's whole job; triggering propagation/shortage detection is a
+DELIBERATE, SEPARATE call the operator (or a future PR) makes afterwards —
+see ``scripts/run_daily_ingest.py``'s docstring. No commit/rollback: like
+every other ``interfaces``/``engine.ingest`` module in this repo, functions
+here never call ``conn.commit()``/``conn.rollback()`` — the caller (the CLI)
+owns the transaction. Baseline-only: every write this module drives — the
+``daily_runs`` rows, the governed decision, the canonical loads via
+``/v1/ingest/<entity>`` — is baseline by construction (ADR-030's rationale:
+an ERP feed is an OBSERVED fact, not a fork's counter-factual); no
+``scenario_id`` parameter is exposed for the load path, and
+``apply_daily_run``'s own ``scenario_id`` defaults to
+``BASELINE_SCENARIO_ID`` and exists only as the same test-seam
+``engine.ingest.apply.record_daily_run_decision`` already carries.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from ootils_core.constants import BASELINE_SCENARIO_ID
+from ootils_core.db.types import DictRowConnection
+from ootils_core.engine.ingest.apply import (
+    DailyRunDecision,
+    FeedDecisionInput,
+    RunDecisionStatus,
+    decide_daily_run,
+    record_daily_run_decision,
+)
+from ootils_core.interfaces.contracts import (
+    FeedContract,
+    list_active_contracts,
+    list_known_feed_keys,
+)
+from ootils_core.interfaces.daily_run import (
+    DailyRunObservation,
+    plan_daily_run_guard_check,
+    record_daily_run,
+)
+from ootils_core.interfaces.guards import FeedGuardEvaluation, GuardStatus, evaluate_feed_guards
+from ootils_core.interfaces.ingest_exec import (
+    DISPATCH,
+    PAYLOAD_BUILDERS,
+    ParsedFilename,
+    archive,
+    archive_group,
+    call_api,
+    find_sibling_parts,
+    parse_ingest_filename,
+    parse_tsv,
+    parse_tsv_parts,
+)
+
+logger = logging.getLogger(__name__)
+
+# FK-respecting load order — mirrors scripts/bulk_ingest.py's ORDERED_FILES
+# (the "MANIFEST V1"). Kept in lockstep by CONVENTION, not by import:
+# scripts/ is outside the installed package boundary (same reason
+# ingest_exec.py exists at all — see module docstring), so this list is a
+# deliberate, documented duplicate of a short constant, not a second
+# canonical WRITER (nothing here re-implements bulk_ingest.py's loaders).
+# A canonical filename absent from this tuple sorts LAST (see
+# `_load_order_key`), never refused outright.
+LOAD_ORDER: tuple[str, ...] = (
+    "items.tsv",
+    "locations.tsv",
+    "suppliers.tsv",
+    "supplier_items.tsv",
+    "item_planning_params.tsv",
+    "on_hand.tsv",
+    "purchase_orders.tsv",
+    "customer_orders.tsv",
+    "transfers.tsv",
+    "forecasts.tsv",
+    "bom_header.tsv",
+)
+
+
+def _mtime_utc(path: Path) -> datetime:
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+
+
+# ─────────────────────────────────────────────────────────────
+# 1. Inbox scan — pure filesystem + parsing, zero DB
+# ─────────────────────────────────────────────────────────────
+@dataclass(frozen=True)
+class ScannedFeedFile:
+    """One feed_key's file(s) found in the inbox for one ``run_date`` — a
+    single file, or N ``.partNN`` siblings already grouped ascending by
+    ``find_sibling_parts``, parsed once (headers + rows kept in memory so
+    the later load phase never re-reads the file from disk)."""
+
+    feed_key: str
+    paths: tuple[Path, ...]
+    file_arrived_at: datetime  # max mtime across paths, UTC-aware
+    headers: tuple[str, ...]
+    rows: tuple[dict[str, str], ...]
+
+    @property
+    def row_count(self) -> int:
+        return len(self.rows)
+
+
+@dataclass(frozen=True)
+class ScanIssue:
+    """A feed_key's file(s) that could not be turned into a
+    ``ScannedFeedFile`` — a malformed part grouping (duplicate part number)
+    or a TSV parse error (bad column count, empty file, ...). The file(s)
+    still exist and their arrival time is still knowable — only their
+    CONTENT is unusable, so ``row_count`` stays ``None`` (never a fabricated
+    0) for the guard evaluation, and the load phase always rejects them."""
+
+    feed_key: str
+    paths: tuple[Path, ...]
+    file_arrived_at: datetime
+    error: str
+
+
+@dataclass(frozen=True)
+class InboxScan:
+    """The result of one ``scan_inbox`` call."""
+
+    run_date: date
+    feeds: dict[str, ScannedFeedFile]
+    issues: dict[str, ScanIssue]
+    ignored: tuple[Path, ...]  # not dated for run_date, or not a '.tsv' name
+
+
+def scan_inbox(inbox_dir: Path, run_date: date) -> InboxScan:
+    """Scan ``inbox_dir`` (non-recursive) for every file dated ``run_date``
+    under the daily-drop grammar (``<feed_key>_<AAAAMMJJ>.tsv``, plus
+    ``.partNN`` groups sharing that date) and parse each into a
+    ``ScannedFeedFile``. Pure filesystem + parsing — no DB, no network,
+    never mutates the directory (files are archived only by the later load
+    phase, and only under ``--apply``).
+
+    A canonical (dateless) file, a file for a different date, or a name that
+    doesn't parse as ``<entity>[...].tsv`` at all is collected in
+    ``InboxScan.ignored`` rather than raising — this scan targets exactly
+    ONE day's drop; anything else is simply not today's business (a
+    canonical file is the ``scripts/ingest_file.py`` manual/on-demand path).
+
+    Raises ``FileNotFoundError`` if ``inbox_dir`` does not exist or is not a
+    directory — a missing inbox is a hard configuration error, never an
+    "empty scan".
+    """
+    if not inbox_dir.is_dir():
+        raise FileNotFoundError(f"scan_inbox: inbox directory does not exist: {inbox_dir}")
+
+    date_str = run_date.strftime("%Y%m%d")
+    feeds: dict[str, ScannedFeedFile] = {}
+    issues: dict[str, ScanIssue] = {}
+    ignored: list[Path] = []
+    handled: set[Path] = set()
+
+    candidates = sorted(p for p in inbox_dir.iterdir() if p.is_file())
+    for path in candidates:
+        if path in handled:
+            continue
+        try:
+            parsed: ParsedFilename = parse_ingest_filename(path.name)
+        except ValueError:
+            ignored.append(path)
+            continue
+        if parsed.date != date_str:
+            ignored.append(path)
+            continue
+
+        feed_key = parsed.entity
+        if feed_key in feeds or feed_key in issues:
+            # Two distinct file groups both resolving to the same feed_key
+            # for the same run_date — ambiguous, fail loudly and refuse BOTH:
+            # the group already accepted is EVICTED from `feeds` (revue PR-4b:
+            # le laisser chargeable contredisait « refusing both »).
+            prior = feeds.pop(feed_key, None)
+            prior_paths = prior.paths if prior is not None else ()
+            existing_issue = issues.get(feed_key)
+            if existing_issue is not None:
+                prior_paths = (*existing_issue.paths, *prior_paths)
+            issues[feed_key] = ScanIssue(
+                feed_key=feed_key,
+                paths=(*prior_paths, path),
+                file_arrived_at=_mtime_utc(path),
+                error=(
+                    f"feed_key {feed_key!r} matched more than one file group "
+                    f"for run_date={run_date} — ambiguous, refusing both"
+                ),
+            )
+            handled.add(path)
+            continue
+
+        if parsed.part is not None:
+            try:
+                group = find_sibling_parts(path)
+            except (FileNotFoundError, ValueError) as exc:
+                issues[feed_key] = ScanIssue(
+                    feed_key=feed_key,
+                    paths=(path,),
+                    file_arrived_at=_mtime_utc(path),
+                    error=str(exc),
+                )
+                handled.add(path)
+                continue
+        else:
+            group = [path]
+
+        for p in group:
+            handled.add(p)
+
+        arrived_at = max(_mtime_utc(p) for p in group)
+        try:
+            if len(group) == 1:
+                headers, rows = parse_tsv(group[0])
+            else:
+                headers, rows = parse_tsv_parts(group)
+        except (FileNotFoundError, ValueError) as exc:
+            issues[feed_key] = ScanIssue(
+                feed_key=feed_key, paths=tuple(group), file_arrived_at=arrived_at, error=str(exc),
+            )
+            continue
+
+        feeds[feed_key] = ScannedFeedFile(
+            feed_key=feed_key,
+            paths=tuple(group),
+            file_arrived_at=arrived_at,
+            headers=tuple(headers),
+            rows=tuple(rows),
+        )
+
+    logger.info(
+        "daily_orchestrator.scan_complete inbox=%s run_date=%s feeds=%d issues=%d ignored=%d",
+        inbox_dir, run_date, len(feeds), len(issues), len(ignored),
+    )
+    return InboxScan(run_date=run_date, feeds=feeds, issues=issues, ignored=tuple(ignored))
+
+
+# ─────────────────────────────────────────────────────────────
+# 2-4. Resolve + observe + decide
+# ─────────────────────────────────────────────────────────────
+@dataclass(frozen=True)
+class FeedRunEvaluation:
+    """One GOVERNED feed's guard evaluation for this run — either a REAL
+    persisted ``daily_runs`` row (``apply_daily_run``, ``daily_run_id``
+    set) or a PURE, zero-write preview (``plan_daily_run``,
+    ``daily_run_id`` is ``None``). Only feeds with an active
+    ``feed_contracts`` row get one of these — see ``DailyRunEvaluation.
+    ungoverned_feed_keys`` for everything else found in the inbox."""
+
+    feed_key: str
+    contract: FeedContract
+    observation: DailyRunObservation
+    evaluation: FeedGuardEvaluation
+    daily_run_id: UUID | None
+
+
+@dataclass(frozen=True)
+class DailyRunEvaluation:
+    """The full guard + governed-decision picture for one ``run_date`` —
+    the return value of both ``plan_daily_run`` (preview) and
+    ``apply_daily_run`` (the sole writer); ``is_applied`` tells them apart.
+    """
+
+    run_date: date
+    is_applied: bool
+    scan: InboxScan
+    feed_evaluations: tuple[FeedRunEvaluation, ...]
+    ungoverned_feed_keys: tuple[str, ...]
+    decision: DailyRunDecision | None  # None iff zero feeds were evaluated at all
+
+
+def _observation_for(feed_key: str, scan: InboxScan) -> DailyRunObservation:
+    """The caller-supplied observation `record_daily_run`/`evaluate_feed_
+    guards` need for one feed_key: file arrival time + row count when a
+    scan produced usable rows, arrival time only (row_count unknown, never
+    fabricated) when the scan hit a parse issue, or nothing at all when no
+    file was found for this feed_key on this run_date (the "flux totalement
+    absent" case the arrival-window guard exists to catch).
+    """
+    scanned = scan.feeds.get(feed_key)
+    if scanned is not None:
+        return DailyRunObservation(file_arrived_at=scanned.file_arrived_at, row_count=scanned.row_count)
+    issue = scan.issues.get(feed_key)
+    if issue is not None:
+        # Present-but-unusable file (unparseable TSV, ambiguous groups, bad
+        # parts). row_count=0 is the HONEST measure here — the file arrived
+        # and carries ZERO exploitable rows (distinct from the absent-file
+        # case below, where nothing was measured → None). Consequence by the
+        # EXISTING pure guard machinery: volume floor FAILED → a blocking
+        # feed escalates the whole run (ADR-042: charger les flux verts
+        # contre un blocking corrompu = image déchirée), an advisory feed is
+        # excluded. Revue PR-4b : sans ce 0, un blocking corrompu tombait en
+        # NOT_EVALUATED → DEGRADED et laissait charger les autres flux.
+        return DailyRunObservation(file_arrived_at=issue.file_arrived_at, row_count=0)
+    return DailyRunObservation(file_arrived_at=None, row_count=None)
+
+
+def _quarantine_deactivated_contracts(
+    scan: InboxScan, governed_keys: set[str], known_feed_keys: set[str],
+) -> InboxScan:
+    """A feed_key REGISTERED in ``feed_contracts`` (it has at least one
+    version, historical or current) but with NO currently active version is
+    a DEACTIVATED contract — distinct from a feed_key the registry has
+    never heard of. It must never fall back to the ungoverned "loaded
+    without governance" path (revue PR-4b, finding 3): any file scanned for
+    such a feed_key — whether it parsed cleanly into ``scan.feeds`` or was
+    already unusable in ``scan.issues`` — is turned into (or kept as) an
+    explicit ``ScanIssue`` so the load phase's existing scan-issue handling
+    rejects it uniformly, and it never appears in ``ungoverned_feed_keys``.
+    """
+    deactivated = (set(scan.feeds) | set(scan.issues)) & (known_feed_keys - governed_keys)
+    if not deactivated:
+        return scan
+
+    feeds = dict(scan.feeds)
+    issues = dict(scan.issues)
+    for feed_key in deactivated:
+        scanned = feeds.pop(feed_key, None)
+        if scanned is None:
+            # Already a ScanIssue for another reason (e.g. malformed TSV) —
+            # stays as-is: already excluded from load, already excluded from
+            # `ungoverned` by the known_feed_keys subtraction below.
+            continue
+        logger.error(
+            "daily_orchestrator.contract_deactivated feed_key=%s run_date=%s — "
+            "feed_contracts row exists but has no active version, refusing feed",
+            feed_key, scan.run_date,
+        )
+        issues[feed_key] = ScanIssue(
+            feed_key=feed_key,
+            paths=scanned.paths,
+            file_arrived_at=scanned.file_arrived_at,
+            error=(
+                f"feed_key {feed_key!r} — contract deactivated — refusing feed "
+                "(registered in feed_contracts but no active version)"
+            ),
+        )
+
+    return InboxScan(run_date=scan.run_date, feeds=feeds, issues=issues, ignored=scan.ignored)
+
+
+def _resolve_ungoverned(scan: InboxScan, known_feed_keys: set[str]) -> tuple[str, ...]:
+    """Feed_keys found in the inbox that the registry has NEVER heard of at
+    all (``known_feed_keys`` already covers active AND deactivated
+    versions, so subtracting it also excludes a deactivated contract's
+    feed_key — that one is surfaced separately by
+    ``_quarantine_deactivated_contracts``, never here)."""
+    scanned_keys = set(scan.feeds) | set(scan.issues)
+    ungoverned = tuple(sorted(scanned_keys - known_feed_keys))
+    for feed_key in ungoverned:
+        logger.warning(
+            "daily_orchestrator.no_contract feed_key=%s run_date=%s — file present "
+            "in inbox but no feed_contracts row at all (referential/on-demand "
+            "entity, or an undeclared feed — loaded without governance if the "
+            "run is not escalated)",
+            feed_key, scan.run_date,
+        )
+    return ungoverned
+
+
+def plan_daily_run(
+    conn: DictRowConnection,
+    inbox_dir: Path,
+    run_date: date,
+    *,
+    now: datetime | None = None,
+) -> DailyRunEvaluation:
+    """Read-only PREVIEW of one run_date's guard verdicts + governed
+    decision: ZERO writes, ZERO events, ZERO L3 webhook calls — safe to call
+    from a dry-run CLI invocation or a future read-only endpoint. Reads the
+    active contracts + each feed's previous ``daily_runs`` row (SELECT
+    only, via ``plan_daily_run_guard_check``) but never INSERTs.
+    """
+    evaluated_at = now if now is not None else datetime.now(timezone.utc)
+    scan = scan_inbox(inbox_dir, run_date)
+    contracts = list_active_contracts(conn)
+    known_feed_keys = list_known_feed_keys(conn)
+    governed_keys = {c.feed_key for c in contracts}
+    scan = _quarantine_deactivated_contracts(scan, governed_keys, known_feed_keys)
+    ungoverned = _resolve_ungoverned(scan, known_feed_keys)
+
+    feed_evaluations: list[FeedRunEvaluation] = []
+    feed_inputs: list[FeedDecisionInput] = []
+    for contract in contracts:
+        observation = _observation_for(contract.feed_key, scan)
+        guard_plan = plan_daily_run_guard_check(conn, contract.feed_key, run_date)
+        evaluation = evaluate_feed_guards(
+            feed_key=contract.feed_key,
+            criticality=contract.criticality,
+            cadence=contract.cadence,
+            arrival_window_minutes=contract.arrival_window_minutes,
+            volume_guard_min_rows=contract.volume_guard_min_rows,
+            volume_guard_max_pct_delta=contract.volume_guard_max_pct_delta,
+            run_date=run_date,
+            file_arrived_at=observation.file_arrived_at,
+            row_count=observation.row_count,
+            previous_row_count=guard_plan.previous_row_count,
+            deleted_count=observation.deleted_count,
+            previous_active_count=observation.previous_active_count,
+            now=evaluated_at,
+        )
+        feed_evaluations.append(
+            FeedRunEvaluation(
+                feed_key=contract.feed_key, contract=contract, observation=observation,
+                evaluation=evaluation, daily_run_id=None,
+            )
+        )
+        feed_inputs.append(
+            FeedDecisionInput(
+                feed_key=contract.feed_key, criticality=contract.criticality,
+                guard_status=evaluation.overall_status, dq_status=None,
+            )
+        )
+
+    decision = decide_daily_run(feed_inputs, run_date, evaluated_at=evaluated_at) if feed_inputs else None
+    return DailyRunEvaluation(
+        run_date=run_date, is_applied=False, scan=scan,
+        feed_evaluations=tuple(feed_evaluations), ungoverned_feed_keys=ungoverned, decision=decision,
+    )
+
+
+def apply_daily_run(
+    conn: DictRowConnection,
+    inbox_dir: Path,
+    run_date: date,
+    *,
+    now: datetime | None = None,
+    scenario_id: UUID = BASELINE_SCENARIO_ID,
+    source: str = "ingestion",
+    webhook_url: str | None = None,
+) -> DailyRunEvaluation:
+    """The SOLE writer of the guard+decision phase: persists one
+    ``daily_runs`` row per active contract (``interfaces.daily_run.
+    record_daily_run``, PR-2) then the governed run-level decision
+    (``engine.ingest.apply.record_daily_run_decision``, PR-3 — emits the
+    ONE ``daily_run_completed`` event and, on ESCALATED, the L3 webhook).
+
+    ``source`` feeds ``events.source`` (migration 002 CHECK: 'api' |
+    'ingestion' | 'engine' | 'user' | 'test') — defaults to ``'ingestion'``,
+    the accurate classification for this pipeline (NOT a free-text CLI
+    attribution string; passing anything outside that vocabulary raises
+    ``ValueError`` inside ``emit_stream_event``).
+
+    ``dq_status_by_feed`` is always ``None`` here — see module docstring
+    "DQ STATUS — V1 IS HONEST, NOT WIRED".
+
+    Does NOT commit — the caller (the CLI) owns the transaction. Does NOT
+    load anything — call ``load_eligible_feeds`` with this function's return
+    value next.
+    """
+    evaluated_at = now if now is not None else datetime.now(timezone.utc)
+    scan = scan_inbox(inbox_dir, run_date)
+    contracts = list_active_contracts(conn)
+    known_feed_keys = list_known_feed_keys(conn)
+    governed_keys = {c.feed_key for c in contracts}
+    scan = _quarantine_deactivated_contracts(scan, governed_keys, known_feed_keys)
+    ungoverned = _resolve_ungoverned(scan, known_feed_keys)
+
+    feed_evaluations: list[FeedRunEvaluation] = []
+    for contract in contracts:
+        observation = _observation_for(contract.feed_key, scan)
+        record = record_daily_run(conn, contract.feed_key, run_date, observation, now=evaluated_at)
+        feed_evaluations.append(
+            FeedRunEvaluation(
+                feed_key=contract.feed_key, contract=contract, observation=observation,
+                evaluation=record.evaluation, daily_run_id=record.daily_run_id,
+            )
+        )
+
+    decision: DailyRunDecision | None
+    if feed_evaluations:
+        decision = record_daily_run_decision(
+            conn, run_date, dq_status_by_feed=None, now=evaluated_at,
+            scenario_id=scenario_id, source=source, webhook_url=webhook_url,
+        )
+    else:
+        logger.error(
+            "daily_orchestrator.no_active_contracts run_date=%s — nothing to "
+            "evaluate, no governed decision possible", run_date,
+        )
+        decision = None
+
+    return DailyRunEvaluation(
+        run_date=run_date, is_applied=True, scan=scan,
+        feed_evaluations=tuple(feed_evaluations), ungoverned_feed_keys=ungoverned, decision=decision,
+    )
+
+
+# ─────────────────────────────────────────────────────────────
+# 5. Gate, then load
+# ─────────────────────────────────────────────────────────────
+class FeedLoadStatus(str, Enum):
+    """One feed's outcome for the load phase. Explicit vocabulary — never a
+    bare string — so a caller/report can branch on it without guessing."""
+
+    LOADED = "loaded"
+    REJECTED = "rejected"                    # API returned a non-2xx status
+    API_CRASH = "api_crash"                  # call_api raised
+    SCAN_ERROR = "scan_error"                # parse/grouping failure — archived to rejected
+    GUARD_FAILED = "guard_failed"            # this feed's own guard evaluation FAILED
+    NO_FILE = "no_file"                      # governed feed, no file found today
+    UNSUPPORTED_ENTITY = "unsupported_entity"  # no ingest_exec builder registered
+    RUN_ESCALATED = "run_escalated"          # top-level gate: whole run blocked
+
+
+@dataclass(frozen=True)
+class FeedLoadOutcome:
+    """One feed's outcome for the load phase — always emitted, even for a
+    feed that was never attempted (``NO_FILE``, ``RUN_ESCALATED``, ...), so
+    a daily report can list every expected feed's fate, not just the
+    successful ones."""
+
+    feed_key: str
+    canonical: str | None
+    status: FeedLoadStatus
+    http_status: int | None
+    detail: str
+
+
+def _canonical_dispatch_name(feed_key: str, contract: FeedContract | None) -> str:
+    """The ``ingest_exec.DISPATCH``/``PAYLOAD_BUILDERS`` lookup key for one
+    feed — see module docstring "THE feed_key / entity_type MISMATCH"."""
+    if contract is not None:
+        return f"{contract.entity_type}.tsv"
+    return f"{feed_key}.tsv"
+
+
+def _load_order_key(canonical: str) -> tuple[int, str]:
+    try:
+        idx = LOAD_ORDER.index(canonical)
+    except ValueError:
+        idx = len(LOAD_ORDER)
+    return (idx, canonical)
+
+
+def _archive_one_or_group(paths: tuple[Path, ...], dest_dir: Path, report: dict[str, Any]) -> None:
+    if len(paths) == 1:
+        archive(paths[0], dest_dir, report)
+    else:
+        archive_group(list(paths), dest_dir, report)
+
+
+def load_eligible_feeds(
+    evaluation: DailyRunEvaluation,
+    *,
+    token: str,
+    inbox_dir: Path,
+    processed_dir: Path | None = None,
+    rejected_dir: Path | None = None,
+) -> tuple[FeedLoadOutcome, ...]:
+    """Load every "green" feed found by ``apply_daily_run`` — reusing
+    ``interfaces.ingest_exec``'s parse/build/call/archive primitives, the
+    SAME ones ``scripts/ingest_file.py`` uses for a manual drop (zero
+    second canonical writer).
+
+    GATING (ADR-042 decision 3 step 7, "tout-ou-rien"): if the governed
+    decision could not be computed at all, or is ESCALATED, NOTHING is
+    attempted — every candidate feed_key gets a ``RUN_ESCALATED`` outcome
+    for visibility, and the L3 webhook has ALREADY fired inside
+    ``apply_daily_run`` (this function never notifies). Otherwise, a feed is
+    loaded iff (a) its scan produced usable rows AND (b) it is either
+    UNGOVERNED (no active contract — see module docstring) or its OWN
+    guard evaluation is ``GuardStatus.OK`` — a FAILED guard always excludes
+    THAT feed from THIS run's load, blocking or advisory alike (advisory
+    only changes whether the run-level decision escalates, never whether
+    this feed's suspect data gets loaded). Feeds are loaded in
+    ``LOAD_ORDER`` (FK dependency order).
+
+    ``processed_dir``/``rejected_dir`` default to ``inbox_dir.parent /
+    "processed"``/``"rejected"`` — siblings of the inbox, mirroring
+    ``scripts/ingest_file.py``'s own ``data/{inbox,processed,rejected}``
+    convention, generalized to whatever ``--inbox`` path is given.
+
+    Raises ``ValueError`` if ``evaluation.is_applied`` is ``False`` — a
+    dry-run preview (``plan_daily_run``) must never be used to drive a real
+    load.
+    """
+    if not evaluation.is_applied:
+        raise ValueError(
+            "load_eligible_feeds: refusing to load from a dry-run "
+            "(plan_daily_run) evaluation — call apply_daily_run first"
+        )
+
+    processed_dir = processed_dir if processed_dir is not None else inbox_dir.parent / "processed"
+    rejected_dir = rejected_dir if rejected_dir is not None else inbox_dir.parent / "rejected"
+
+    outcomes: list[FeedLoadOutcome] = []
+    scan = evaluation.scan
+
+    if evaluation.decision is None or evaluation.decision.status == RunDecisionStatus.ESCALATED:
+        reason = (
+            "no governed decision could be computed (no active feed_contracts row)"
+            if evaluation.decision is None
+            else f"run ESCALATED: {'; '.join(evaluation.decision.reasons) or 'blocking feed guard failure'}"
+        )
+        logger.error(
+            "daily_orchestrator.run_blocked run_date=%s reason=%s", evaluation.run_date, reason,
+        )
+        # Every candidate feed_key gets a RUN_ESCALATED outcome, including a
+        # governed feed absent from today's inbox — a complete picture of
+        # "nothing was loaded", not just the ones that had a file.
+        all_feed_keys = (
+            set(scan.feeds) | set(scan.issues) | {fe.feed_key for fe in evaluation.feed_evaluations}
+        )
+        for feed_key in sorted(all_feed_keys):
+            outcomes.append(
+                FeedLoadOutcome(feed_key=feed_key, canonical=None, status=FeedLoadStatus.RUN_ESCALATED,
+                                 http_status=None, detail=reason)
+            )
+        return tuple(outcomes)
+
+    guard_by_feed = {fe.feed_key: fe for fe in evaluation.feed_evaluations}
+
+    # Scan issues are structurally unloadable regardless of governance —
+    # always rejected, archived so tomorrow's scan (a different run_date)
+    # never re-discovers the same broken drop.
+    for feed_key, issue in scan.issues.items():
+        # The issue.error already names its own cause (parse failure,
+        # ambiguous groups, deactivated contract…) — no cause-prefix here,
+        # it would lie for the non-parse cases.
+        detail = f"scan issue: {issue.error}"
+        logger.error(
+            "daily_orchestrator.scan_error feed_key=%s run_date=%s detail=%s",
+            feed_key, evaluation.run_date, detail,
+        )
+        report: dict[str, Any] = {
+            "feed_key": feed_key, "run_date": evaluation.run_date.isoformat(),
+            "outcome": "scan_error", "error": issue.error,
+            "source_files": [p.name for p in issue.paths],
+        }
+        _archive_one_or_group(issue.paths, rejected_dir, report)
+        outcomes.append(
+            FeedLoadOutcome(feed_key=feed_key, canonical=None, status=FeedLoadStatus.SCAN_ERROR,
+                             http_status=None, detail=detail)
+        )
+
+    candidates: list[tuple[str, str]] = []  # (feed_key, canonical)
+    for feed_key in scan.feeds:
+        fe = guard_by_feed.get(feed_key)
+        contract = fe.contract if fe is not None else None
+        if fe is not None and fe.evaluation.overall_status != GuardStatus.OK:
+            reasons = "; ".join(r.detail for r in fe.evaluation.results if r.status == GuardStatus.FAILED)
+            logger.warning(
+                "daily_orchestrator.guard_failed feed_key=%s run_date=%s reasons=%s",
+                feed_key, evaluation.run_date, reasons,
+            )
+            outcomes.append(
+                FeedLoadOutcome(feed_key=feed_key, canonical=None, status=FeedLoadStatus.GUARD_FAILED,
+                                 http_status=None, detail=reasons)
+            )
+            continue
+        candidates.append((feed_key, _canonical_dispatch_name(feed_key, contract)))
+
+    # Governed feeds expected (active contract) but absent from the scan.
+    scanned_feed_keys = set(scan.feeds) | set(scan.issues)
+    for fe in evaluation.feed_evaluations:
+        if fe.feed_key in scanned_feed_keys:
+            continue
+        logger.info(
+            "daily_orchestrator.no_file feed_key=%s run_date=%s", fe.feed_key, evaluation.run_date,
+        )
+        outcomes.append(
+            FeedLoadOutcome(feed_key=fe.feed_key, canonical=None, status=FeedLoadStatus.NO_FILE,
+                             http_status=None, detail="no file found in inbox for this run_date")
+        )
+
+    candidates.sort(key=lambda pair: _load_order_key(pair[1]))
+
+    for feed_key, canonical in candidates:
+        scanned = scan.feeds[feed_key]
+        if canonical not in PAYLOAD_BUILDERS or canonical not in DISPATCH:
+            detail = (
+                f"no ingest builder registered for canonical={canonical!r} "
+                f"(feed_key={feed_key!r}) — see module docstring 'BOM IS OUT OF SCOPE IN V1'"
+            )
+            logger.error(
+                "daily_orchestrator.unsupported_entity feed_key=%s run_date=%s detail=%s",
+                feed_key, evaluation.run_date, detail,
+            )
+            report = {
+                "feed_key": feed_key, "canonical": canonical, "run_date": evaluation.run_date.isoformat(),
+                "outcome": "unsupported_entity", "error": detail,
+            }
+            _archive_one_or_group(scanned.paths, rejected_dir, report)
+            outcomes.append(
+                FeedLoadOutcome(feed_key=feed_key, canonical=canonical, status=FeedLoadStatus.UNSUPPORTED_ENTITY,
+                                 http_status=None, detail=detail)
+            )
+            continue
+
+        cfg = DISPATCH[canonical]
+        builder = PAYLOAD_BUILDERS[canonical]
+        try:
+            payload = builder(list(scanned.rows), False)
+        except ValueError as exc:
+            detail = f"payload build error: {exc}"
+            logger.error(
+                "daily_orchestrator.build_error feed_key=%s run_date=%s detail=%s",
+                feed_key, evaluation.run_date, detail,
+            )
+            report = {
+                "feed_key": feed_key, "canonical": canonical, "run_date": evaluation.run_date.isoformat(),
+                "outcome": "build_error", "error": detail,
+            }
+            _archive_one_or_group(scanned.paths, rejected_dir, report)
+            outcomes.append(
+                FeedLoadOutcome(feed_key=feed_key, canonical=canonical, status=FeedLoadStatus.SCAN_ERROR,
+                                 http_status=None, detail=detail)
+            )
+            continue
+
+        try:
+            status_code, body = call_api(cfg["endpoint"], payload, token)
+        except Exception:  # noqa: BLE001 — mirrors ingest_file.py's own api-crash carve-out
+            logger.exception(
+                "daily_orchestrator.api_crash feed_key=%s run_date=%s endpoint=%s",
+                feed_key, evaluation.run_date, cfg["endpoint"],
+            )
+            report = {
+                "feed_key": feed_key, "canonical": canonical, "endpoint": cfg["endpoint"],
+                "run_date": evaluation.run_date.isoformat(), "outcome": "api_crash",
+            }
+            _archive_one_or_group(scanned.paths, rejected_dir, report)
+            outcomes.append(
+                FeedLoadOutcome(feed_key=feed_key, canonical=canonical, status=FeedLoadStatus.API_CRASH,
+                                 http_status=None, detail="call_api raised — see logs")
+            )
+            continue
+
+        accepted = 200 <= status_code < 300
+        summary = body.get("summary", {}) if isinstance(body, dict) else {}
+        report = {
+            "feed_key": feed_key, "canonical": canonical, "endpoint": cfg["endpoint"],
+            "run_date": evaluation.run_date.isoformat(), "outcome": "ok" if accepted else "rejected",
+            "http_status": status_code, "rows_parsed": len(scanned.rows), "api_summary": summary,
+            "api_response": body,
+        }
+        dest = processed_dir if accepted else rejected_dir
+        _archive_one_or_group(scanned.paths, dest, report)
+
+        status = FeedLoadStatus.LOADED if accepted else FeedLoadStatus.REJECTED
+        detail = f"HTTP {status_code}" if accepted else f"HTTP {status_code}, summary={summary}"
+        logger.info(
+            "daily_orchestrator.load feed_key=%s run_date=%s canonical=%s status=%s http_status=%d",
+            feed_key, evaluation.run_date, canonical, status.value, status_code,
+        )
+        outcomes.append(
+            FeedLoadOutcome(feed_key=feed_key, canonical=canonical, status=status,
+                             http_status=status_code, detail=detail)
+        )
+
+    return tuple(outcomes)

--- a/src/ootils_core/interfaces/__init__.py
+++ b/src/ootils_core/interfaces/__init__.py
@@ -1,18 +1,26 @@
 """
-External-interface contracts (INT-1/ADR-037, daily-run guards/ADR-042 PR-2).
+External-interface contracts (INT-1/ADR-037, daily-run guards/ADR-042).
 
 ``contracts.py`` is the Python half of the feed-contract registry: strict
 pydantic parsing of ``config/feed-contracts/*.yaml``, a versioned/idempotent
-loader into the ``feed_contracts`` table (migration 073), and the
-``get_active_contract`` reader.
+loader into the ``feed_contracts`` table (migration 073), the
+``get_active_contract`` single-feed reader, and ``list_active_contracts``
+(the full active set — what a daily run cross-references its inbox scan
+against).
 
 ``guards.py`` is the pure (DB-free) runtime-guard evaluator ADR-037 §6
 describes (arrival window, volume floor/delta, deletion ratio) — see its
 module docstring. ``daily_run.py`` is the DB-touching persistence layer
 (``daily_runs`` table, migration 078) that gathers a feed's active contract
 + previous run stats and records one guard-evaluation attempt. The governed
-auto-approve/escalate DECISION that consumes these verdicts is PR-3
-territory (``engine/ingest/apply.py``, not yet written).
+auto-approve/escalate DECISION that consumes these verdicts lives in
+``engine/ingest/apply.py`` (ADR-042 PR-3). ``ingest_exec.py`` is the
+canonical TSV-ingest execution primitives (filename grammar, payload
+builders, in-process API call, archiving) shared by
+``scripts/ingest_file.py`` (manual/dev CLI) and
+``engine/ingest/daily_orchestrator.py`` (the governed daily run, ADR-042
+PR-4b) — see its module docstring for why it is not simply imported from
+the script.
 """
 from ootils_core.interfaces.contracts import (
     ContractError,
@@ -20,6 +28,7 @@ from ootils_core.interfaces.contracts import (
     FeedContractSpec,
     LoadOutcome,
     get_active_contract,
+    list_active_contracts,
     load_contract_dir,
     parse_contract_file,
     upsert_contract,
@@ -51,6 +60,7 @@ __all__ = [
     "FeedContractSpec",
     "LoadOutcome",
     "get_active_contract",
+    "list_active_contracts",
     "load_contract_dir",
     "parse_contract_file",
     "upsert_contract",

--- a/src/ootils_core/interfaces/contracts.py
+++ b/src/ootils_core/interfaces/contracts.py
@@ -318,6 +318,41 @@ def get_active_contract(conn: DictRowConnection, feed_key: str) -> FeedContract 
     return FeedContract(**row)
 
 
+def list_known_feed_keys(conn: DictRowConnection) -> set[str]:
+    """Every ``feed_key`` ever registered in ``feed_contracts`` — active OR
+    retired (``SELECT DISTINCT``, no ``WHERE active``). Distinguishes a
+    REGISTRY-KNOWN feed whose contract has since been deactivated (must be
+    refused explicitly — see ``engine.ingest.daily_orchestrator``'s
+    "contract deactivated" quarantine) from a feed_key the registry has
+    NEVER heard of at all (a referential/on-demand entity, or a genuinely
+    undeclared feed — still loaded ungoverned if the run is not escalated).
+    Writes nothing. Empty set is a valid, honest result (no feed ever
+    registered)."""
+    cur = conn.cursor(row_factory=dict_row)
+    rows = cur.execute("SELECT DISTINCT feed_key FROM feed_contracts").fetchall()
+    return {row["feed_key"] for row in rows}
+
+
+def list_active_contracts(conn: DictRowConnection) -> list[FeedContract]:
+    """Every currently active ``feed_contracts`` row, ordered by ``feed_key``
+    — the full "expected feeds" set a daily run cross-references its inbox
+    scan against (ADR-042 decision 3 step 2: "scan de l'inbox croisé avec
+    get_active_contract() ... pour chaque feed_key attendu"), consumed by
+    ``engine.ingest.daily_orchestrator``. Writes nothing. Empty list is a
+    valid, honest result (no feed registered yet) — callers must not treat
+    it as an error on its own."""
+    cur = conn.cursor(row_factory=dict_row)
+    rows = cur.execute(
+        "SELECT feed_contract_id, feed_key, version, entity_type, "
+        "source_system, format, key_columns, mandatory_columns, load_mode, "
+        "cadence, arrival_window_minutes, owner, criticality, "
+        "volume_guard_min_rows, volume_guard_max_pct_delta, depends_on, "
+        "active, created_at, updated_at "
+        "FROM feed_contracts WHERE active ORDER BY feed_key"
+    ).fetchall()
+    return [FeedContract(**row) for row in rows]
+
+
 def upsert_contract(conn: DictRowConnection, spec: FeedContractSpec) -> LoadOutcome:
     """Idempotently register ``spec`` as the (possibly new) active version of
     its ``feed_key``.

--- a/src/ootils_core/interfaces/ingest_exec.py
+++ b/src/ootils_core/interfaces/ingest_exec.py
@@ -1,0 +1,841 @@
+"""
+ingest_exec.py — the canonical, importable TSV-ingest execution primitives
+(ADR-042 PR-4b, the daily orchestrator's prerequisite).
+
+WHY THIS MODULE EXISTS. ``scripts/ingest_file.py`` (PR-4a) is the manual/dev
+entry point for loading one TSV drop — filename grammar, per-entity payload
+builders, the in-process API call, and archiving. ``engine/ingest/
+daily_orchestrator.py`` (PR-4b) needs the EXACT SAME logic to load the
+"green" feeds of a governed daily run, with zero drift between the two
+callers (a second, slightly-different implementation of "how a TSV becomes
+an API payload" would be exactly the kind of silent divergence this repo's
+conventions forbid). Directly importing ``scripts/ingest_file.py`` from
+``src/ootils_core/`` is improper: ``scripts/`` is NOT part of the installed
+package (``[tool.setuptools.packages.find] where = ["src"]``), and the
+script reconfigures the root logger as an import side effect
+(``logging.basicConfig(...)`` at module scope) — acceptable for a CLI
+entry point, not for a library import reachable from engine code.
+
+So the reusable, DB/API-agnostic pieces live HERE — the single canonical
+implementation — and ``scripts/ingest_file.py`` becomes a thin re-export
+shim over this module for everything it used to define itself, keeping its
+CLI behaviour (including the exact objects the PR-4a test suite imports and
+monkeypatches, e.g. ``DISPATCH``) byte-for-byte unchanged. Zero second
+canonical writer: there is exactly ONE ``parse_tsv``, ONE set of payload
+builders, ONE ``call_api``, ONE ``archive``.
+
+DELIBERATELY NOT MOVED HERE (stay in ``scripts/ingest_file.py``, unchanged):
+``PROCESSED``/``REJECTED``/``INBOX`` (repo-relative default archive
+directories — the daily orchestrator computes its OWN, inbox-relative
+destinations, see its module docstring) and ``_find_archived`` (reads those
+same module globals directly — the PR-4a test suite monkeypatches them on
+``ingest_file`` itself and expects ``_find_archived`` to observe the patch,
+which only holds if the function keeps living in that module). BOM-bundle
+orchestration (``handle_bom_bundle``) and part-group CLI orchestration
+(``handle_part_group``) also stay in ``ingest_file.py``: both are CLI-shaped
+(dry-run JSON printing to stdout, process exit codes) — only the DB/API
+primitives they call (``parse_tsv``, ``PAYLOAD_BUILDERS``, ``call_api``,
+``archive``/``archive_group``, ``build_bom_payloads``) are canonical here.
+"""
+from __future__ import annotations
+
+import csv
+import json
+import re
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+# ─────────────────────────────────────────────────────────────
+# Filename grammar (PR-4a) — pure, no filesystem access
+# ─────────────────────────────────────────────────────────────
+# Beyond the canonical '<entity>.tsv' name (the DISPATCH keys below), two
+# real-world drop conventions are accepted:
+#   - daily drop:  '<entity>_<AAAAMMJJ>.tsv'          e.g. on_hand_20260718.tsv
+#   - part file:   '<entity>.partNN.tsv'              e.g. forecasts.part01.tsv
+#                  '<entity>.partNN_<AAAAMMJJ>.tsv'   e.g. forecasts.part01_20260718.tsv
+# The date suffix is ignored for dispatch (informational only — the entity
+# alone decides the endpoint). Part files sharing the same (entity, date)
+# in the same directory are grouped into ONE logical load — see
+# `find_sibling_parts`/`parse_tsv_parts` below and `handle_part_group` in
+# scripts/ingest_file.py's main() dispatch section.
+_DATE_SUFFIX_RE = re.compile(r"^(?P<stem>.+)_(?P<date>\d{8})$")
+_PART_SUFFIX_RE = re.compile(r"^(?P<stem>.+)\.part(?P<part>\d{2,})$")
+
+
+@dataclass(frozen=True)
+class ParsedFilename:
+    """Result of `parse_ingest_filename`.
+
+    `entity` is the bare feed-key stem — no '.tsv' extension, no date or
+    part marker (e.g. 'on_hand', 'bom_header', 'forecasts'). This parser has
+    zero knowledge of which entities are actually supported; callers must
+    still check `f"{entity}.tsv"` against DISPATCH — or, for a governed feed
+    (``engine.ingest.daily_orchestrator``), translate `entity` (a
+    feed_contracts `feed_key`, e.g. 'on-hand') through the active contract's
+    `entity_type` first (see that module's docstring — a known kebab-vs-
+    snake_case mismatch between the two vocabularies).
+    """
+
+    entity: str
+    date: str | None
+    part: int | None
+
+
+def parse_ingest_filename(filename: str) -> ParsedFilename:
+    """Pure parser: basename -> (entity, date, part). No filesystem access.
+
+    Accepted grammars (basename only, no directory component):
+        '<entity>.tsv'                    canonical (e.g. 'items.tsv')
+        '<entity>_<AAAAMMJJ>.tsv'         daily drop (e.g. 'on_hand_20260718.tsv')
+        '<entity>.partNN.tsv'             part file (e.g. 'forecasts.part01.tsv')
+        '<entity>.partNN_<AAAAMMJJ>.tsv'  dated part file
+
+    The date, when present, is returned as its raw 8-digit string (not
+    parsed/validated as a real calendar date — same structural-only
+    tolerance as `_to_date_str` elsewhere in this file) and is otherwise
+    unused: it exists for traceability/grouping, never for dispatch.
+
+    Raises ValueError if `filename` doesn't end in '.tsv', has an empty
+    entity segment once date/part markers are stripped, or a malformed
+    '.part' marker (no digits).
+    """
+    if not filename.endswith(".tsv"):
+        raise ValueError(f"filename must end with '.tsv': '{filename}'")
+    stem = filename[: -len(".tsv")]
+
+    date: str | None = None
+    date_match = _DATE_SUFFIX_RE.match(stem)
+    if date_match:
+        stem = date_match.group("stem")
+        date = date_match.group("date")
+
+    part: int | None = None
+    part_match = _PART_SUFFIX_RE.match(stem)
+    if part_match:
+        stem = part_match.group("stem")
+        part = int(part_match.group("part"))
+
+    if not stem:
+        raise ValueError(f"filename has no entity segment: '{filename}'")
+
+    return ParsedFilename(entity=stem, date=date, part=part)
+
+
+# ─────────────────────────────────────────────────────────────
+# Type coercion helpers
+# ─────────────────────────────────────────────────────────────
+_TRUE_VALUES = {"true", "1", "yes", "y", "t"}
+_FALSE_VALUES = {"false", "0", "no", "n", "f", ""}
+
+
+def _to_bool(raw: str, *, field: str, line: str) -> bool:
+    v = raw.strip().lower()
+    if v in _TRUE_VALUES:
+        return True
+    if v in _FALSE_VALUES:
+        return False
+    raise ValueError(
+        f"line {line}: {field} '{raw}' is not a valid boolean "
+        f"(accepted: true/false/1/0/yes/no/y/n/t/f)"
+    )
+
+
+def _to_int(raw: str, *, field: str, line: str) -> int:
+    try:
+        return int(raw)
+    except ValueError as e:
+        raise ValueError(f"line {line}: {field} '{raw}' is not a valid integer") from e
+
+
+def _to_float(raw: str, *, field: str, line: str) -> float:
+    try:
+        return float(raw)
+    except ValueError as e:
+        raise ValueError(f"line {line}: {field} '{raw}' is not a valid number") from e
+
+
+# ─────────────────────────────────────────────────────────────
+# TSV parsing
+# ─────────────────────────────────────────────────────────────
+def parse_tsv(path: Path) -> tuple[list[str], list[dict[str, str]]]:
+    """Parse a UTF-8 TSV file into (headers, rows-as-dicts).
+
+    - Tabulation separator (no escape — values must not contain raw tabs).
+    - No quoting whatsoever (TSV-FILES-SPEC.md §1.1: "aucun guillemet"): a
+      literal `"` in a cell (e.g. an inch-mark item description like
+      `"U" BOLT 1/4"`) must be preserved verbatim, never treated as a CSV
+      quote character. `quoting=csv.QUOTE_NONE` is required here — the
+      default QUOTE_MINIMAL silently swallows a leading `"` and everything
+      up to the next `"`, corrupting the value.
+    - First non-empty line is the header.
+    - Empty lines are skipped.
+    - BOM (UTF-8 signature) is tolerated and stripped.
+    - Returns dicts using header names as keys.
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"input file not found: {path}")
+    if path.stat().st_size == 0:
+        raise ValueError(f"input file is empty: {path}")
+
+    with path.open("r", encoding="utf-8-sig", newline="") as f:
+        reader = csv.reader(f, delimiter="\t", quoting=csv.QUOTE_NONE)
+        rows = [r for r in reader if any(cell.strip() for cell in r)]
+
+    if not rows:
+        raise ValueError(f"input file contains no non-empty lines: {path}")
+
+    headers = [h.strip() for h in rows[0]]
+    if not all(headers):
+        raise ValueError(f"header row contains empty column name: {headers}")
+
+    data_rows: list[dict[str, str]] = []
+    for i, raw in enumerate(rows[1:], start=2):  # line numbers 1-based, header is line 1
+        if len(raw) != len(headers):
+            raise ValueError(
+                f"line {i}: column count {len(raw)} != header count {len(headers)}"
+            )
+        row = {headers[j]: raw[j].strip() for j in range(len(headers))}
+        # Tag with the original line number for error reporting
+        row["__line__"] = str(i)
+        data_rows.append(row)
+
+    return headers, data_rows
+
+
+# ─────────────────────────────────────────────────────────────
+# Part-file grouping (PR-4a)
+# ─────────────────────────────────────────────────────────────
+def find_sibling_parts(path: Path) -> list[Path]:
+    """Return every sibling '.partNN' file for the same (entity, date) as
+    `path`, scanned in `path`'s own directory ONLY (never data/processed/
+    or data/rejected/ — grouping is scoped to files currently sitting
+    together in the inbox), sorted by part number ascending. `path` itself
+    is included.
+
+    Raises ValueError if:
+      - `path`'s own filename doesn't parse as a part file (part is None);
+      - two files in the directory collide on the same part number for
+        this (entity, date) group (ambiguous — cannot pick one);
+      - `path` itself is not among the files found in its own directory
+        (typo, or the file was already archived by a prior run — the
+        caller should treat this as a hard error, not silently ingest
+        whatever siblings remain).
+
+    Propagates FileNotFoundError if `path.parent` doesn't exist.
+    """
+    parsed = parse_ingest_filename(path.name)
+    if parsed.part is None:
+        raise ValueError(f"'{path.name}' is not a '.partNN' file")
+
+    by_part: dict[int, Path] = {}
+    for candidate in sorted(path.parent.iterdir()):
+        if not candidate.is_file():
+            continue
+        try:
+            c_parsed = parse_ingest_filename(candidate.name)
+        except ValueError:
+            continue
+        if c_parsed.part is None:
+            continue
+        if c_parsed.entity != parsed.entity or c_parsed.date != parsed.date:
+            continue
+        if c_parsed.part in by_part:
+            raise ValueError(
+                f"duplicate part {c_parsed.part:02d} for entity '{parsed.entity}' "
+                f"(date={parsed.date}): '{by_part[c_parsed.part].name}' "
+                f"and '{candidate.name}'"
+            )
+        by_part[c_parsed.part] = candidate
+
+    siblings = [by_part[k] for k in sorted(by_part)]
+    if not any(p.name == path.name for p in siblings):
+        raise ValueError(
+            f"'{path.name}' was not found in '{path.parent}' "
+            f"(found {len(siblings)} other part(s) for entity '{parsed.entity}'"
+            + (f", date {parsed.date}" if parsed.date else "")
+            + ") — check the path, or whether this part was already archived"
+        )
+    return siblings
+
+
+def parse_tsv_parts(paths: list[Path]) -> tuple[list[str], list[dict[str, str]]]:
+    """Parse and concatenate N sibling part files into one logical
+    (headers, rows), in the given order (expected: ascending by part
+    number, see `find_sibling_parts`).
+
+    Every part is parsed independently via `parse_tsv`; all parts must
+    share byte-identical headers (same column names, same order) — a
+    mismatch raises ValueError naming the offending file. Each row's
+    `__line__` tag is re-prefixed with its source file's name so error
+    messages built from it stay traceable across parts, e.g.
+    "forecasts.part02.tsv:L14".
+    """
+    if not paths:
+        raise ValueError("no part files to parse")
+
+    headers: list[str] | None = None
+    all_rows: list[dict[str, str]] = []
+    for p in paths:
+        p_headers, p_rows = parse_tsv(p)
+        if headers is None:
+            headers = p_headers
+        elif p_headers != headers:
+            raise ValueError(
+                f"part file '{p.name}' header {p_headers} does not match "
+                f"first part's header {headers}"
+            )
+        for row in p_rows:
+            row = dict(row)
+            row["__line__"] = f"{p.name}:L{row.get('__line__', '?')}"
+            all_rows.append(row)
+
+    assert headers is not None  # `paths` non-empty => at least one iteration ran
+    return headers, all_rows
+
+
+# ─────────────────────────────────────────────────────────────
+# Dispatch table — filename → endpoint + payload body_key
+# ─────────────────────────────────────────────────────────────
+# Aligned with data-input-canonique-v1/endpoint_mapping.json.
+# Extend here when adding a new supported entity.
+DISPATCH: dict[str, dict[str, str]] = {
+    "items.tsv":                {"endpoint": "/v1/ingest/items",            "body_key": "items"},
+    "locations.tsv":            {"endpoint": "/v1/ingest/locations",        "body_key": "locations"},
+    "suppliers.tsv":            {"endpoint": "/v1/ingest/suppliers",        "body_key": "suppliers"},
+    "supplier_items.tsv":       {"endpoint": "/v1/ingest/supplier-items",   "body_key": "supplier_items"},
+    "item_planning_params.tsv": {"endpoint": "/v1/ingest/planning-params",  "body_key": "params"},
+    "on_hand.tsv":              {"endpoint": "/v1/ingest/on-hand",          "body_key": "on_hand"},
+    "purchase_orders.tsv":      {"endpoint": "/v1/ingest/purchase-orders",  "body_key": "purchase_orders"},
+    "customer_orders.tsv":      {"endpoint": "/v1/ingest/customer-orders",  "body_key": "customer_orders"},
+    "forecasts.tsv":            {"endpoint": "/v1/ingest/forecast-demand",  "body_key": "forecasts"},
+    "transfers.tsv":            {"endpoint": "/v1/ingest/transfers",        "body_key": "transfers"},
+    # BOM bundle: entry point is bom_header.tsv, which auto-loads bom_components.tsv
+    # alongside and emits N POSTs (one per BOM). Special-cased in
+    # scripts/ingest_file.py's main() / handle_bom_bundle — NOT in
+    # PAYLOAD_BUILDERS below (no single-payload builder exists for it), and
+    # therefore NOT loadable by engine/ingest/daily_orchestrator.py's
+    # generic single-payload load loop (a named V1 limitation — see that
+    # module's docstring).
+    "bom_header.tsv":           {"endpoint": "/v1/ingest/bom",              "body_key": "_bom_bundle"},
+}
+
+
+# ─────────────────────────────────────────────────────────────
+# Payload construction
+# ─────────────────────────────────────────────────────────────
+def build_items_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
+    """Build the JSON body for POST /v1/ingest/items.
+
+    Applies defaults for optional fields when blank: item_type, uom, status.
+    All-or-nothing validation happens server-side; we just pass values through.
+    """
+    items: list[dict[str, Any]] = []
+    for row in rows:
+        item = {
+            "external_id": row.get("external_id", ""),
+            "name": row.get("name", ""),
+        }
+        # Optional fields — only include if the column exists AND the cell is non-empty,
+        # so the server applies its Pydantic defaults otherwise.
+        if row.get("item_type"):
+            item["item_type"] = row["item_type"]
+        if row.get("uom"):
+            item["uom"] = row["uom"]
+        if row.get("status"):
+            item["status"] = row["status"]
+        items.append(item)
+    return {"items": items, "dry_run": dry_run}
+
+
+def build_locations_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
+    """Build the JSON body for POST /v1/ingest/locations.
+
+    Sends only non-empty optional fields so the server applies Pydantic defaults
+    (e.g. location_type → 'dc'). The API itself validates `parent_external_id`
+    refs against the payload + the existing DB.
+    """
+    locations: list[dict[str, Any]] = []
+    for row in rows:
+        loc = {
+            "external_id": row.get("external_id", ""),
+            "name": row.get("name", ""),
+        }
+        if row.get("location_type"):
+            loc["location_type"] = row["location_type"]
+        if row.get("country"):
+            loc["country"] = row["country"]
+        if row.get("timezone"):
+            loc["timezone"] = row["timezone"]
+        if row.get("parent_external_id"):
+            loc["parent_external_id"] = row["parent_external_id"]
+        locations.append(loc)
+    return {"locations": locations, "dry_run": dry_run}
+
+
+def build_suppliers_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
+    """Build the JSON body for POST /v1/ingest/suppliers."""
+    suppliers: list[dict[str, Any]] = []
+    for row in rows:
+        line = row.get("__line__", "?")
+        sup: dict[str, Any] = {
+            "external_id": row.get("external_id", ""),
+            "name": row.get("name", ""),
+        }
+        if row.get("country"):
+            sup["country"] = row["country"]
+        if row.get("status"):
+            sup["status"] = row["status"]
+        if row.get("lead_time_days"):
+            sup["lead_time_days"] = _to_int(row["lead_time_days"], field="lead_time_days", line=line)
+        if row.get("reliability_score"):
+            sup["reliability_score"] = _to_float(row["reliability_score"], field="reliability_score", line=line)
+        suppliers.append(sup)
+    return {"suppliers": suppliers, "dry_run": dry_run}
+
+
+def build_supplier_items_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
+    """Build the JSON body for POST /v1/ingest/supplier-items.
+
+    Required: supplier_external_id, item_external_id, lead_time_days.
+    Optional with defaults: currency='EUR', is_preferred=false.
+    Optional nullable: moq, unit_cost.
+    """
+    pairs: list[dict[str, Any]] = []
+    for row in rows:
+        line = row.get("__line__", "?")
+        si: dict[str, Any] = {
+            "supplier_external_id": row.get("supplier_external_id", ""),
+            "item_external_id": row.get("item_external_id", ""),
+        }
+        # lead_time_days is REQUIRED by the API (gt=0). Empty → fail explicitly here.
+        if not row.get("lead_time_days"):
+            raise ValueError(
+                f"line {line}: lead_time_days is required and cannot be empty"
+            )
+        si["lead_time_days"] = _to_int(row["lead_time_days"], field="lead_time_days", line=line)
+
+        if row.get("currency"):
+            si["currency"] = row["currency"]
+        if row.get("moq"):
+            si["moq"] = _to_float(row["moq"], field="moq", line=line)
+        if row.get("unit_cost"):
+            si["unit_cost"] = _to_float(row["unit_cost"], field="unit_cost", line=line)
+        # is_preferred: column may exist but be blank (treated as False).
+        # Only normalize if the column is present in headers — but we already
+        # received it through row dict via parse_tsv, so test for presence.
+        if "is_preferred" in row:
+            si["is_preferred"] = _to_bool(row["is_preferred"], field="is_preferred", line=line)
+        pairs.append(si)
+    return {"supplier_items": pairs, "dry_run": dry_run}
+
+
+# Field-type map for item_planning_params columns.
+# Server applies SCD2 partial-push: any column ABSENT from payload = "keep current value".
+# So we must include a key in the payload ONLY when its TSV cell is non-empty,
+# and we must coerce it to the right type.
+_IPP_INT_FIELDS = {
+    "lead_time_sourcing_days",
+    "lead_time_manufacturing_days",
+    "lead_time_transit_days",
+    "planning_horizon_days",
+    "lot_size_poq_periods",
+    "frozen_time_fence_days",
+    "slashed_time_fence_days",
+    "consumption_window_days",
+}
+_IPP_FLOAT_FIELDS = {
+    "safety_stock_qty",
+    "safety_stock_days",
+    "reorder_point_qty",
+    "min_order_qty",
+    "max_order_qty",
+    "order_multiple",
+    "economic_order_qty",
+    "order_multiple_qty",
+}
+_IPP_BOOL_FIELDS = {"is_make"}
+_IPP_STRING_FIELDS = {
+    "lot_size_rule",
+    "preferred_supplier_external_id",
+    "forecast_consumption_strategy",
+}
+
+
+def build_item_planning_params_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
+    """Build the JSON body for POST /v1/ingest/planning-params.
+
+    SCD2 partial-push semantics:
+      - empty cell → key is OMITTED from the payload → server keeps current value
+      - non-empty cell → key included, value coerced to the right type
+
+    Required: item_external_id, location_external_id.
+    All other columns optional. The server resolves FKs (items, locations,
+    suppliers for preferred_supplier_external_id) before any write.
+    """
+    params: list[dict[str, Any]] = []
+    for row in rows:
+        line = row.get("__line__", "?")
+        p: dict[str, Any] = {
+            "item_external_id": row.get("item_external_id", ""),
+            "location_external_id": row.get("location_external_id", ""),
+        }
+        for col, raw in row.items():
+            if col in ("item_external_id", "location_external_id", "__line__"):
+                continue
+            if not raw:  # empty cell → omit → server keeps current value
+                continue
+            if col in _IPP_INT_FIELDS:
+                p[col] = _to_int(raw, field=col, line=line)
+            elif col in _IPP_FLOAT_FIELDS:
+                p[col] = _to_float(raw, field=col, line=line)
+            elif col in _IPP_BOOL_FIELDS:
+                p[col] = _to_bool(raw, field=col, line=line)
+            elif col in _IPP_STRING_FIELDS:
+                p[col] = raw
+            else:
+                # Unknown column → pass through as string; server may reject as 422 or ignore.
+                # Better to let the API decide than to silently drop.
+                p[col] = raw
+        params.append(p)
+    return {"params": params, "dry_run": dry_run}
+
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _to_date_str(raw: str, *, field: str, line: str) -> str:
+    """Validate ISO date format YYYY-MM-DD. API expects a string here, not a date object."""
+    v = raw.strip()
+    if not _DATE_RE.match(v):
+        raise ValueError(f"line {line}: {field} '{raw}' must be ISO date YYYY-MM-DD")
+    return v
+
+
+def build_on_hand_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
+    """Build the JSON body for POST /v1/ingest/on-hand.
+
+    Required: item_external_id, location_external_id, quantity, as_of_date.
+    Optional: uom (default 'EA').
+
+    Note: `lot_number` is part of the canonical V1 TSV template but the API
+    Pydantic model does NOT consume it (V1.0). We drop it silently here to
+    avoid sending unknown fields and confusing the user with rejections.
+    """
+    on_hand: list[dict[str, Any]] = []
+    for row in rows:
+        line = row.get("__line__", "?")
+        if not row.get("quantity"):
+            raise ValueError(f"line {line}: quantity is required and cannot be empty")
+        if not row.get("as_of_date"):
+            raise ValueError(f"line {line}: as_of_date is required and cannot be empty")
+        rec: dict[str, Any] = {
+            "item_external_id": row.get("item_external_id", ""),
+            "location_external_id": row.get("location_external_id", ""),
+            "quantity": _to_float(row["quantity"], field="quantity", line=line),
+            "as_of_date": _to_date_str(row["as_of_date"], field="as_of_date", line=line),
+        }
+        if row.get("uom"):
+            rec["uom"] = row["uom"]
+        # lot_number intentionally dropped (V1.0 API doesn't consume it).
+        on_hand.append(rec)
+    return {"on_hand": on_hand, "dry_run": dry_run}
+
+
+def build_purchase_orders_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
+    """Build the JSON body for POST /v1/ingest/purchase-orders.
+
+    Required: external_id, item_external_id, location_external_id,
+              supplier_external_id, quantity, expected_delivery_date.
+    Optional: uom (default 'EA'), status (default 'confirmed').
+    """
+    pos: list[dict[str, Any]] = []
+    for row in rows:
+        line = row.get("__line__", "?")
+        # Required fields — explicit blank checks before building
+        for required in ("quantity", "expected_delivery_date"):
+            if not row.get(required):
+                raise ValueError(f"line {line}: {required} is required and cannot be empty")
+        po: dict[str, Any] = {
+            "external_id": row.get("external_id", ""),
+            "item_external_id": row.get("item_external_id", ""),
+            "location_external_id": row.get("location_external_id", ""),
+            "supplier_external_id": row.get("supplier_external_id", ""),
+            "quantity": _to_float(row["quantity"], field="quantity", line=line),
+            "expected_delivery_date": _to_date_str(row["expected_delivery_date"], field="expected_delivery_date", line=line),
+        }
+        if row.get("uom"):
+            po["uom"] = row["uom"]
+        if row.get("status"):
+            po["status"] = row["status"]
+        pos.append(po)
+    return {"purchase_orders": pos, "dry_run": dry_run}
+
+
+def build_customer_orders_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
+    """Build the JSON body for POST /v1/ingest/customer-orders.
+
+    Required: external_id, item_external_id, location_external_id,
+              quantity, requested_delivery_date.
+    Optional: status (default 'open').
+    """
+    cos: list[dict[str, Any]] = []
+    for row in rows:
+        line = row.get("__line__", "?")
+        for required in ("quantity", "requested_delivery_date"):
+            if not row.get(required):
+                raise ValueError(f"line {line}: {required} is required and cannot be empty")
+        co: dict[str, Any] = {
+            "external_id": row.get("external_id", ""),
+            "item_external_id": row.get("item_external_id", ""),
+            "location_external_id": row.get("location_external_id", ""),
+            "quantity": _to_float(row["quantity"], field="quantity", line=line),
+            "requested_delivery_date": _to_date_str(row["requested_delivery_date"], field="requested_delivery_date", line=line),
+        }
+        if row.get("status"):
+            co["status"] = row["status"]
+        cos.append(co)
+    return {"customer_orders": cos, "dry_run": dry_run}
+
+
+def build_forecasts_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
+    """Build the JSON body for POST /v1/ingest/forecast-demand.
+
+    Required: item_external_id, location_external_id, quantity, bucket_date.
+    Optional: time_grain (default 'week'), source (default 'statistical').
+    quantity may be 0 (explicit "no forecast" for this bucket) — only blocks if blank.
+    """
+    forecasts: list[dict[str, Any]] = []
+    for row in rows:
+        line = row.get("__line__", "?")
+        # quantity can be 0 but must be present
+        q_raw = row.get("quantity", "")
+        if q_raw == "":
+            raise ValueError(f"line {line}: quantity is required and cannot be empty")
+        if not row.get("bucket_date"):
+            raise ValueError(f"line {line}: bucket_date is required and cannot be empty")
+        rec: dict[str, Any] = {
+            "item_external_id": row.get("item_external_id", ""),
+            "location_external_id": row.get("location_external_id", ""),
+            "quantity": _to_float(q_raw, field="quantity", line=line),
+            "bucket_date": _to_date_str(row["bucket_date"], field="bucket_date", line=line),
+        }
+        if row.get("time_grain"):
+            rec["time_grain"] = row["time_grain"]
+        if row.get("source"):
+            rec["source"] = row["source"]
+        forecasts.append(rec)
+    return {"forecasts": forecasts, "dry_run": dry_run}
+
+
+def build_transfers_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
+    """Build the JSON body for POST /v1/ingest/transfers.
+
+    Required: external_id, item_external_id, from_location_external_id,
+              to_location_external_id, quantity, expected_delivery_date.
+    Optional: status (default 'planned').
+    Local extra check: from != to (also enforced server-side but caught earlier here).
+    """
+    transfers: list[dict[str, Any]] = []
+    for row in rows:
+        line = row.get("__line__", "?")
+        for required in ("quantity", "expected_delivery_date"):
+            if not row.get(required):
+                raise ValueError(f"line {line}: {required} is required and cannot be empty")
+        f_loc = row.get("from_location_external_id", "")
+        t_loc = row.get("to_location_external_id", "")
+        if f_loc and t_loc and f_loc == t_loc:
+            raise ValueError(
+                f"line {line}: from_location_external_id and to_location_external_id "
+                f"must differ (both = '{f_loc}')"
+            )
+        tr: dict[str, Any] = {
+            "external_id": row.get("external_id", ""),
+            "item_external_id": row.get("item_external_id", ""),
+            "from_location_external_id": f_loc,
+            "to_location_external_id": t_loc,
+            "quantity": _to_float(row["quantity"], field="quantity", line=line),
+            "expected_delivery_date": _to_date_str(row["expected_delivery_date"], field="expected_delivery_date", line=line),
+        }
+        if row.get("status"):
+            tr["status"] = row["status"]
+        transfers.append(tr)
+    return {"transfers": transfers, "dry_run": dry_run}
+
+
+PAYLOAD_BUILDERS = {
+    "items.tsv":                build_items_payload,
+    "locations.tsv":            build_locations_payload,
+    "suppliers.tsv":             build_suppliers_payload,
+    "supplier_items.tsv":       build_supplier_items_payload,
+    "item_planning_params.tsv": build_item_planning_params_payload,
+    "on_hand.tsv":              build_on_hand_payload,
+    "purchase_orders.tsv":      build_purchase_orders_payload,
+    "customer_orders.tsv":      build_customer_orders_payload,
+    "forecasts.tsv":            build_forecasts_payload,
+    "transfers.tsv":            build_transfers_payload,
+}
+
+
+# ─────────────────────────────────────────────────────────────
+# API call (in-process via TestClient)
+# ─────────────────────────────────────────────────────────────
+def call_api(endpoint: str, payload: dict[str, Any], token: str) -> tuple[int, dict]:
+    """Call the FastAPI app in-process via TestClient. No HTTP server needed."""
+    from fastapi.testclient import TestClient
+    from ootils_core.api.app import app
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    with TestClient(app) as client:
+        resp = client.post(endpoint, json=payload, headers=headers)
+    try:
+        body = resp.json()
+    except Exception:
+        body = {"raw_body": resp.text}
+    return resp.status_code, body
+
+
+# ─────────────────────────────────────────────────────────────
+# Archiving
+# ─────────────────────────────────────────────────────────────
+def archive(source: Path, dest_dir: Path, report: dict[str, Any]) -> tuple[Path, Path]:
+    """Move source file to dest_dir with a timestamp-suffixed name + drop report next to it."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    stem = source.stem
+    suffix = source.suffix
+    new_name = f"{stem}_{ts}{suffix}"
+    target = dest_dir / new_name
+    shutil.move(str(source), str(target))
+
+    report_path = dest_dir / f"{stem}_{ts}.report.json"
+    report_path.write_text(
+        json.dumps(report, indent=2, default=str, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return target, report_path
+
+
+def archive_group(sources: list[Path], dest_dir: Path, report: dict[str, Any]) -> list[Path]:
+    """Archive N sibling files (a part group) together, one timestamped move
+    each (same naming as `archive()`), sharing ONE `--report.json` next to
+    the FIRST file (caller's ordering — expected ascending part number) and
+    a minimal pointer report next to every other file. Mirrors the existing
+    bom-bundle archiving pattern (`handle_bom_bundle`, scripts/ingest_file.py)."""
+    if not sources:
+        raise ValueError("no source files to archive")
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    primary_name = sources[0].name
+    targets: list[Path] = []
+
+    for i, source in enumerate(sources):
+        stem = source.stem
+        suffix = source.suffix
+        target = dest_dir / f"{stem}_{ts}{suffix}"
+        shutil.move(str(source), str(target))
+        targets.append(target)
+
+        report_path = dest_dir / f"{stem}_{ts}.report.json"
+        body = report if i == 0 else {"bundled_with": primary_name, "see_main_report": True}
+        report_path.write_text(
+            json.dumps(body, indent=2, default=str, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+    return targets
+
+
+# ─────────────────────────────────────────────────────────────
+# BOM bundle — payload construction only (the API-calling loop stays a thin
+# CLI-shaped wrapper in scripts/ingest_file.py:handle_bom_bundle)
+# ─────────────────────────────────────────────────────────────
+def build_bom_payloads(
+    header_rows: list[dict[str, str]],
+    component_rows: list[dict[str, str]],
+) -> list[dict[str, Any]]:
+    """Group components by (parent_external_id, bom_version) and merge with
+    header metadata. Returns one payload dict per BOM, ready to POST.
+
+    Raises ValueError if a component references a (parent, version) absent
+    from the header, or if a header has zero components.
+    """
+    # Index headers by (parent, version)
+    header_index: dict[tuple[str, str], dict[str, str]] = {}
+    for hr in header_rows:
+        line = hr.get("__line__", "?")
+        parent = hr.get("parent_external_id", "").strip()
+        version = hr.get("bom_version", "").strip() or "1.0"
+        if not parent:
+            raise ValueError(f"bom_header.tsv line {line}: parent_external_id is required")
+        key = (parent, version)
+        if key in header_index:
+            raise ValueError(
+                f"bom_header.tsv line {line}: duplicate (parent={parent}, version={version})"
+            )
+        header_index[key] = hr
+
+    # Group components by (parent, version)
+    components_by_key: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for cr in component_rows:
+        line = cr.get("__line__", "?")
+        parent = cr.get("parent_external_id", "").strip()
+        version = cr.get("bom_version", "").strip()
+        if not parent or not version:
+            raise ValueError(
+                f"bom_components.tsv line {line}: parent_external_id and bom_version are required"
+            )
+        key = (parent, version)
+        if key not in header_index:
+            raise ValueError(
+                f"bom_components.tsv line {line}: (parent={parent}, version={version}) "
+                f"has no matching row in bom_header.tsv"
+            )
+        comp_ext = cr.get("component_external_id", "").strip()
+        if not comp_ext:
+            raise ValueError(
+                f"bom_components.tsv line {line}: component_external_id is required"
+            )
+        if not cr.get("quantity_per"):
+            raise ValueError(
+                f"bom_components.tsv line {line}: quantity_per is required"
+            )
+        comp: dict[str, Any] = {
+            "component_external_id": comp_ext,
+            "quantity_per": _to_float(cr["quantity_per"], field="quantity_per", line=line),
+        }
+        if cr.get("uom"):
+            comp["uom"] = cr["uom"]
+        if cr.get("scrap_factor"):
+            comp["scrap_factor"] = _to_float(cr["scrap_factor"], field="scrap_factor", line=line)
+        components_by_key.setdefault(key, []).append(comp)
+
+    # Build one payload per BOM (every header must have at least 1 component)
+    payloads: list[dict[str, Any]] = []
+    for (parent, version), hr in header_index.items():
+        comps = components_by_key.get((parent, version))
+        if not comps:
+            raise ValueError(
+                f"bom_header.tsv: BOM (parent={parent}, version={version}) "
+                f"has no components in bom_components.tsv"
+            )
+        line = hr.get("__line__", "?")
+        payload: dict[str, Any] = {
+            "parent_external_id": parent,
+            "bom_version": version,
+            "components": comps,
+        }
+        if hr.get("effective_from"):
+            payload["effective_from"] = _to_date_str(
+                hr["effective_from"], field="effective_from", line=line
+            )
+        payloads.append(payload)
+
+    return payloads

--- a/tests/integration/test_daily_orchestrator_integration.py
+++ b/tests/integration/test_daily_orchestrator_integration.py
@@ -612,6 +612,18 @@ class TestDryRunPreview:
         drop = _on_hand_file(
             inbox, R4, [(seed["item1"], "1"), (seed["item2"], "2")], _utc(R4, *GREEN_ON_HAND)
         )
+        # Seed the OTHER blocking feed green too (same shape as Scenario 1) —
+        # without it, open-purchase-orders is missing past its deadline at
+        # 08:00 → arrival FAILED on a blocking feed → ESCALATED, and the
+        # DEGRADED pin below would be asserting the wrong scenario.
+        _write_tsv(
+            inbox / f"open-purchase-orders.part01_{R4:%Y%m%d}.tsv",
+            _PO_HEADER, [_po_row(_ext("PO-PREVIEW-1"), seed["item1"])], _utc(R4, *GREEN_PO),
+        )
+        _write_tsv(
+            inbox / f"open-purchase-orders.part02_{R4:%Y%m%d}.tsv",
+            _PO_HEADER, [_po_row(_ext("PO-PREVIEW-2"), seed["item2"])], _utc(R4, *GREEN_PO),
+        )
 
         total_before = _count_all_events(conn2)
         evaluation = plan_daily_run(conn2, inbox, R4, now=_utc(R4, 8))

--- a/tests/integration/test_daily_orchestrator_integration.py
+++ b/tests/integration/test_daily_orchestrator_integration.py
@@ -1,0 +1,635 @@
+"""
+tests/integration/test_daily_orchestrator_integration.py — the governed daily
+run end to end (ADR-042 PR-4b) against a real PostgreSQL — no mocks
+(CLAUDE.md). The pure scan/resolution/load-phase logic lives in
+tests/test_daily_orchestrator.py.
+
+The three canonical scenarios of the PR-4b contract, each on its own
+run_date so they stay order-independent:
+
+  1. TOUT VERT (R1) — every guard green: one ``daily_runs`` row is persisted
+     per active contract, the governed decision is DEGRADED — NEVER
+     AUTO_APPROVED, because DQ status has no DB wiring in V1 and
+     NOT_EVALUATED is never promoted to green (apply.py, "DQ STATUS — V1 IS
+     HONEST, NOT WIRED") — the green feeds ACTUALLY load through the real
+     ``/v1/ingest/*`` endpoints (kebab feed_key → snake entity_type
+     translation included, on-hand → on_hand, open-purchase-orders →
+     purchase_orders as a grouped .partNN drop), and EXACTLY ONE
+     ``daily_run_completed`` event is emitted for the run.
+  2. GARDE ROUGE BLOCKING (R2) — a blocking feed (on-hand) fails its volume
+     floor: the decision is ESCALATED, NOTHING loads (every candidate gets a
+     RUN_ESCALATED outcome, the green PO drop included), the inbox is left
+     untouched, and the run adds exactly ONE event total (the escalated
+     ``daily_run_completed`` — zero load-side events).
+  3. ADVISORY ROUGE (R3) — the advisory feed (open-work-orders) arrives
+     after its deadline: the run is DEGRADED (never escalated by an
+     advisory), the red feed is EXCLUDED from the load (GUARD_FAILED, its
+     file stays in the inbox), and the other feeds load normally.
+
+Plus the write-free preview: ``plan_daily_run`` (R4) persists no
+``daily_runs`` row, emits no event, and its evaluation is REFUSED by
+``load_eligible_feeds`` (a dry-run must never drive a real load).
+
+Determinism: every file's arrival time is pinned with ``os.utime`` and every
+``now`` is caller-supplied — no wall-clock dependence (guards.py timezone
+contract). Contract seeding goes through the REAL loader path
+(``parse_contract_file`` on the 3 seed ``config/feed-contracts/*.yaml`` +
+``upsert_contract``), with only the volume guards adapted to minuscule test
+files (min_rows 100 → 2/1, delta → None so scenarios can't contaminate each
+other through the previous-day baseline).
+
+Isolation (pattern of test_bom_obsolete_integration.py): referential seeds
+under a unique PREFIX via the real API, neutralized by DEACTIVATION in a
+module finalizer (items obsoleted, suppliers inactivated, nodes/contracts
+deactivated) — never a DELETE cascade (leçon #461). daily_runs/events stay
+append-only audit rows on far-past run_dates; the shared governance tables
+get one pre-clean TRUNCATE (child first, one statement — 078's FK) before
+the module's contracts are registered, same convention as
+test_daily_runs_integration.py.
+"""
+from __future__ import annotations
+
+import os
+from datetime import date, datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import psycopg
+import pytest
+from psycopg.rows import dict_row
+
+from ootils_core.engine.ingest.apply import RunDecisionStatus
+from ootils_core.engine.ingest.daily_orchestrator import (
+    FeedLoadStatus,
+    apply_daily_run,
+    load_eligible_feeds,
+    plan_daily_run,
+)
+from ootils_core.interfaces.contracts import parse_contract_file, upsert_contract
+from ootils_core.interfaces.guards import GuardStatus
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+TOKEN = "integration-test-token"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+PREFIX = f"DOR-{uuid4().hex[:8]}"
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACTS_DIR = _REPO_ROOT / "config" / "feed-contracts"
+SEED_FEED_KEYS = ("on-hand", "open-purchase-orders", "open-work-orders")
+
+# One run_date per scenario — far in the past relative to nothing (all clocks
+# are pinned), distinct so daily_runs/decision queries never cross-talk.
+R1 = date(2026, 3, 2)   # tout vert
+R2 = date(2026, 3, 9)   # garde rouge sur flux blocking
+R3 = date(2026, 3, 16)  # advisory rouge
+R4 = date(2026, 3, 23)  # dry-run preview
+R5 = date(2026, 3, 30)  # flux blocking present mais corrompu (revue PR-4b, finding 2)
+
+# Deadlines from the REAL seed cadences: on-hand 06:00+90' = 07:30 UTC,
+# open-purchase-orders 05:30+120' = 07:30 UTC, open-work-orders (advisory)
+# 07:00+180' = 10:00 UTC.
+GREEN_ON_HAND = (6, 10)
+GREEN_PO = (5, 40)
+LATE = (23, 30)
+
+
+def _utc(d: date, hour: int, minute: int = 0) -> datetime:
+    return datetime(d.year, d.month, d.day, hour, minute, tzinfo=timezone.utc)
+
+
+def _touch(path: Path, arrived: datetime) -> None:
+    ts = arrived.timestamp()
+    os.utime(path, (ts, ts))
+
+
+def _ext(base: str) -> str:
+    return f"{PREFIX}-{base}"
+
+
+def _write_tsv(path: Path, header: list[str], rows: list[list[str]], arrived: datetime) -> Path:
+    lines = ["\t".join(header)] + ["\t".join(r) for r in rows]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    _touch(path, arrived)
+    return path
+
+
+def _on_hand_file(inbox: Path, run_date: date, rows: list[tuple[str, str]], arrived: datetime) -> Path:
+    return _write_tsv(
+        inbox / f"on-hand_{run_date:%Y%m%d}.tsv",
+        ["item_external_id", "location_external_id", "quantity", "uom", "as_of_date"],
+        [[item, _ext("LOC-1"), qty, "EA", run_date.isoformat()] for item, qty in rows],
+        arrived,
+    )
+
+
+_PO_HEADER = [
+    "external_id", "item_external_id", "location_external_id",
+    "supplier_external_id", "quantity", "uom", "expected_delivery_date", "status",
+]
+
+
+def _po_row(po_ext: str, item: str) -> list[str]:
+    return [po_ext, item, _ext("LOC-1"), _ext("SUP-1"), "12", "EA", "2026-04-01", "confirmed"]
+
+
+def _events_for(conn, run_date: date) -> list[dict]:
+    return conn.execute(
+        "SELECT field_changed, new_date, new_quantity, old_text, source "
+        "FROM events WHERE event_type = 'daily_run_completed' AND new_date = %s "
+        "ORDER BY created_at, stream_seq",
+        (run_date,),
+    ).fetchall()
+
+
+def _count_all_events(conn) -> int:
+    return conn.execute("SELECT COUNT(*) AS n FROM events").fetchone()["n"]
+
+
+def _daily_rows(conn, run_date: date) -> list[dict]:
+    return conn.execute(
+        "SELECT feed_key, overall_status, row_count, file_arrived_at "
+        "FROM daily_runs WHERE run_date = %s ORDER BY feed_key",
+        (run_date,),
+    ).fetchall()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def api_client(migrated_db):
+    """Module-scoped FastAPI TestClient bound to the real test DB (same
+    pattern as test_bom_obsolete_integration.py). Also pins the environment
+    the orchestrator's load phase (ingest_exec.call_api → the module-level
+    app) will read: DATABASE_URL + OOTILS_API_TOKEN."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = TOKEN
+
+    from fastapi.testclient import TestClient
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="module")
+def seed(api_client, request, migrated_db):
+    """The 3 REAL seed contracts (config/feed-contracts/*.yaml) through the
+    real loader path, volume guards adapted to tiny files; referential data
+    (items / location / supplier) under PREFIX via the real ingest API.
+    Neutralized by DEACTIVATION — never a DELETE cascade."""
+    # Pre-clean the shared governance tables (child listed with its parent —
+    # 078's FK forbids truncating feed_contracts alone), same convention as
+    # test_daily_runs_integration.py.
+    with psycopg.connect(migrated_db, autocommit=True) as c:
+        c.execute("TRUNCATE daily_runs, feed_contracts")
+
+    guard_overrides = {
+        # Real file: min 100 rows. Test drop: 3 rows. Delta guard silenced so
+        # each scenario's row count never becomes the next one's red baseline.
+        "on-hand": {"volume_guard_min_rows": 2, "volume_guard_max_pct_delta": None},
+        "open-purchase-orders": {"volume_guard_min_rows": 1, "volume_guard_max_pct_delta": None},
+        "open-work-orders": {},  # already None/None in the seed YAML
+    }
+    with psycopg.connect(migrated_db) as conn:
+        for feed_key in SEED_FEED_KEYS:
+            spec = parse_contract_file(CONTRACTS_DIR / f"{feed_key}.yaml")
+            assert spec.feed_key == feed_key
+            if guard_overrides[feed_key]:
+                spec = spec.model_copy(update=guard_overrides[feed_key])
+            upsert_contract(conn, spec)
+        conn.commit()
+
+    items = [
+        {"external_id": _ext(f"ITEM-{i}"), "name": f"Daily orchestrator item {i}",
+         "item_type": "component", "uom": "EA", "status": "active"}
+        for i in (1, 2, 3)
+    ]
+    resp = api_client.post("/v1/ingest/items", json={"items": items}, headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    resp = api_client.post(
+        "/v1/ingest/locations",
+        json={"locations": [{"external_id": _ext("LOC-1"), "name": "Daily orchestrator DC"}]},
+        headers=AUTH,
+    )
+    assert resp.status_code == 200, resp.text
+    resp = api_client.post(
+        "/v1/ingest/suppliers",
+        json={"suppliers": [{"external_id": _ext("SUP-1"), "name": "Daily orchestrator supplier"}]},
+        headers=AUTH,
+    )
+    assert resp.status_code == 200, resp.text
+
+    def _neutralize():
+        with psycopg.connect(migrated_db, autocommit=True) as conn:
+            conn.execute(
+                "UPDATE feed_contracts SET active = FALSE WHERE feed_key = ANY(%s)",
+                (list(SEED_FEED_KEYS),),
+            )
+            conn.execute(
+                """
+                UPDATE nodes SET active = FALSE
+                WHERE item_id IN (SELECT item_id FROM items WHERE external_id LIKE %s)
+                """,
+                (PREFIX + "%",),
+            )
+            conn.execute(
+                "UPDATE items SET status = 'obsolete' WHERE external_id LIKE %s",
+                (PREFIX + "%",),
+            )
+            conn.execute(
+                "UPDATE suppliers SET status = 'inactive' WHERE external_id LIKE %s",
+                (PREFIX + "%",),
+            )
+
+    request.addfinalizer(_neutralize)
+    return {
+        "item1": _ext("ITEM-1"),
+        "item2": _ext("ITEM-2"),
+        "item3": _ext("ITEM-3"),
+        "loc": _ext("LOC-1"),
+        "sup": _ext("SUP-1"),
+    }
+
+
+@pytest.fixture
+def conn2(migrated_db):
+    """Function-scoped dict_row connection the tests drive the orchestrator
+    with (the CLI's role: it owns — and here commits — the transaction)."""
+    with psycopg.connect(migrated_db, row_factory=dict_row) as c:
+        yield c
+        c.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — tout vert
+# ---------------------------------------------------------------------------
+
+
+class TestScenario1AllGreen:
+    def test_green_run_persists_decides_degraded_loads_and_emits_one_event(
+        self, seed, migrated_db, conn2, tmp_path
+    ):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        _on_hand_file(
+            inbox, R1,
+            [(seed["item1"], "25"), (seed["item2"], "40"), (seed["item3"], "10")],
+            _utc(R1, *GREEN_ON_HAND),
+        )
+        # The PO drop arrives as a grouped .partNN pair — the PR-4a grammar
+        # through the whole governed pipeline.
+        _write_tsv(
+            inbox / f"open-purchase-orders.part01_{R1:%Y%m%d}.tsv",
+            _PO_HEADER, [_po_row(_ext("PO-1"), seed["item1"])], _utc(R1, *GREEN_PO),
+        )
+        _write_tsv(
+            inbox / f"open-purchase-orders.part02_{R1:%Y%m%d}.tsv",
+            _PO_HEADER, [_po_row(_ext("PO-2"), seed["item2"])], _utc(R1, *GREEN_PO),
+        )
+        # open-work-orders: no file, and now (08:00) is BEFORE its 10:00
+        # deadline — NOT_EVALUATED, which must not block anything.
+
+        evaluation = apply_daily_run(conn2, inbox, R1, now=_utc(R1, 8))
+        conn2.commit()
+
+        # Decision: DEGRADED — and NEVER AUTO_APPROVED (DQ unwired in V1).
+        assert evaluation.decision is not None
+        assert evaluation.decision.status is RunDecisionStatus.DEGRADED
+        assert evaluation.decision.status is not RunDecisionStatus.AUTO_APPROVED
+
+        # One PERSISTED daily_runs row per active contract.
+        assert all(fe.daily_run_id is not None for fe in evaluation.feed_evaluations)
+        rows = _daily_rows(conn2, R1)
+        assert [(r["feed_key"], r["overall_status"], r["row_count"]) for r in rows] == [
+            ("on-hand", "ok", 3),
+            ("open-purchase-orders", "ok", 2),
+            ("open-work-orders", "ok", None),  # NOT_EVALUATED guards never fail a feed
+        ]
+
+        # Load: green feeds through the REAL endpoints, kebab → snake.
+        outcomes = load_eligible_feeds(evaluation, token=TOKEN, inbox_dir=inbox)
+        by = {o.feed_key: o for o in outcomes}
+        assert by["on-hand"].status is FeedLoadStatus.LOADED
+        assert by["on-hand"].canonical == "on_hand.tsv"
+        assert by["on-hand"].http_status == 200
+        assert by["open-purchase-orders"].status is FeedLoadStatus.LOADED
+        assert by["open-purchase-orders"].canonical == "purchase_orders.tsv"
+        assert by["open-work-orders"].status is FeedLoadStatus.NO_FILE
+
+        # Chargement EFFECTIF: canonical rows really landed.
+        qty = conn2.execute(
+            """
+            SELECT n.quantity FROM nodes n
+            JOIN items i ON i.item_id = n.item_id
+            WHERE i.external_id = %s AND n.node_type = 'OnHandSupply' AND n.active
+            """,
+            (seed["item1"],),
+        ).fetchone()
+        assert qty is not None and float(qty["quantity"]) == 25.0
+        n_pos = conn2.execute(
+            "SELECT COUNT(*) AS n FROM external_references "
+            "WHERE entity_type = 'purchase_order' AND external_id = ANY(%s)",
+            ([_ext("PO-1"), _ext("PO-2")],),
+        ).fetchone()["n"]
+        assert n_pos == 2
+
+        # EXACTLY ONE daily_run_completed event for this run.
+        events = _events_for(conn2, R1)
+        assert len(events) == 1
+        assert events[0]["field_changed"] == "degraded"
+        assert events[0]["new_quantity"] == 3  # the 3 governed feeds
+        assert events[0]["source"] == "ingestion"
+
+        # Inbox drained, drops archived to processed/ with their reports.
+        assert list(inbox.iterdir()) == []
+        processed = sorted(p.name for p in (tmp_path / "processed").iterdir())
+        assert sum(1 for n in processed if n.endswith(".tsv")) == 3
+        assert any(n.endswith(".report.json") for n in processed)
+        assert not (tmp_path / "rejected").exists()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — garde rouge sur flux blocking
+# ---------------------------------------------------------------------------
+
+
+class TestScenario2BlockingRed:
+    def test_blocking_red_escalates_loads_nothing_one_event_only(
+        self, seed, migrated_db, conn2, tmp_path
+    ):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        # on-hand: ONE row — below the (test-adapted) volume floor of 2 on a
+        # BLOCKING feed. Arrival itself is green: the floor is the red guard.
+        _on_hand_file(inbox, R2, [(seed["item1"], "99")], _utc(R2, *GREEN_ON_HAND))
+        # open-purchase-orders: perfectly green — must STILL not load.
+        _write_tsv(
+            inbox / f"open-purchase-orders_{R2:%Y%m%d}.tsv",
+            _PO_HEADER, [_po_row(_ext("PO-9"), seed["item1"])], _utc(R2, *GREEN_PO),
+        )
+        inbox_before = sorted(p.name for p in inbox.iterdir())
+
+        total_before = _count_all_events(conn2)
+        evaluation = apply_daily_run(conn2, inbox, R2, now=_utc(R2, 8))
+        conn2.commit()
+
+        assert evaluation.decision is not None
+        assert evaluation.decision.status is RunDecisionStatus.ESCALATED
+        on_hand_eval = {fe.feed_key: fe for fe in evaluation.feed_evaluations}["on-hand"]
+        assert on_hand_eval.evaluation.overall_status is GuardStatus.FAILED
+        assert on_hand_eval.evaluation.by_name("volume_floor").status is GuardStatus.FAILED
+
+        outcomes = load_eligible_feeds(evaluation, token=TOKEN, inbox_dir=inbox)
+
+        # ZERO chargement: every candidate blocked, green PO included.
+        assert sorted(o.feed_key for o in outcomes) == [
+            "on-hand", "open-purchase-orders", "open-work-orders",
+        ]
+        assert all(o.status is FeedLoadStatus.RUN_ESCALATED for o in outcomes)
+
+        # Nothing landed in the canonical model.
+        assert conn2.execute(
+            "SELECT 1 FROM external_references "
+            "WHERE entity_type = 'purchase_order' AND external_id = %s",
+            (_ext("PO-9"),),
+        ).fetchone() is None
+
+        # Exactly ONE event total for the whole apply+load — the escalated
+        # daily_run_completed; zero load-side events (nothing loaded).
+        assert _count_all_events(conn2) - total_before == 1
+        events = _events_for(conn2, R2)
+        assert len(events) == 1
+        assert events[0]["field_changed"] == "escalated"
+        assert "on-hand" in (events[0]["old_text"] or "")
+
+        # Inbox untouched — no archive dir ever appears.
+        assert sorted(p.name for p in inbox.iterdir()) == inbox_before
+        assert not (tmp_path / "processed").exists()
+        assert not (tmp_path / "rejected").exists()
+
+        # The daily_runs audit trail still recorded every feed honestly.
+        rows = _daily_rows(conn2, R2)
+        assert [(r["feed_key"], r["overall_status"]) for r in rows] == [
+            ("on-hand", "failed"),
+            ("open-purchase-orders", "ok"),
+            ("open-work-orders", "ok"),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2b — blocking feed PRESENT but CORRUPTED (revue PR-4b, finding 2)
+# ---------------------------------------------------------------------------
+
+
+class TestScenario2bBlockingCorrupted:
+    def test_corrupted_blocking_file_escalates_and_loads_nothing(
+        self, seed, migrated_db, conn2, tmp_path
+    ):
+        """A file EXISTS for the blocking feed (on-hand) but fails TSV
+        parsing (bad column count) — distinct from Scenario 2's "too few
+        rows" axis. Before finding 2's fix, an unparseable-but-present file
+        yielded ``row_count=None`` (NOT_EVALUATED), which never fails a
+        guard and let the run settle on DEGRADED with the corrupted feed
+        simply skipped — silently loading the OTHER green feeds against a
+        torn picture. The fix measures 0 exploitable rows instead, which
+        the volume floor guard treats as an honest FAILED, correctly
+        escalating the whole run and blocking every candidate feed."""
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        # Malformed on-hand drop: 2 cells vs the header's 5 columns.
+        bad = inbox / f"on-hand_{R5:%Y%m%d}.tsv"
+        bad.write_text(
+            "item_external_id\tlocation_external_id\tquantity\tuom\tas_of_date\n"
+            "IT-1\tLOC-1\n",
+            encoding="utf-8",
+        )
+        _touch(bad, _utc(R5, *GREEN_ON_HAND))
+        # open-purchase-orders: perfectly green — must STILL not load.
+        _write_tsv(
+            inbox / f"open-purchase-orders_{R5:%Y%m%d}.tsv",
+            _PO_HEADER, [_po_row(_ext("PO-5"), seed["item1"])], _utc(R5, *GREEN_PO),
+        )
+        inbox_before = sorted(p.name for p in inbox.iterdir())
+
+        total_before = _count_all_events(conn2)
+        evaluation = apply_daily_run(conn2, inbox, R5, now=_utc(R5, 8))
+        conn2.commit()
+
+        assert "on-hand" in evaluation.scan.issues
+        on_hand_eval = {fe.feed_key: fe for fe in evaluation.feed_evaluations}["on-hand"]
+        assert on_hand_eval.observation.row_count == 0  # honest zero, never None
+        assert on_hand_eval.evaluation.overall_status is GuardStatus.FAILED
+        assert on_hand_eval.evaluation.by_name("volume_floor").status is GuardStatus.FAILED
+
+        assert evaluation.decision is not None
+        assert evaluation.decision.status is RunDecisionStatus.ESCALATED
+
+        outcomes = load_eligible_feeds(evaluation, token=TOKEN, inbox_dir=inbox)
+
+        # ZERO chargement: every candidate blocked, green PO included.
+        assert sorted(o.feed_key for o in outcomes) == [
+            "on-hand", "open-purchase-orders", "open-work-orders",
+        ]
+        assert all(o.status is FeedLoadStatus.RUN_ESCALATED for o in outcomes)
+
+        # Nothing landed in the canonical model.
+        assert conn2.execute(
+            "SELECT 1 FROM external_references "
+            "WHERE entity_type = 'purchase_order' AND external_id = %s",
+            (_ext("PO-5"),),
+        ).fetchone() is None
+
+        # Exactly ONE event total for the whole apply+load.
+        assert _count_all_events(conn2) - total_before == 1
+        events = _events_for(conn2, R5)
+        assert len(events) == 1
+        assert events[0]["field_changed"] == "escalated"
+        assert "on-hand" in (events[0]["old_text"] or "")
+
+        # Inbox untouched — no archive dir ever appears (apply_daily_run
+        # records the guard verdict but load_eligible_feeds never runs the
+        # archive step for an escalated run; the malformed file itself was
+        # never archived by scan_inbox either — only load-phase writes move
+        # files).
+        assert sorted(p.name for p in inbox.iterdir()) == inbox_before
+        assert not (tmp_path / "processed").exists()
+        assert not (tmp_path / "rejected").exists()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — advisory rouge
+# ---------------------------------------------------------------------------
+
+
+class TestScenario3AdvisoryRed:
+    def test_advisory_red_is_excluded_and_the_others_load(
+        self, seed, migrated_db, conn2, tmp_path
+    ):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        _on_hand_file(
+            inbox, R3,
+            [(seed["item1"], "60"), (seed["item2"], "5"), (seed["item3"], "7")],
+            _utc(R3, *GREEN_ON_HAND),
+        )
+        _write_tsv(
+            inbox / f"open-purchase-orders_{R3:%Y%m%d}.tsv",
+            _PO_HEADER, [_po_row(_ext("PO-3"), seed["item3"])], _utc(R3, *GREEN_PO),
+        )
+        # open-work-orders (ADVISORY): arrives well after its 10:00 deadline.
+        wo_file = _write_tsv(
+            inbox / f"open-work-orders_{R3:%Y%m%d}.tsv",
+            ["external_id", "item_external_id", "location_external_id", "quantity", "status"],
+            [[_ext("WO-1"), seed["item1"], seed["loc"], "4", "released"]],
+            _utc(R3, *LATE),
+        )
+
+        evaluation = apply_daily_run(conn2, inbox, R3, now=_utc(R3, 23, 45))
+        conn2.commit()
+
+        # An advisory red DEGRADES, it never escalates.
+        assert evaluation.decision is not None
+        assert evaluation.decision.status is RunDecisionStatus.DEGRADED
+        wo_eval = {fe.feed_key: fe for fe in evaluation.feed_evaluations}["open-work-orders"]
+        assert wo_eval.evaluation.overall_status is GuardStatus.FAILED
+        assert wo_eval.evaluation.by_name("arrival_window").status is GuardStatus.FAILED
+
+        outcomes = load_eligible_feeds(evaluation, token=TOKEN, inbox_dir=inbox)
+        by = {o.feed_key: o for o in outcomes}
+
+        # Flux exclu: the advisory-red feed never loads — suspect data stays
+        # out whatever the criticality — and its drop stays in the inbox.
+        assert by["open-work-orders"].status is FeedLoadStatus.GUARD_FAILED
+        assert "deadline" in by["open-work-orders"].detail
+        assert wo_file.exists()
+
+        # Les autres chargent.
+        assert by["on-hand"].status is FeedLoadStatus.LOADED
+        assert by["open-purchase-orders"].status is FeedLoadStatus.LOADED
+        qty = conn2.execute(
+            """
+            SELECT n.quantity FROM nodes n
+            JOIN items i ON i.item_id = n.item_id
+            WHERE i.external_id = %s AND n.node_type = 'OnHandSupply' AND n.active
+            """,
+            (seed["item1"],),
+        ).fetchone()
+        assert qty is not None and float(qty["quantity"]) == 60.0
+        assert conn2.execute(
+            "SELECT 1 FROM external_references "
+            "WHERE entity_type = 'purchase_order' AND external_id = %s",
+            (_ext("PO-3"),),
+        ).fetchone() is not None
+        # The excluded feed left no canonical trace.
+        assert conn2.execute(
+            """
+            SELECT 1 FROM nodes n JOIN items i ON i.item_id = n.item_id
+            WHERE i.external_id LIKE %s AND n.node_type = 'WorkOrderSupply'
+            """,
+            (PREFIX + "%",),
+        ).fetchone() is None
+
+        # Still exactly ONE daily_run_completed for this run.
+        events = _events_for(conn2, R3)
+        assert len(events) == 1
+        assert events[0]["field_changed"] == "degraded"
+
+        # Green drops archived; only the red one remains in the inbox.
+        assert [p.name for p in inbox.iterdir()] == [f"open-work-orders_{R3:%Y%m%d}.tsv"]
+        processed = [p.name for p in (tmp_path / "processed").iterdir() if p.suffix == ".tsv"]
+        assert len(processed) == 2
+
+
+# ---------------------------------------------------------------------------
+# Dry-run preview — write-free by construction
+# ---------------------------------------------------------------------------
+
+
+class TestDryRunPreview:
+    def test_plan_daily_run_writes_nothing_and_cannot_drive_a_load(
+        self, seed, migrated_db, conn2, tmp_path
+    ):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        drop = _on_hand_file(
+            inbox, R4, [(seed["item1"], "1"), (seed["item2"], "2")], _utc(R4, *GREEN_ON_HAND)
+        )
+
+        total_before = _count_all_events(conn2)
+        evaluation = plan_daily_run(conn2, inbox, R4, now=_utc(R4, 8))
+
+        assert evaluation.is_applied is False
+        assert all(fe.daily_run_id is None for fe in evaluation.feed_evaluations)
+        assert evaluation.decision is not None
+        assert evaluation.decision.status is RunDecisionStatus.DEGRADED  # in memory only
+
+        # SELECT-only: zero daily_runs rows, zero events — visible from a
+        # FRESH connection (nothing was even left uncommitted).
+        assert _daily_rows(conn2, R4) == []
+        assert _events_for(conn2, R4) == []
+        assert _count_all_events(conn2) == total_before
+        with psycopg.connect(migrated_db, row_factory=dict_row) as fresh:
+            assert _daily_rows(fresh, R4) == []
+
+        # A preview can never drive a real load.
+        with pytest.raises(ValueError, match="apply_daily_run"):
+            load_eligible_feeds(evaluation, token=TOKEN, inbox_dir=inbox)
+        assert drop.exists()

--- a/tests/test_daily_orchestrator.py
+++ b/tests/test_daily_orchestrator.py
@@ -1,0 +1,810 @@
+"""
+tests/test_daily_orchestrator.py — Pure unit tests (no DB) for
+engine/ingest/daily_orchestrator.py (ADR-042 PR-4b) and the
+scripts/run_daily_ingest.py kill switch.
+
+Five axes:
+
+1. `scan_inbox` — the pure filesystem scan: one run_date's dated drops only
+   (canonical/dateless, other-date, non-TSV names all land in `ignored`,
+   never an error), `.partNN` siblings grouped ascending with `__line__`
+   re-prefixed per source file, duplicate part numbers and malformed TSVs
+   collected as `ScanIssue`, same-feed_key ambiguity flagged and BOTH groups
+   evicted from `feeds` (revue PR-4b, finding 1 — "refusing both" actually
+   honoured), missing inbox a hard FileNotFoundError. `_observation_for`
+   distinguishes a present-but-unusable file (row_count=0, honest measured
+   zero — revue PR-4b, finding 2) from a genuinely absent one (row_count
+   None, nothing measured at all).
+
+2. Resolution — the feed_key/entity_type mismatch (module docstring of
+   daily_orchestrator.py): a governed kebab-case feed_key ('on-hand')
+   translates through its contract's snake_case `entity_type` to the
+   DISPATCH/PAYLOAD_BUILDERS key ('on_hand.tsv'); an ungoverned feed_key is
+   used as the stem directly. Plus `_resolve_ungoverned` (warning logged,
+   sorted output, restricted to feed_keys the registry has NEVER heard of),
+   `_quarantine_deactivated_contracts` (a feed_key the registry KNOWS but
+   has no active version for becomes an explicit ScanIssue, never
+   ungoverned — revue PR-4b, finding 3), `_observation_for` (scanned /
+   issue / absent), and `_load_order_key` (LOAD_ORDER respected, unknown
+   canonicals sort last — and every registered builder has an explicit
+   position).
+
+3. The load gate — `load_eligible_feeds` refuses a dry-run evaluation
+   (ValueError), and an ESCALATED (or decision-less) run loads NOTHING:
+   every candidate feed_key (scanned or governed-but-absent) gets a
+   RUN_ESCALATED outcome and no file moves.
+
+4. The load phase with `call_api` monkeypatched (the API/DB boundary —
+   integration covers the real call): guard-failed feeds excluded (file
+   left in the inbox), green feeds loaded in LOAD_ORDER through the
+   translated canonical endpoint, non-2xx → REJECTED + archived to
+   rejected/, a raising call_api → API_CRASH, builderless entities →
+   UNSUPPORTED_ENTITY, builder ValueError → SCAN_ERROR, scan issues
+   archived to rejected/, governed feeds without a file → NO_FILE.
+
+5. The CLI kill switch (scripts/run_daily_ingest.py): --apply without
+   OOTILS_DAILY_RUN_ENABLED (or with a falsy value) is refused with exit
+   code 1 BEFORE any DB connection; --apply with the switch on but no
+   OOTILS_API_TOKEN likewise; dry-run is deliberately NOT gated by either;
+   missing DSN / bad --date exit 2.
+
+No DB required — this file must stay collectible and green without
+DATABASE_URL.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from ootils_core.engine.ingest import daily_orchestrator
+from ootils_core.engine.ingest.apply import (
+    DailyRunDecision,
+    FeedDecisionInput,
+    RunDecisionStatus,
+    decide_daily_run,
+)
+from ootils_core.engine.ingest.daily_orchestrator import (
+    LOAD_ORDER,
+    DailyRunEvaluation,
+    FeedLoadStatus,
+    FeedRunEvaluation,
+    InboxScan,
+    _canonical_dispatch_name,
+    _load_order_key,
+    _observation_for,
+    _quarantine_deactivated_contracts,
+    _resolve_ungoverned,
+    load_eligible_feeds,
+    scan_inbox,
+)
+from ootils_core.interfaces.contracts import FeedContract
+from ootils_core.interfaces.guards import FeedGuardEvaluation, GuardStatus, evaluate_feed_guards
+from ootils_core.interfaces.ingest_exec import DISPATCH, PAYLOAD_BUILDERS
+
+# scripts/ are not a package — same import pattern as tests/test_ingest_file_naming.py.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import run_daily_ingest  # noqa: E402
+
+RUN_DATE = date(2026, 3, 2)
+DATE_STR = "20260302"  # RUN_DATE as AAAAMMJJ
+
+
+# ─────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────
+_HEADER = "item_external_id\tlocation_external_id\tquantity\tuom\tas_of_date"
+
+
+def _utc(hour: int, minute: int = 0, run_date: date = RUN_DATE) -> datetime:
+    return datetime(run_date.year, run_date.month, run_date.day, hour, minute, tzinfo=timezone.utc)
+
+
+def _write_tsv(path: Path, rows: list[str], header: str = _HEADER) -> Path:
+    path.write_text("\n".join([header, *rows]) + "\n", encoding="utf-8")
+    return path
+
+
+def _row(item: str = "IT-1", qty: str = "5") -> str:
+    return f"{item}\tLOC-1\t{qty}\tEA\t2026-03-02"
+
+
+def _contract(feed_key: str, entity_type: str, criticality: str = "blocking") -> FeedContract:
+    """A hand-built FeedContract row (pure dataclass — no DB involved)."""
+    now = datetime.now(timezone.utc)
+    return FeedContract(
+        feed_contract_id=uuid4(),
+        feed_key=feed_key,
+        version=1,
+        entity_type=entity_type,
+        source_system="UNIT",
+        format="tsv",
+        key_columns=["item_external_id"],
+        mandatory_columns=["item_external_id"],
+        load_mode="full",
+        cadence="0 6 * * *",
+        arrival_window_minutes=90,
+        owner="unit-tests",
+        criticality=criticality,
+        volume_guard_min_rows=None,
+        volume_guard_max_pct_delta=None,
+        depends_on=[],
+        active=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _guard_eval(feed_key: str, criticality: str, *, failed: bool = False) -> FeedGuardEvaluation:
+    """A real FeedGuardEvaluation via the pure evaluator: green = file within
+    the 07:30 deadline (cadence 06:00 + 90 min), red = file after it."""
+    arrived = _utc(23, 0) if failed else _utc(6, 30)
+    return evaluate_feed_guards(
+        feed_key=feed_key,
+        criticality=criticality,
+        cadence="0 6 * * *",
+        arrival_window_minutes=90,
+        volume_guard_min_rows=None,
+        volume_guard_max_pct_delta=None,
+        run_date=RUN_DATE,
+        file_arrived_at=arrived,
+        row_count=3,
+        previous_row_count=None,
+        deleted_count=None,
+        previous_active_count=None,
+        now=_utc(8),
+    )
+
+
+def _feed_eval(
+    feed_key: str, entity_type: str, scan: InboxScan, *,
+    criticality: str = "blocking", failed: bool = False,
+) -> FeedRunEvaluation:
+    return FeedRunEvaluation(
+        feed_key=feed_key,
+        contract=_contract(feed_key, entity_type, criticality),
+        observation=_observation_for(feed_key, scan),
+        evaluation=_guard_eval(feed_key, criticality, failed=failed),
+        daily_run_id=uuid4(),
+    )
+
+
+def _decision(*inputs: FeedDecisionInput) -> DailyRunDecision:
+    return decide_daily_run(list(inputs), RUN_DATE, evaluated_at=_utc(8))
+
+
+def _input(feed_key: str, criticality: str, status: GuardStatus) -> FeedDecisionInput:
+    return FeedDecisionInput(
+        feed_key=feed_key, criticality=criticality, guard_status=status, dq_status=None
+    )
+
+
+def _evaluation(
+    scan: InboxScan,
+    feed_evals: list[FeedRunEvaluation],
+    decision: DailyRunDecision | None,
+    *,
+    is_applied: bool = True,
+    ungoverned: tuple[str, ...] = (),
+) -> DailyRunEvaluation:
+    return DailyRunEvaluation(
+        run_date=RUN_DATE,
+        is_applied=is_applied,
+        scan=scan,
+        feed_evaluations=tuple(feed_evals),
+        ungoverned_feed_keys=ungoverned,
+        decision=decision,
+    )
+
+
+# ─────────────────────────────────────────────────────────────
+# 1. scan_inbox
+# ─────────────────────────────────────────────────────────────
+class TestScanInbox:
+    def test_missing_inbox_is_a_hard_error(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="inbox directory does not exist"):
+            scan_inbox(tmp_path / "nope", RUN_DATE)
+        # A FILE at the inbox path is just as much a config error as nothing.
+        not_a_dir = tmp_path / "inbox"
+        not_a_dir.write_text("oops", encoding="utf-8")
+        with pytest.raises(FileNotFoundError):
+            scan_inbox(not_a_dir, RUN_DATE)
+
+    def test_dated_file_scanned_with_rows_and_utc_mtime(self, tmp_path):
+        _write_tsv(tmp_path / f"on-hand_{DATE_STR}.tsv", [_row("IT-1"), _row("IT-2")])
+        scan = scan_inbox(tmp_path, RUN_DATE)
+
+        assert set(scan.feeds) == {"on-hand"}
+        assert scan.issues == {}
+        assert scan.ignored == ()
+        scanned = scan.feeds["on-hand"]
+        assert scanned.row_count == 2  # header excluded
+        assert scanned.headers == tuple(_HEADER.split("\t"))
+        assert scanned.rows[0]["item_external_id"] == "IT-1"
+        assert scanned.rows[0]["__line__"] == "2"  # 1-based, header is line 1
+        assert [p.name for p in scanned.paths] == [f"on-hand_{DATE_STR}.tsv"]
+        # mtime is returned timezone-AWARE UTC (the guards' hard contract).
+        assert scanned.file_arrived_at.tzinfo is not None
+        assert scanned.file_arrived_at.utcoffset().total_seconds() == 0
+
+    def test_not_todays_business_is_ignored_not_an_error(self, tmp_path):
+        _write_tsv(tmp_path / "on_hand.tsv", [_row()])              # canonical (dateless)
+        _write_tsv(tmp_path / "on-hand_20260301.tsv", [_row()])     # another day's drop
+        _write_tsv(tmp_path / "notes.txt", [_row()])                # not a .tsv name
+        _write_tsv(tmp_path / f"on-hand_{DATE_STR}.TSV", [_row()])  # extension is case-sensitive
+        (tmp_path / "subdir").mkdir()                               # directories skipped silently
+
+        scan = scan_inbox(tmp_path, RUN_DATE)
+        assert scan.feeds == {}
+        assert scan.issues == {}
+        assert sorted(p.name for p in scan.ignored) == [
+            "notes.txt", "on-hand_20260301.tsv", f"on-hand_{DATE_STR}.TSV", "on_hand.tsv",
+        ]
+
+    def test_part_group_grouped_ascending_and_lines_traceable(self, tmp_path):
+        # Written part02-first to prove the ordering comes from the part
+        # number, not from creation/collation order.
+        _write_tsv(tmp_path / f"forecasts.part02_{DATE_STR}.tsv", [_row("IT-3")])
+        _write_tsv(tmp_path / f"forecasts.part01_{DATE_STR}.tsv", [_row("IT-1"), _row("IT-2")])
+
+        scan = scan_inbox(tmp_path, RUN_DATE)
+        assert set(scan.feeds) == {"forecasts"}
+        scanned = scan.feeds["forecasts"]
+        assert [p.name for p in scanned.paths] == [
+            f"forecasts.part01_{DATE_STR}.tsv", f"forecasts.part02_{DATE_STR}.tsv",
+        ]
+        assert scanned.row_count == 3
+        assert [r["item_external_id"] for r in scanned.rows] == ["IT-1", "IT-2", "IT-3"]
+        # __line__ re-prefixed with the source part for cross-part traceability.
+        assert scanned.rows[0]["__line__"] == f"forecasts.part01_{DATE_STR}.tsv:L2"
+        assert scanned.rows[2]["__line__"] == f"forecasts.part02_{DATE_STR}.tsv:L2"
+
+    def test_part_group_ignores_other_dates_and_other_entities(self, tmp_path):
+        _write_tsv(tmp_path / f"forecasts.part01_{DATE_STR}.tsv", [_row("IT-1")])
+        _write_tsv(tmp_path / "forecasts.part02_20260301.tsv", [_row("OLD")])   # other date
+        _write_tsv(tmp_path / f"transfers.part01_{DATE_STR}.tsv", [_row("TR")])  # other entity
+
+        scan = scan_inbox(tmp_path, RUN_DATE)
+        assert [p.name for p in scan.feeds["forecasts"].paths] == [
+            f"forecasts.part01_{DATE_STR}.tsv"
+        ]
+        assert scan.feeds["forecasts"].row_count == 1
+        assert set(scan.feeds) == {"forecasts", "transfers"}
+        assert [p.name for p in scan.ignored] == ["forecasts.part02_20260301.tsv"]
+
+    def test_duplicate_part_number_is_a_scan_issue(self, tmp_path):
+        # part001 and part01 both parse to part=1 — ambiguous, cannot pick one.
+        _write_tsv(tmp_path / f"on-hand.part001_{DATE_STR}.tsv", [_row()])
+        _write_tsv(tmp_path / f"on-hand.part01_{DATE_STR}.tsv", [_row()])
+
+        scan = scan_inbox(tmp_path, RUN_DATE)
+        assert scan.feeds == {}
+        assert set(scan.issues) == {"on-hand"}
+        # The refusal survives (as the ambiguity flag once the second file is
+        # reached); the feed never becomes loadable.
+        assert "on-hand" in scan.issues["on-hand"].error
+
+    def test_malformed_tsv_is_a_scan_issue_with_no_fabricated_row_count(self, tmp_path):
+        bad = tmp_path / f"on-hand_{DATE_STR}.tsv"
+        bad.write_text(_HEADER + "\nIT-1\tLOC-1\n", encoding="utf-8")  # 2 cells vs 5 headers
+
+        scan = scan_inbox(tmp_path, RUN_DATE)
+        assert scan.feeds == {}
+        issue = scan.issues["on-hand"]
+        assert "column count" in issue.error
+        assert issue.file_arrived_at.tzinfo is not None
+        obs = _observation_for("on-hand", scan)
+        assert obs.file_arrived_at is not None
+        # A present-but-unusable file measures 0 exploitable rows — honest,
+        # never a fabricated non-zero count, and distinct from the
+        # absent-file case (row_count=None, tested below).
+        assert obs.row_count == 0
+
+    def test_empty_file_is_a_scan_issue(self, tmp_path):
+        (tmp_path / f"on-hand_{DATE_STR}.tsv").write_bytes(b"")
+        scan = scan_inbox(tmp_path, RUN_DATE)
+        assert scan.feeds == {}
+        assert "empty" in scan.issues["on-hand"].error
+
+    def test_same_feed_key_from_two_file_groups_is_flagged(self, tmp_path):
+        # A part group AND a plain dated file for the same (feed_key, date):
+        # BOTH groups are refused — the group already accepted into `feeds`
+        # is EVICTED once the second group is discovered (revue PR-4b,
+        # finding 1: "refusing both" is now actually honoured, not just the
+        # second-seen group).
+        part01 = _write_tsv(tmp_path / f"on-hand.part01_{DATE_STR}.tsv", [_row("IT-1")])
+        part02 = _write_tsv(tmp_path / f"on-hand.part02_{DATE_STR}.tsv", [_row("IT-2")])
+        plain = _write_tsv(tmp_path / f"on-hand_{DATE_STR}.tsv", [_row("IT-9")])
+
+        scan = scan_inbox(tmp_path, RUN_DATE)
+        assert "on-hand" not in scan.feeds
+        assert "on-hand" in scan.issues
+        issue = scan.issues["on-hand"]
+        assert "more than one file group" in issue.error
+        # The issue's paths cover BOTH groups — the 2-file part group AND the
+        # plain single-file group — not just the one seen second.
+        assert set(issue.paths) == {part01, part02, plain}
+
+
+# ─────────────────────────────────────────────────────────────
+# 2. Resolution — feed_key kebab vs entity_type snake, ungoverned, ordering
+# ─────────────────────────────────────────────────────────────
+class TestResolution:
+    def test_governed_feed_key_translates_through_contract_entity_type(self):
+        # THE mismatch: registry feed_keys are kebab-case, DISPATCH keys are
+        # snake_case — the active contract's entity_type is the only bridge.
+        assert _canonical_dispatch_name("on-hand", _contract("on-hand", "on_hand")) == "on_hand.tsv"
+        assert (
+            _canonical_dispatch_name(
+                "open-purchase-orders", _contract("open-purchase-orders", "purchase_orders")
+            )
+            == "purchase_orders.tsv"
+        )
+        assert (
+            _canonical_dispatch_name(
+                "open-work-orders", _contract("open-work-orders", "work_orders", "advisory")
+            )
+            == "work_orders.tsv"
+        )
+
+    def test_ungoverned_feed_key_is_used_as_the_stem_directly(self):
+        assert _canonical_dispatch_name("items", None) == "items.tsv"
+        assert _canonical_dispatch_name("bom_header", None) == "bom_header.tsv"
+        # A kebab feed_key with no contract has no translation — honest miss,
+        # refused later at the DISPATCH lookup (UNSUPPORTED_ENTITY).
+        assert _canonical_dispatch_name("on-hand", None) == "on-hand.tsv"
+
+    def test_resolve_ungoverned_warns_and_sorts(self, tmp_path, caplog):
+        _write_tsv(tmp_path / f"items_{DATE_STR}.tsv", [_row()])
+        _write_tsv(tmp_path / f"on-hand_{DATE_STR}.tsv", [_row()])
+        gizmos = tmp_path / f"gizmos_{DATE_STR}.tsv"
+        gizmos.write_text(_HEADER + "\nIT-1\tLOC-1\n", encoding="utf-8")  # scan ISSUE, still scanned
+        scan = scan_inbox(tmp_path, RUN_DATE)
+
+        # known_feed_keys covers every feed_key ever registered (active or
+        # not) — "on-hand" is both active and known here, so it is excluded
+        # from `ungoverned` regardless.
+        with caplog.at_level(logging.WARNING, logger="ootils_core.engine.ingest.daily_orchestrator"):
+            ungoverned = _resolve_ungoverned(scan, known_feed_keys={"on-hand"})
+
+        assert ungoverned == ("gizmos", "items")  # sorted; issues included; governed excluded
+        assert "no_contract" in caplog.text
+        assert "gizmos" in caplog.text and "items" in caplog.text
+        assert "on-hand" not in [k for k in ungoverned]
+
+    def test_quarantine_deactivated_contract_moves_feed_to_scan_issue(self, tmp_path, caplog):
+        # "on-hand" is KNOWN to the registry (a prior version was uploaded)
+        # but currently has no ACTIVE contract — must never be treated as an
+        # ungoverned/undeclared feed (revue PR-4b, finding 3).
+        on_hand = _write_tsv(tmp_path / f"on-hand_{DATE_STR}.tsv", [_row(), _row("IT-2")])
+        scan = scan_inbox(tmp_path, RUN_DATE)
+        assert "on-hand" in scan.feeds
+
+        with caplog.at_level(logging.ERROR, logger="ootils_core.engine.ingest.daily_orchestrator"):
+            quarantined = _quarantine_deactivated_contracts(
+                scan, governed_keys=set(), known_feed_keys={"on-hand"}
+            )
+
+        assert "on-hand" not in quarantined.feeds
+        issue = quarantined.issues["on-hand"]
+        assert "contract deactivated" in issue.error
+        assert "refusing feed" in issue.error
+        assert issue.paths == (on_hand,)
+        assert "contract_deactivated" in caplog.text
+
+        # Never surfaced as ungoverned once quarantined.
+        ungoverned = _resolve_ungoverned(quarantined, known_feed_keys={"on-hand"})
+        assert ungoverned == ()
+
+    def test_quarantine_is_a_no_op_for_active_or_unknown_feeds(self, tmp_path):
+        _write_tsv(tmp_path / f"on-hand_{DATE_STR}.tsv", [_row()])
+        _write_tsv(tmp_path / f"gizmos_{DATE_STR}.tsv", [_row()])
+        scan = scan_inbox(tmp_path, RUN_DATE)
+
+        # "on-hand" is active (governed) and "gizmos" is truly unknown to the
+        # registry — neither should be moved into `issues`.
+        quarantined = _quarantine_deactivated_contracts(
+            scan, governed_keys={"on-hand"}, known_feed_keys={"on-hand"}
+        )
+        assert quarantined is scan  # unchanged scan returned as-is
+        assert set(quarantined.feeds) == {"on-hand", "gizmos"}
+        assert quarantined.issues == {}
+
+    def test_quarantine_leaves_an_existing_scan_issue_untouched(self, tmp_path):
+        # A malformed file for a deactivated feed_key was ALREADY a scan
+        # issue for its own reason — quarantine must not clobber it, and it
+        # still never appears in `ungoverned`.
+        bad = tmp_path / f"on-hand_{DATE_STR}.tsv"
+        bad.write_text(_HEADER + "\nIT-1\tLOC-1\n", encoding="utf-8")  # bad column count
+        scan = scan_inbox(tmp_path, RUN_DATE)
+        original_error = scan.issues["on-hand"].error
+
+        quarantined = _quarantine_deactivated_contracts(
+            scan, governed_keys=set(), known_feed_keys={"on-hand"}
+        )
+        assert quarantined.issues["on-hand"].error == original_error
+        assert _resolve_ungoverned(quarantined, known_feed_keys={"on-hand"}) == ()
+
+    def test_observation_for_three_branches(self, tmp_path):
+        _write_tsv(tmp_path / f"on-hand_{DATE_STR}.tsv", [_row(), _row("IT-2")])
+        bad = tmp_path / f"transfers_{DATE_STR}.tsv"
+        bad.write_text(_HEADER + "\nIT-1\n", encoding="utf-8")
+        scan = scan_inbox(tmp_path, RUN_DATE)
+
+        scanned = _observation_for("on-hand", scan)
+        assert scanned.row_count == 2 and scanned.file_arrived_at is not None
+
+        # Present-but-unusable content measures 0 exploitable rows — honest,
+        # never None (that stays reserved for "no file at all").
+        issue = _observation_for("transfers", scan)
+        assert issue.row_count == 0 and issue.file_arrived_at is not None
+
+        absent = _observation_for("open-work-orders", scan)
+        assert absent.row_count is None and absent.file_arrived_at is None
+
+    def test_load_order_key_respects_manifest_and_unknowns_sort_last(self):
+        assert _load_order_key("items.tsv") < _load_order_key("locations.tsv")
+        assert _load_order_key("suppliers.tsv") < _load_order_key("on_hand.tsv")
+        assert _load_order_key("on_hand.tsv") < _load_order_key("purchase_orders.tsv")
+        # Unknown canonicals sort AFTER every known one, tie-broken by name —
+        # never refused outright.
+        assert _load_order_key("zzz_custom.tsv")[0] == len(LOAD_ORDER)
+        assert _load_order_key("purchase_orders.tsv") < _load_order_key("aaa_custom.tsv")
+        assert _load_order_key("aaa_custom.tsv") < _load_order_key("zzz_custom.tsv")
+
+    def test_every_registered_builder_has_an_explicit_load_order_slot(self):
+        # A new PAYLOAD_BUILDERS entry that forgets LOAD_ORDER would silently
+        # load LAST — fail here instead, loudly.
+        assert set(PAYLOAD_BUILDERS) <= set(LOAD_ORDER)
+        assert set(PAYLOAD_BUILDERS) <= set(DISPATCH)
+
+
+# ─────────────────────────────────────────────────────────────
+# 3. The load gate
+# ─────────────────────────────────────────────────────────────
+class TestLoadGate:
+    def test_refuses_a_dry_run_evaluation(self, tmp_path):
+        (tmp_path / "inbox").mkdir()
+        scan = scan_inbox(tmp_path / "inbox", RUN_DATE)
+        evaluation = _evaluation(scan, [], None, is_applied=False)
+        with pytest.raises(ValueError, match="apply_daily_run"):
+            load_eligible_feeds(evaluation, token="t", inbox_dir=tmp_path / "inbox")
+
+    def test_escalated_run_loads_nothing_and_touches_no_file(self, tmp_path):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        on_hand = _write_tsv(inbox / f"on-hand_{DATE_STR}.tsv", [_row()])
+        scan = scan_inbox(inbox, RUN_DATE)
+
+        decision = _decision(
+            _input("on-hand", "blocking", GuardStatus.FAILED),
+            _input("open-work-orders", "advisory", GuardStatus.OK),
+        )
+        assert decision.status is RunDecisionStatus.ESCALATED
+        evaluation = _evaluation(
+            scan,
+            [
+                _feed_eval("on-hand", "on_hand", scan, failed=True),
+                _feed_eval("open-work-orders", "work_orders", scan, criticality="advisory"),
+            ],
+            decision,
+        )
+
+        outcomes = load_eligible_feeds(evaluation, token="t", inbox_dir=inbox)
+
+        # Every candidate — scanned OR governed-but-absent — gets an outcome.
+        assert sorted(o.feed_key for o in outcomes) == ["on-hand", "open-work-orders"]
+        assert all(o.status is FeedLoadStatus.RUN_ESCALATED for o in outcomes)
+        assert all(o.http_status is None and o.canonical is None for o in outcomes)
+        # Zero side effects: the drop stays in place, no archive dir appears.
+        assert on_hand.exists()
+        assert not (tmp_path / "processed").exists()
+        assert not (tmp_path / "rejected").exists()
+
+    def test_no_computable_decision_also_blocks_everything(self, tmp_path):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        gizmos = _write_tsv(inbox / f"gizmos_{DATE_STR}.tsv", [_row()])
+        scan = scan_inbox(inbox, RUN_DATE)
+        evaluation = _evaluation(scan, [], None, ungoverned=("gizmos",))
+
+        outcomes = load_eligible_feeds(evaluation, token="t", inbox_dir=inbox)
+        assert [o.feed_key for o in outcomes] == ["gizmos"]
+        assert outcomes[0].status is FeedLoadStatus.RUN_ESCALATED
+        assert "no governed decision" in outcomes[0].detail
+        assert gizmos.exists()
+
+
+# ─────────────────────────────────────────────────────────────
+# 4. The load phase (call_api monkeypatched — integration covers the real API)
+# ─────────────────────────────────────────────────────────────
+class TestLoadPhase:
+    @pytest.fixture
+    def api_calls(self, monkeypatch):
+        """Record every call_api invocation; respond 200 unless the endpoint
+        was primed otherwise via .responses."""
+        calls: list[tuple[str, dict, str]] = []
+        responses: dict[str, tuple[int, dict]] = {}
+
+        def fake_call_api(endpoint, payload, token):
+            calls.append((endpoint, payload, token))
+            return responses.get(endpoint, (200, {"summary": {"inserted": len(next(iter(payload.values())))}}))
+
+        fake_call_api.responses = responses  # type: ignore[attr-defined]
+        monkeypatch.setattr(daily_orchestrator, "call_api", fake_call_api)
+        fake_call_api.calls = calls  # type: ignore[attr-defined]
+        return fake_call_api
+
+    def _degraded_evaluation(self, scan: InboxScan, feed_evals, ungoverned=()):
+        inputs = [
+            _input(fe.feed_key, fe.contract.criticality, fe.evaluation.overall_status)
+            for fe in feed_evals
+        ] or [_input("placeholder", "advisory", GuardStatus.OK)]
+        decision = _decision(*inputs)
+        assert decision.status is not RunDecisionStatus.ESCALATED
+        return _evaluation(scan, list(feed_evals), decision, ungoverned=tuple(ungoverned))
+
+    def test_guard_failed_feed_excluded_green_feed_loads_through_translation(
+        self, tmp_path, api_calls
+    ):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        _write_tsv(inbox / f"on-hand_{DATE_STR}.tsv", [_row("IT-1", "5"), _row("IT-2", "7")])
+        wo_file = _write_tsv(
+            inbox / f"open-work-orders_{DATE_STR}.tsv", [_row("WO-1")],
+        )
+        scan = scan_inbox(inbox, RUN_DATE)
+        evaluation = self._degraded_evaluation(
+            scan,
+            [
+                _feed_eval("on-hand", "on_hand", scan),
+                _feed_eval(
+                    "open-work-orders", "work_orders", scan,
+                    criticality="advisory", failed=True,
+                ),
+            ],
+        )
+
+        outcomes = load_eligible_feeds(evaluation, token="tok", inbox_dir=inbox)
+        by = {o.feed_key: o for o in outcomes}
+
+        # kebab feed_key -> snake entity_type -> canonical endpoint, end to end.
+        assert by["on-hand"].status is FeedLoadStatus.LOADED
+        assert by["on-hand"].canonical == "on_hand.tsv"
+        assert by["on-hand"].http_status == 200
+        assert [c[0] for c in api_calls.calls] == ["/v1/ingest/on-hand"]
+        endpoint, payload, token = api_calls.calls[0]
+        assert token == "tok"
+        assert payload["dry_run"] is False
+        assert [r["item_external_id"] for r in payload["on_hand"]] == ["IT-1", "IT-2"]
+
+        # The advisory-red feed is EXCLUDED (never sent, file left in place).
+        assert by["open-work-orders"].status is FeedLoadStatus.GUARD_FAILED
+        assert "deadline" in by["open-work-orders"].detail
+        assert wo_file.exists()
+
+        # The green feed's drop was archived to processed/ with its report.
+        assert not (inbox / f"on-hand_{DATE_STR}.tsv").exists()
+        processed = sorted(p.name for p in (tmp_path / "processed").iterdir())
+        assert any(n.startswith(f"on-hand_{DATE_STR}_") and n.endswith(".tsv") for n in processed)
+        assert any(n.endswith(".report.json") for n in processed)
+
+    def test_ungoverned_referential_feed_loads_in_load_order(self, tmp_path, api_calls):
+        # items (referential, no contract) must be POSTed BEFORE on_hand
+        # (LOAD_ORDER is the FK manifest), whatever the scan order was.
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        _write_tsv(
+            inbox / f"items_{DATE_STR}.tsv", ["IT-1\tItem one"],
+            header="external_id\tname",
+        )
+        _write_tsv(inbox / f"on-hand_{DATE_STR}.tsv", [_row("IT-1")])
+        scan = scan_inbox(inbox, RUN_DATE)
+        evaluation = self._degraded_evaluation(
+            scan, [_feed_eval("on-hand", "on_hand", scan)], ungoverned=("items",)
+        )
+
+        outcomes = load_eligible_feeds(evaluation, token="tok", inbox_dir=inbox)
+        assert [c[0] for c in api_calls.calls] == ["/v1/ingest/items", "/v1/ingest/on-hand"]
+        assert {o.status for o in outcomes} == {FeedLoadStatus.LOADED}
+        assert list(inbox.iterdir()) == []
+
+    def test_rejected_non_2xx_is_archived_to_rejected(self, tmp_path, api_calls):
+        api_calls.responses["/v1/ingest/on-hand"] = (422, {"detail": [{"errors": ["nope"]}]})
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        _write_tsv(inbox / f"on-hand_{DATE_STR}.tsv", [_row()])
+        scan = scan_inbox(inbox, RUN_DATE)
+        evaluation = self._degraded_evaluation(scan, [_feed_eval("on-hand", "on_hand", scan)])
+
+        outcomes = load_eligible_feeds(evaluation, token="tok", inbox_dir=inbox)
+        assert outcomes[0].status is FeedLoadStatus.REJECTED
+        assert outcomes[0].http_status == 422
+        assert not (tmp_path / "processed").exists()
+        rejected = sorted(p.name for p in (tmp_path / "rejected").iterdir())
+        assert any(n.endswith(".tsv") for n in rejected)
+        assert any(n.endswith(".report.json") for n in rejected)
+
+    def test_api_crash_is_reported_and_archived_to_rejected(self, tmp_path, monkeypatch):
+        def boom(endpoint, payload, token):
+            raise RuntimeError("connection lost")
+
+        monkeypatch.setattr(daily_orchestrator, "call_api", boom)
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        _write_tsv(inbox / f"on-hand_{DATE_STR}.tsv", [_row()])
+        scan = scan_inbox(inbox, RUN_DATE)
+        evaluation = self._degraded_evaluation(scan, [_feed_eval("on-hand", "on_hand", scan)])
+
+        outcomes = load_eligible_feeds(evaluation, token="tok", inbox_dir=inbox)
+        assert outcomes[0].status is FeedLoadStatus.API_CRASH
+        assert outcomes[0].http_status is None
+        assert any(p.suffix == ".tsv" for p in (tmp_path / "rejected").iterdir())
+
+    def test_builderless_entities_are_unsupported_never_bypassed(self, tmp_path, api_calls):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        # Governed feed whose entity has no PAYLOAD_BUILDERS entry (work_orders)
+        _write_tsv(inbox / f"open-work-orders_{DATE_STR}.tsv", [_row("WO-1")])
+        # BOM bundle sentinel: in DISPATCH but deliberately NOT in builders
+        _write_tsv(inbox / f"bom_header_{DATE_STR}.tsv", ["P-1\t1.0"], header="parent_external_id\tbom_version")
+        scan = scan_inbox(inbox, RUN_DATE)
+        evaluation = self._degraded_evaluation(
+            scan,
+            [_feed_eval("open-work-orders", "work_orders", scan, criticality="advisory")],
+            ungoverned=("bom_header",),
+        )
+
+        outcomes = load_eligible_feeds(evaluation, token="tok", inbox_dir=inbox)
+        by = {o.feed_key: o for o in outcomes}
+        assert by["open-work-orders"].status is FeedLoadStatus.UNSUPPORTED_ENTITY
+        assert by["open-work-orders"].canonical == "work_orders.tsv"
+        assert by["bom_header"].status is FeedLoadStatus.UNSUPPORTED_ENTITY
+        assert api_calls.calls == []  # nothing ever reached the API
+        assert list(inbox.iterdir()) == []  # both archived to rejected/
+        assert len([p for p in (tmp_path / "rejected").iterdir() if p.suffix == ".tsv"]) == 2
+
+    def test_builder_value_error_is_a_scan_error_not_a_crash(self, tmp_path, api_calls):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        # quantity blank -> build_on_hand_payload raises ValueError
+        _write_tsv(inbox / f"on-hand_{DATE_STR}.tsv", ["IT-1\tLOC-1\t\tEA\t2026-03-02"])
+        scan = scan_inbox(inbox, RUN_DATE)
+        evaluation = self._degraded_evaluation(scan, [_feed_eval("on-hand", "on_hand", scan)])
+
+        outcomes = load_eligible_feeds(evaluation, token="tok", inbox_dir=inbox)
+        assert outcomes[0].status is FeedLoadStatus.SCAN_ERROR
+        assert "payload build error" in outcomes[0].detail
+        assert api_calls.calls == []
+        assert any(p.suffix == ".tsv" for p in (tmp_path / "rejected").iterdir())
+
+    def test_scan_issues_archived_and_absent_governed_feed_reported(self, tmp_path, api_calls):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        bad = inbox / f"on-hand_{DATE_STR}.tsv"
+        bad.write_text(_HEADER + "\nIT-1\tLOC-1\n", encoding="utf-8")  # malformed
+        scan = scan_inbox(inbox, RUN_DATE)
+        assert "on-hand" in scan.issues
+        evaluation = self._degraded_evaluation(
+            scan,
+            [
+                _feed_eval("on-hand", "on_hand", scan),
+                _feed_eval("open-purchase-orders", "purchase_orders", scan),  # no file today
+            ],
+        )
+
+        outcomes = load_eligible_feeds(evaluation, token="tok", inbox_dir=inbox)
+        by = {o.feed_key: o for o in outcomes}
+        assert by["on-hand"].status is FeedLoadStatus.SCAN_ERROR
+        assert "column count" in by["on-hand"].detail
+        assert by["open-purchase-orders"].status is FeedLoadStatus.NO_FILE
+        assert api_calls.calls == []
+        assert not bad.exists()  # broken drop archived so tomorrow never re-sees it
+        assert any(p.suffix == ".tsv" for p in (tmp_path / "rejected").iterdir())
+
+    def test_deactivated_contract_feed_is_never_loaded(self, tmp_path, api_calls):
+        # A feed_key KNOWN to the registry but with no active version today
+        # (revue PR-4b, finding 3): quarantined into a ScanIssue upstream —
+        # this proves the load phase then treats it exactly like any other
+        # unloadable scan issue, never reaching the API.
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        _write_tsv(inbox / f"on-hand_{DATE_STR}.tsv", [_row("IT-1", "5")])
+        scan = scan_inbox(inbox, RUN_DATE)
+        assert "on-hand" in scan.feeds
+
+        quarantined = _quarantine_deactivated_contracts(
+            scan, governed_keys=set(), known_feed_keys={"on-hand"}
+        )
+        assert "on-hand" not in quarantined.feeds
+        evaluation = self._degraded_evaluation(quarantined, [])
+
+        outcomes = load_eligible_feeds(evaluation, token="tok", inbox_dir=inbox)
+        assert outcomes[0].feed_key == "on-hand"
+        assert outcomes[0].status is FeedLoadStatus.SCAN_ERROR
+        assert "contract deactivated" in outcomes[0].detail
+        assert api_calls.calls == []
+        assert any(p.suffix == ".tsv" for p in (tmp_path / "rejected").iterdir())
+
+
+# ─────────────────────────────────────────────────────────────
+# 5. CLI kill switch — scripts/run_daily_ingest.py
+# ─────────────────────────────────────────────────────────────
+class _Boom(Exception):
+    """Sentinel raised by the patched psycopg.connect."""
+
+
+def _no_db(monkeypatch):
+    def connect(*args, **kwargs):
+        raise _Boom("psycopg.connect must not be reached")
+
+    monkeypatch.setattr(run_daily_ingest.psycopg, "connect", connect)
+
+
+class TestCliKillSwitch:
+    DSN = "postgresql://localhost/ootils_unit"
+
+    def test_apply_refused_when_kill_switch_unset(self, monkeypatch, caplog):
+        monkeypatch.delenv("OOTILS_DAILY_RUN_ENABLED", raising=False)
+        monkeypatch.setenv("OOTILS_API_TOKEN", "t")
+        _no_db(monkeypatch)
+        with caplog.at_level(logging.ERROR, logger="run_daily_ingest"):
+            rc = run_daily_ingest.main(["--dsn", self.DSN, "--apply"])
+        assert rc == 1
+        assert "OOTILS_DAILY_RUN_ENABLED" in caplog.text
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "2", "enabled"])
+    def test_apply_refused_on_falsy_or_unknown_values(self, monkeypatch, value):
+        monkeypatch.setenv("OOTILS_DAILY_RUN_ENABLED", value)
+        monkeypatch.setenv("OOTILS_API_TOKEN", "t")
+        _no_db(monkeypatch)
+        assert run_daily_ingest.main(["--dsn", self.DSN, "--apply"]) == 1
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE", "  On  "])
+    def test_truthy_values_pass_the_switch_then_hit_the_token_gate(
+        self, monkeypatch, caplog, value
+    ):
+        monkeypatch.setenv("OOTILS_DAILY_RUN_ENABLED", value)
+        monkeypatch.delenv("OOTILS_API_TOKEN", raising=False)
+        _no_db(monkeypatch)
+        with caplog.at_level(logging.ERROR, logger="run_daily_ingest"):
+            rc = run_daily_ingest.main(["--dsn", self.DSN, "--apply"])
+        assert rc == 1
+        assert "OOTILS_API_TOKEN" in caplog.text
+        assert "OOTILS_DAILY_RUN_ENABLED" not in caplog.text  # the switch itself passed
+
+    def test_dry_run_is_not_gated_by_switch_or_token(self, monkeypatch):
+        # Neither the kill switch nor the token guards a preview — main
+        # proceeds all the way to the DB connection (our sentinel).
+        monkeypatch.delenv("OOTILS_DAILY_RUN_ENABLED", raising=False)
+        monkeypatch.delenv("OOTILS_API_TOKEN", raising=False)
+        _no_db(monkeypatch)
+        with pytest.raises(_Boom):
+            run_daily_ingest.main(["--dsn", self.DSN])
+
+    def test_missing_dsn_exits_2(self, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        _no_db(monkeypatch)
+        assert run_daily_ingest.main(["--apply"]) == 2
+
+    def test_bad_date_exits_2(self, monkeypatch):
+        _no_db(monkeypatch)
+        assert run_daily_ingest.main(["--dsn", self.DSN, "--date", "18/07/2026"]) == 2
+
+    def test_daily_run_enabled_truth_table(self, monkeypatch):
+        for value, expected in [
+            ("1", True), ("true", True), ("yes", True), ("on", True),
+            ("TRUE", True), ("  on  ", True),
+            ("0", False), ("", False), ("off", False), ("no", False),
+            ("2", False), ("enabled", False),
+        ]:
+            monkeypatch.setenv("OOTILS_DAILY_RUN_ENABLED", value)
+            assert run_daily_ingest._daily_run_enabled() is expected, value
+        monkeypatch.delenv("OOTILS_DAILY_RUN_ENABLED")
+        assert run_daily_ingest._daily_run_enabled() is False


### PR DESCRIPTION
Deuxieme etage de PR-4 (plan architecte) — le chef d'orchestre qui fait vivre PR-2/PR-3 : scan inbox datee → contrats (073) → gardes (078) → decision gouvernee (PR-3) → gating tout-ou-rien → chargement des flux verts par le chemin canonique (ingest_exec factorise, ingest_file.py = shim, ZERO second ecrivain) → UN event/run.

- **Honnetete V1** : DQ non cablee ⇒ plafond DEGRADED, jamais AUTO_APPROVED ; DEGRADED charge quand meme les flux a garde verte.
- **Durcissements revue** : ambiguite ⇒ les DEUX groupes refuses ; blocking corrompu ⇒ row_count=0 honnete ⇒ ESCALATED tout-ou-rien ; contrat desactive ⇒ quarantaine explicite.
- CLI dry-run par defaut + kill switch OOTILS_DAILY_RUN_ENABLED (defaut OFF). Aucune migration.
- 47 unitaires + 5 integrations Postgres ; suite 3274 verts ; mypy/ruff clean.

Suite : PR-4c — compte-rendu quotidien Markdown depose dans la Dropbox (le daily update pilote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)