### PR TITLE
docs(descent): DESC-1 PR-F -- specs TSV des flux de distribution + demande ERP

### DIFF
--- a/docs/contracts/distribution_links/format-distribution-links-tsv.md
+++ b/docs/contracts/distribution_links/format-distribution-links-tsv.md
@@ -1,0 +1,134 @@
+# Format de fichier — `distribution_links.tsv`
+
+> Fichier référentiel : les **lanes de réapprovisionnement inter-sites** — d'où un centre peut recevoir du stock quand il en manque.
+> Famille référentielle « à la demande », **jamais bloquante** pour le run quotidien (ADR-042 §1, ligne « Référentiel »).
+> Endpoint cible : **à construire** — voir « Statut » ci-dessous.
+
+---
+
+## ⚠️ Statut — spec cible, ingestion pas encore construite
+
+- **Aucun endpoint `POST /v1/ingest/...` n'existe encore.** La table `distribution_links` elle-même **existe déjà** en base (migration `029_drp_models.sql`, colonne `transfer_multiple` ajoutée par la migration `065_distribution_links_transfer_multiple.sql`) mais n'est aujourd'hui peuplée que par script/seed direct, jamais par un fichier ERP. L'ingestion TSV décrite ici est le travail de la **PR-D** du chantier DESC-1 (plan `giggly-wandering-moon.md`, « Ingest `distribution_links` + preuve DRP »).
+- Le moteur DRP qui **consomme** cette table (`src/ootils_core/engine/drp/`) est, lui, déjà écrit et mergé — c'est le point clé : « l'échelon DRP per-site […] tourne à vide faute de demande localisée » (plan DESC-1, Contexte). Charger ce fichier n'active pas un nouveau moteur, il **alimente un moteur qui attend déjà des données**.
+- Ne pas confondre avec `state_to_dc.tsv` — voir §7 de ce document.
+
+---
+
+## 1. Caractéristiques du fichier
+
+| Propriété | Valeur |
+|---|---|
+| **Nom** | `distribution_links.tsv` (exact) |
+| **Format** | TSV |
+| **Encodage** | UTF-8 (sans BOM de préférence) |
+| **Délimiteur** | tabulation (`\t`) |
+| **Header** | ligne 1 obligatoire |
+| **Cadence** | À la demande — renvoyer uniquement lors d'un changement de réseau logistique (nouvelle lane, délai de transit révisé, changement de multiple d'expédition). |
+| **Criticité** | Advisory (jamais bloquant, ADR-042 §1) |
+| **Endpoint** | à construire (chantier DESC-1 PR-D) |
+| **Table cible** | `distribution_links` (migration 029 + 065, déjà en base) |
+
+---
+
+## 2. Nature de la donnée
+
+Une ligne = **une lane de réapprovisionnement autorisée entre deux sites** :
+> « Le site `upstream_external_id` peut réapprovisionner le site `downstream_external_id` (pour l'article `item_external_id`, ou tout article si vide), en `transit_lead_time_days` jours. »
+
+C'est le réseau physique que le moteur DRP (Distribution Requirements Planning, déjà mergé et opérationnel) utilise pour proposer des **transferts inter-sites gouvernés** quand un centre est en déficit projeté et qu'un autre a de l'excédent. Sans ce fichier, le DRP n'a aucune lane à considérer et ne peut rien recommander, même si le déséquilibre entre centres est réel et détecté ailleurs.
+
+**Différence avec un transfert (`transfers.tsv`)** : une lane n'est pas un mouvement, c'est une **autorisation structurelle** (« PAT peut réapprovisionner DCW ») — le mouvement concret (quantité, date) est soit posé manuellement via `transfers.tsv`, soit généré comme recommandation par le DRP à partir des lanes actives.
+
+---
+
+## 3. Colonnes
+
+**Ordre du contrat** : `upstream_external_id`, `downstream_external_id`, `item_external_id`, `transit_lead_time_days`, `minimum_shipment_qty`, `transfer_multiple`, `priority`.
+
+| # | Colonne | Obligatoire | Type | Domaine | Description |
+|---|---|---|---|---|---|
+| 1 | `upstream_external_id` | **oui** | texte | FK `locations` | Site **amont** — celui qui expédie / source de réappro. |
+| 2 | `downstream_external_id` | **oui** | texte | FK `locations`, ≠ `upstream_external_id` | Site **aval** — celui qui reçoit / demande. |
+| 3 | `item_external_id` | non | texte | FK `items` si renseigné ; **vide = lane générique** (valable pour tout article sur ce couple amont/aval) | Portée du lien. |
+| 4 | `transit_lead_time_days` | **oui** | décimal | ≥ 0 | Délai de transit en jours. **Obligatoire dans ce fichier** bien que la colonne DB porte un défaut technique de 7 jours — un délai de transit réseau est une donnée structurante ; le contrat fichier refuse le silence dessus plutôt que d'hériter d'une valeur générique non vérifiée. |
+| 5 | `minimum_shipment_qty` | non | décimal | ≥ 0 | Quantité minimum par expédition. Défaut : `1` (défaut DB — `0` est une valeur légitime signifiant « pas de plancher »). |
+| 6 | `transfer_multiple` | non | décimal | **strictement** > 0 | Multiple logistique d'expédition (carton/palette/camion complet), arrondi **vers le bas** côté DRP (ADR-028 — délibérément l'inverse de l'arrondi MRP, qui arrondit vers le haut). Défaut : `1` (= pas d'arrondi). `0` ou négatif rejeté. |
+| 7 | `priority` | non | entier | ≥ 1 (1 = le plus prioritaire) | Priorité de sourcing quand plusieurs lanes desservent le même site aval. Défaut : `100`. |
+
+**Clé business (proposée)** : triplet (`upstream_external_id`, `downstream_external_id`, `item_external_id`) — `item_external_id` vide compte comme sa propre valeur (NULL) dans ce triplet. C'est une proposition de conception pour la PR-D, cohérente avec le modèle « clé composite » déjà utilisé par `supplier_items.tsv` (pas de colonne `external_id` dédiée sur la table `distribution_links`) — à confirmer à l'implémentation.
+
+---
+
+## 4. Comportement du moteur — lane générique vs lane spécifique à un article
+
+Le moteur DRP (`engine/drp/core.py:_resolve_candidate_links`, déjà en place) applique une règle de **spécificité** : pour un couple amont/aval donné, une lane **spécifique à un article** prime sur la lane **générique** du même couple quand les deux existent — elles ne sont pas des doublons, leurs portées diffèrent. Utile pour affiner les paramètres (délai, quantité minimum, multiple, priorité) d'un article particulier sans dupliquer le réseau générique pour tous les autres.
+
+---
+
+## 5. Exemples
+
+### 5.1 Réseau générique (aucun article ciblé)
+
+```
+upstream_external_id	downstream_external_id	item_external_id	transit_lead_time_days	minimum_shipment_qty	transfer_multiple	priority
+PLANT-LYON	WH-PARIS-01		2
+WH-PARIS-01	DC-LILLE		1
+```
+
+(`minimum_shipment_qty`, `transfer_multiple`, `priority` vides → défauts serveur `1`/`1`/`100`.)
+
+### 5.2 Avec une lane affinée pour un article précis
+
+```
+upstream_external_id	downstream_external_id	item_external_id	transit_lead_time_days	minimum_shipment_qty	transfer_multiple	priority
+WH-PARIS-01	DC-LILLE		1
+WH-PARIS-01	DC-LILLE	FG-APU-100	1	200	24	1
+```
+
+Lecture : la lane générique Paris→Lille dessert tous les articles en 1 jour, sans contrainte de lot. Une deuxième ligne affine spécifiquement `FG-APU-100` sur le même couple : même délai, mais expédition par lot minimum de 200, multiple logistique de 24 (carton), priorité 1 (préférée pour cet article précis) — remplace la lane générique pour cet article seul (§4), sans toucher aux autres articles qui restent sur la ligne générique.
+
+### 5.3 Cas invalides (prévus)
+
+```
+upstream_external_id	downstream_external_id	item_external_id	transit_lead_time_days	minimum_shipment_qty	transfer_multiple	priority
+PLANT-LYON	PLANT-LYON		2                        ← amont == aval → 422
+LOC-XYZ	DC-LILLE		2                            ← amont inconnu → 422
+PLANT-LYON	DC-LILLE	ITEM-UNKNOWN	2            ← item inconnu → 422
+PLANT-LYON	DC-LILLE				                 ← transit_lead_time_days manquant → 422 (obligatoire dans ce fichier)
+PLANT-LYON	DC-LILLE		2			0            ← transfer_multiple = 0 → 422 (doit être strictement > 0)
+PLANT-LYON	DC-LILLE		2
+PLANT-LYON	DC-LILLE		3                            ← doublon exact du triplet (amont, aval, item vide) → 422
+```
+
+---
+
+## 6. Règles de validation côté Ootils (prévues)
+
+- `upstream_external_id`, `downstream_external_id` : obligatoires, FK `locations`, doivent différer (même contrainte DB que `chk_distribution_link_locations_different`, migration 029).
+- `item_external_id` : optionnel ; si renseigné, FK `items` — un code inconnu est rejeté (jamais traité silencieusement comme générique).
+- `transit_lead_time_days` : obligatoire, décimal ≥ 0.
+- `minimum_shipment_qty` : optionnel, décimal ≥ 0, défaut `1`.
+- `transfer_multiple` : optionnel, décimal strictement > 0, défaut `1`.
+- `priority` : optionnel, entier ≥ 1, défaut `100`.
+- Triplet (`upstream_external_id`, `downstream_external_id`, `item_external_id`) **unique dans le fichier** — une lane générique et une lane spécifique à un article pour le **même** couple amont/aval **coexistent** (portées différentes, pas un doublon ; voir §4).
+- Comportement all-or-nothing général (`docs/contracts/TSV-FILES-SPEC.md` §1.3).
+
+---
+
+## 7. Lien avec `state_to_dc.tsv` — ne pas confondre
+
+Voir `docs/contracts/state_to_dc/format-state-to-dc-tsv.md` §7 pour le tableau comparatif complet. En bref : `state_to_dc.tsv` route la **demande sortante** (client → centre) ; `distribution_links.tsv` route le **réapprovisionnement entrant** d'un centre (centre → centre). Les deux sont nécessaires et n'ont aucune ligne en commun.
+
+---
+
+## 8. Limitations connues V1 (non couvertes par ce fichier)
+
+La table DB `distribution_links` porte des colonnes supplémentaires que ce fichier V1 ne couvre pas (coûts de transit, quantité maximum, fréquence/jours d'expédition, flag `active`) — elles restent gérées hors fichier (script/seed) tant qu'un besoin ERP concret ne les réclame pas. Le détail transporteur/mode (`transportation_lanes`, table enfant de `distribution_links`) reste également hors périmètre de ce fichier — un lien = un jeu de paramètres de planification, pas un catalogue de transporteurs.
+
+## 9. Dépôt
+
+Une fois l'ingestion construite : dossier Dropbox `ootils-inbox/`, nommage `distribution_links_<AAAAMMJJ>.tsv` (convention générale `SPEC-FICHIERS-ENTREE-OOTILS.md` §1) — envoyé uniquement lors d'un changement réseau.
+
+## 10. Ordre de chargement
+
+Nécessite `locations.tsv` (2 FK) et, si `item_external_id` est renseigné, `items.tsv`. Indépendant des flux quotidiens.

--- a/docs/contracts/item_dc_eligibility/format-item-dc-eligibility-tsv.md
+++ b/docs/contracts/item_dc_eligibility/format-item-dc-eligibility-tsv.md
@@ -1,0 +1,143 @@
+# Format de fichier — `item_dc_eligibility.tsv`
+
+> Fichier référentiel : **quels centres de distribution ont le droit de stocker/servir un article donné**.
+> Famille référentielle « à la demande », **jamais bloquante** pour le run quotidien (ADR-042 §1, ligne « Référentiel »).
+> Endpoint cible : **à construire** — voir « Statut » ci-dessous.
+
+---
+
+## ⚠️ Statut — spec cible, ingestion pas encore construite
+
+Comme `state_to_dc.tsv`, ce fichier fixe un contrat cible avant que l'ingestion existe (ADR-042, famille référentiel « à la demande »).
+
+- **Aucun endpoint `POST /v1/ingest/...` n'existe encore.**
+- **Aucune table dédiée n'existe encore** — réservée au chantier **DESC-1**, migration **083** (PR-A, plan `giggly-wandering-moon.md`), nom de table non arrêté.
+- Tant que ce fichier n'est pas chargé, l'éligibilité produit→centre est **dérivée** par le moteur (historique de vente ∪ lanes de réappro actives) — défaut assumé et flaggé, jamais silencieux. Ce fichier, une fois disponible, devient la source de vérité **pour les articles qu'il couvre** (voir §4, modèle fermé).
+
+---
+
+## 1. Caractéristiques du fichier
+
+| Propriété | Valeur |
+|---|---|
+| **Nom** | `item_dc_eligibility.tsv` (exact) |
+| **Format** | TSV |
+| **Encodage** | UTF-8 (sans BOM de préférence) |
+| **Délimiteur** | tabulation (`\t`) |
+| **Header** | ligne 1 obligatoire |
+| **Cadence** | À la demande — renvoyer uniquement lors d'un changement (nouvel article, retrait d'un centre, arrêt d'un article dans un centre). |
+| **Criticité** | Advisory (jamais bloquant, ADR-042 §1) |
+| **Endpoint** | à construire (chantier DESC-1) |
+
+---
+
+## 2. Nature de la donnée
+
+Une ligne = **une autorisation produit × centre** :
+> « L'article `item_external_id` est autorisé au centre `dc_location_external_id` — sauf si `eligible` dit explicitement le contraire. »
+
+Certains articles n'existent physiquement que dans un sous-ensemble des centres (contraintes réglementaires, gamme régionale, capacité). Sans ce fichier, le moteur de descente de demande (DESC-1) ne peut pas savoir qu'un article ne doit **jamais** atterrir sur un centre donné, et risque de proposer une répartition ou une commande sur un site qui, en réalité, ne le référence pas. C'est le complément produit de `state_to_dc.tsv` (qui, lui, route le *client*, pas l'article).
+
+---
+
+## 3. Colonnes
+
+| # | Colonne | Obligatoire | Type | Domaine | Description |
+|---|---|---|---|---|---|
+| 1 | `item_external_id` | **oui** | texte | FK `items` | Article concerné. |
+| 2 | `dc_location_external_id` | **oui** | texte | FK `locations` | Centre pour lequel l'éligibilité est déclarée. |
+| 3 | `eligible` | non | booléen | voir §5 (**divergence assumée** de la convention booléenne générale — lire avant d'utiliser cette colonne) | Défaut : `true`. |
+
+**Clé business** : couple (`item_external_id`, `dc_location_external_id`).
+
+---
+
+## 4. Modèle : fermé par article, ouvert par défaut
+
+- Un article qui **n'apparaît jamais** dans ce fichier (dans aucun envoi cumulé) reste sans restriction connue — son éligibilité continue d'être **dérivée** par le moteur (historique ∪ lanes), pas fermée.
+- Dès qu'un article apparaît **au moins une fois** (toutes lignes confondues, cumulées sur l'ensemble des envois — cette table est en ajout/mise à jour, jamais remise à zéro par un nouvel envoi), ce fichier devient la **source de vérité exclusive pour cet article** : seuls les centres marqués `eligible=true` restent autorisés ; tout centre absent de la liste de cet article, ou marqué `eligible=false`, est **non éligible**.
+- Cas limite légitime et **volontairement fail-loud** : un article dont tous les centres connus finissent à `eligible=false` n'a **aucun** centre éligible. Le moteur de descente ne fabrique pas d'exception silencieuse dans ce cas — la demande nationale de cet article **reste au national**, non descendue, jusqu'à correction du référentiel (comportement du moteur DESC-1, cf. plan `giggly-wandering-moon.md` §« Approche retenue »).
+
+---
+
+## 5. La colonne `eligible` — divergence assumée par rapport à la convention booléenne générale
+
+La convention booléenne générale du dépôt (`docs/contracts/TSV-FILES-SPEC.md` §1.2) traite une **cellule vide** comme `false`. Sur ce fichier précis, l'intention métier (« la présence d'une ligne = éligible ») est différente : la plupart des envois n'auront **pas du tout** de colonne `eligible` — un fichier à 2 colonnes (`item_external_id`, `dc_location_external_id`) suffit dans le cas courant.
+
+Règle retenue (à respecter par l'implémentation, PR-A) :
+
+| Situation | Résultat |
+|---|---|
+| Colonne `eligible` **absente du header** | Toutes les lignes du fichier valent `eligible=true` implicite. |
+| Colonne `eligible` **présente**, cellule renseignée (`true`/`false`, voir §1.2 pour les alias acceptés) | Valeur explicite appliquée. |
+| Colonne `eligible` **présente**, cellule **vide** pour une ligne donnée | Suit la convention booléenne générale : `false` — **pas** de traitement spécial ligne par ligne. Pour déclarer une ligne éligible dans un fichier qui a par ailleurs la colonne, écrire `true` explicitement. |
+
+En clair : pour **révoquer** une éligibilité déjà déclarée, renvoyer la ligne avec `eligible=false` explicite — ne jamais se contenter d'omettre la ligne (l'omission ne signifie *rien* pour un article déjà « fermé », voir §4 : elle laisse simplement l'état précédent inchangé).
+
+---
+
+## 6. Exemples
+
+### 6.1 Cas courant — fichier à 2 colonnes (liste blanche simple)
+
+```
+item_external_id	dc_location_external_id
+FG-APU-100	DC-LILLE
+FG-APU-100	DC-PARIS
+FG-APU-200	DC-LILLE
+```
+
+Lecture : `FG-APU-100` éligible uniquement à Lille et Paris (fermé dès la première ligne le concernant) ; `FG-APU-200` éligible uniquement à Lille.
+
+### 6.2 Avec révocation explicite
+
+```
+item_external_id	dc_location_external_id	eligible
+FG-APU-100	DC-LILLE	true
+FG-APU-100	DC-PARIS	true
+FG-APU-200	DC-LILLE	false
+```
+
+Lecture : `FG-APU-200` était éligible à Lille (envoi antérieur) et vient d'en être explicitement retiré — s'il n'a aucun autre centre déclaré ailleurs, il n'a **plus aucun** centre éligible (cf. §4, cas fail-loud).
+
+### 6.3 Cas invalides
+
+```
+item_external_id	dc_location_external_id	eligible
+	DC-LILLE	true                          ← item_external_id vide → 422
+ITEM-UNKNOWN	DC-LILLE	true                  ← item inconnu (FK items) → 422
+FG-APU-100	LOC-XYZ	true                      ← centre inconnu (FK locations) → 422
+FG-APU-100	DC-LILLE	true
+FG-APU-100	DC-LILLE	false                     ← doublon (item, centre) dans le même fichier → 422
+```
+
+---
+
+## 7. Règles de validation côté Ootils (prévues)
+
+- `item_external_id` : obligatoire, FK `items`.
+- `dc_location_external_id` : obligatoire, FK `locations`.
+- `eligible` : optionnel, booléen — voir §5 pour la sémantique exacte (absence de colonne ≠ cellule vide).
+- Couple (`item_external_id`, `dc_location_external_id`) **unique dans le fichier** — doublon exact rejeté (all-or-nothing).
+- Comportement all-or-nothing général (`docs/contracts/TSV-FILES-SPEC.md` §1.3).
+
+---
+
+## 8. Comportement à l'ingestion (prévu)
+
+- Upsert par couple (`item_external_id`, `dc_location_external_id`).
+- **Jamais de suppression par absence** : une paire déjà connue et non renvoyée garde sa dernière valeur — la seule façon de fermer une éligibilité est le `eligible=false` explicite (§5).
+- La table cumule l'historique de tous les envois pour un article donné (§4 : le modèle fermé se construit par accumulation, pas par un seul fichier isolé).
+
+---
+
+## 9. Limitations connues V1
+
+| Manque | Raison |
+|---|---|
+| Pas de date d'effet (`effective_from`) | Contrairement à `state_to_dc.tsv` — un changement d'éligibilité est immédiat en V1. |
+| Pas de raison/commentaire sur une exclusion | Utile pour l'audit (« pourquoi cet article n'est plus à ce centre ») — V1.1 si besoin. |
+
+## 10. Ordre de chargement
+
+Nécessite `items.tsv` et `locations.tsv` déjà chargés (2 FK). Indépendant des flux quotidiens.

