### PR TITLE
feat(ingest): DESC-1 PR-D -- ingestion des lanes + preuve DRP (le moteur se reveille)

### DIFF
--- a/src/ootils_core/api/routers/ingest.py
+++ b/src/ootils_core/api/routers/ingest.py
@@ -2868,3 +2868,223 @@ def ingest_routings(
     ingest_response = _ok(inserted, updated, len(body.routings), results, batch_id=batch_id, dq_status=dq_status)
     _finalize_ingest_batch(db, batch_id, ingest_response)
     return ingest_response
+
+
+# ─────────────────────────────────────────────────────────────
+# 13. POST /v1/ingest/distribution-links (DRP lanes, DESC-1 PR-D)
+# ─────────────────────────────────────────────────────────────
+#
+# Referential/on-demand entity (ADR-042 doctrine — "à la demande, jamais
+# dans le run bloquant quotidien"). The `distribution_links` table already
+# exists (migration 029 + 065, transfer_multiple); this is the FIRST
+# writer that is not a script/seed. See
+# docs/contracts/distribution_links/format-distribution-links-tsv.md for
+# the full contract this endpoint implements.
+#
+# Upsert key: (upstream_location_id, downstream_location_id, item_id),
+# item_id NULL = generic lane (all items) — a generic lane and an
+# item-specific lane on the SAME (upstream, downstream) pair coexist (spec
+# §4, consumed by engine/drp/core.py's specificity rule), they are never
+# duplicates of each other. distribution_links carries NO unique
+# constraint on that triplet (unlike supplier_items' UNIQUE(supplier_id,
+# item_id)), so the upsert is SELECT-then-INSERT/UPDATE, same shape as
+# ingest_supplier_items — with `item_id IS NOT DISTINCT FROM %s` for the
+# NULL-safe match a plain `=` cannot express.
+#
+# NO ingest_batches / DQ / idempotency-key plumbing here — deliberately,
+# mirroring bom.py's `ingest_bom` (the OTHER referential/topology
+# endpoint, not a master-data one): `ingest_batches.entity_type` is a
+# named CHECK constraint (migrations 023→035→036, kept in lockstep by
+# convention) that would need widening via a NEW migration to accept
+# 'distribution_links' — out of scope for this chantier (no migration).
+# Widening it is a documented follow-up if/when this endpoint needs the
+# audit-trail / DQ-pipeline treatment the master-data endpoints get.
+#
+# Columns intentionally NOT covered by this endpoint (spec §8 — stay
+# script/seed-managed until an ERP need appears): transit_cost_per_unit,
+# transit_cost_fixed, maximum_shipment_qty, shipment_frequency,
+# shipment_days. An UPDATE here never touches them, so a pre-existing
+# value set out-of-band survives a re-push untouched.
+
+class DistributionLinkRow(BaseModel):
+    upstream_external_id: str = Field(..., description="Upstream site (source of the lane). FK locations.")
+    downstream_external_id: str = Field(..., description="Downstream site (destination of the lane). FK locations, must differ from upstream.")
+    item_external_id: Optional[str] = Field(None, description="Scoping item. Empty/absent = generic lane (item_id NULL, valid for every item on this pair).")
+    transit_lead_time_days: float = Field(..., ge=0, description="Transit lead time in days. Mandatory in this file — the DB column carries a technical default of 7, but a network transit time is structural data; the file contract refuses to inherit it silently.")
+    minimum_shipment_qty: Optional[float] = Field(None, ge=0, description="Minimum quantity per shipment. Default 1 (DB default) when omitted; 0 is a legitimate 'no floor' value.")
+    transfer_multiple: Optional[float] = Field(None, gt=0, description="Logistics shipment multiple (case/pallet/truck), rounded DOWN by the DRP planner (ADR-028). Default 1 (no rounding) when omitted. Must be strictly > 0 — 0 or negative is rejected.")
+    priority: Optional[int] = Field(None, ge=1, description="Sourcing priority when several lanes serve the same downstream site (1 = most preferred). Default 100 when omitted.")
+    active: bool = Field(True, description="Whether this lane is usable by the DRP planner. Not part of the TSV file contract (spec §8) — JSON callers only.")
+
+    @field_validator("upstream_external_id", "downstream_external_id")
+    @classmethod
+    def non_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("must not be empty")
+        return v
+
+    @field_validator("item_external_id")
+    @classmethod
+    def blank_to_none(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not v.strip():
+            return None
+        return v
+
+
+class IngestDistributionLinksRequest(BaseModel):
+    distribution_links: list[DistributionLinkRow]
+    dry_run: bool = False
+
+
+def _distribution_link_key(row: DistributionLinkRow) -> tuple[str, str, Optional[str]]:
+    return (row.upstream_external_id, row.downstream_external_id, row.item_external_id)
+
+
+@router.post(
+    "/distribution-links",
+    response_model=IngestResponse,
+    summary="Import distribution links (DRP lanes)",
+    description=(
+        "Upsert inter-site replenishment lanes consumed by the DRP planner "
+        "(engine/drp). Upsert key: (upstream_external_id, downstream_external_id, "
+        "item_external_id) — item_external_id empty/absent = generic lane (all "
+        "items), coexists with a specific-item lane on the same pair (see "
+        "docs/contracts/distribution_links/format-distribution-links-tsv.md §4)."
+    ),
+)
+def ingest_distribution_links(
+    body: IngestDistributionLinksRequest,
+    db: DictRowConnection = Depends(get_db),
+    _principal: Principal = Depends(require_scope("ingest")),
+) -> IngestResponse:
+    """Upsert distribution_links by (upstream, downstream, item) natural key. All-or-nothing: any error → HTTP 422."""
+    loc_ext_ids = list({
+        ext_id
+        for row in body.distribution_links
+        for ext_id in (row.upstream_external_id, row.downstream_external_id)
+    })
+    item_ext_ids = list({
+        row.item_external_id for row in body.distribution_links if row.item_external_id
+    })
+
+    loc_map = _batch_existing(db, "locations", "external_id", "location_id", loc_ext_ids)
+    item_map = _batch_existing(db, "items", "external_id", "item_id", item_ext_ids)
+
+    errors: list[dict] = []
+    seen_keys: dict[tuple[str, str, Optional[str]], int] = {}
+    for i, row in enumerate(body.distribution_links):
+        row_errs: list[str] = []
+        if row.upstream_external_id not in loc_map:
+            row_errs.append(f"upstream_external_id '{row.upstream_external_id}' not found in DB")
+        if row.downstream_external_id not in loc_map:
+            row_errs.append(f"downstream_external_id '{row.downstream_external_id}' not found in DB")
+        if row.upstream_external_id == row.downstream_external_id:
+            row_errs.append(
+                f"upstream_external_id and downstream_external_id must differ "
+                f"(both = '{row.upstream_external_id}')"
+            )
+        if row.item_external_id is not None and row.item_external_id not in item_map:
+            row_errs.append(f"item_external_id '{row.item_external_id}' not found in DB")
+
+        key = _distribution_link_key(row)
+        if key in seen_keys:
+            row_errs.append(
+                "duplicate (upstream_external_id, downstream_external_id, "
+                f"item_external_id) triplet within this payload, also at row {seen_keys[key]}"
+            )
+        else:
+            seen_keys[key] = i
+
+        if row_errs:
+            errors.append({
+                "upstream_external_id": row.upstream_external_id,
+                "downstream_external_id": row.downstream_external_id,
+                "item_external_id": row.item_external_id,
+                "row": i,
+                "errors": row_errs,
+            })
+
+    if errors:
+        _raise_422(errors)
+
+    if body.dry_run:
+        return IngestResponse(
+            status="dry_run",
+            summary=IngestSummary(total=len(body.distribution_links), inserted=0, updated=0, errors=0),
+            results=[
+                {
+                    "upstream_external_id": row.upstream_external_id,
+                    "downstream_external_id": row.downstream_external_id,
+                    "item_external_id": row.item_external_id,
+                    "action": "dry_run",
+                }
+                for row in body.distribution_links
+            ],
+        )
+
+    results: list[dict] = []
+    inserted = updated = 0
+
+    for row in body.distribution_links:
+        upstream_id = loc_map[row.upstream_external_id]
+        downstream_id = loc_map[row.downstream_external_id]
+        item_id = item_map[row.item_external_id] if row.item_external_id else None
+        min_qty = row.minimum_shipment_qty if row.minimum_shipment_qty is not None else 1.0
+        multiple = row.transfer_multiple if row.transfer_multiple is not None else 1.0
+        priority = row.priority if row.priority is not None else 100
+
+        existing = db.execute(
+            """
+            SELECT distribution_link_id FROM distribution_links
+            WHERE upstream_location_id = %s
+              AND downstream_location_id = %s
+              AND item_id IS NOT DISTINCT FROM %s
+            """,
+            (upstream_id, downstream_id, item_id),
+        ).fetchone()
+
+        if existing:
+            distribution_link_id = existing["distribution_link_id"]
+            db.execute(
+                """
+                UPDATE distribution_links
+                SET transit_lead_time_days = %s,
+                    minimum_shipment_qty = %s,
+                    transfer_multiple = %s,
+                    priority = %s,
+                    active = %s,
+                    updated_at = now()
+                WHERE distribution_link_id = %s
+                """,
+                (row.transit_lead_time_days, min_qty, multiple, priority, row.active, distribution_link_id),
+            )
+            action = "updated"
+            updated += 1
+        else:
+            distribution_link_id = uuid4()
+            db.execute(
+                """
+                INSERT INTO distribution_links
+                    (distribution_link_id, upstream_location_id, downstream_location_id, item_id,
+                     transit_lead_time_days, minimum_shipment_qty, transfer_multiple, priority, active)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (distribution_link_id, upstream_id, downstream_id, item_id,
+                 row.transit_lead_time_days, min_qty, multiple, priority, row.active),
+            )
+            action = "inserted"
+            inserted += 1
+
+        results.append({
+            "upstream_external_id": row.upstream_external_id,
+            "downstream_external_id": row.downstream_external_id,
+            "item_external_id": row.item_external_id,
+            "distribution_link_id": str(distribution_link_id),
+            "action": action,
+        })
+
+    logger.info(
+        "ingest.distribution_links total=%d inserted=%d updated=%d",
+        len(body.distribution_links), inserted, updated,
+    )
+    return _ok(inserted, updated, len(body.distribution_links), results)

--- a/src/ootils_core/engine/ingest/daily_orchestrator.py
+++ b/src/ootils_core/engine/ingest/daily_orchestrator.py
@@ -164,13 +164,27 @@ logger = logging.getLogger(__name__)
 # deliberate, documented duplicate of a short constant, not a second
 # canonical WRITER (nothing here re-implements bulk_ingest.py's loaders).
 # A canonical filename absent from this tuple sorts LAST (see
-# `_load_order_key`), never refused outright.
+# `_load_order_key`), never refused outright — but
+# `test_every_registered_builder_has_an_explicit_load_order_slot`
+# (tests/test_daily_orchestrator.py) still requires every
+# `interfaces.ingest_exec.PAYLOAD_BUILDERS` key to have an EXPLICIT slot
+# here, so a new entity is never silently pushed to "last" by omission.
+#
+# `distribution_links.tsv` (DESC-1 PR-D) is a DELIBERATE, DOCUMENTED
+# divergence from scripts/bulk_ingest.py's ORDERED_FILES — that script has
+# no `load_distribution_links` loader yet (a separate, DB-direct-write
+# implementation, out of this chantier's scope), so mirroring it exactly
+# is not possible today. Positioned right after the other referential/
+# topology entries (items/locations/suppliers/supplier_items/
+# item_planning_params) since its own FKs are items (optional) + locations
+# only.
 LOAD_ORDER: tuple[str, ...] = (
     "items.tsv",
     "locations.tsv",
     "suppliers.tsv",
     "supplier_items.tsv",
     "item_planning_params.tsv",
+    "distribution_links.tsv",
     "on_hand.tsv",
     "purchase_orders.tsv",
     "customer_orders.tsv",

--- a/src/ootils_core/interfaces/ingest_exec.py
+++ b/src/ootils_core/interfaces/ingest_exec.py
@@ -313,6 +313,12 @@ DISPATCH: dict[str, dict[str, str]] = {
     "customer_orders.tsv":      {"endpoint": "/v1/ingest/customer-orders",  "body_key": "customer_orders"},
     "forecasts.tsv":            {"endpoint": "/v1/ingest/forecast-demand",  "body_key": "forecasts"},
     "transfers.tsv":            {"endpoint": "/v1/ingest/transfers",        "body_key": "transfers"},
+    # Referential/on-demand (ADR-042 doctrine — never in the blocking daily
+    # run's governed set, no feed_contracts row by design): the daily
+    # orchestrator falls back to the raw feed_key as canonical dispatch name
+    # for exactly this class of entity (see engine/ingest/daily_orchestrator.py
+    # module docstring, "THE feed_key / entity_type MISMATCH").
+    "distribution_links.tsv":   {"endpoint": "/v1/ingest/distribution-links", "body_key": "distribution_links"},
     # BOM bundle: entry point is bom_header.tsv, which auto-loads bom_components.tsv
     # alongside and emits N POSTs (one per BOM). Special-cased in
     # scripts/ingest_file.py's main() / handle_bom_bundle — NOT in
@@ -666,6 +672,53 @@ def build_transfers_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[s
     return {"transfers": transfers, "dry_run": dry_run}
 
 
+def build_distribution_links_payload(rows: list[dict[str, str]], dry_run: bool) -> dict[str, Any]:
+    """Build the JSON body for POST /v1/ingest/distribution-links.
+
+    Column order per the contract (docs/contracts/distribution_links/
+    format-distribution-links-tsv.md §3): upstream_external_id,
+    downstream_external_id, item_external_id, transit_lead_time_days,
+    minimum_shipment_qty, transfer_multiple, priority.
+
+    Required: upstream_external_id, downstream_external_id,
+              transit_lead_time_days (mandatory IN THIS FILE, unlike the DB
+              column which carries a technical default — §3 refuses the
+              silent inheritance).
+    Optional: item_external_id (blank/absent = generic lane, all items),
+              minimum_shipment_qty (server default 1, 0 is a legitimate
+              'no floor'), transfer_multiple (server default 1),
+              priority (server default 100).
+    `active` is out of this file's contract (§8) — never sent here; the
+    server default (True) applies.
+    """
+    links: list[dict[str, Any]] = []
+    for row in rows:
+        line = row.get("__line__", "?")
+        if not row.get("transit_lead_time_days"):
+            raise ValueError(f"line {line}: transit_lead_time_days is required and cannot be empty")
+        link: dict[str, Any] = {
+            "upstream_external_id": row.get("upstream_external_id", ""),
+            "downstream_external_id": row.get("downstream_external_id", ""),
+            "transit_lead_time_days": _to_float(
+                row["transit_lead_time_days"], field="transit_lead_time_days", line=line
+            ),
+        }
+        if row.get("item_external_id"):
+            link["item_external_id"] = row["item_external_id"]
+        if row.get("minimum_shipment_qty"):
+            link["minimum_shipment_qty"] = _to_float(
+                row["minimum_shipment_qty"], field="minimum_shipment_qty", line=line
+            )
+        if row.get("transfer_multiple"):
+            link["transfer_multiple"] = _to_float(
+                row["transfer_multiple"], field="transfer_multiple", line=line
+            )
+        if row.get("priority"):
+            link["priority"] = _to_int(row["priority"], field="priority", line=line)
+        links.append(link)
+    return {"distribution_links": links, "dry_run": dry_run}
+
+
 PAYLOAD_BUILDERS = {
     "items.tsv":                build_items_payload,
     "locations.tsv":            build_locations_payload,
@@ -677,6 +730,7 @@ PAYLOAD_BUILDERS = {
     "customer_orders.tsv":      build_customer_orders_payload,
     "forecasts.tsv":            build_forecasts_payload,
     "transfers.tsv":            build_transfers_payload,
+    "distribution_links.tsv":   build_distribution_links_payload,
 }
 
 

--- a/tests/integration/test_descent_to_drp_integration.py
+++ b/tests/integration/test_descent_to_drp_integration.py
@@ -1,0 +1,359 @@
+"""
+tests/integration/test_descent_to_drp_integration.py — LE TEST DE PREUVE DRP
+(DESC-1, ADR-043 x #395): the end-to-end chain that was the plan's "done"
+criterion — national demand on a virtual channel, descended onto real DCs,
+recomputed, then THE DRP WAKES UP and drafts a governed inter-site TRANSFER
+from the surplus DC toward the deficit DC.
+
+The scenario, driven through the REAL surface only (module-scoped TestClient,
+pattern of test_demand_descent_run_integration.py):
+
+  SEED  — one virtual channel (``locations.is_stocking = FALSE``), two DCs;
+          baseline ``demand_split_pct`` 60/40 + ``item_dc_eligibility`` TRUE
+          for one item (direct INSERT — migration 083 has no ingest surface);
+          on-hand via /v1/ingest/on-hand: DC1 = 500 (excédentaire), DC2 = 0
+          (vide); ONE lane DC1 -> DC2 through the NEW
+          POST /v1/ingest/distribution-links endpoint (generic lane, transit
+          7 d = 1 weekly bucket); ONE national CustomerOrderDemand of 100 on
+          the channel at DB-CURRENT_DATE + 14 (bucket 2) via
+          /v1/ingest/customer-orders.
+  RUN   — POST /v1/demand/descend (kill switch OOTILS_DESCENT_ENABLED armed
+          via monkeypatch): 60 land on DC1, 40 on DC2, the national source is
+          deactivated. Then POST /v1/calc/run {full_recompute: true} (the
+          descent never recomputes — its own contract). Then POST /v1/drp/run
+          (OOTILS_DRP_ENABLED armed via monkeypatch).
+  PROOF — at least one governed recommendation with action='TRANSFER',
+          status DRAFT, decision_level L1, source = the surplus DC1,
+          dest = the deficit DC2, recommended_qty == 40 (the hand-checkable
+          fair-share: deficit 40 = safety 0 - (0 on-hand - 40 demand),
+          against DC1's excess 500 - 60 = 440; transfer_multiple 1). The DRP
+          woke up on data that entered EXCLUSIVELY through the half-interface
+          chain. Plus ADR-021: the DRP run itself wrote NOTHING into
+          ``shortages`` (the shortage rows of the calc run are the
+          ShortageDetector's, counted before/after the DRP call).
+
+Isolation (pattern of the sibling descent test): referential seeds under a
+unique PREFIX via the real API, neutralized by DEACTIVATION in a module
+finalizer (nodes off, items obsoleted, eligibility revoked, channel
+is_stocking restored, lanes deactivated, drp_run DRAFTs expired) — never a
+DELETE. The module-scoped ``migrated_db`` teardown drops the schema as the
+backstop.
+"""
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import psycopg
+import pytest
+from psycopg.rows import dict_row
+
+from .conftest import requires_db
+
+pytestmark = requires_db
+
+TOKEN = "integration-test-token"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+PREFIX = f"D2DRP-{uuid4().hex[:8]}"
+
+BASELINE = UUID("00000000-0000-0000-0000-000000000001")
+
+CO_QTY = 100.0        # national demand on the channel
+DC1_ONHAND = 500.0    # surplus DC
+DC2_ONHAND = 0.0      # empty DC
+CO_WEEKS_OUT = 2      # CO at DB_TODAY + 14 d -> weekly bucket 2
+
+
+def _ext(base: str) -> str:
+    return f"{PREFIX}-{base}"
+
+
+@pytest.fixture(scope="module")
+def api_client(migrated_db):
+    """Module-scoped FastAPI TestClient bound to the real test DB. The two
+    kill switches (OOTILS_DESCENT_ENABLED / OOTILS_DRP_ENABLED) are read PER
+    REQUEST by their routers and are deliberately NOT set here — the proof
+    test arms them via monkeypatch (the plan's own wording)."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = TOKEN
+
+    from fastapi.testclient import TestClient
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(scope="module")
+def seed(api_client, request, migrated_db):
+    """The full DESC-1 seed: channel + DCs + shares + eligibility + on-hand +
+    lane (via the NEW endpoint) + national demand. Every referential row goes
+    through the REAL ingest endpoints; migration 083's tables (shares,
+    eligibility) by direct INSERT — no ingest surface yet (PR-F is TSV spec).
+    Neutralized by DEACTIVATION, never a DELETE."""
+    resp = api_client.post(
+        "/v1/ingest/items",
+        json={"items": [{"external_id": _ext("ITEM"), "name": "Descent-to-DRP item",
+                         "item_type": "finished_good", "uom": "EA",
+                         "status": "active"}]},
+        headers=AUTH,
+    )
+    assert resp.status_code == 200, resp.text
+    resp = api_client.post(
+        "/v1/ingest/locations",
+        json={"locations": [
+            {"external_id": _ext("NAT"), "name": "National channel (virtual)"},
+            {"external_id": _ext("DC1"), "name": "Surplus DC", "location_type": "dc"},
+            {"external_id": _ext("DC2"), "name": "Deficit DC", "location_type": "dc"},
+        ]},
+        headers=AUTH,
+    )
+    assert resp.status_code == 200, resp.text
+
+    with psycopg.connect(migrated_db, row_factory=dict_row) as c:
+        db_today = c.execute("SELECT CURRENT_DATE AS d").fetchone()["d"]
+        item = c.execute(
+            "SELECT item_id FROM items WHERE external_id = %s", (_ext("ITEM"),)
+        ).fetchone()["item_id"]
+        locs = {
+            r["external_id"]: r["location_id"]
+            for r in c.execute(
+                "SELECT external_id, location_id FROM locations "
+                "WHERE external_id LIKE %s",
+                (PREFIX + "%",),
+            ).fetchall()
+        }
+        channel = locs[_ext("NAT")]
+        dc1, dc2 = locs[_ext("DC1")], locs[_ext("DC2")]
+
+        # The channel is a VIRTUAL demand-only location (migration 081) — the
+        # descent's national-demand scope key AND the is_stocking detection
+        # exclusion of ADR-021.
+        c.execute(
+            "UPDATE locations SET is_stocking = FALSE WHERE location_id = %s",
+            (channel,),
+        )
+        # Eligibility: explicit TRUE rows (an absent pair is NOT eligible).
+        for dc in (dc1, dc2):
+            c.execute(
+                "INSERT INTO item_dc_eligibility (item_id, dc_location_id, eligible, source) "
+                "VALUES (%s, %s, TRUE, 'manual')",
+                (item, dc),
+            )
+        # Baseline split 60/40 (scenario_id NULL = baseline, migration 083).
+        for dc, pct in ((dc1, Decimal("0.6")), (dc2, Decimal("0.4"))):
+            c.execute(
+                "INSERT INTO demand_split_pct (scenario_id, item_id, dc_location_id, pct, method) "
+                "VALUES (NULL, %s, %s, %s, 'manual')",
+                (item, dc, pct),
+            )
+        c.commit()
+
+    co_date = db_today + timedelta(days=7 * CO_WEEKS_OUT)
+
+    # On-hand through the REAL endpoint: DC1 excédentaire, DC2 vide (an
+    # explicit 0 row, so the empty DC exists as a coordinate with stock 0).
+    resp = api_client.post(
+        "/v1/ingest/on-hand",
+        json={"on_hand": [
+            {"item_external_id": _ext("ITEM"), "location_external_id": _ext("DC1"),
+             "quantity": DC1_ONHAND, "as_of_date": db_today.isoformat()},
+            {"item_external_id": _ext("ITEM"), "location_external_id": _ext("DC2"),
+             "quantity": DC2_ONHAND, "as_of_date": db_today.isoformat()},
+        ]},
+        headers=AUTH,
+    )
+    assert resp.status_code == 200, resp.text
+
+    # THE LANE between the two DCs — through the NEW endpoint (DESC-1 PR-D).
+    # Generic lane (item empty): the DRP specificity rule serves any item on
+    # it. Transit 7 d -> lead 1 weekly bucket.
+    resp = api_client.post(
+        "/v1/ingest/distribution-links",
+        json={"distribution_links": [
+            {"upstream_external_id": _ext("DC1"),
+             "downstream_external_id": _ext("DC2"),
+             "item_external_id": "",
+             "transit_lead_time_days": 7},
+        ]},
+        headers=AUTH,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["summary"]["inserted"] == 1
+
+    # National demand on the channel: ONE CustomerOrderDemand of 100.
+    resp = api_client.post(
+        "/v1/ingest/customer-orders",
+        json={"customer_orders": [
+            {"external_id": _ext("CO-1"), "item_external_id": _ext("ITEM"),
+             "location_external_id": _ext("NAT"), "quantity": CO_QTY,
+             "requested_delivery_date": co_date.isoformat(), "status": "open"},
+        ]},
+        headers=AUTH,
+    )
+    assert resp.status_code == 200, resp.text
+
+    def _neutralize():
+        with psycopg.connect(migrated_db, autocommit=True) as c:
+            c.execute(
+                "UPDATE nodes SET active = FALSE WHERE item_id = %s", (item,)
+            )
+            c.execute(
+                "UPDATE items SET status = 'obsolete' WHERE external_id LIKE %s",
+                (PREFIX + "%",),
+            )
+            c.execute(
+                "UPDATE item_dc_eligibility SET eligible = FALSE WHERE item_id = %s",
+                (item,),
+            )
+            c.execute(
+                "UPDATE locations SET is_stocking = TRUE WHERE location_id = %s",
+                (channel,),
+            )
+            c.execute(
+                "UPDATE distribution_links SET active = FALSE "
+                "WHERE upstream_location_id = %s AND downstream_location_id = %s",
+                (dc1, dc2),
+            )
+            c.execute(
+                "UPDATE recommendations SET status = 'EXPIRED', updated_at = now() "
+                "WHERE agent_name = 'drp_run' AND status = 'DRAFT' AND item_id = %s",
+                (item,),
+            )
+
+    request.addfinalizer(_neutralize)
+    return {
+        "item": item, "channel": channel, "dc1": dc1, "dc2": dc2,
+        "db_today": db_today, "co_date": co_date,
+    }
+
+
+def test_descent_then_recompute_then_drp_wakes_up(
+    api_client, seed, migrated_db, monkeypatch
+):
+    """Le critère de done du plan: après descente + full recompute, le DRP se
+    réveille — au moins une recommendation TRANSFER L1 DRAFT du DC
+    excédentaire vers le DC en déficit."""
+    monkeypatch.setenv("OOTILS_DESCENT_ENABLED", "1")
+    monkeypatch.setenv("OOTILS_DRP_ENABLED", "1")
+
+    # ---- 1. Descent: 100 national -> 60 DC1 / 40 DC2, source deactivated.
+    resp = api_client.post("/v1/demand/descend", json={"dry_run": False}, headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["source_nodes_considered"] == 1
+    assert body["source_nodes_deactivated"] == 1
+    assert body["derived_nodes_created"] == 2
+    assert body["lines_written"] == 2
+    assert body["items_without_shares"] == []
+    assert body["recompute_triggered"] is False  # its own contract — step 2 is on us
+
+    with psycopg.connect(migrated_db, row_factory=dict_row) as c:
+        derived = {
+            r["location_id"]: float(r["quantity"])
+            for r in c.execute(
+                "SELECT location_id, quantity FROM nodes "
+                "WHERE item_id = %s AND node_type = 'CustomerOrderDemand' "
+                "AND active = TRUE AND location_id = ANY(%s)",
+                (seed["item"], [seed["dc1"], seed["dc2"]]),
+            ).fetchall()
+        }
+        assert derived == {seed["dc1"]: 60.0, seed["dc2"]: 40.0}
+
+    # ---- 2. Full recompute (the descent never recomputes — its contract).
+    resp = api_client.post(
+        "/v1/calc/run", json={"full_recompute": True}, headers=AUTH
+    )
+    assert resp.status_code == 200, resp.text
+    calc = resp.json()
+    assert calc["status"] == "completed"
+    assert calc["calc_run_id"] is not None
+    # The seeded PI series (channel + both DCs) were all walked.
+    assert calc["nodes_recalculated"] + calc["nodes_unchanged"] > 0
+
+    # Snapshot the shortages count AFTER the calc run (the ShortageDetector's
+    # rows) and BEFORE the DRP — ADR-021 says the DRP adds none.
+    with psycopg.connect(migrated_db, row_factory=dict_row) as c:
+        shortages_before_drp_baseline = c.execute(
+            "SELECT COUNT(*) AS n FROM shortages"
+        ).fetchone()["n"]
+
+    # ---- 3. DRP run — LE RÉVEIL.
+    resp = api_client.post("/v1/drp/run", json={}, headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    drp = resp.json()
+    assert drp["scenario_id"] == str(BASELINE)
+    assert drp["decision_level"] == "L1"
+    assert drp["signals"] >= 1
+    assert drp["recommendations_emitted"] >= 1
+    assert drp["unresolved_coords"] == 0
+
+    # ---- 4. THE PROOF: a governed TRANSFER L1 DRAFT, surplus DC -> deficit DC.
+    with psycopg.connect(migrated_db, row_factory=dict_row) as c:
+        recos = c.execute(
+            "SELECT * FROM recommendations "
+            "WHERE agent_name = 'drp_run' AND scenario_id = %s "
+            "AND action = 'TRANSFER' AND status = 'DRAFT' AND item_id = %s",
+            (str(BASELINE), seed["item"]),
+        ).fetchall()
+        assert len(recos) >= 1, "le DRP ne s'est pas réveillé — aucune reco TRANSFER"
+        r = recos[0]
+        assert r["decision_level"] == "L1"
+        assert r["source_location_id"] == seed["dc1"]  # from the surplus DC ...
+        assert r["dest_location_id"] == seed["dc2"]    # ... toward the deficit DC
+        # Hand-checkable fair-share: deficit 40 (0 on-hand - 40 demand, safety
+        # 0) against DC1's excess 500 - 60 = 440, transfer_multiple 1 -> 40.
+        assert float(r["recommended_qty"]) == 40.0
+        assert float(r["deficit_qty"]) == 40.0
+        # Ship before (or at) the deficit date: lead 1 bucket ahead of bucket 2.
+        assert r["proposed_date"] < r["shortage_date"]
+        # Evidence trail carries the human-readable lane coordinates.
+        assert r["evidence"]["signal"] == "TRANSFER"
+        assert r["evidence"]["source_location"] == _ext("DC1")
+        assert r["evidence"]["dest_location"] == _ext("DC2")
+        assert r["evidence"]["item"] == _ext("ITEM")
+
+        # ADR-021: the DRP run wrote NOTHING into `shortages`.
+        assert c.execute(
+            "SELECT COUNT(*) AS n FROM shortages"
+        ).fetchone()["n"] == shortages_before_drp_baseline
+
+
+def test_drp_rerun_on_unchanged_plan_is_idempotent(api_client, seed, migrated_db, monkeypatch):
+    """Bonus invariant (#395): re-running the DRP on the unchanged plan
+    re-derives the SAME deterministic ids — zero new rows, the no-op is
+    self-reported. Runs AFTER the proof test (module order is definition
+    order; the plan has not moved in between)."""
+    monkeypatch.setenv("OOTILS_DRP_ENABLED", "1")
+
+    with psycopg.connect(migrated_db, row_factory=dict_row) as c:
+        before = c.execute(
+            "SELECT COUNT(*) AS n FROM recommendations WHERE agent_name = 'drp_run'"
+        ).fetchone()["n"]
+    assert before >= 1, "the proof test must have emitted first"
+
+    resp = api_client.post("/v1/drp/run", json={}, headers=AUTH)
+    assert resp.status_code == 200, resp.text
+    drp = resp.json()
+    assert drp["recommendations_emitted"] == 0
+    assert drp["recommendations_idempotent_noop"] >= 1
+
+    with psycopg.connect(migrated_db, row_factory=dict_row) as c:
+        after = c.execute(
+            "SELECT COUNT(*) AS n FROM recommendations WHERE agent_name = 'drp_run'"
+        ).fetchone()["n"]
+    assert after == before

--- a/tests/integration/test_distribution_links_ingest_integration.py
+++ b/tests/integration/test_distribution_links_ingest_integration.py
@@ -1,0 +1,290 @@
+"""
+tests/integration/test_distribution_links_ingest_integration.py — DESC-1 PR-D:
+POST /v1/ingest/distribution-links against a real PostgreSQL, no mocks
+(CLAUDE.md). The mocked-DB branch coverage lives in
+tests/test_ingest_distribution_links.py; this file asserts what a FakeDB
+cannot: the real SELECT-then-INSERT/UPDATE upsert on the NULL-safe
+(upstream, downstream, item) natural key, the columns the endpoint must NEVER
+touch, and the FK validation against real rows.
+
+The three contract axes (module-scoped api_client, pattern of
+test_ingest_routings_integration.py; each test seeds its OWN uuid-suffixed
+referential rows via the real /v1/ingest/* endpoints):
+
+  1. INGEST 2 LANES — one generic (item empty -> item_id NULL) + one
+     item-specific lane on the SAME (upstream, downstream) pair: both are
+     inserted (coexistence, spec §4 — the DRP specificity rule consumes them,
+     never a duplicate refusal), FKs resolved to the real location/item UUIDs,
+     server defaults (min 1, multiple 1, priority 100, active TRUE) applied.
+  2. IDEMPOTENT UPSERT — a re-push of the same 2 keys with different values is
+     an UPDATE, not a doublon: summary says updated=2/inserted=0, the table
+     still holds exactly 2 rows for the pair, the distribution_link_id is
+     STABLE (never re-minted), the pushed values landed — and the columns the
+     file contract does NOT cover (maximum_shipment_qty here, set out-of-band
+     between the two pushes) survive the re-push untouched (spec §8).
+  3. LOCATIONS INCONNUES — unknown upstream AND downstream -> nominative 422
+     naming each missing external_id, and ZERO rows written (all-or-nothing).
+
+Isolation: unique PREFIX per test; neutralized by DEACTIVATION in a finally
+block (lanes active=FALSE, items obsoleted) — never a DELETE. The module-scoped
+``migrated_db`` teardown drops the schema as the backstop.
+"""
+from __future__ import annotations
+
+import os
+from uuid import UUID, uuid4
+
+import psycopg
+import pytest
+from psycopg.rows import dict_row
+
+from .conftest import requires_db, TEST_DB_URL
+
+pytestmark = requires_db
+
+TOKEN = "integration-test-token"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+
+@pytest.fixture(scope="module")
+def api_client(migrated_db):
+    """Module-scoped FastAPI TestClient bound to the real test DB (same
+    pattern as test_ingest_routings_integration.py)."""
+    os.environ["DATABASE_URL"] = migrated_db
+    os.environ["OOTILS_API_TOKEN"] = TOKEN
+
+    from fastapi.testclient import TestClient
+    from ootils_core.api.app import create_app
+    from ootils_core.api.dependencies import get_db
+    from ootils_core.db.connection import OotilsDB
+
+    app = create_app()
+
+    def override_db():
+        db = OotilsDB(migrated_db)
+        with db.conn() as c:
+            yield c
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+def _conn():
+    return psycopg.connect(TEST_DB_URL, row_factory=dict_row)
+
+
+def _seed(api_client, prefix: str) -> dict:
+    """Two DCs + one item through the REAL ingest endpoints; returns the
+    resolved UUIDs keyed by role."""
+    resp = api_client.post(
+        "/v1/ingest/locations",
+        json={"locations": [
+            {"external_id": f"{prefix}-UP", "name": "Lane upstream DC",
+             "location_type": "dc"},
+            {"external_id": f"{prefix}-DOWN", "name": "Lane downstream DC",
+             "location_type": "dc"},
+        ]},
+        headers=AUTH,
+    )
+    assert resp.status_code == 200, resp.text
+    resp = api_client.post(
+        "/v1/ingest/items",
+        json={"items": [{"external_id": f"{prefix}-ITEM", "name": "Lane item",
+                         "item_type": "finished_good", "uom": "EA",
+                         "status": "active"}]},
+        headers=AUTH,
+    )
+    assert resp.status_code == 200, resp.text
+
+    with _conn() as c:
+        up, down = (
+            c.execute(
+                "SELECT location_id FROM locations WHERE external_id = %s",
+                (f"{prefix}-{tag}",),
+            ).fetchone()["location_id"]
+            for tag in ("UP", "DOWN")
+        )
+        item = c.execute(
+            "SELECT item_id FROM items WHERE external_id = %s",
+            (f"{prefix}-ITEM",),
+        ).fetchone()["item_id"]
+    return {"up": up, "down": down, "item": item}
+
+
+def _neutralize(prefix: str, up: UUID, down: UUID) -> None:
+    """Deactivation, never DELETE: lanes off, items obsoleted."""
+    with psycopg.connect(TEST_DB_URL, autocommit=True) as c:
+        c.execute(
+            "UPDATE distribution_links SET active = FALSE "
+            "WHERE upstream_location_id = %s AND downstream_location_id = %s",
+            (up, down),
+        )
+        c.execute(
+            "UPDATE items SET status = 'obsolete' WHERE external_id LIKE %s",
+            (prefix + "%",),
+        )
+
+
+def _lanes_for_pair(c, up: UUID, down: UUID) -> list[dict]:
+    return c.execute(
+        "SELECT distribution_link_id, item_id, transit_lead_time_days, "
+        "minimum_shipment_qty, transfer_multiple, maximum_shipment_qty, "
+        "priority, active "
+        "FROM distribution_links "
+        "WHERE upstream_location_id = %s AND downstream_location_id = %s "
+        "ORDER BY item_id NULLS FIRST",
+        (up, down),
+    ).fetchall()
+
+
+class TestDistributionLinksIngest:
+    def test_ingests_generic_and_specific_lane_verified_in_db(self, api_client):
+        prefix = f"DLINK-{uuid4().hex[:8]}"
+        ids = _seed(api_client, prefix)
+        try:
+            resp = api_client.post(
+                "/v1/ingest/distribution-links",
+                json={"distribution_links": [
+                    # Generic lane: blank item -> item_id NULL, all defaults.
+                    {"upstream_external_id": f"{prefix}-UP",
+                     "downstream_external_id": f"{prefix}-DOWN",
+                     "item_external_id": "",
+                     "transit_lead_time_days": 7},
+                    # Item-specific lane on the SAME pair: coexists (spec §4).
+                    {"upstream_external_id": f"{prefix}-UP",
+                     "downstream_external_id": f"{prefix}-DOWN",
+                     "item_external_id": f"{prefix}-ITEM",
+                     "transit_lead_time_days": 3,
+                     "minimum_shipment_qty": 5,
+                     "transfer_multiple": 10,
+                     "priority": 2},
+                ]},
+                headers=AUTH,
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["summary"]["inserted"] == 2
+            assert body["summary"]["updated"] == 0
+            assert [r["action"] for r in body["results"]] == ["inserted", "inserted"]
+
+            with _conn() as c:
+                lanes = _lanes_for_pair(c, ids["up"], ids["down"])
+            assert len(lanes) == 2
+            generic, specific = lanes
+            # Generic lane: item_id NULL + server defaults.
+            assert generic["item_id"] is None
+            assert float(generic["transit_lead_time_days"]) == 7.0
+            assert float(generic["minimum_shipment_qty"]) == 1.0
+            assert float(generic["transfer_multiple"]) == 1.0
+            assert generic["priority"] == 100
+            assert generic["active"] is True
+            # Specific lane: FK resolved to the real item, explicit values.
+            assert specific["item_id"] == ids["item"]
+            assert float(specific["transit_lead_time_days"]) == 3.0
+            assert float(specific["minimum_shipment_qty"]) == 5.0
+            assert float(specific["transfer_multiple"]) == 10.0
+            assert specific["priority"] == 2
+            assert specific["active"] is True
+        finally:
+            _neutralize(prefix, ids["up"], ids["down"])
+
+    def test_repush_updates_in_place_never_duplicates(self, api_client):
+        prefix = f"DLINK-{uuid4().hex[:8]}"
+        ids = _seed(api_client, prefix)
+        try:
+            lanes = [
+                {"upstream_external_id": f"{prefix}-UP",
+                 "downstream_external_id": f"{prefix}-DOWN",
+                 "transit_lead_time_days": 7},
+                {"upstream_external_id": f"{prefix}-UP",
+                 "downstream_external_id": f"{prefix}-DOWN",
+                 "item_external_id": f"{prefix}-ITEM",
+                 "transit_lead_time_days": 3},
+            ]
+            r1 = api_client.post(
+                "/v1/ingest/distribution-links",
+                json={"distribution_links": lanes},
+                headers=AUTH,
+            )
+            assert r1.status_code == 200, r1.text
+            assert r1.json()["summary"]["inserted"] == 2
+            ids_before = {r["item_external_id"]: r["distribution_link_id"]
+                          for r in r1.json()["results"]}
+
+            # Out-of-band value on a column the file contract does NOT cover
+            # (spec §8) — must survive the re-push untouched.
+            with psycopg.connect(TEST_DB_URL, autocommit=True) as c:
+                c.execute(
+                    "UPDATE distribution_links SET maximum_shipment_qty = 999 "
+                    "WHERE upstream_location_id = %s AND downstream_location_id = %s "
+                    "AND item_id IS NULL",
+                    (ids["up"], ids["down"]),
+                )
+
+            # Re-push the SAME 2 keys with different covered values.
+            lanes[0]["transit_lead_time_days"] = 14
+            lanes[0]["priority"] = 5
+            lanes[1]["transfer_multiple"] = 25
+            r2 = api_client.post(
+                "/v1/ingest/distribution-links",
+                json={"distribution_links": lanes},
+                headers=AUTH,
+            )
+            assert r2.status_code == 200, r2.text
+            body2 = r2.json()
+            assert body2["summary"]["updated"] == 2
+            assert body2["summary"]["inserted"] == 0
+            assert [r["action"] for r in body2["results"]] == ["updated", "updated"]
+            # The link identity is STABLE across pushes (upsert, not re-mint).
+            ids_after = {r["item_external_id"]: r["distribution_link_id"]
+                         for r in body2["results"]}
+            assert ids_after == ids_before
+
+            with _conn() as c:
+                rows = _lanes_for_pair(c, ids["up"], ids["down"])
+            assert len(rows) == 2, "re-push must never create a doublon"
+            generic, specific = rows
+            assert generic["item_id"] is None
+            assert float(generic["transit_lead_time_days"]) == 14.0
+            assert generic["priority"] == 5
+            # The uncovered column survived (spec §8).
+            assert float(generic["maximum_shipment_qty"]) == 999.0
+            assert specific["item_id"] == ids["item"]
+            assert float(specific["transfer_multiple"]) == 25.0
+            # A value the re-push did not resend falls back to the server
+            # default on UPDATE too (full-row upsert of the covered columns).
+            assert float(specific["minimum_shipment_qty"]) == 1.0
+        finally:
+            _neutralize(prefix, ids["up"], ids["down"])
+
+    def test_unknown_locations_422_nominative_and_nothing_written(self, api_client):
+        prefix = f"DLINK-{uuid4().hex[:8]}"
+        ids = _seed(api_client, prefix)
+        try:
+            resp = api_client.post(
+                "/v1/ingest/distribution-links",
+                json={"distribution_links": [
+                    {"upstream_external_id": f"{prefix}-GHOST-UP",
+                     "downstream_external_id": f"{prefix}-GHOST-DOWN",
+                     "transit_lead_time_days": 7},
+                    # A valid row in the same batch: all-or-nothing, it must
+                    # NOT be written either.
+                    {"upstream_external_id": f"{prefix}-UP",
+                     "downstream_external_id": f"{prefix}-DOWN",
+                     "transit_lead_time_days": 7},
+                ]},
+                headers=AUTH,
+            )
+            assert resp.status_code == 422, resp.text
+            detail = resp.json()["detail"]
+            errs = [e for row in detail for e in row["errors"]]
+            assert any(f"upstream_external_id '{prefix}-GHOST-UP' not found" in e
+                       for e in errs)
+            assert any(f"downstream_external_id '{prefix}-GHOST-DOWN' not found" in e
+                       for e in errs)
+            with _conn() as c:
+                assert _lanes_for_pair(c, ids["up"], ids["down"]) == []
+        finally:
+            _neutralize(prefix, ids["up"], ids["down"])

--- a/tests/test_ingest_distribution_links.py
+++ b/tests/test_ingest_distribution_links.py
@@ -1,0 +1,450 @@
+"""
+tests/test_ingest_distribution_links.py — unit tests (mocked DB, no Postgres)
+for the DESC-1 PR-D delivery: POST /v1/ingest/distribution-links
+(api/routers/ingest.py) + the TSV payload builder
+(interfaces/ingest_exec.py:build_distribution_links_payload).
+
+Pattern of tests/test_router_ingest.py: FakeDB/FakeCursor scripted cursors via
+FastAPI dependency override — every branch of the router is driven without a
+live database. The builder tests are pure (no app, no DB).
+
+Coverage:
+  Builder — full row conversion, minimal row (only the 3 required keys),
+    generic lane (blank item omitted), '0' minimum_shipment_qty preserved (a
+    legitimate 'no floor'), `active` NEVER emitted (out of the file contract,
+    spec §8), required transit_lead_time_days (empty -> ValueError naming the
+    line), numeric conversion errors naming field + line, dry_run passthrough.
+  Router — auth 401; happy insert of 2 lanes (1 generic item_id NULL + 1
+    item-specific) with server defaults (min 1, multiple 1, priority 100,
+    active TRUE); upsert-update branch (existing triplet -> UPDATE, never a
+    second INSERT); dry_run writes nothing; nominative 422s (unknown upstream /
+    downstream / item, upstream == downstream, duplicate triplet in payload —
+    including blank-item vs absent-item normalizing to the SAME generic key);
+    Pydantic 422s (empty upstream, negative transit, transfer_multiple 0,
+    priority 0); transit 0 valid (ge=0); blank item -> None via blank_to_none.
+"""
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+
+# Auth token must be set BEFORE the app is imported (same guard as
+# test_router_ingest.py — importing it below triggers create_app()).
+os.environ.setdefault("OOTILS_API_TOKEN", "test-token")
+
+from ootils_core.api.routers.ingest import (  # noqa: E402
+    DistributionLinkRow,
+    _distribution_link_key,
+)
+from ootils_core.interfaces.ingest_exec import (  # noqa: E402
+    DISPATCH,
+    PAYLOAD_BUILDERS,
+    build_distribution_links_payload,
+)
+
+from tests.test_router_ingest import (  # noqa: E402
+    AUTH_HEADERS,
+    FakeCursor,
+    FakeDB,
+    make_client,
+)
+
+
+# ─────────────────────────────────────────────────────────────
+# Builder: build_distribution_links_payload (pure, no DB)
+# ─────────────────────────────────────────────────────────────
+
+
+def _row(**overrides) -> dict[str, str]:
+    base = {
+        "__line__": "2",
+        "upstream_external_id": "DC-A",
+        "downstream_external_id": "DC-B",
+        "item_external_id": "",
+        "transit_lead_time_days": "7",
+        "minimum_shipment_qty": "",
+        "transfer_multiple": "",
+        "priority": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_builder_registered_in_dispatch_and_payload_builders():
+    """The daily-orchestrator wiring: distribution_links.tsv routes to the new
+    endpoint with body_key 'distribution_links' and to this builder."""
+    assert DISPATCH["distribution_links.tsv"] == {
+        "endpoint": "/v1/ingest/distribution-links",
+        "body_key": "distribution_links",
+    }
+    assert PAYLOAD_BUILDERS["distribution_links.tsv"] is build_distribution_links_payload
+
+
+def test_builder_full_row_converts_all_fields():
+    payload = build_distribution_links_payload(
+        [_row(item_external_id="SKU-1", minimum_shipment_qty="5",
+              transfer_multiple="10", priority="2",
+              transit_lead_time_days="7.5")],
+        dry_run=False,
+    )
+    assert payload["dry_run"] is False
+    assert payload["distribution_links"] == [{
+        "upstream_external_id": "DC-A",
+        "downstream_external_id": "DC-B",
+        "item_external_id": "SKU-1",
+        "transit_lead_time_days": 7.5,
+        "minimum_shipment_qty": 5.0,
+        "transfer_multiple": 10.0,
+        "priority": 2,
+    }]
+    # priority is an int (server model expects int), the quantities floats.
+    assert isinstance(payload["distribution_links"][0]["priority"], int)
+
+
+def test_builder_minimal_row_emits_only_required_keys():
+    """Blank optional cells are OMITTED (server defaults apply) and `active`
+    is NEVER sent — it is out of the TSV file contract (spec §8)."""
+    payload = build_distribution_links_payload([_row()], dry_run=False)
+    assert set(payload["distribution_links"][0]) == {
+        "upstream_external_id",
+        "downstream_external_id",
+        "transit_lead_time_days",
+    }
+    assert "active" not in payload["distribution_links"][0]
+
+
+def test_builder_generic_lane_blank_item_omitted():
+    """A blank/absent item cell = generic lane: the key is simply not sent
+    (the server's blank_to_none would normalize it anyway; the builder never
+    forwards an empty string)."""
+    for row in (_row(item_external_id=""), {k: v for k, v in _row().items()
+                                            if k != "item_external_id"}):
+        payload = build_distribution_links_payload([row], dry_run=False)
+        assert "item_external_id" not in payload["distribution_links"][0]
+
+
+def test_builder_zero_minimum_shipment_qty_preserved():
+    """'0' is a legitimate 'no floor' value — a truthy non-empty string, so it
+    must flow through as 0.0, not be dropped as a blank."""
+    payload = build_distribution_links_payload(
+        [_row(minimum_shipment_qty="0")], dry_run=False
+    )
+    assert payload["distribution_links"][0]["minimum_shipment_qty"] == 0.0
+
+
+def test_builder_missing_transit_raises_naming_line():
+    """transit_lead_time_days is mandatory IN THIS FILE (§3 refuses inheriting
+    the DB column's technical default silently)."""
+    with pytest.raises(ValueError, match=r"line 9: transit_lead_time_days is required"):
+        build_distribution_links_payload(
+            [_row(transit_lead_time_days="", __line__="9")], dry_run=False
+        )
+
+
+def test_builder_non_numeric_transit_raises_naming_field_and_line():
+    with pytest.raises(ValueError, match=r"line 4: transit_lead_time_days 'sept' is not a valid number"):
+        build_distribution_links_payload(
+            [_row(transit_lead_time_days="sept", __line__="4")], dry_run=False
+        )
+
+
+def test_builder_non_numeric_priority_raises_naming_field_and_line():
+    with pytest.raises(ValueError, match=r"line 3: priority 'high' is not a valid integer"):
+        build_distribution_links_payload(
+            [_row(priority="high", __line__="3")], dry_run=False
+        )
+
+
+def test_builder_dry_run_passthrough():
+    assert build_distribution_links_payload([], dry_run=True) == {
+        "distribution_links": [],
+        "dry_run": True,
+    }
+
+
+# ─────────────────────────────────────────────────────────────
+# Pydantic model: blank item normalization + the payload dedup key
+# ─────────────────────────────────────────────────────────────
+
+
+def test_row_blank_item_normalized_to_none():
+    """blank_to_none: a whitespace-only item_external_id IS a generic lane."""
+    row = DistributionLinkRow(
+        upstream_external_id="DC-A", downstream_external_id="DC-B",
+        item_external_id="   ", transit_lead_time_days=7,
+    )
+    assert row.item_external_id is None
+    # ... and it shares the SAME upsert key as an absent item (both generic).
+    absent = DistributionLinkRow(
+        upstream_external_id="DC-A", downstream_external_id="DC-B",
+        transit_lead_time_days=7,
+    )
+    assert _distribution_link_key(row) == _distribution_link_key(absent) == (
+        "DC-A", "DC-B", None
+    )
+
+
+# ─────────────────────────────────────────────────────────────
+# Router: mock infrastructure
+# ─────────────────────────────────────────────────────────────
+
+
+def _links_db(loc_rows=None, item_rows=None, existing_link_id=None) -> FakeDB:
+    """FakeDB router for /v1/ingest/distribution-links: serves the two
+    _batch_existing map SELECTs and the SELECT-then-INSERT/UPDATE existence
+    probe; every other statement gets a default cursor."""
+
+    def handler(sql, params):
+        if "FROM locations" in sql and "ANY" in sql:
+            return FakeCursor(fetchall_value=list(loc_rows or []))
+        if "FROM items" in sql and "ANY" in sql:
+            return FakeCursor(fetchall_value=list(item_rows or []))
+        if "SELECT distribution_link_id FROM distribution_links" in sql:
+            if existing_link_id is not None:
+                return FakeCursor(fetchone_value={"distribution_link_id": existing_link_id})
+            return FakeCursor(fetchone_value=None)
+        return FakeCursor()
+
+    return FakeDB(handler=handler)
+
+
+def _loc_rows(*external_ids):
+    return [{"external_id": e, "location_id": uuid4()} for e in external_ids]
+
+
+def _lane(**overrides) -> dict:
+    base = {
+        "upstream_external_id": "DC-A",
+        "downstream_external_id": "DC-B",
+        "transit_lead_time_days": 7,
+    }
+    base.update(overrides)
+    return base
+
+
+def _post(client, links, **body_extra):
+    return client.post(
+        "/v1/ingest/distribution-links",
+        json={"distribution_links": links, **body_extra},
+        headers=AUTH_HEADERS,
+    )
+
+
+# ─────────────────────────────────────────────────────────────
+# Router: auth
+# ─────────────────────────────────────────────────────────────
+
+
+def test_ingest_distribution_links_requires_auth():
+    client = make_client(FakeDB())
+    resp = client.post(
+        "/v1/ingest/distribution-links", json={"distribution_links": []}
+    )
+    assert resp.status_code == 401
+
+
+# ─────────────────────────────────────────────────────────────
+# Router: happy paths
+# ─────────────────────────────────────────────────────────────
+
+
+def test_happy_insert_generic_and_specific_lanes_coexist():
+    """1 generic (item empty -> item_id NULL) + 1 item-specific lane on the
+    SAME (upstream, downstream) pair: NOT duplicates of each other (spec §4),
+    both inserted, server defaults applied where the row omitted a value."""
+    locs = _loc_rows("DC-A", "DC-B")
+    item_id = uuid4()
+    db = _links_db(loc_rows=locs, item_rows=[{"external_id": "SKU-1", "item_id": item_id}])
+    client = make_client(db)
+    resp = _post(client, [
+        _lane(item_external_id=""),               # generic lane, blank item
+        _lane(item_external_id="SKU-1", minimum_shipment_qty=5,
+              transfer_multiple=10, priority=2),  # item-specific lane
+    ])
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["summary"]["inserted"] == 2
+    assert body["summary"]["updated"] == 0
+    assert [r["action"] for r in body["results"]] == ["inserted", "inserted"]
+    assert body["results"][0]["item_external_id"] is None      # generic
+    assert body["results"][1]["item_external_id"] == "SKU-1"   # specific
+    assert all(r["distribution_link_id"] for r in body["results"])
+
+    inserts = [c for c in db.calls if "INSERT INTO distribution_links" in c[0]]
+    assert len(inserts) == 2
+    # INSERT params: (link_id, upstream, downstream, item_id, transit, min,
+    # multiple, priority, active).
+    generic, specific = inserts[0][1], inserts[1][1]
+    assert generic[3] is None                      # item_id NULL = generic lane
+    assert specific[3] == item_id
+    # Server defaults where the row omitted the value (generic lane).
+    assert generic[4:9] == (7.0, 1.0, 1.0, 100, True)
+    # Explicit values flow through untouched (specific lane).
+    assert specific[4:9] == (7.0, 5.0, 10.0, 2, True)
+
+
+def test_happy_update_existing_lane_never_reinserts():
+    existing_id = uuid4()
+    db = _links_db(loc_rows=_loc_rows("DC-A", "DC-B"), existing_link_id=existing_id)
+    client = make_client(db)
+    resp = _post(client, [_lane(transit_lead_time_days=14)])
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["summary"]["updated"] == 1
+    assert body["summary"]["inserted"] == 0
+    assert body["results"][0]["action"] == "updated"
+    assert body["results"][0]["distribution_link_id"] == str(existing_id)
+    updates = [c for c in db.calls if "UPDATE distribution_links" in c[0]]
+    assert len(updates) == 1
+    # UPDATE params: (transit, min, multiple, priority, active, link_id).
+    assert updates[0][1] == (14.0, 1.0, 1.0, 100, True, existing_id)
+    assert not any("INSERT INTO distribution_links" in c[0] for c in db.calls)
+
+
+def test_dry_run_validates_but_writes_nothing():
+    db = _links_db(loc_rows=_loc_rows("DC-A", "DC-B"))
+    client = make_client(db)
+    resp = _post(client, [_lane()], dry_run=True)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "dry_run"
+    assert body["results"][0]["action"] == "dry_run"
+    assert not any("INSERT INTO distribution_links" in c[0] for c in db.calls)
+    assert not any("UPDATE distribution_links" in c[0] for c in db.calls)
+    assert not any("SELECT distribution_link_id" in c[0] for c in db.calls)
+
+
+def test_transit_zero_is_valid():
+    """ge=0: a 0-day transit (same-campus lane) is legitimate."""
+    db = _links_db(loc_rows=_loc_rows("DC-A", "DC-B"))
+    client = make_client(db)
+    resp = _post(client, [_lane(transit_lead_time_days=0)])
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["summary"]["inserted"] == 1
+
+
+# ─────────────────────────────────────────────────────────────
+# Router: nominative 422s (server-side validation)
+# ─────────────────────────────────────────────────────────────
+
+
+def test_unknown_upstream_422_names_the_location():
+    db = _links_db(loc_rows=_loc_rows("DC-B"))  # DC-A missing from DB
+    client = make_client(db)
+    resp = _post(client, [_lane()])
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert len(detail) == 1
+    assert detail[0]["row"] == 0
+    assert any("upstream_external_id 'DC-A' not found in DB" in e
+               for e in detail[0]["errors"])
+
+
+def test_unknown_downstream_422_names_the_location():
+    db = _links_db(loc_rows=_loc_rows("DC-A"))  # DC-B missing from DB
+    client = make_client(db)
+    resp = _post(client, [_lane()])
+    assert resp.status_code == 422
+    assert any("downstream_external_id 'DC-B' not found in DB" in e
+               for e in resp.json()["detail"][0]["errors"])
+
+
+def test_unknown_item_422_names_the_item():
+    db = _links_db(loc_rows=_loc_rows("DC-A", "DC-B"), item_rows=[])
+    client = make_client(db)
+    resp = _post(client, [_lane(item_external_id="SKU-MISS")])
+    assert resp.status_code == 422
+    assert any("item_external_id 'SKU-MISS' not found in DB" in e
+               for e in resp.json()["detail"][0]["errors"])
+
+
+def test_same_upstream_and_downstream_422():
+    db = _links_db(loc_rows=_loc_rows("DC-A"))
+    client = make_client(db)
+    resp = _post(client, [_lane(downstream_external_id="DC-A")])
+    assert resp.status_code == 422
+    assert any("must differ" in e for e in resp.json()["detail"][0]["errors"])
+
+
+def test_duplicate_triplet_in_payload_422_points_at_first_row():
+    """Two rows with the same (upstream, downstream, item) key — including a
+    blank-item row vs an absent-item row, which BOTH normalize to the generic
+    key — are refused, the error naming the first occurrence's row index."""
+    db = _links_db(loc_rows=_loc_rows("DC-A", "DC-B"))
+    client = make_client(db)
+    resp = _post(client, [
+        _lane(item_external_id=""),  # generic (blank item)
+        _lane(),                     # generic (absent item) — SAME key
+    ])
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert detail[0]["row"] == 1
+    assert any("duplicate" in e and "also at row 0" in e for e in detail[0]["errors"])
+
+
+def test_generic_and_specific_rows_are_not_duplicates():
+    """The dedup key includes the item: a generic row + a specific row on the
+    same pair must NOT trip the duplicate check."""
+    db = _links_db(
+        loc_rows=_loc_rows("DC-A", "DC-B"),
+        item_rows=[{"external_id": "SKU-1", "item_id": uuid4()}],
+    )
+    client = make_client(db)
+    resp = _post(client, [_lane(), _lane(item_external_id="SKU-1")])
+    assert resp.status_code == 200, resp.text
+
+
+def test_all_or_nothing_one_bad_row_fails_the_batch():
+    """Any error -> HTTP 422 and ZERO writes, even for the valid rows."""
+    db = _links_db(loc_rows=_loc_rows("DC-A", "DC-B"))
+    client = make_client(db)
+    resp = _post(client, [
+        _lane(),                                       # valid
+        _lane(upstream_external_id="DC-GHOST"),        # unknown upstream
+    ])
+    assert resp.status_code == 422
+    assert not any("INSERT INTO distribution_links" in c[0] for c in db.calls)
+
+
+# ─────────────────────────────────────────────────────────────
+# Router: Pydantic 422s (schema-level validation)
+# ─────────────────────────────────────────────────────────────
+
+
+def test_pydantic_empty_upstream_422():
+    client = make_client(FakeDB())
+    resp = _post(client, [_lane(upstream_external_id="  ")])
+    assert resp.status_code == 422
+
+
+def test_pydantic_negative_transit_422():
+    client = make_client(FakeDB())
+    resp = _post(client, [_lane(transit_lead_time_days=-1)])
+    assert resp.status_code == 422
+
+
+def test_pydantic_zero_transfer_multiple_422():
+    """transfer_multiple is gt=0 — 0 would make the DOWN-rounding degenerate."""
+    client = make_client(FakeDB())
+    resp = _post(client, [_lane(transfer_multiple=0)])
+    assert resp.status_code == 422
+
+
+def test_pydantic_zero_priority_422():
+    """priority is ge=1 (1 = most preferred)."""
+    client = make_client(FakeDB())
+    resp = _post(client, [_lane(priority=0)])
+    assert resp.status_code == 422
+
+
+def test_pydantic_zero_minimum_shipment_qty_is_valid():
+    """ge=0: 0 is a legitimate 'no floor' minimum."""
+    db = _links_db(loc_rows=_loc_rows("DC-A", "DC-B"))
+    client = make_client(db)
+    resp = _post(client, [_lane(minimum_shipment_qty=0)])
+    assert resp.status_code == 200, resp.text
+    inserts = [c for c in db.calls if "INSERT INTO distribution_links" in c[0]]
+    assert inserts[0][1][5] == 0.0  # min_qty param — 0, not the default 1


### PR DESCRIPTION
L'ingestion de `distribution_links` (spec PR-F) + LE test de preuve du plan : descente 60/40 → recompute → `/v1/drp/run` émet une recommandation de TRANSFER gouvernée du centre excédentaire vers le centre en déficit. Le DRP qui tournait à vide depuis ADR-028 se réveille.

🤖 Generated with [Claude Code](https://claude.com/claude-code)