### PR TITLE
fix(ingest): un POST par part dans le chargement groupe (413 attrape a la demo)

### DIFF
--- a/scripts/ingest_file.py
+++ b/scripts/ingest_file.py
@@ -69,6 +69,7 @@ from ootils_core.interfaces.ingest_exec import (  # noqa: E402
     DISPATCH,
     PAYLOAD_BUILDERS,
     ParsedFilename,
+    PartPostOutcome,
     archive,
     archive_group,
     build_bom_payloads,
@@ -77,6 +78,8 @@ from ootils_core.interfaces.ingest_exec import (  # noqa: E402
     parse_ingest_filename,
     parse_tsv,
     parse_tsv_parts,
+    parse_tsv_parts_each,
+    post_parts,
 )
 
 logging.basicConfig(
@@ -93,6 +96,7 @@ __all__ = [
     "DISPATCH",
     "PAYLOAD_BUILDERS",
     "ParsedFilename",
+    "PartPostOutcome",
     "archive",
     "archive_group",
     "build_bom_payloads",
@@ -101,6 +105,8 @@ __all__ = [
     "parse_ingest_filename",
     "parse_tsv",
     "parse_tsv_parts",
+    "parse_tsv_parts_each",
+    "post_parts",
     "handle_bom_bundle",
     "handle_part_group",
     "main",
@@ -284,7 +290,18 @@ def handle_bom_bundle(header_path: Path, dry_run: bool, token: str, *, date: str
 def handle_part_group(first_part: Path, dry_run: bool, token: str) -> int:
     """Group `first_part` with all its same-(entity, date) siblings found in
     its own directory (see `find_sibling_parts`) and ingest them as ONE
-    logical load — one concatenated payload, one POST, archived together.
+    logical load — archived TOGETHER at the end, one shared report — but
+    POSTed as N SEPARATE payloads, one per part (#413: concatenating every
+    part into one payload defeats the whole point of splitting the drop
+    into parts in the first place — see `interfaces.ingest_exec` module
+    docstring, "PART-GROUP LOADS ARE N POSTS, NEVER ONE").
+
+    Header identity across every part is still validated BEFORE any part is
+    POSTed (`parse_tsv_parts_each`). POSTing then proceeds part by part,
+    fail-fast (`post_parts`): a failure on part K leaves parts 1..K-1
+    already acquired server-side (ingestion is upsert-idempotent) and marks
+    the whole group `rejected` with a report naming exactly which parts
+    made it through — re-running the group is safe.
 
     Returns process exit code (0 ok, non-zero on any failure), mirroring
     the single-file flow in main().
@@ -302,13 +319,14 @@ def handle_part_group(first_part: Path, dry_run: bool, token: str) -> int:
 
     started_at = datetime.now(timezone.utc).isoformat()
     logger.info(
-        "ingesting %s (%d part(s): %s) → %s",
+        "ingesting %s (%d part(s): %s) → %s, one POST per part",
         canonical, len(siblings), [p.name for p in siblings], cfg["endpoint"],
     )
 
-    # ── 1. Parse + concatenate parts ───────────────────────
+    # ── 1. Parse each part separately (header identity still enforced
+    #        across the whole group, before ANY part is POSTed) ───────
     try:
-        headers, rows = parse_tsv_parts(siblings)
+        headers, parts_rows = parse_tsv_parts_each(siblings)
     except (FileNotFoundError, ValueError) as e:
         logger.error("parse error: %s", e)
         report: dict[str, Any] = {
@@ -325,38 +343,38 @@ def handle_part_group(first_part: Path, dry_run: bool, token: str) -> int:
             print(json.dumps(report, indent=2, ensure_ascii=False))
         return 4
 
+    rows_total = sum(len(r) for r in parts_rows)
     logger.info(
         "parsed %d rows from %d part(s) (header: %s)",
-        len(rows), len(siblings), headers,
+        rows_total, len(siblings), headers,
     )
 
-    # ── 2. Build payload ───────────────────────────────────
-    payload = builder(rows, dry_run)
+    # ── 2+3. Build + POST one payload PER part, fail-fast ─────────
+    outcomes: list[PartPostOutcome] = post_parts(
+        cfg["endpoint"], builder, list(zip(siblings, parts_rows)), token, dry_run,
+        call_api_fn=call_api,
+    )
 
-    # ── 3. Call API ────────────────────────────────────────
-    try:
-        status_code, body = call_api(cfg["endpoint"], payload, token)
-    except Exception as e:  # noqa: BLE001
-        logger.exception("API call crashed")
-        report = {
-            "filename": first_part.name,
-            "source_files": [p.name for p in siblings],
-            "started_at": started_at,
-            "finished_at": datetime.now(timezone.utc).isoformat(),
-            "outcome": "api_crash",
-            "error": str(e),
-            "rows_parsed": len(rows),
-        }
-        if not dry_run:
-            archive_group(siblings, REJECTED, report)
-        else:
-            print(json.dumps(report, indent=2, ensure_ascii=False))
-        return 5
-
-    # ── 4. Outcome + archive ──────────────────────────────
-    accepted = 200 <= status_code < 300
+    # ── 4. Outcome + archive (the group, together, at the end) ────
+    accepted = all(o.accepted for o in outcomes)
     outcome = "ok" if accepted else "rejected"
-    summary = body.get("summary", {}) if isinstance(body, dict) else {}
+    parts_ok = sum(1 for o in outcomes if o.accepted)
+    part_results = [
+        {
+            "source": o.source,
+            "rows_parsed": o.rows_count,
+            "attempted": o.attempted,
+            "outcome": (
+                "ok" if o.accepted
+                else "not_attempted" if not o.attempted
+                else o.error_kind or "rejected"
+            ),
+            "http_status": o.http_status,
+            "error": o.error,
+            "api_response": o.response,
+        }
+        for o in outcomes
+    ]
 
     report = {
         "filename": first_part.name,
@@ -366,26 +384,25 @@ def handle_part_group(first_part: Path, dry_run: bool, token: str) -> int:
         "finished_at": datetime.now(timezone.utc).isoformat(),
         "outcome": outcome,
         "dry_run": dry_run,
-        "http_status": status_code,
-        "rows_parsed": len(rows),
+        "rows_parsed": rows_total,
         "parts_count": len(siblings),
-        "api_summary": summary,
-        "api_response": body,
+        "parts_ok": parts_ok,
+        "part_results": part_results,
     }
 
     if dry_run:
-        logger.info("DRY-RUN — files not moved. Outcome: %s (HTTP %d)", outcome, status_code)
+        logger.info("DRY-RUN — files not moved. Outcome: %s (%d/%d parts ok)", outcome, parts_ok, len(siblings))
         print(json.dumps(report, indent=2, ensure_ascii=False))
         return 0 if accepted else 1
 
     dest = PROCESSED if accepted else REJECTED
     targets = archive_group(siblings, dest, report)
     logger.info(
-        "%s — %d part(s) archived to %s",
-        outcome.upper(), len(targets), dest,
+        "%s — %d part(s) archived to %s (%d/%d parts ok)",
+        outcome.upper(), len(targets), dest, parts_ok, len(siblings),
     )
     if not accepted:
-        print(json.dumps(body, indent=2, ensure_ascii=False), file=sys.stderr)
+        print(json.dumps(part_results, indent=2, ensure_ascii=False), file=sys.stderr)
     return 0 if accepted else 1
 
 

--- a/src/ootils_core/engine/ingest/daily_orchestrator.py
+++ b/src/ootils_core/engine/ingest/daily_orchestrator.py
@@ -7,7 +7,7 @@ Wires together, end to end, everything PR-2/PR-3 already built:
   1. **Scan** an inbox directory for TODAY's dated TSV drops
      (``<feed_key>_<AAAAMMJJ>.tsv``, plus grouped ``.partNN`` siblings —
      ``interfaces.ingest_exec.parse_ingest_filename``/``find_sibling_parts``/
-     ``parse_tsv_parts``, PR-4a's filename grammar).
+     ``parse_tsv_parts_each``, PR-4a's filename grammar).
   2. **Resolve** each scanned feed_key's active contract
      (``interfaces.contracts.list_active_contracts``/``get_active_contract``)
      — see "THE feed_key / entity_type MISMATCH" below.
@@ -25,7 +25,11 @@ Wires together, end to end, everything PR-2/PR-3 already built:
      whose OWN guard evaluation is green gets loaded, in FK-dependency
      order, by re-using — never duplicating — ``interfaces.ingest_exec``'s
      canonical parse/build/call/archive primitives (the same ones
-     ``scripts/ingest_file.py`` uses for a manual single-file drop).
+     ``scripts/ingest_file.py`` uses for a manual single-file drop). A
+     part-group feed is POSTed as N SEPARATE payloads via ``post_parts``
+     (``ScannedFeedFile.per_part()``), never one concatenated payload —
+     see ``interfaces.ingest_exec``'s module docstring, "PART-GROUP LOADS
+     ARE N POSTS, NEVER ONE" (#413).
 
 THE feed_key / entity_type MISMATCH (read before touching ``_canonical_
 dispatch_name``). A governed feed's inbox filename is named after its
@@ -146,13 +150,15 @@ from ootils_core.interfaces.ingest_exec import (
     DISPATCH,
     PAYLOAD_BUILDERS,
     ParsedFilename,
+    PartPostOutcome,
     archive,
     archive_group,
     call_api,
     find_sibling_parts,
     parse_ingest_filename,
     parse_tsv,
-    parse_tsv_parts,
+    parse_tsv_parts_each,
+    post_parts,
 )
 
 logger = logging.getLogger(__name__)
@@ -206,17 +212,52 @@ class ScannedFeedFile:
     """One feed_key's file(s) found in the inbox for one ``run_date`` — a
     single file, or N ``.partNN`` siblings already grouped ascending by
     ``find_sibling_parts``, parsed once (headers + rows kept in memory so
-    the later load phase never re-reads the file from disk)."""
+    the later load phase never re-reads the file from disk).
+
+    ``rows`` is the CONCATENATED view across every part — the right shape
+    for an aggregate need (the guard row-count check via ``row_count``).
+    ``part_rows``, when populated by ``scan_inbox`` (one entry per
+    ``paths``, same order), is the PER-PART view the load phase's
+    ``per_part()`` needs — see the #413 fix, module docstring "PART-GROUP
+    LOADS ARE N POSTS, NEVER ONE": flattening N parts into ONE POST payload
+    defeats the whole reason a drop is split into parts. Defaults to
+    ``()`` for backward compatibility with a ``ScannedFeedFile`` built
+    directly (bypassing ``scan_inbox``, e.g. a test fixture for a
+    different concern) — ``per_part()`` falls back safely for that case.
+    """
 
     feed_key: str
     paths: tuple[Path, ...]
     file_arrived_at: datetime  # max mtime across paths, UTC-aware
     headers: tuple[str, ...]
     rows: tuple[dict[str, str], ...]
+    part_rows: tuple[tuple[dict[str, str], ...], ...] = ()
 
     @property
     def row_count(self) -> int:
         return len(self.rows)
+
+    def per_part(self) -> list[tuple[Path, tuple[dict[str, str], ...]]]:
+        """Rows grouped per source path, ``paths`` order — the #413 load
+        primitive (feeds ``post_parts`` so each part gets its own POST).
+        Falls back to a single ``(paths[0], rows)`` pair when
+        ``part_rows`` was never populated (a test-constructed
+        ``ScannedFeedFile`` bypassing ``scan_inbox``) and there is exactly
+        one path — the concatenated and per-part views coincide for a
+        single file. Raises ``ValueError`` for the genuinely ambiguous
+        case (multiple paths, no ``part_rows`` breakdown) rather than
+        guessing which rows belong to which file.
+        """
+        if self.part_rows:
+            return list(zip(self.paths, self.part_rows))
+        if len(self.paths) == 1:
+            return [(self.paths[0], self.rows)]
+        raise ValueError(
+            f"ScannedFeedFile for feed_key={self.feed_key!r} has {len(self.paths)} "
+            "paths but no part_rows breakdown — scan_inbox always populates "
+            "this; a caller must not construct a multi-path ScannedFeedFile "
+            "directly"
+        )
 
 
 @dataclass(frozen=True)
@@ -329,8 +370,11 @@ def scan_inbox(inbox_dir: Path, run_date: date) -> InboxScan:
         try:
             if len(group) == 1:
                 headers, rows = parse_tsv(group[0])
+                part_rows: tuple[tuple[dict[str, str], ...], ...] = (tuple(rows),)
             else:
-                headers, rows = parse_tsv_parts(group)
+                headers, parts_list = parse_tsv_parts_each(group)
+                part_rows = tuple(tuple(part) for part in parts_list)
+                rows = [row for part in parts_list for row in part]
         except (FileNotFoundError, ValueError) as exc:
             issues[feed_key] = ScanIssue(
                 feed_key=feed_key, paths=tuple(group), file_arrived_at=arrived_at, error=str(exc),
@@ -343,6 +387,7 @@ def scan_inbox(inbox_dir: Path, run_date: date) -> InboxScan:
             file_arrived_at=arrived_at,
             headers=tuple(headers),
             rows=tuple(rows),
+            part_rows=part_rows,
         )
 
     logger.info(
@@ -807,63 +852,90 @@ def load_eligible_feeds(
 
         cfg = DISPATCH[canonical]
         builder = PAYLOAD_BUILDERS[canonical]
-        try:
-            payload = builder(list(scanned.rows), False)
-        except ValueError as exc:
-            detail = f"payload build error: {exc}"
-            logger.error(
-                "daily_orchestrator.build_error feed_key=%s run_date=%s detail=%s",
-                feed_key, evaluation.run_date, detail,
-            )
-            report = {
-                "feed_key": feed_key, "canonical": canonical, "run_date": evaluation.run_date.isoformat(),
-                "outcome": "build_error", "error": detail,
-            }
-            _archive_one_or_group(scanned.paths, rejected_dir, report)
-            outcomes.append(
-                FeedLoadOutcome(feed_key=feed_key, canonical=canonical, status=FeedLoadStatus.SCAN_ERROR,
-                                 http_status=None, detail=detail)
-            )
-            continue
 
-        try:
-            status_code, body = call_api(cfg["endpoint"], payload, token)
-        except Exception:  # noqa: BLE001 — mirrors ingest_file.py's own api-crash carve-out
-            logger.exception(
-                "daily_orchestrator.api_crash feed_key=%s run_date=%s endpoint=%s",
-                feed_key, evaluation.run_date, cfg["endpoint"],
+        # One POST PER PART (#413) — see interfaces.ingest_exec module
+        # docstring "PART-GROUP LOADS ARE N POSTS, NEVER ONE". `per_part()`
+        # degenerates to a single (path, rows) pair for a plain dated drop,
+        # so this is also the single-file path — no behaviour change there.
+        part_outcomes: tuple[PartPostOutcome, ...] = tuple(
+            post_parts(
+                cfg["endpoint"], builder, scanned.per_part(), token, False,
+                call_api_fn=call_api,
             )
-            report = {
-                "feed_key": feed_key, "canonical": canonical, "endpoint": cfg["endpoint"],
-                "run_date": evaluation.run_date.isoformat(), "outcome": "api_crash",
-            }
-            _archive_one_or_group(scanned.paths, rejected_dir, report)
-            outcomes.append(
-                FeedLoadOutcome(feed_key=feed_key, canonical=canonical, status=FeedLoadStatus.API_CRASH,
-                                 http_status=None, detail="call_api raised — see logs")
-            )
-            continue
+        )
+        first_failure = next(
+            (o for o in part_outcomes if o.attempted and not o.accepted), None
+        )
+        accepted = first_failure is None
+        parts_ok = sum(1 for o in part_outcomes if o.accepted)
+        http_status: int | None
 
-        accepted = 200 <= status_code < 300
-        summary = body.get("summary", {}) if isinstance(body, dict) else {}
         report = {
             "feed_key": feed_key, "canonical": canonical, "endpoint": cfg["endpoint"],
-            "run_date": evaluation.run_date.isoformat(), "outcome": "ok" if accepted else "rejected",
-            "http_status": status_code, "rows_parsed": len(scanned.rows), "api_summary": summary,
-            "api_response": body,
+            "run_date": evaluation.run_date.isoformat(),
+            "outcome": "ok" if accepted else "rejected",
+            "rows_parsed": sum(o.rows_count for o in part_outcomes),
+            "parts_count": len(part_outcomes),
+            "parts_ok": parts_ok,
+            "part_results": [
+                {
+                    "source": o.source, "attempted": o.attempted, "accepted": o.accepted,
+                    "http_status": o.http_status, "rows_parsed": o.rows_count,
+                    "error": o.error, "api_response": o.response,
+                }
+                for o in part_outcomes
+            ],
         }
         dest = processed_dir if accepted else rejected_dir
         _archive_one_or_group(scanned.paths, dest, report)
 
-        status = FeedLoadStatus.LOADED if accepted else FeedLoadStatus.REJECTED
-        detail = f"HTTP {status_code}" if accepted else f"HTTP {status_code}, summary={summary}"
-        logger.info(
-            "daily_orchestrator.load feed_key=%s run_date=%s canonical=%s status=%s http_status=%d",
-            feed_key, evaluation.run_date, canonical, status.value, status_code,
-        )
+        if first_failure is None:
+            status = FeedLoadStatus.LOADED
+            http_status = part_outcomes[-1].http_status if part_outcomes else None
+            detail = f"HTTP {http_status}" if len(part_outcomes) == 1 else (
+                f"{len(part_outcomes)} part(s), all HTTP 2xx (last={http_status})"
+            )
+            logger.info(
+                "daily_orchestrator.load feed_key=%s run_date=%s canonical=%s status=%s "
+                "parts=%d parts_ok=%d",
+                feed_key, evaluation.run_date, canonical, status.value, len(part_outcomes), parts_ok,
+            )
+        elif first_failure.error_kind == "build_error":
+            status = FeedLoadStatus.SCAN_ERROR
+            http_status = None
+            detail = f"payload build error on part '{first_failure.source}': {first_failure.error}"
+            logger.error(
+                "daily_orchestrator.build_error feed_key=%s run_date=%s detail=%s",
+                feed_key, evaluation.run_date, detail,
+            )
+        elif first_failure.error_kind == "api_crash":
+            status = FeedLoadStatus.API_CRASH
+            http_status = None
+            detail = f"call_api raised on part '{first_failure.source}' — see logs"
+            logger.error(
+                "daily_orchestrator.api_crash feed_key=%s run_date=%s endpoint=%s part=%s",
+                feed_key, evaluation.run_date, cfg["endpoint"], first_failure.source,
+            )
+        else:
+            status = FeedLoadStatus.REJECTED
+            http_status = first_failure.http_status
+            fail_summary = (
+                first_failure.response.get("summary", {})
+                if isinstance(first_failure.response, dict) else {}
+            )
+            detail = (
+                f"part '{first_failure.source}' HTTP {first_failure.http_status}, "
+                f"summary={fail_summary}"
+            )
+            logger.info(
+                "daily_orchestrator.load feed_key=%s run_date=%s canonical=%s status=%s "
+                "parts=%d parts_ok=%d",
+                feed_key, evaluation.run_date, canonical, status.value, len(part_outcomes), parts_ok,
+            )
+
         outcomes.append(
             FeedLoadOutcome(feed_key=feed_key, canonical=canonical, status=status,
-                             http_status=status_code, detail=detail)
+                             http_status=http_status, detail=detail)
         )
 
     return tuple(outcomes)

--- a/src/ootils_core/interfaces/ingest_exec.py
+++ b/src/ootils_core/interfaces/ingest_exec.py
@@ -36,6 +36,26 @@ orchestration (``handle_bom_bundle``) and part-group CLI orchestration
 (dry-run JSON printing to stdout, process exit codes) — only the DB/API
 primitives they call (``parse_tsv``, ``PAYLOAD_BUILDERS``, ``call_api``,
 ``archive``/``archive_group``, ``build_bom_payloads``) are canonical here.
+
+PART-GROUP LOADS ARE N POSTS, NEVER ONE (#413). A ``.partNN`` group exists
+BECAUSE a single file would be too big — ``TSV-FILES-SPEC.md`` §1.1 caps
+every FILE at ~50 000 lines / 10 MB precisely so it clears
+``IngestPayloadSizeLimitMiddleware``'s 10 MB request-body cap. Concatenating
+N parts into ONE in-memory payload (the pre-#413 shape of both
+``handle_part_group`` and ``daily_orchestrator.load_eligible_feeds``)
+defeats that guarantee arithmetically — N x 4.5 MB parts trivially exceed
+10 MB even though every individual part is safely under it (the exact
+failure caught at the 2026-07 demo: 3 forecast parts, ~13 MB concatenated,
+POST /v1/ingest/forecast-demand -> 413). The fix is structural, not a bigger
+cap: ``parse_tsv_parts_each``/``post_parts`` below keep every part's rows
+and its own POST separate all the way to ``call_api``, so each request body
+never grows past one part's own (contractually bounded) size. A "logical
+load" stays ONE unit for archiving/reporting purposes (still one
+``archive_group`` call, one shared report) — only the wire representation
+changed, both callers (``scripts/ingest_file.py:handle_part_group`` and
+``engine/ingest/daily_orchestrator.py:load_eligible_feeds``) build their own
+report/archiving around these two shared primitives, never a second
+implementation of the POST loop itself.
 """
 from __future__ import annotations
 
@@ -43,10 +63,11 @@ import csv
 import json
 import re
 import shutil
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 
 # ─────────────────────────────────────────────────────────────
@@ -262,23 +283,30 @@ def find_sibling_parts(path: Path) -> list[Path]:
     return siblings
 
 
-def parse_tsv_parts(paths: list[Path]) -> tuple[list[str], list[dict[str, str]]]:
-    """Parse and concatenate N sibling part files into one logical
-    (headers, rows), in the given order (expected: ascending by part
-    number, see `find_sibling_parts`).
+def parse_tsv_parts_each(paths: list[Path]) -> tuple[list[str], list[list[dict[str, str]]]]:
+    """Parse N sibling part files INDEPENDENTLY — never concatenated — into
+    one shared `headers` (validated byte-identical across every part, same
+    rule as `parse_tsv_parts`) plus each part's own row list, in `paths`
+    order (expected: ascending by part number, see `find_sibling_parts`).
 
-    Every part is parsed independently via `parse_tsv`; all parts must
-    share byte-identical headers (same column names, same order) — a
-    mismatch raises ValueError naming the offending file. Each row's
-    `__line__` tag is re-prefixed with its source file's name so error
-    messages built from it stay traceable across parts, e.g.
-    "forecasts.part02.tsv:L14".
+    This is the #413 fix's parsing primitive (see module docstring,
+    "PART-GROUP LOADS ARE N POSTS, NEVER ONE"): a part-group LOAD must POST
+    each part as its own payload, so the parser must keep parts separate
+    all the way through rather than flattening them into one row list a
+    caller can no longer split. Each row's `__line__` tag is re-prefixed
+    with its source file's name so error messages stay traceable across
+    parts, e.g. "forecasts.part02.tsv:L14".
+
+    Raises ValueError if `paths` is empty, or if any part's header
+    (names AND order) differs from the first part's — naming the offending
+    file — BEFORE any payload is built for ANY part (header validation
+    covers the whole group upfront, never discovered mid-POST).
     """
     if not paths:
         raise ValueError("no part files to parse")
 
     headers: list[str] | None = None
-    all_rows: list[dict[str, str]] = []
+    parts: list[list[dict[str, str]]] = []
     for p in paths:
         p_headers, p_rows = parse_tsv(p)
         if headers is None:
@@ -288,12 +316,30 @@ def parse_tsv_parts(paths: list[Path]) -> tuple[list[str], list[dict[str, str]]]
                 f"part file '{p.name}' header {p_headers} does not match "
                 f"first part's header {headers}"
             )
+        tagged_rows: list[dict[str, str]] = []
         for row in p_rows:
             row = dict(row)
             row["__line__"] = f"{p.name}:L{row.get('__line__', '?')}"
-            all_rows.append(row)
+            tagged_rows.append(row)
+        parts.append(tagged_rows)
 
     assert headers is not None  # `paths` non-empty => at least one iteration ran
+    return headers, parts
+
+
+def parse_tsv_parts(paths: list[Path]) -> tuple[list[str], list[dict[str, str]]]:
+    """Parse and concatenate N sibling part files into one logical
+    (headers, rows) — an AGGREGATE view, for callers that only need the
+    combined row set (e.g. the daily orchestrator's guard row-count check).
+
+    Built on `parse_tsv_parts_each` (one parser walk, no second reader):
+    same header-identity validation, same `__line__` re-prefixing. NOT the
+    right primitive for building a POST payload out of a part group — see
+    `parse_tsv_parts_each`/`post_parts` and the module docstring
+    "PART-GROUP LOADS ARE N POSTS, NEVER ONE" (#413).
+    """
+    headers, parts = parse_tsv_parts_each(paths)
+    all_rows: list[dict[str, str]] = [row for part in parts for row in part]
     return headers, all_rows
 
 
@@ -753,6 +799,124 @@ def call_api(endpoint: str, payload: dict[str, Any], token: str) -> tuple[int, d
     except Exception:
         body = {"raw_body": resp.text}
     return resp.status_code, body
+
+
+# ─────────────────────────────────────────────────────────────
+# Part-group POSTing (#413) — N parts, N payloads, N calls
+# ─────────────────────────────────────────────────────────────
+@dataclass(frozen=True)
+class PartPostOutcome:
+    """One part's outcome from `post_parts`. `attempted=False` means the
+    group already failed on an earlier part and this one was deliberately
+    never built/POSTed (fail-fast, see `post_parts`) — its
+    `http_status`/`response` stay `None`, never a fabricated value.
+    `error_kind` distinguishes WHERE a failure happened (`'build_error'` —
+    the payload builder raised before any network call; `'api_crash'` —
+    `call_api` itself raised; `None` — either accepted, or a genuine
+    non-2xx HTTP response, both of which carry `response`/`http_status`
+    instead) so a caller can classify the outcome without re-deriving it
+    from `error`'s free text.
+    """
+
+    source: str
+    attempted: bool
+    accepted: bool
+    http_status: int | None
+    rows_count: int
+    response: dict[str, Any] | None
+    error: str | None
+    error_kind: str | None  # "build_error" | "api_crash" | None
+
+
+def post_parts(
+    endpoint: str,
+    builder: Callable[[list[dict[str, str]], bool], dict[str, Any]],
+    parts: Sequence[tuple[Path, Sequence[dict[str, str]]]],
+    token: str,
+    dry_run: bool,
+    *,
+    call_api_fn: Callable[[str, dict[str, Any], str], tuple[int, dict]] = call_api,
+) -> list[PartPostOutcome]:
+    """POST N sibling parts as N SEPARATE payloads against the same
+    `endpoint` — the #413 fix (module docstring, "PART-GROUP LOADS ARE N
+    POSTS, NEVER ONE"). Each part is contractually <= ~50 000 rows / <= 10 MB
+    (`TSV-FILES-SPEC.md` §1.1's per-FILE cap), so POSTing them individually
+    always stays clear of `IngestPayloadSizeLimitMiddleware`'s 10 MB
+    request-body cap; concatenating N parts into ONE payload does not (the
+    exact failure caught at the 2026-07 demo).
+
+    Builds each part's payload via `builder(rows, dry_run)` immediately
+    before POSTing it (never ahead of time for the whole group), so a
+    payload-construction error on a LATER part can never be discovered only
+    after an EARLIER part already POSTed successfully.
+
+    Fail-fast: stops at the first non-accepted part (a payload-build
+    `ValueError`, a `call_api_fn` exception, or a non-2xx response) — every
+    part already POSTed successfully stays acquired (ingestion is
+    upsert-idempotent, `TSV-FILES-SPEC.md`), remaining parts are reported
+    `attempted=False`, and the caller can safely re-run the WHOLE group:
+    already-loaded parts just upsert to the same result.
+
+    `call_api_fn` defaults to this module's `call_api` and exists so each
+    CALLER can pass through its OWN module-local `call_api` name instead —
+    Python resolves a bare `call_api(...)` call inside e.g.
+    `daily_orchestrator.py` against THAT module's global, not
+    `ingest_exec`'s, so `monkeypatch.setattr(daily_orchestrator, "call_api",
+    ...)` only takes effect if the caller passes `call_api` (its own,
+    possibly-patched module attribute) through explicitly rather than
+    relying on this default.
+    """
+    results: list[PartPostOutcome] = []
+    failed = False
+    for source, rows in parts:
+        if failed:
+            results.append(
+                PartPostOutcome(
+                    source=source.name, attempted=False, accepted=False,
+                    http_status=None, rows_count=len(rows), response=None,
+                    error=None, error_kind=None,
+                )
+            )
+            continue
+
+        try:
+            payload = builder(list(rows), dry_run)
+        except ValueError as e:
+            results.append(
+                PartPostOutcome(
+                    source=source.name, attempted=True, accepted=False,
+                    http_status=None, rows_count=len(rows), response=None,
+                    error=str(e), error_kind="build_error",
+                )
+            )
+            failed = True
+            continue
+
+        try:
+            status_code, body = call_api_fn(endpoint, payload, token)
+        except Exception as e:  # noqa: BLE001 — mirrors the single-payload api-crash carve-out
+            results.append(
+                PartPostOutcome(
+                    source=source.name, attempted=True, accepted=False,
+                    http_status=None, rows_count=len(rows), response=None,
+                    error=str(e), error_kind="api_crash",
+                )
+            )
+            failed = True
+            continue
+
+        accepted = 200 <= status_code < 300
+        results.append(
+            PartPostOutcome(
+                source=source.name, attempted=True, accepted=accepted,
+                http_status=status_code, rows_count=len(rows), response=body,
+                error=None, error_kind=None,
+            )
+        )
+        if not accepted:
+            failed = True
+
+    return results
 
 
 # ─────────────────────────────────────────────────────────────

--- a/tests/test_daily_orchestrator.py
+++ b/tests/test_daily_orchestrator.py
@@ -53,6 +53,7 @@ DATABASE_URL.
 """
 from __future__ import annotations
 
+import json
 import logging
 import os
 import sys
@@ -528,15 +529,23 @@ class TestLoadPhase:
     @pytest.fixture
     def api_calls(self, monkeypatch):
         """Record every call_api invocation; respond 200 unless the endpoint
-        was primed otherwise via .responses."""
+        was primed otherwise via .responses (by endpoint) or
+        .indexed_responses (by 0-based call index — e.g. to fail one
+        specific PART of a `.partNN` group while the others succeed;
+        additive on top of .responses, never used by pre-#413 tests)."""
         calls: list[tuple[str, dict, str]] = []
         responses: dict[str, tuple[int, dict]] = {}
+        indexed_responses: dict[int, tuple[int, dict]] = {}
 
         def fake_call_api(endpoint, payload, token):
+            idx = len(calls)
             calls.append((endpoint, payload, token))
+            if idx in indexed_responses:
+                return indexed_responses[idx]
             return responses.get(endpoint, (200, {"summary": {"inserted": len(next(iter(payload.values())))}}))
 
         fake_call_api.responses = responses  # type: ignore[attr-defined]
+        fake_call_api.indexed_responses = indexed_responses  # type: ignore[attr-defined]
         monkeypatch.setattr(daily_orchestrator, "call_api", fake_call_api)
         fake_call_api.calls = calls  # type: ignore[attr-defined]
         return fake_call_api
@@ -731,6 +740,82 @@ class TestLoadPhase:
         assert "contract deactivated" in outcomes[0].detail
         assert api_calls.calls == []
         assert any(p.suffix == ".tsv" for p in (tmp_path / "rejected").iterdir())
+
+    # ── #413: a part-group feed is N POSTs, never one concatenated POST ──
+    def test_part_group_feed_is_posted_as_n_separate_payloads(self, tmp_path, api_calls):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        _write_tsv(
+            inbox / f"on-hand.part01_{DATE_STR}.tsv", [_row("IT-1", "5")],
+        )
+        _write_tsv(
+            inbox / f"on-hand.part02_{DATE_STR}.tsv",
+            [_row("IT-2", "7"), _row("IT-3", "9")],
+        )
+        scan = scan_inbox(inbox, RUN_DATE)
+        evaluation = self._degraded_evaluation(
+            scan, [_feed_eval("on-hand", "on_hand", scan)]
+        )
+
+        outcomes = load_eligible_feeds(evaluation, token="tok", inbox_dir=inbox)
+
+        # ONE POST per part — never a single concatenated payload for the group.
+        assert len(api_calls.calls) == 2
+        assert [c[0] for c in api_calls.calls] == ["/v1/ingest/on-hand"] * 2
+        assert len(api_calls.calls[0][1]["on_hand"]) == 1
+        assert len(api_calls.calls[1][1]["on_hand"]) == 2
+        assert [r["item_external_id"] for r in api_calls.calls[0][1]["on_hand"]] == ["IT-1"]
+        assert [r["item_external_id"] for r in api_calls.calls[1][1]["on_hand"]] == ["IT-2", "IT-3"]
+
+        assert outcomes[0].status is FeedLoadStatus.LOADED
+        assert outcomes[0].http_status == 200
+        # Group archived together, inbox drained (archive_group writes one
+        # report.json per source file — the full report lives next to
+        # part01, a pointer stub next to every other part).
+        assert list(inbox.iterdir()) == []
+        processed = sorted(p.name for p in (tmp_path / "processed").iterdir())
+        assert sum(1 for n in processed if n.endswith(".tsv")) == 2
+        assert sum(1 for n in processed if n.endswith(".report.json")) == 2
+
+    def test_part_group_fails_fast_on_second_part_and_rejects_whole_group(self, tmp_path, api_calls):
+        # The 2nd POST (0-based idx 1) is rejected — the 3rd part must never
+        # be attempted, and the group's shared report must name exactly
+        # which part(s) made it through (parts already POSTed stay acquired
+        # server-side — ingestion is upsert-idempotent — a re-run is safe).
+        api_calls.indexed_responses[1] = (422, {"detail": "bad row"})
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        _write_tsv(inbox / f"on-hand.part01_{DATE_STR}.tsv", [_row("IT-1")])
+        _write_tsv(inbox / f"on-hand.part02_{DATE_STR}.tsv", [_row("IT-2")])
+        _write_tsv(inbox / f"on-hand.part03_{DATE_STR}.tsv", [_row("IT-3")])
+        scan = scan_inbox(inbox, RUN_DATE)
+        evaluation = self._degraded_evaluation(
+            scan, [_feed_eval("on-hand", "on_hand", scan)]
+        )
+
+        outcomes = load_eligible_feeds(evaluation, token="tok", inbox_dir=inbox)
+
+        # fail-fast: only 2 of the 3 parts were ever POSTed.
+        assert len(api_calls.calls) == 2
+        assert outcomes[0].status is FeedLoadStatus.REJECTED
+        assert outcomes[0].http_status == 422
+
+        # Whole group archived to rejected/ together, report next to part01
+        # (ascending order) names each part's own fate honestly.
+        assert list(inbox.iterdir()) == []
+        rejected = list((tmp_path / "rejected").iterdir())
+        report_path = next(
+            p for p in rejected
+            if p.name.startswith("on-hand.part01") and p.name.endswith(".report.json")
+        )
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        assert report["outcome"] == "rejected"
+        assert report["parts_count"] == 3
+        assert report["parts_ok"] == 1
+        parts = report["part_results"]
+        assert parts[0]["accepted"] is True
+        assert parts[1]["accepted"] is False and parts[1]["http_status"] == 422
+        assert parts[2]["attempted"] is False
 
 
 # ─────────────────────────────────────────────────────────────

--- a/tests/test_ingest_file_naming.py
+++ b/tests/test_ingest_file_naming.py
@@ -31,6 +31,7 @@ DATABASE_URL.
 """
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -390,3 +391,156 @@ class TestFindArchived:
 
         missing = tmp_path / "inbox" / "items.tsv"
         assert _find_archived(missing) == newer
+
+
+# ─────────────────────────────────────────────────────────────
+# 5. handle_part_group — #413: a `.partNN` group is N POSTs, never one
+#    concatenated payload (the real 413 caught at the 2026-07 demo:
+#    3 forecast parts concatenated into ~13 MB blew past the 10 MB
+#    IngestPayloadSizeLimitMiddleware cap, even though each individual
+#    part was safely under TSV-FILES-SPEC.md's per-FILE 10 MB / ~50k-row
+#    cap).
+# ─────────────────────────────────────────────────────────────
+_FC_HEADER = "item_external_id\tlocation_external_id\tquantity\tbucket_date"
+
+
+class TestHandlePartGroup:
+    @pytest.fixture()
+    def archive_dirs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        processed = tmp_path / "processed"
+        rejected = tmp_path / "rejected"
+        monkeypatch.setattr(ingest_file, "PROCESSED", processed)
+        monkeypatch.setattr(ingest_file, "REJECTED", rejected)
+        return processed, rejected
+
+    @pytest.fixture()
+    def api_calls(self, monkeypatch: pytest.MonkeyPatch):
+        """Record every call_api invocation; respond 200 unless a specific
+        0-based call index was primed otherwise via .responses — lets a
+        test fail exactly ONE part while its siblings succeed."""
+        calls: list[tuple[str, dict, str]] = []
+        responses: dict[int, tuple[int, dict]] = {}
+
+        def fake_call_api(endpoint, payload, token):
+            idx = len(calls)
+            calls.append((endpoint, payload, token))
+            return responses.get(
+                idx, (200, {"summary": {"inserted": len(payload.get("forecasts", []))}})
+            )
+
+        fake_call_api.calls = calls  # type: ignore[attr-defined]
+        fake_call_api.responses = responses  # type: ignore[attr-defined]
+        monkeypatch.setattr(ingest_file, "call_api", fake_call_api)
+        return fake_call_api
+
+    def test_three_parts_are_three_separate_posts_never_concatenated(
+        self, tmp_path: Path, archive_dirs, api_calls
+    ) -> None:
+        p1 = _write_tsv(
+            tmp_path / "forecasts.part01.tsv", ["IT-1\tLOC-1\t5\t2026-07-20"], header=_FC_HEADER
+        )
+        _write_tsv(
+            tmp_path / "forecasts.part02.tsv",
+            ["IT-2\tLOC-1\t7\t2026-07-20", "IT-3\tLOC-1\t9\t2026-07-20"],
+            header=_FC_HEADER,
+        )
+        _write_tsv(
+            tmp_path / "forecasts.part03.tsv", ["IT-4\tLOC-1\t1\t2026-07-20"], header=_FC_HEADER
+        )
+
+        rc = ingest_file.handle_part_group(p1, dry_run=False, token="tok")
+
+        assert rc == 0
+        assert len(api_calls.calls) == 3
+        assert [c[0] for c in api_calls.calls] == ["/v1/ingest/forecast-demand"] * 3
+        # Each POST's payload carries ONLY its own part's rows — never the
+        # concatenated group (the #413 bug).
+        assert [len(c[1]["forecasts"]) for c in api_calls.calls] == [1, 2, 1]
+        assert [r["item_external_id"] for r in api_calls.calls[0][1]["forecasts"]] == ["IT-1"]
+        assert [r["item_external_id"] for r in api_calls.calls[1][1]["forecasts"]] == ["IT-2", "IT-3"]
+        assert [r["item_external_id"] for r in api_calls.calls[2][1]["forecasts"]] == ["IT-4"]
+
+        processed, rejected = archive_dirs
+        assert sum(1 for _ in processed.glob("*.tsv")) == 3
+        assert not rejected.exists() or not any(rejected.iterdir())
+
+    def test_failure_on_part_two_stops_part_three_and_rejects_group(
+        self, tmp_path: Path, archive_dirs, api_calls
+    ) -> None:
+        api_calls.responses[1] = (422, {"detail": "bad quantity"})  # the 2nd POST fails
+        p1 = _write_tsv(
+            tmp_path / "forecasts.part01.tsv", ["IT-1\tLOC-1\t5\t2026-07-20"], header=_FC_HEADER
+        )
+        _write_tsv(
+            tmp_path / "forecasts.part02.tsv", ["IT-2\tLOC-1\t7\t2026-07-20"], header=_FC_HEADER
+        )
+        _write_tsv(
+            tmp_path / "forecasts.part03.tsv", ["IT-3\tLOC-1\t9\t2026-07-20"], header=_FC_HEADER
+        )
+
+        rc = ingest_file.handle_part_group(p1, dry_run=False, token="tok")
+
+        assert rc == 1
+        # Fail-fast: part03 is never POSTed once part02 is rejected.
+        assert len(api_calls.calls) == 2
+
+        processed, rejected = archive_dirs
+        assert not processed.exists() or not any(processed.iterdir())
+        assert sum(1 for _ in rejected.glob("*.tsv")) == 3
+        report_path = next(rejected.glob("forecasts.part01*.report.json"))
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        assert report["outcome"] == "rejected"
+        assert report["parts_count"] == 3
+        assert report["parts_ok"] == 1
+        parts = report["part_results"]
+        # part01 got through (and stays acquired — ingestion is
+        # upsert-idempotent, so a re-run of the whole group is safe).
+        assert parts[0]["outcome"] == "ok" and parts[0]["source"] == "forecasts.part01.tsv"
+        assert parts[1]["outcome"] == "rejected" and parts[1]["http_status"] == 422
+        assert parts[2]["outcome"] == "not_attempted" and parts[2]["attempted"] is False
+
+    def test_header_mismatch_raises_before_any_post(
+        self, tmp_path: Path, archive_dirs, api_calls
+    ) -> None:
+        p1 = _write_tsv(
+            tmp_path / "forecasts.part01.tsv", ["IT-1\tLOC-1\t5\t2026-07-20"], header=_FC_HEADER
+        )
+        _write_tsv(
+            tmp_path / "forecasts.part02.tsv",
+            ["IT-2\tLOC-1\t7\t2026-07-20"],
+            header="item_external_id\tlocation_external_id\tqty\tbucket_date",  # 'qty' != 'quantity'
+        )
+
+        rc = ingest_file.handle_part_group(p1, dry_run=False, token="tok")
+
+        assert rc == 4
+        assert api_calls.calls == []  # header identity is checked BEFORE any POST
+
+        processed, rejected = archive_dirs
+        assert not processed.exists() or not any(processed.iterdir())
+        report_path = next(rejected.glob("forecasts.part01*.report.json"))
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        assert report["outcome"] == "parse_error"
+        assert "forecasts.part02.tsv" in report["error"]
+
+    def test_dry_run_posts_but_never_archives(
+        self, tmp_path: Path, archive_dirs, api_calls, capsys
+    ) -> None:
+        p1 = _write_tsv(
+            tmp_path / "forecasts.part01.tsv", ["IT-1\tLOC-1\t5\t2026-07-20"], header=_FC_HEADER
+        )
+        _write_tsv(
+            tmp_path / "forecasts.part02.tsv", ["IT-2\tLOC-1\t7\t2026-07-20"], header=_FC_HEADER
+        )
+
+        rc = ingest_file.handle_part_group(p1, dry_run=True, token="tok")
+
+        assert rc == 0
+        assert len(api_calls.calls) == 2
+        assert all(c[1]["dry_run"] is True for c in api_calls.calls)
+        # No archiving under --dry-run: both parts stay exactly where they were.
+        assert p1.exists()
+        assert (tmp_path / "forecasts.part02.tsv").exists()
+        processed, rejected = archive_dirs
+        assert not processed.exists()
+        assert not rejected.exists()


### PR DESCRIPTION
Le regroupement de parts concaténait tout en un payload → 413 sur les 120 237 lignes de forecasts. Fix : une primitive canonique `post_parts` (un POST par part, fail-fast, rapport honnête par part), appliquée aux DEUX chemins (ingest_file + orchestrateur quotidien). 3 400 unitaires verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)