--- a/docs/contracts/state_to_dc/format-state-to-dc-tsv.md
+++ b/docs/contracts/state_to_dc/format-state-to-dc-tsv.md
@@ -1,0 +1,136 @@
+# Format de fichier — `state_to_dc.tsv`
+
+> Fichier de **dispatch d'exécution** : pour chaque état client US, quel centre de distribution (DC) livre.
+> Famille référentielle « à la demande », **jamais bloquante** pour le run quotidien (ADR-042 §1, ligne « Référentiel »).
+> Endpoint cible : **à construire** — voir « Statut » ci-dessous.
+
+---
+
+## ⚠️ Statut — spec cible, ingestion pas encore construite
+
+Ce document fixe **le contrat de fichier** avant que l'ingestion existe côté Ootils, pour que l'équipe ERP puisse commencer l'extraction pendant que le moteur est construit (ADR-042, famille référentiel « à la demande » — long délai côté ERP, donc spec livrée en premier).
+
+- **Aucun endpoint `POST /v1/ingest/...` n'existe encore** pour cette entité.
+- **Aucune table dédiée n'existe encore** — elle sera créée par le chantier **DESC-1** (plan `giggly-wandering-moon.md`, PR-A, migration **083**, prochain numéro libre après `082_supplier_items_updated_at.sql`). Le nom exact de la table n'est pas arrêté à ce stade.
+- Tant que ce fichier n'est pas chargé, le moteur de descente de demande (DESC-1 PR-B) traite l'éligibilité/dispatch par défaut dérivé (historique de vente ∪ lanes actives) — ce fichier, une fois disponible, devient la source de vérité et remplace ce défaut.
+- Ne pas confondre avec `distribution_links.tsv` (lanes de **réapprovisionnement** inter-sites, un tout autre flux physique — voir §7).
+
+---
+
+## 1. Caractéristiques du fichier
+
+| Propriété | Valeur |
+|---|---|
+| **Nom** | `state_to_dc.tsv` (exact) |
+| **Format** | TSV |
+| **Encodage** | UTF-8 (sans BOM de préférence) |
+| **Délimiteur** | tabulation (`\t`) |
+| **Header** | ligne 1 obligatoire |
+| **Cadence** | À la demande — pas de cadence fixe. Renvoyer le fichier uniquement quand une affectation état→centre change. |
+| **Criticité** | Advisory (jamais bloquant pour le run quotidien pénurie, ADR-042 §1) |
+| **Endpoint** | à construire (chantier DESC-1) |
+
+---
+
+## 2. Nature de la donnée
+
+Une ligne = **une règle d'exécution** :
+> « Les clients de l'état `state_code` sont livrés depuis le centre `dc_location_external_id`, à compter du `effective_from`. »
+
+C'est la table de dispatch qui permet au moteur de descente de demande (DESC-1) de faire atterrir la demande nationale (aujourd'hui posée sur les canaux virtuels USA/CAN/ICO) sur les **vrais** centres physiques. Sans elle, la planification reste correcte au niveau national mais l'exécution (quel entrepôt sert quel client) reste invisible — c'est exactement le trou identifié au premier chargement réel (`RAPPORT-PREMIER-CHARGEMENT-2026-07-18.md` : « la masse de la demande vit sur les canaux virtuels […] l'étape qui donnera tout son sens à ces chiffres : les lanes de distribution »).
+
+Modèle V1 : **un seul centre actif par état** (pas de multi-sourcing géographique — un état a un centre de rattachement, pas une liste ordonnée). Portée : États-Unis uniquement (`state_code` est un code US 2 lettres) — les canaux CAN/ICO ne sont pas concernés par ce fichier.
+
+---
+
+## 3. Colonnes
+
+| # | Colonne | Obligatoire | Type | Domaine | Description |
+|---|---|---|---|---|---|
+| 1 | `state_code` | **oui** | texte (2) | code USPS 2 lettres, majuscules (`CA`, `TX`, `NY`...), doit appartenir à la liste des 50 états + DC (District of Columbia) | État client US. Clé d'upsert (une ligne par état). |
+| 2 | `dc_location_external_id` | **oui** | texte | FK `locations` | Centre de distribution qui livre cet état en exécution. |
+| 3 | `effective_from` | non | date | ISO `YYYY-MM-DD` | Date à partir de laquelle l'affectation prend effet. Défaut : date d'ingestion. Sémantique exacte (simple horodatage informatif vs bascule SCD2 façon `item_planning_params`) non tranchée — à décider à l'implémentation (PR-A). |
+
+---
+
+## 4. Exemples
+
+### 4.1 Exemple minimal
+
+```
+state_code	dc_location_external_id
+NY	DC-PAT
+```
+
+### 4.2 Réseau à 3 centres
+
+```
+state_code	dc_location_external_id	effective_from
+NY	DC-PAT	2026-01-01
+TX	DC-TXO	2026-01-01
+CA	DC-DCW	2026-01-01
+```
+
+Lecture : les clients New York sont livrés depuis PAT, le Texas depuis TXO, la Californie depuis DCW — 3 lignes, 3 états, 3 centres distincts (illustratif — remplacer par les codes de centre réels de l'équipe ERP).
+
+### 4.3 Cas invalides (prévus)
+
+```
+state_code	dc_location_external_id	effective_from
+ZZ	DC-PAT	2026-01-01                  ← code état hors liste USPS → 422
+	DC-PAT	2026-01-01                  ← state_code vide → 422
+NY	DC-UNKNOWN	2026-01-01              ← centre inconnu (FK locations) → 422
+NY	DC-PAT	2026-01-01
+NY	DC-TXO	2026-02-01                  ← doublon state_code dans le même fichier → 422 (un seul centre actif par état en V1)
+```
+
+---
+
+## 5. Règles de validation côté Ootils (prévues)
+
+- `state_code` : obligatoire, non vide, exactement 2 caractères, normalisé en majuscule côté serveur, doit appartenir à la liste canonique des codes USPS (50 états + DC). Code hors liste ou mal formé → 422, code fautif nommé dans le rapport de rejet (jamais un rejet silencieux).
+- `state_code` **unique dans le fichier** — une seule ligne par état (pas de second centre de repli en V1 ; le repli en cas de rupture locale reste porté par le stock de sécurité national, ADR-021, pas par une deuxième ligne ici).
+- `dc_location_external_id` : obligatoire, doit exister en base (`locations.external_id`). Pas de contrainte stricte de `location_type` en V1 (même logique que `parent_external_id` sur `locations.tsv` §4), mais un `dc` est attendu en pratique.
+- `effective_from` : optionnel, ISO `YYYY-MM-DD`.
+- Comportement all-or-nothing (comme tous les fichiers du contrat, cf. `docs/contracts/TSV-FILES-SPEC.md` §1.3) : une seule ligne invalide → rien n'est chargé.
+
+---
+
+## 6. Comportement à l'ingestion (prévu)
+
+**Clé business** : `state_code`.
+- Existe en base → UPDATE (`dc_location_external_id`/`effective_from` écrasés — un changement d'affectation se fait en renvoyant la même ligne avec le nouveau centre).
+- N'existe pas → INSERT.
+- **Jamais de suppression par absence** : un état omis dans un envoi ultérieur garde sa dernière affectation connue (même convention que les 11 entités déjà en production, `docs/contracts/TSV-FILES-SPEC.md` §1.3).
+
+---
+
+## 7. Lien avec `distribution_links.tsv` — ne pas confondre
+
+| | `state_to_dc.tsv` | `distribution_links.tsv` |
+|---|---|---|
+| Sens du flux | **Sortant** — quel centre livre quel client (dispatch d'exécution) | **Entrant vers un centre** — comment un centre se réapprovisionne depuis un autre site |
+| Question posée | « Ce client de cet état, qui le sert ? » | « Ce centre en manque, qui peut lui envoyer du stock ? » |
+| Consommateur moteur | Le run de descente de demande (DESC-1 PR-B) | Le moteur DRP existant (`engine/drp/`) |
+
+Les deux sont complémentaires et distinctes — voir `docs/contracts/distribution_links/format-distribution-links-tsv.md`.
+
+---
+
+## 8. Limitations connues V1
+
+| Manque | Raison |
+|---|---|
+| Pas de multi-sourcing par état (un seul centre actif) | Décision V1 délibérée — cf. §5. Un repli géographique par état est un sujet V2. |
+| Pas de granularité infra-état (code postal, comté) | Hors périmètre — le pilote raisonne à la maille état. |
+| Sémantique exacte de `effective_from` (horodatage vs SCD2) | Non tranchée — à décider à l'implémentation (PR-A). |
+
+---
+
+## 9. Dépôt
+
+Une fois l'ingestion construite : dossier Dropbox `ootils-inbox/`, nommage `state_to_dc_<AAAAMMJJ>.tsv` (convention générale `SPEC-FICHIERS-ENTREE-OOTILS.md` §1) — envoyé uniquement lors d'un changement, pas de cadence fixe.
+
+## 10. Ordre de chargement
+
+Nécessite `locations.tsv` déjà chargé (FK `dc_location_external_id`). Indépendant des flux quotidiens.


### PR DESCRIPTION
Premier etage de DESC-1 (plan approuve — la descente de demande national → centres). Doc-only : les 3 specs de flux referentiels (état→centre, éligibilité produit-centre, lanes) avec bandeau « spec cible » honnête, + copies Dropbox pour l'équipe ERP (SPEC v2.2 + lettre de demande). Débloque le long délai ERP pendant que PR-A/B se fabriquent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)